### PR TITLE
docs: add focused Crab CLI skills

### DIFF
--- a/.codex/skills/crab-cli-core/SKILL.md
+++ b/.codex/skills/crab-cli-core/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: crab-cli-core
+description: Shared implementation and routing guidance for the Crab CLI. Use whenever a task changes Crab command dispatch, configuration, structured output, error handling, CLI architecture, or when a Crab CLI request needs to be routed to a focused skill. Read the command map before choosing an owner.
+compatibility: Crab monorepo with Rust 2024, Cargo, and repository-local `.codex/skills`.
+---
+
+# Crab CLI core
+
+Use this skill for cross-cutting Crab CLI work and as the routing layer for
+specialized skills. Keep the command surface boring: one canonical path,
+narrow APIs, typed errors, and evidence for externally visible behavior.
+
+## Route first
+
+Read `references/command-map.md`, then choose the narrowest skill. Use the
+specialized skill for the user-facing workflow and keep this skill active for
+cross-cutting contracts. Existing `crab-cli-verification` and
+`crab-release-publish` take precedence for their respective tasks.
+
+## Implementation loop
+
+1. Read `AGENTS.md`, the relevant command definition in
+   `crab/src/main.rs`, the complete command module, its callers and callees,
+   sibling implementations, tests, and the relevant guide.
+2. Identify the owner boundary and the public contract before editing. Search
+   all consumers when changing a type, schema, config key, storage layout,
+   pointer format, or error.
+3. Make the smallest bounded refactor that leaves one canonical path. Delete
+   stale branches and wrappers when they are not a shipped compatibility
+   contract.
+4. Preserve typed errors, cancellation, lock release, SlateDB closure, and
+   structured output behavior. Do not add `unwrap`, `expect`, `panic`,
+   `todo!`, or an untracked fallback path.
+5. Update the adjacent guide when behavior or a public option changes.
+6. Verify with focused tests first, then the appropriate broad gate. Use the
+   RustFS E2E skill when a real object-store side effect is part of the claim.
+
+## Shared references
+
+- `references/command-map.md` — complete command-to-skill ownership and
+  overlap rules.
+- `references/contracts.md` — output, storage, safety, and verification
+  contracts that every Crab skill must honor.
+
+## Common validation
+
+```bash
+cd crab
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/crab-main cargo check --locked
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/crab-main cargo test --locked
+```
+
+Use a dedicated target directory for another checkout or worktree. Report
+exactly which gate ran and which proof remains unavailable.

--- a/.codex/skills/crab-cli-core/references/command-map.md
+++ b/.codex/skills/crab-cli-core/references/command-map.md
@@ -1,0 +1,38 @@
+# Crab CLI command map
+
+Use this map to choose the narrowest skill. The command implementation in
+`crab/src/main.rs` and the module under `crab/src/cmd/` remain authoritative
+when this map and a guide disagree.
+
+| Skill | Primary commands | Main source and guide surfaces |
+| --- | --- | --- |
+| `crab-repository-lifecycle` | `init`, `setup`, `clone`, `mirror`, `worktree`, `config`, `track`, `untrack`, `install`, `uninstall`, `completions` | `crab/src/cmd/{init,setup,clone,mirror,worktree,config,track}.rs`; guides `init`, `getting-started`, `clone`, `adopting-existing-repos`, `project-config`, `worktree` |
+| `crab-large-files` | `add`, `reset`, default `status`, `why`, `hydrate`, `dehydrate`, `diff`, `diff-driver`, `ls-files`, hidden native `FilterProcess`, `fetch`, `prune`, `du`, `stat`, `cache`, `staging`, `adopt`, `unadopt`, `undo`, `migrate`, selective `download` | `crab/src/{engine,hydrate,cache,cmd/{add,reset,status,hydrate,dehydrate,diff,download,migrate,staging}}`; guides `add`, `hydrate`, `dehydrate`, `status`, `large-file-versioning`, `staging`, `cache`, `migrate` |
+| `crab-git-sync` | `push`, `pull`, `ship`, `import`, `export`, `lock`, `unlock`, `locks`, Git remote-helper behavior | `crab/src/git/`, `crab/src/cmd/{push,pull,ship,import,export,lock}.rs`; design `push`; guides `fetch`, `import`, `export`, `ship`, `lock` |
+| `crab-workflow` | `run`, `repro`, `stage`, `freeze`, `unfreeze`, `exp`, `queue`, `workflow`, `params`, `metrics`, `plots`, `status --workflow`, `migrate from-dvc` | `crab/src/workflow/`, `crab/src/cmd/{run,stage,freeze,exp,exp_queue,workflow,status_workflow,workflow_journal,workflow_lockfile,params,metrics}.rs`; guides `workflow`, `hermetic-workflows`, `project-config`; `crates/crab-workflow/` |
+| `crab-lfs` | `lfs` and hidden `lfs-transfer-agent`; `optimize lfs` | `crab/src/lfs/`, `crab/src/cmd/lfs/`, `crates/crab-lfs/`; architecture `lfs-compatibility`; guide `lfs` |
+| `crab-storage-ops` | `gc`, `fsck`, `compact`, `repack`, `optimize plan/apply/repo/xorbs/packs/shards/cache/indexes`, `metadb`, maintenance `cache` and `staging`, remote/index-focused `du` and `stat` | `crab/src/{metadata,storage,restripe,cmd/gc/,cmd/{fsck,compact,repack,optimize,metadb,staging,stat}}`; guides `gc`, `fsck`, `repack`, `optimize-xorbs`, `metadb`, `staging`, `du`, `stat` |
+| `crab-tier-replication` | `tier`, `optimize tiers`, `replica`, `optimize replicas`, hidden `coordinator` | `crab/src/{tier,replication,restripe,cmd/tier/,cmd/{replica,coordinator}}`; guides `tier`, `replica`, `cost`; designs `replica-*`; `crates/crab-coordination/` |
+| `crab-mount` | `mount`, `unmount`, `daemon`, hidden coordinator lifecycle | `crab/src/{vfs,git/worktree_hydration,cmd/mount}.rs`; architecture `virtual-filesystem`, `vfs-coordinator`, `nfs-mount-architecture`; guides `mount`, `daemon` |
+| `crab-managed-operations` | `login`, `logout`, `auth`, `organization`, `repo`, `member`, `service-account`, `audit`, `release` | `crab/src/{auth,audit,release,cmd/{login,logout,auth_status,managed_admin,audit,release}}`; guides `auth/*`, `audit`, `release-manifests` |
+| `crab-diagnostics-recovery` | `doctor`, `env`, `errors`, `logs`, `version`, `update`, `recover` and `recover history` | `crab/src/{core/error_catalog,cmd/{doctor,env,errors,logs,version,update,recover,history_recovery}}`; guides `doctor`, `env`, `errors`, `logs`, `recovery`, `repository-recovery` |
+| `crab-cli-verification` | End-to-end proof for any command | `.codex/skills/crab-cli-verification/`; local RustFS fixture and side-effect proof |
+| `crab-release-publish` | Publishing Crab CLI binaries and updating Homebrew | `.codex/skills/crab-release-publish/`; release scripts and GitHub release contract |
+
+## Boundary rules
+
+- A user-facing large-file operation belongs to `crab-large-files`; a remote
+  ref/object transfer belongs to `crab-git-sync`.
+- `du` and `stat` go to `crab-large-files` when the question is local file,
+  staging, or hydration space; use `crab-storage-ops` when the question is
+  remote object classes, indexes, or storage maintenance.
+- `crab lfs` is always routed to `crab-lfs`, even when the request mentions
+  large files. Native Crab pointer workflows and Git LFS compatibility are
+  related but have different pointer formats and protocols.
+- Workflow stage outputs belong to `crab-workflow`; repository-level file
+  hydration of those outputs belongs to `crab-large-files`.
+- `optimize` is routed by the noun after it: storage/index/cache work to
+  `crab-storage-ops`, tier/replica work to `crab-tier-replication`, LFS work
+  to `crab-lfs`, and workflow-cache work to `crab-workflow`.
+- `crab release` creates dataset release manifests. Publishing Crab CLI
+  archives is the separate `crab-release-publish` skill.

--- a/.codex/skills/crab-cli-core/references/contracts.md
+++ b/.codex/skills/crab-cli-core/references/contracts.md
@@ -1,0 +1,59 @@
+# Crab CLI contracts
+
+Read this reference before changing a command, diagnosing a data-path issue,
+or claiming that a fix is safe.
+
+## Authority order
+
+1. Repository `AGENTS.md` and any nearer scoped guide.
+2. The CLI definition and dispatch in `crab/src/main.rs`.
+3. The command module and its callers/callees.
+4. Tests, snapshots, and the matching guide or design document.
+5. Upstream dependency source and documentation for dependency-backed
+   behavior.
+
+Do not infer defaults, timing, error shapes, storage paths, or compatibility
+from a command name alone.
+
+## Data-path invariants
+
+- Every SlateDB instance is closed on every exit path.
+- A ref lock is released after every acquisition, including errors and
+  cancellation.
+- GC never deletes referenced objects or objects inside the grace period.
+- Reconstruction is byte-identical to the original or returns an error.
+- Staged xorbs are flushed before a bundle push begins.
+- Shard reconstruction terms cover every chunk for the file.
+- `chunks_for_file(file_hash)` returns every chunk for that file version.
+
+## Output and errors
+
+- Treat `--json` and `--jsonl` as public machine-readable contracts. Find the
+  schema constant and serializer in source before changing fields.
+- `--json` is a terminal envelope; `--jsonl` is a stream of event envelopes.
+  Do not make a consumer parse human progress text.
+- Preserve typed source errors through `CrabError`; do not stringify away the
+  source error or invent a second error path.
+- Keep human output and structured output behavior aligned for the same command.
+
+## Storage and safety
+
+- Repository staging lives under `.crab/staging/`; the global cache is separate
+  and normally rooted under the Crab cache directory.
+- Inspect the configured remote and scope before any remote mutation.
+- Never use bucket-wide GC as a repository operation. Prefer a repository
+  scope and a dry run, then prove the object set affected.
+- Treat recovery, tiering, replica repair, force GC, overlay reset, and cache
+  deletion as destructive or externally visible operations. Ask for explicit
+  confirmation when the user has not already authorized them.
+
+## Verification
+
+- For Rust compilation or tests, set `CARGO_TARGET_DIR` to a dedicated path
+  under `/Volumes/Workspace/crabbuild-target/` on every invocation.
+- For remote behavior, use the existing `crab-cli-verification` skill and its
+  local RustFS fixture when feasible.
+- Validate the command's side effect, not only its exit code. For content
+  paths, compare the original and reconstructed bytes or their documented
+  content hashes.
+- Check `git status --short` before and after. Preserve unrelated user changes.

--- a/.codex/skills/crab-diagnostics-recovery/SKILL.md
+++ b/.codex/skills/crab-diagnostics-recovery/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: crab-diagnostics-recovery
+description: Diagnose Crab installations and plan or apply repository recovery. Use whenever a user mentions `crab doctor`, environment or error reports, logs, support bundles, missing or corrupt objects, `crab fsck` evidence, `crab recover`, historical roots, or restoring files and remote content after data loss.
+compatibility: Crab CLI with access to the repository, recovery inventories, and any authorized backup or replica sources.
+---
+
+# Crab diagnostics and recovery
+
+Start with evidence and a read-only diagnosis. Recovery is a typed, planned
+operation: identify what is repairable, what is inventory-only, and what is
+unrecoverable before writing files or remote objects.
+
+## Command scope
+
+`doctor`, `env`, `errors`, `logs`, `version`, `update`, `recover plan/show/apply`
+and `recover history` subcommands. Use `crab-storage-ops` for ordinary fsck,
+GC, metadata rebuild, or compaction; this skill consumes their reports when
+planning recovery.
+
+## Diagnostic loop
+
+1. Capture `crab version`, `crab env`, config origin, Git state, relevant logs,
+   and the exact command/error code. Redact credentials, tokens, signed URLs,
+   and private service endpoints.
+2. Run the appropriate `doctor` mode. Distinguish a configuration problem,
+   local cache problem, metadata/index problem, remote availability problem,
+   and missing source bytes.
+3. Prefer structured output and retain the JSON/JSONL report. Do not use a
+   human log phrase as a stable contract.
+4. For recovery, assemble the release manifest and inventories from the
+   documented sources: local files, workflow/import journals, pointer roots,
+   shard/xorb/pack lists, file-index data, replicas, and fsck JSONL.
+5. Run `recover plan`, inspect every candidate's identity and action, and save
+   the plan. Do not apply a plan that has not been reviewed.
+6. Apply only the explicitly authorized actions: restore verified files,
+   rebuild the file index, restore shards/xorbs/packs, or repair selected refs
+   through the canonical push path. Verify hashes before and after each action.
+7. Re-run doctor/fsck, inspect the audit event, and prove a fresh clone or
+   hydrate for repaired content. Report unrecoverable and inventory-only items
+   separately from successful repairs.
+
+## Historical recovery
+
+Read the history-recovery command and repository-recovery guide before
+inspecting immutable roots. Preserve the distinction between a historical
+manifest being discoverable, its metadata being intact, its bytes being
+available, and a remote repair being successfully published.
+
+## Operational boundaries
+
+- `doctor --support-bundle` must be redacted; do not include raw credentials.
+- `doctor --cache-service-active-probe` is an opt-in write/read/cleanup probe;
+  confirm the target service and scope.
+- `update` is an installation change, not a diagnostic workaround. Use the
+  release skill for published release operations.
+- Never invent bytes from metadata. A successful pointer parse is not data
+  recovery.
+
+## Read first
+
+- `crab/docs/guides/doctor.md`
+- `crab/docs/guides/env.md`
+- `crab/docs/guides/errors.md`
+- `crab/docs/guides/logs.md`
+- `crab/docs/guides/recovery.md`
+- `crab/docs/guides/repository-recovery.md`
+- `crab/src/cmd/{doctor,env,errors,logs,version,update,recover,history_recovery}.rs`
+- `crab/src/core/{error,error_catalog}.rs`
+- `.codex/skills/crab-cli-core/references/contracts.md`

--- a/.codex/skills/crab-git-sync/SKILL.md
+++ b/.codex/skills/crab-git-sync/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: crab-git-sync
+description: Operate and change Crab's Git synchronization and remote-transfer paths. Use whenever a user mentions `crab push`, `crab pull`, `crab ship`, import/export, remote helpers, refs, locks, non-fast-forward handling, or proving remote object and ref side effects.
+compatibility: Crab CLI with Git and a reachable Crab remote or object-storage backend.
+---
+
+# Crab Git synchronization
+
+Own the boundary between a local Git repository and the Crab remote. Separate
+Git refs and packs from Crab-native file content, and preserve the lock/CAS
+contracts that serialize remote mutations.
+
+## Command scope
+
+`push`, `pull`, `ship`, `import`, `export`, `lock`, `unlock`, `locks`, and
+remote-helper behavior for `crab://`.
+
+Use `crab-large-files` for preparing or reconstructing file bytes, selective
+`download`, and prefetch. Use `crab-workflow` for pushing workflow stage cache
+entries.
+
+## Choose the path
+
+- Use native `crab push` when the goal is concurrent Crab-aware upload and the
+  user wants explicit control of refs or retries.
+- Use `crab pull` when the goal is Git pull plus Crab's configured post-pull
+  hydration behavior.
+- Use `crab ship` for the intentional one-shot add + commit + push path. Treat
+  `--no-push`, dry-run, branch, remote, and integration retry options as part of
+  the user's requested contract.
+- Use the Git remote helper path when Git itself is invoking `git-remote-crab`.
+  Do not assume it has the same process or output behavior as a direct CLI
+  command.
+- Use `import`/`export` for raw object-storage onboarding or snapshot export;
+  read their URL and versioning rules before choosing flags.
+- Use advisory file locks only for the intended paths and owners. `force` is a
+  destructive exception, not a normal retry.
+
+## Push/pull reasoning
+
+1. Inspect the configured remote, current branch/ref, worktree cleanliness,
+   staged Crab data, and any existing lock or push state.
+2. For a push, ensure staged chunks and prepared xorbs are flushed before
+   remote metadata or ref publication. Preserve per-ref lock release on every
+   error or cancellation path.
+3. For a pull, distinguish fetched pointer blobs from files that still need
+   hydration. Do not report full content as available merely because Git refs
+   advanced.
+4. For non-fast-forward or lock contention, use the command's documented
+   integration/retry behavior. Do not add an ad-hoc force-push fallback.
+5. Verify the side effect: remote ref state, expected pack/xorb/shard objects,
+   audit event where applicable, and a fresh clone or hydrate for content paths.
+
+## Import and export
+
+Treat import as a resumable, journaled migration and export as a snapshot
+materialization contract. Read the source, destination, versioning, timestamp,
+collision, and dry-run behavior in the guide before running a mutation. Keep
+generated manifests and journals outside unrelated tracked changes.
+
+## Read first
+
+- `crab/docs/design/push.md`
+- `crab/docs/architecture/git-integration.md`
+- `crab/docs/guides/fetch.md`
+- `crab/docs/guides/ship.md`
+- `crab/docs/guides/import.md`
+- `crab/docs/guides/export.md`
+- `crab/docs/guides/lock.md`
+- `crab/src/git/`
+- `crab/src/cmd/{push,pull,ship,import,export,lock}.rs`
+- `.codex/skills/crab-cli-core/references/contracts.md`

--- a/.codex/skills/crab-large-files/SKILL.md
+++ b/.codex/skills/crab-large-files/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: crab-large-files
+description: Manage Crab-native large files end to end, including tracking, parallel add, staging, pointers, lazy hydration, dehydration, prefetch, selective download, chunk diffs, cache maintenance, and migration. Use whenever a user asks about large files, model or dataset files, pointers, hydration, disk pressure, `crab add`, `crab hydrate`, `crab dehydrate`, or `crab migrate`.
+compatibility: Crab CLI with a Git worktree and Crab-native large-file tracking.
+---
+
+# Crab large files
+
+Use the native Crab path for files whose bytes should live in content-addressed
+object storage while Git stores small pointer blobs. Keep the content identity
+and the local staging durability boundary explicit in every explanation.
+
+## Command scope
+
+`add`, `reset`, default `status`, `why`, `hydrate`, `dehydrate`, `diff`,
+`diff-driver`, `ls-files`, hidden native `FilterProcess`, `fetch`, `prune`,
+`du`, `stat`, `cache`, `staging`, `adopt`, `unadopt`, `undo`, `migrate`, and
+selective `download`.
+
+Route `crab lfs` and `optimize lfs` to `crab-lfs`. Route remote ref/object
+transfer, `push`, `pull`, and `ship` orchestration to `crab-git-sync`.
+
+## Mental model
+
+```text
+full file -> hash + CDC chunks -> .crab/staging -> pointer blob in Git
+           -> commit -> Crab push -> remote xorbs/shards/metadata
+pointer   -> local cache/staging or remote reconstruction -> full file
+full file -> dehydrate -> verified pointer, disk bytes released
+```
+
+## File lifecycle
+
+1. Before adding, inspect tracking patterns, pointer state, staged rows, and
+   the file's current content hash. Use `--dry-run` for broad globs.
+2. `crab add` is the high-throughput staging path: it hashes and chunks files,
+   writes staged chunks and the file push plan, emits pointers, and optionally
+   runs the final Git staging step. Do not bypass the staging contract by
+   inventing pointer files or copying chunks into the global cache.
+3. After a commit, use `crab-git-sync` for the push. A staged xorb must be
+   durable before the bundle push can be considered valid.
+4. For `hydrate`, resolve patterns, manifests, profiles, sparse-checkout, local
+   recovery sources, and archived-object restore options before downloading.
+   Verify the reconstructed file hash and size, not only its existence.
+5. For `dehydrate`, protect files selected by an active prefetch profile unless
+   the user explicitly chooses `--ignore-profiles`. Confirm that replacing full
+   bytes with a pointer does not discard uncommitted content.
+6. Use `fetch` or cache warm operations when the user wants bytes available
+   locally without replacing pointers. Use selective `download` when they want
+   files under a destination without cloning a repository.
+
+## Diagnostics and maintenance
+
+- `status`, `why`, `ls-files`, `diff`, and `diff-driver` explain pointer and
+  hydration state. Read their source output schema before scripting against it.
+- `staging stats/verify/clean` concerns the repository-local staging area;
+  `cache stats/verify/clean/prune` concerns reusable local cache objects. Do
+  not conflate them or recommend deleting staging to solve cache pressure.
+- `stat push-plan --verify` checks add-time prepared xorb metadata. A plan is
+  useful acceleration, not a replacement for authoritative staged bytes.
+- `migrate` rewrites history or converts formats. Require a dry-run, identify
+  refs affected, and explain rollback/backup expectations before mutation.
+- `adopt`, `unadopt`, and `undo` are working-tree transitions. Check Git staged
+  changes and content hashes before acting.
+
+## Proof
+
+For any content-changing claim, compare original and hydrated bytes or the
+documented Blake3 identity. For remote paths, use the RustFS end-to-end fixture
+from `crab-cli-verification`. For implementation work, also read
+`crab/docs/design/add.md`, `crab/docs/design/cache.md`, and
+`.codex/skills/crab-cli-core/references/contracts.md`.
+
+## Read first
+
+- `crab/docs/guides/large-file-versioning.md`
+- `crab/docs/guides/add.md`
+- `crab/docs/guides/hydrate.md`
+- `crab/docs/guides/dehydrate.md`
+- `crab/docs/guides/status.md`
+- `crab/docs/guides/staging.md`
+- `crab/docs/guides/cache.md`
+- `crab/docs/guides/migrate.md`
+- `crab/docs/design/add.md`
+- `crab/docs/design/cache.md`
+- `crab/src/{engine,hydrate,cache}/`
+- `crab/src/cmd/{add,reset,status,hydrate,dehydrate,diff,download,migrate,staging}.rs`

--- a/.codex/skills/crab-lfs/SKILL.md
+++ b/.codex/skills/crab-lfs/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: crab-lfs
+description: Implement and operate Crab's Git LFS compatibility layer, including native and transfer-agent modes, LFS hooks, pointers, locks, fetch/push/pull, conversion, deduplication, pruning, and protocol diagnostics. Use whenever a request mentions `crab lfs`, Git LFS interoperability, `.gitattributes` LFS filters, the LFS transfer agent, or `optimize lfs`.
+compatibility: Crab CLI with Git LFS-compatible repositories and the `crab-lfs` crate.
+---
+
+# Crab Git LFS compatibility
+
+Keep Git LFS compatibility separate from Crab-native pointer workflows. The
+two systems may share storage or conversion tools, but their pointer formats,
+hooks, transfer protocols, and verification rules differ.
+
+## Command scope
+
+All `crab lfs` subcommands, hidden `crab lfs-transfer-agent`, and
+`crab optimize lfs` (`dedup`, `convert`, `prune`).
+
+## Operating modes
+
+1. Read `crab/docs/architecture/lfs-compatibility.md` and determine whether
+   the repository uses native mode, transfer-agent mode, or a conversion path.
+2. Inspect `.gitattributes`, Git config, LFS config, pointer format, object
+   location, and the command's hook/protocol entry point.
+3. For fetch/push/checkout/prune, prove remote object identity and local
+   checkout behavior. A Git LFS pointer being present is not proof that its
+   content is available.
+4. For conversion, require a dry-run and retain the documented rollback or
+   transaction boundary. Never silently convert a repository's pointer format.
+5. For deduplication and prune, verify the destination or Crab cache before
+   deleting any LFS object. Respect remote verification flags and recent-object
+   protection.
+
+## Protocol discipline
+
+- Treat the transfer-agent stdin/stdout protocol as machine-readable; do not
+  write human logs into the protocol stream.
+- Preserve LFS lock ownership and force semantics.
+- Keep credentials and signed URLs out of logs and final reports.
+- Use the crate tests and a real remote fixture for protocol changes. Do not
+  substitute a native Crab hydration test for LFS interoperability proof.
+
+## Read first
+
+- `crab/docs/guides/lfs.md`
+- `crab/docs/architecture/lfs-compatibility.md`
+- `crab/docs/design/lfs.md`
+- `crab/src/lfs/`
+- `crab/src/cmd/lfs/`
+- `crates/crab-lfs/`
+- `.codex/skills/crab-cli-core/references/contracts.md`

--- a/.codex/skills/crab-managed-operations/SKILL.md
+++ b/.codex/skills/crab-managed-operations/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: crab-managed-operations
+description: Manage Crab authentication, managed-service organizations and repositories, memberships, service accounts, audit events, and dataset release manifests. Use whenever a request mentions `crab login`, `logout`, `auth`, organization or repository administration, members, service accounts, `crab audit`, or `crab release` manifests.
+compatibility: Crab CLI with the selected managed Crab service and the required administrative permissions.
+---
+
+# Crab managed operations
+
+Keep identity, administrative control-plane state, auditability, and dataset
+release records separate from local Git/object-store mechanics. Never expose
+tokens or infer permissions from a successful local configuration read.
+
+## Command scope
+
+`login`, `logout`, `auth status/refresh`, `organization`, `repo`, `member`,
+`service-account`, `audit`, and `release create/verify/export/list`.
+
+The existing `crab-release-publish` skill owns publishing Crab CLI archives to
+the release repository and updating Homebrew; `crab release` here owns
+repository dataset release manifests.
+
+## Authentication
+
+1. Inspect the active profile, provider, service origin, config precedence,
+   and headless/interactive context before login.
+2. Use the documented provider flow. Let the credential store and refresh path
+   manage tokens; do not copy tokens into shell history or reports.
+3. Verify with `crab auth status` and a least-privilege read against the
+   intended service. Distinguish authentication from authorization and object
+   storage reachability.
+4. For logout or provider changes, identify whether the action affects one
+   service or all cached providers before deleting credentials.
+
+## Managed administration
+
+- Confirm the selected service, organization, repository, actor, and requested
+  operation before any create/update/delete action.
+- Inspect existing membership or repository state first; use idempotent paths
+  where the command provides them and do not silently change ownership.
+- Treat service-account credentials as secrets. Show identifiers and redacted
+  status only.
+
+## Audit and release manifests
+
+- `audit log`, `verify`, and `export` operate on the local JSONL audit chain.
+  Verify schema, digest, sequence, redaction, and operation filters.
+- `release create` binds a Git revision to pointer inventory, workflow metadata,
+  params, metrics, and optional signatures. It should refuse an unintended
+  dirty worktree; use an explicit override only when authorized.
+- `release verify --deep` is content proof: it must reconstruct pointer-backed
+  files and check identity, not merely parse JSON.
+- `release export` is a portability boundary. Preserve signature and identity
+  metadata and verify the exported bytes.
+
+## Read first
+
+- `crab/docs/guides/auth/enterprise-auth.md`
+- `crab/docs/guides/auth/enterprise-auth-static.md`
+- `crab/docs/guides/auth/enterprise-auth-aws.md`
+- `crab/docs/guides/auth/enterprise-auth-gcp.md`
+- `crab/docs/guides/auth/enterprise-auth-azure.md`
+- `crab/docs/guides/auth/enterprise-auth-crab-auth.md`
+- `crab/docs/guides/audit.md`
+- `crab/docs/guides/release-manifests.md`
+- `crab/src/{auth,audit,release}/`
+- `crab/src/cmd/{login,logout,auth_status,managed_admin,audit,release}.rs`
+- `.codex/skills/crab-cli-core/references/contracts.md`

--- a/.codex/skills/crab-mount/SKILL.md
+++ b/.codex/skills/crab-mount/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: crab-mount
+description: Use and implement Crab virtual filesystem mounts and daemon-managed repositories. Use whenever a request mentions `crab mount`, unmounting, FUSE, NFS, on-demand file access, writable overlays, mount refresh/switch/commit, or the mount daemon and coordinator.
+compatibility: Platform-specific Crab build with FUSE or NFS support and the appropriate OS mount permissions.
+---
+
+# Crab mounts
+
+Own the VFS boundary: remote or local repository snapshots, on-demand
+hydration, writable overlays, the coordinator, and daemon-managed mounts.
+Keep platform readiness distinct from repository content correctness.
+
+## Command scope
+
+`mount`, `unmount`, `daemon`, and hidden `coordinator` lifecycle commands.
+
+## Mount lifecycle
+
+1. Run the backend doctor and inspect platform features, mountpoint state,
+   permissions, existing mounts, repository/ref, and read-only intent.
+2. Mount the smallest requested repository/ref. Confirm whether reads should
+   hydrate on demand and whether writes go to an overlay.
+3. Use `status`, `list`, and `refresh` to distinguish a live backend state from
+   persisted fallback state. Use `switch` only with an explicit ref.
+4. Treat overlay `diff`, `export`, `reset`, and `commit` as separate state
+   transitions. `reset --overlay --yes` discards mutations; verify the target
+   mount and confirmation before running it.
+5. For `commit --push`, verify both the Git commit and remote push using the
+   `crab-git-sync` boundary. Do not report a successful mount commit from a
+   local overlay alone.
+6. For daemon-managed repos, manage registration, enable/disable, refresh,
+   remount, fetch, and commit through the daemon namespace. Keep mount root,
+   repo name, backend, and branch explicit.
+
+## Platform and concurrency rules
+
+- Read the feature gates and platform-specific implementation before
+  recommending FUSE or NFS. A command can parse while the backend is absent.
+- Preserve coordinator lock, socket, PID, idle shutdown, and graceful mount
+  cleanup behavior. Do not kill a coordinator to repair an ordinary overlay
+  issue.
+- Verify that active mounts are absent before cleaning mount caches.
+- Test read-only, dirty overlay, refresh, switch, and shutdown paths separately.
+
+## Read first
+
+- `crab/docs/guides/mount.md`
+- `crab/docs/guides/daemon.md`
+- `crab/docs/architecture/virtual-filesystem.md`
+- `crab/docs/architecture/vfs-coordinator.md`
+- `crab/docs/architecture/nfs-mount-architecture.md`
+- `crab/src/cmd/mount.rs`
+- `crab/src/vfs/`
+- `.codex/skills/crab-cli-core/references/contracts.md`

--- a/.codex/skills/crab-repository-lifecycle/SKILL.md
+++ b/.codex/skills/crab-repository-lifecycle/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: crab-repository-lifecycle
+description: Set up, adopt, clone, configure, and maintain the Git-facing lifecycle of a Crab repository. Use whenever a user mentions `crab init`, `crab setup`, `crab clone`, mirror mode, tracking patterns, adoption, worktrees, config, Git filter installation, or repository onboarding.
+compatibility: Crab CLI repository with Git and a configured Crab or object-storage remote.
+---
+
+# Crab repository lifecycle
+
+Own the transition from an ordinary Git repository to a Crab-aware repository
+and the surrounding local configuration. Read the exact guide before giving a
+command sequence; defaults such as lazy checkout, remote naming, and config
+precedence are contracts, not guesses.
+
+## Command scope
+
+`init`, `setup`, `clone`, `mirror`, `worktree`, `config`, `track`, `untrack`,
+`install`, `uninstall`, and `completions`.
+
+Use `crab-large-files` for the mechanics of hashing, staging, hydration, and
+dehydration. Use `crab-git-sync` for a push/pull/import/export transfer.
+
+## Onboarding sequence
+
+1. Inspect the repository root, existing Git remotes, `.crab.toml`,
+   `.crab/config.toml`, `.gitattributes`, and worktree state. Preserve existing
+   patterns and user edits.
+2. Choose the canonical setup path:
+   - `crab init` for a new Crab remote and repository config.
+   - `crab setup` to install the local large-file integration after init.
+   - `crab clone` for a new checkout; decide lazy, eager, include, exclude,
+     and optional chunk-index warming from the user's intent.
+   - `crab adopt` when full files already exist in a working tree and should
+     become Crab pointers.
+3. Configure tracking deliberately. Auto-detection is a proposal to review,
+   not permission to rewrite unrelated `.gitattributes` entries. Use dry-run
+   for uncertain patterns and explain the resulting filter behavior.
+4. Confirm the Git filter driver and Crab remote are installed in the scope the
+   user requested. Do not silently switch between repository, global, and
+   system Git config.
+5. For worktrees, inspect the shared Git metadata and the Crab-specific
+   worktree state before creating, switching, cleaning, or hydrating one.
+6. After setup, hand off content operations to `crab-large-files` and prove the
+   first real add/commit/push or clone/hydrate path with
+   `crab-cli-verification` when the user asks whether setup works.
+
+## Safety boundaries
+
+- Never overwrite `.gitattributes`, `.crab.toml`, or `.crab/config.toml`
+  without reading and preserving existing entries.
+- Never claim a repository is ready because the command parsed. Check the
+  installed filter, remote URL, tracked patterns, and a representative file.
+- Treat `--force`, history rewrite, worktree cleanup, and system-wide install
+  as explicit state changes. Preview or confirm when the user did not already
+  authorize them.
+- Keep provider credentials and tokens out of command output and reports.
+
+## Read first
+
+- `crab/docs/guides/getting-started.md`
+- `crab/docs/guides/init.md`
+- `crab/docs/guides/clone.md`
+- `crab/docs/guides/adopting-existing-repos.md`
+- `crab/docs/guides/project-config.md`
+- `crab/docs/guides/worktree.md`
+- `crab/docs/guides/track.md`
+- `crab/src/cmd/{init,setup,clone,mirror,worktree,config,track}.rs`
+- `.codex/skills/crab-cli-core/references/contracts.md`

--- a/.codex/skills/crab-storage-ops/SKILL.md
+++ b/.codex/skills/crab-storage-ops/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: crab-storage-ops
+description: Inspect, compact, verify, repair, and optimize Crab storage, metadata indexes, staging, caches, shards, packs, xorbs, and garbage collection. Use whenever a user mentions `crab gc`, `fsck`, `du`, `stat`, `cache`, `staging`, `metadb`, `compact`, `repack`, `restripe`, or storage-related `optimize` commands.
+compatibility: Crab CLI with a configured object-storage remote; some operations require provider access.
+---
+
+# Crab storage operations
+
+Use this skill for operator-facing maintenance of the Crab data plane. Start
+with inventory and a dry-run, identify the exact repository and object scope,
+then perform the smallest operation that restores the documented invariant.
+
+## Command scope
+
+`gc`, `fsck`, `compact`, `repack`, `du`, `stat`, `cache`, `staging`, `metadb`,
+`optimize plan/apply/xorbs/packs/shards/cache/indexes`, and storage-side
+`prune`. Route `tier`, `replica`, and workflow-cache operations to their
+specialized skills.
+
+## Operation selection
+
+- `du`, `stat`, cache, and staging inspection establish local and remote cost
+  before mutation.
+- `fsck` checks integrity and may offer safe repairs; capture structured output
+  and distinguish missing, corrupt, and merely uncached objects.
+- `gc` removes unreachable remote objects only after reference and grace-period
+  analysis. Use repository scope. Never run bucket-wide GC for a repository
+  task, and never bypass confirmation without explicit authorization.
+- `compact` consolidates metadata shards; `repack` consolidates Git packs;
+  xorb optimization/restripe changes content-addressed layout. Verify that
+  canonical metadata and reads remain valid after each operation.
+- `metadb diagnose/rebuild/compact` operates on derived indexes. Rebuild from
+  durable shard metadata and prove the rebuilt index agrees with its source.
+- Local cache and staging cleanup have different ownership and locks. Check
+  active writers before clean, force-breaking a stale lock only with evidence.
+- `optimize plan/apply` is an orchestrator. Inspect the plan, cost inputs,
+  selected operations, and audit record before applying it.
+
+## Safe maintenance loop
+
+1. Read the relevant guide and source command module.
+2. Run the read-only inventory or dry-run in the intended repository scope.
+3. Save JSON/JSONL output and identify the exact objects, refs, indexes, or
+   segments affected.
+4. Apply only the authorized operation.
+5. Re-run fsck or the command's verify path, inspect audit events, and perform
+   a fresh clone/hydrate when content or metadata was changed.
+
+## Read first
+
+- `crab/docs/guides/gc.md`
+- `crab/docs/guides/fsck.md`
+- `crab/docs/guides/du.md`
+- `crab/docs/guides/stat.md`
+- `crab/docs/guides/cache.md`
+- `crab/docs/guides/staging.md`
+- `crab/docs/guides/metadb.md`
+- `crab/docs/guides/repack.md`
+- `crab/docs/guides/optimize-xorbs.md`
+- `crab/docs/design/cache.md`
+- `crab/src/{metadata,storage,restripe}/`
+- `crab/src/cmd/{gc/,fsck,compact,repack,optimize,metadb,staging,stat,du}.rs`
+- `.codex/skills/crab-cli-core/references/contracts.md`

--- a/.codex/skills/crab-tier-replication/SKILL.md
+++ b/.codex/skills/crab-tier-replication/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: crab-tier-replication
+description: Operate Crab storage lifecycle tiers, archived-object restore, read replicas, active-active coordination, backfill, readiness, repair, failover, evidence, runbooks, and replication cost reports. Use whenever a request mentions `crab tier`, `crab replica`, `optimize tiers`, `optimize replicas`, failover, fencing, coordinator, or multi-cloud replication.
+compatibility: Crab CLI with provider-specific tier or replication features enabled and the required cloud permissions.
+---
+
+# Crab tiering and replication
+
+Treat lifecycle tiering and replication as provider-backed operational
+contracts. Verify configuration and readiness before changing a rule or
+routing decision, and keep a reversible plan for destructive or expensive
+actions.
+
+## Command scope
+
+`tier` plan/apply/rollback, `optimize tiers`, `replica`,
+`optimize replicas` (status, doctor, verify, backfill, wait, repair, cost,
+runbook, diagnostics, certify, evidence, failover), and hidden coordinator
+management when debugging the active-active control plane.
+
+## Tiering loop
+
+1. Inspect provider, bucket, region, current rules, object classes, and the
+   configured restore policy.
+2. Generate a plan and review conflicts, object counts, estimated cost, and
+   whether the rule is scoped to the intended repository/prefix.
+3. Apply only after authorization. Retain the operation identity and audit
+   event; use rollback when the command provides it.
+4. For archived content, verify restore completion and readability before
+   asking `crab-large-files` to hydrate. A successful restore request is not
+   the same as readable bytes.
+
+## Replica and failover loop
+
+1. Run `doctor`, `status`, and readiness/backfill checks before enabling reads.
+2. Verify manifest-referenced objects with the documented exhaustive or sample
+   mode, then wait for the replica's read-ready state.
+3. For repair, failover, fencing, or resume, capture a plan and confirm the
+   coordinator's authoritative state. Do not improvise a ref or region switch.
+4. After mutation, verify refs, manifests, object availability, routing state,
+   lag, audit/evidence artifacts, and a read from the selected region.
+
+## Safety
+
+- Provider flags and feature gates are part of the implementation contract;
+  read `crab/Cargo.toml` and the provider module before claiming support.
+- Never print credentials, access tokens, or private endpoints.
+- Treat replica repair, failover, fence, tier apply, and early restore/delete
+  as externally visible operations with explicit scope.
+- Use `crab-cli-verification` for live provider/RustFS proof only when the
+  fixture actually exercises the feature; otherwise state what remains
+  unverified.
+
+## Read first
+
+- `crab/docs/guides/tier.md`
+- `crab/docs/guides/replica.md`
+- `crab/docs/guides/cost.md`
+- `crab/docs/design/replica-active-active-failover.md`
+- `crab/docs/design/replica-enterprise-readiness.md`
+- `crab/src/{tier,replication,restripe}/`
+- `crab/src/cmd/{tier/,replica,coordinator}.rs`
+- `crates/crab-coordination/README.md`
+- `.codex/skills/crab-cli-core/references/contracts.md`

--- a/.codex/skills/crab-workflow/SKILL.md
+++ b/.codex/skills/crab-workflow/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: crab-workflow
+description: Build, run, inspect, reproduce, and maintain Crab content-addressed workflows and experiments. Use whenever a user mentions `crab.yaml`, workflow stages, `crab run` or `repro`, stage caches, lockfiles, journals, DAGs, parameters, metrics, plots, experiments, queues, or workflow cache push.
+compatibility: Crab CLI with the workflow feature enabled and a repository-local workflow definition.
+---
+
+# Crab workflow
+
+Own the workflow graph and its content-addressed execution state. Treat stage
+identity, dependency order, lockfiles, journals, and cache entries as one
+contract rather than independent convenience features.
+
+## Command scope
+
+`run`, `repro`, `stage`, `freeze`, `unfreeze`, `exp`, `queue`, `workflow`,
+`params`, `metrics`, `plots`, `status --workflow`, `migrate from-dvc`, and
+workflow-cache operations under `optimize`.
+
+Route ordinary file hydration of workflow outputs to `crab-large-files` and
+remote Git/ref synchronization to `crab-git-sync`.
+
+## Workflow model
+
+1. Discover the applicable `crab.yaml` or `*.workflow.yaml`, project config,
+   lockfile mode, and selected targets. Do not silently choose a different
+   nested workflow.
+2. Compute or inspect stage identity from command, dependencies, parameters,
+   environment, and declared outputs as implemented by the workflow crate.
+3. Use the lockfile to resolve dependency versions and the journal to explain
+   in-flight, completed, failed, or stale runs. A stale stage is not the same
+   as a missing output.
+4. Run only the selected DAG closure. Preserve cancellation and journal
+   transitions if a stage fails; do not mark a cache hit optimistically.
+5. Verify outputs, metadata, and cache state. If remote cache is involved,
+   prove the remote entry or use `crab workflow push-cache --all` as the
+   documented batch path.
+
+## Command guidance
+
+- `crab run` is the canonical executor; `crab repro` is its DVC-compatible
+  spelling. Keep their semantics aligned.
+- `stage add/list` edits or inspects declarations; `freeze/unfreeze` changes
+  execution eligibility, not the stage definition.
+- `status --workflow`, `workflow status`, `workflow dag`, and `workflow
+  journal` are inspection paths. Use `--why`, dependency expansion, cloud
+  comparison, and journal inspection to explain state instead of guessing.
+- `workflow lockfile resolve/split` is for lockfile structure and merge
+  conflicts. Read the selected lockfile mode before writing files.
+- `exp` creates isolated experiment runs and metadata; `queue` controls batch
+  execution workers. Keep experiment cleanup separate from repository data.
+- `params`, `metrics`, and `plots` compare or render recorded workflow data;
+  do not treat rendered output as a source-of-truth mutation unless the command
+  explicitly says so.
+- `migrate from-dvc` is a conversion boundary. Preview the generated workflow
+  and preserve semantics that Crab does not support rather than dropping them.
+
+## Verification
+
+Use a tiny deterministic stage graph to prove cache miss → execution → cache
+hit, dependency invalidation, lock/journal state, and failure recovery. For
+remote cache or Crab refs, use the RustFS E2E skill. Read
+`crates/crab-workflow/README.md` and the relevant source before changing the
+stage identity or serialized metadata contract.
+
+## Read first
+
+- `crab/docs/guides/workflow.md`
+- `crab/docs/guides/hermetic-workflows.md`
+- `crab/docs/workflow/`
+- `crab/docs/design/vs-dvc-workflow.md`
+- `crab/src/cmd/{run,stage,freeze,exp,exp_queue,workflow,status_workflow,workflow_journal,workflow_lockfile,params,metrics}.rs`
+- `crates/crab-workflow/README.md`
+- `.codex/skills/crab-cli-core/references/contracts.md`


### PR DESCRIPTION
## Summary

- Add 11 focused Crab CLI skills covering repository lifecycle, native large files, Git synchronization, workflows, LFS, storage operations, tiering and replication, mounts, managed operations, and diagnostics/recovery.
- Add a shared command ownership map and cross-cutting Crab contracts reference.
- Preserve the existing RustFS verification and CLI release-publishing skills.

## Validation

- Skill frontmatter checks passed.
- Command map covers the top-level Crab CLI commands.
- Referenced documentation and source paths were checked.
- Staged diff whitespace check passed.
- No Rust build was required for this documentation-only change.

The PR branch is based directly on `origin/main` and contains only the 13 skill files.
