### PR TITLE
deps: upgrade Xet dependencies to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2294,6 +2294,7 @@ dependencies = [
  "tracing",
  "xet-client",
  "xet-data",
+ "xet-runtime",
 ]
 
 [[package]]
@@ -2641,41 +2642,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctor"
-version = "0.6.3"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "link-section",
+ "linktime-proc-macro",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctutils"
@@ -2795,7 +2769,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2814,21 +2788,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "dtor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -2923,7 +2882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3950,7 +3909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.17.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5003,7 +4962,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5023,7 +4982,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5279,7 +5238,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5637,6 +5596,18 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
 
 [[package]]
 name = "linux-raw-sys"
@@ -6065,7 +6036,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6897,7 +6868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6987,7 +6958,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7025,9 +6996,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7559,7 +7530,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7639,7 +7610,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7975,7 +7946,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
- "sha2-asm",
 ]
 
 [[package]]
@@ -7987,15 +7957,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -8409,7 +8370,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8643,6 +8604,30 @@ dependencies = [
  "hashbrown 0.15.5",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9426,7 +9411,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9633,7 +9618,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9642,16 +9627,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9669,31 +9645,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -9721,22 +9680,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9745,22 +9692,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9769,22 +9704,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9793,22 +9716,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -9958,20 +9869,18 @@ dependencies = [
 
 [[package]]
 name = "xet-client"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1e496dcbe6a09017acdfaf48e1a646735e7ff5b2a49e2c7e081cca77a59bc8"
+checksum = "c3b8da8cc70aa2e3c500c0400e012df82c656ab9fca47f9f939fffc5afd89aca"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "clap",
  "crc32fast",
  "futures",
  "http 1.4.0",
  "hyper 1.9.0",
- "lazy_static",
  "more-asserts",
  "rand 0.10.1",
  "redb",
@@ -9985,8 +9894,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
+ "tokio_with_wasm",
  "tracing",
- "tracing-subscriber",
  "url",
  "urlencoding",
  "web-time",
@@ -9996,24 +9905,21 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb838aa8eb67d730af301584cf003caad407487606058292a6750711b603fbee"
+checksum = "73503c223783dccc864abde22115e09d12f190448a0baf58ab2c54bc709e2f99"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "blake3",
  "bytemuck",
  "bytes",
- "clap",
  "countio",
- "csv",
  "futures",
  "futures-util",
  "getrandom 0.4.2",
  "heapify",
  "itertools 0.14.0",
- "lazy_static",
  "lz4_flex 0.13.0",
  "more-asserts",
  "rand 0.10.1",
@@ -10021,7 +9927,6 @@ dependencies = [
  "safe-transmute",
  "serde",
  "static_assertions",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -10033,32 +9938,31 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fd409bef621411a9d9013798540bb8036cb2678f03ab39af89a5e88034ed8c"
+checksum = "c89052ec5dec2187cad30b86af92cc24fd61c4a57a795f1ff7ff5f38d49184eb"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "chrono",
- "clap",
  "gearhash",
  "http 1.4.0",
  "itertools 0.14.0",
- "lazy_static",
  "more-asserts",
  "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tracing",
  "url",
  "uuid",
- "walkdir",
+ "web-time",
  "xet-client",
  "xet-core-structures",
  "xet-runtime",
@@ -10066,9 +9970,9 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d8f121c33866f7648b737abe70d0e2dd9c0af4ffdd7219207531d0283aa63d"
+checksum = "af5c60d5eed38ab4c576f4421bae835e7bd07631fb381705605529d2015c106b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10082,7 +9986,6 @@ dependencies = [
  "git-version",
  "humantime",
  "konst",
- "lazy_static",
  "libc",
  "more-asserts",
  "oneshot",
@@ -10096,9 +9999,11 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "web-time",
  "whoami",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,10 @@ crab-vfs = { path = "crates/crab-vfs", default-features = false }
 crab-workflow = { path = "crates/crab-workflow", default-features = false }
 crab-xet = { path = "crates/crab-xet", default-features = false }
 
-xet-client = "1.5.2"
-xet-core-structures = "1.5.2"
-xet-data = "1.5.2"
-xet-runtime = "1.5.2"
+xet-client = "1.6.0"
+xet-core-structures = "1.6.0"
+xet-data = "1.6.0"
+xet-runtime = "1.6.0"
 
 gix = "0.83.0"
 gix-attributes = "0.33.0"

--- a/crab/src/cmd/compact.rs
+++ b/crab/src/cmd/compact.rs
@@ -23,7 +23,10 @@ use crate::storage::store::Store;
 use crab_metadata::manifests::ShardList;
 use crab_metadata::ref_registry::RefRegistry;
 use crab_xet::hash::{MerkleHash, compute_data_hash};
-use crab_xet::shard::{MDBMinimalShard, MDBShardFile, merge_shards, shard_set_union};
+use crab_xet::shard::{
+    MDBMinimalShard, MDBShardFile, merge_shards, new_shard_file_cache, shard_set_union,
+};
+use xet_runtime::core::XetContext;
 
 /// Default maximum compacted shard size (100 MiB).
 pub const DEFAULT_MAX_SHARD_SIZE: u64 = 100 * 1024 * 1024;
@@ -131,11 +134,25 @@ pub async fn run_compact(args: &CompactArgs, store: &Store) -> Result<CompactOut
     download_shards(store, &source_hashes, source_dir.path()).await?;
 
     // Step 3: Merge shards via xet-core.
+    let xet_context = XetContext::default().map_err(|error| {
+        CrabError::Internal(format!("failed to initialize xet context: {error}"))
+    })?;
+    let runtime = Arc::clone(&xet_context.runtime);
+    let shard_file_cache = new_shard_file_cache();
     let merge_result = tokio::task::spawn_blocking({
         let source_path = source_dir.path().to_owned();
         let target_path = target_dir.path().to_owned();
         let max_size = args.max_shard_size;
-        move || merge_shards(source_path, target_path, max_size, false)
+        move || {
+            merge_shards(
+                &runtime,
+                source_path,
+                target_path,
+                max_size,
+                false,
+                &shard_file_cache,
+            )
+        }
     })
     .await
     .map_err(|e| CrabError::Internal(format!("merge_shards join error: {e}")))?
@@ -272,6 +289,7 @@ async fn download_shards(
     shard_hashes: &[String],
     target_dir: &std::path::Path,
 ) -> Result<()> {
+    let shard_file_cache = new_shard_file_cache();
     for hash_hex in shard_hashes {
         let shard_path = ObjectPath::from(format!("{GLOBAL_PREFIX}/shards/{hash_hex}"));
 
@@ -285,9 +303,9 @@ async fn download_shards(
 
         // Write shard bytes to the temp directory via MDBShardFile.
         let mut cursor = std::io::Cursor::new(data.as_ref());
-        MDBShardFile::write_out_from_reader(target_dir, &mut cursor).map_err(|e| {
-            CrabError::Internal(format!("failed to write shard {hash_hex} to temp dir: {e}"))
-        })?;
+        MDBShardFile::write_out_from_reader(target_dir, &mut cursor, &shard_file_cache).map_err(
+            |e| CrabError::Internal(format!("failed to write shard {hash_hex} to temp dir: {e}")),
+        )?;
 
         debug!(shard = %hash_hex, size = data.len(), "downloaded shard");
     }
@@ -305,6 +323,7 @@ fn filter_unreferenced_xorbs(
     merged: &[Arc<MDBShardFile>],
     output_dir: &std::path::Path,
 ) -> std::result::Result<Vec<Arc<MDBShardFile>>, CrabError> {
+    let shard_file_cache = new_shard_file_cache();
     let mut result = Vec::with_capacity(merged.len());
 
     for shard_file in merged {
@@ -372,11 +391,13 @@ fn filter_unreferenced_xorbs(
         let file_only_handle = MDBShardFile::write_out_from_reader(
             output_dir,
             &mut std::io::Cursor::new(&file_only_buf),
+            &shard_file_cache,
         )
         .map_err(|e| CrabError::Internal(format!("write file-only shard: {e}")))?;
         let xorb_only_handle = MDBShardFile::write_out_from_reader(
             output_dir,
             &mut std::io::Cursor::new(&xorb_only_buf),
+            &shard_file_cache,
         )
         .map_err(|e| CrabError::Internal(format!("write xorb-only shard: {e}")))?;
 
@@ -402,6 +423,7 @@ fn filter_unreferenced_xorbs(
         let filtered_handle = MDBShardFile::write_out_from_reader(
             output_dir,
             &mut std::io::Cursor::new(&combined_buf),
+            &shard_file_cache,
         )
         .map_err(|e| CrabError::Internal(format!("write filtered shard: {e}")))?;
 
@@ -614,9 +636,11 @@ mod tests {
         // Write shard to a temp dir and load as MDBShardFile.
         let source_dir = tempfile::tempdir().unwrap();
         let output_dir = tempfile::tempdir().unwrap();
+        let shard_file_cache = new_shard_file_cache();
         let shard_file = MDBShardFile::write_out_from_reader(
             source_dir.path(),
             &mut std::io::Cursor::new(&shard_bytes),
+            &shard_file_cache,
         )
         .unwrap();
 
@@ -697,9 +721,11 @@ mod tests {
 
         let source_dir = tempfile::tempdir().unwrap();
         let output_dir = tempfile::tempdir().unwrap();
+        let shard_file_cache = new_shard_file_cache();
         let shard_file = MDBShardFile::write_out_from_reader(
             source_dir.path(),
             &mut std::io::Cursor::new(&shard_bytes),
+            &shard_file_cache,
         )
         .unwrap();
 

--- a/crab/src/cmd/hydrate.rs
+++ b/crab/src/cmd/hydrate.rs
@@ -615,7 +615,7 @@ impl ShardHydrator {
     pub fn new(store: crab_cache_store::CachingStore, router: HydrateStoreLayout) -> Result<Self> {
         let concurrency = fixed_hydrate_concurrency(
             crate::core::config::HydrateConfig::default().download_concurrency,
-        );
+        )?;
         Ok(Self::with_concurrency(store, router, concurrency))
     }
 
@@ -671,7 +671,7 @@ impl ShardHydrator {
         router: HydrateStoreLayout,
         config: &Config,
     ) -> Result<Self> {
-        let concurrency = fixed_hydrate_concurrency(config.hydrate.download_concurrency);
+        let concurrency = fixed_hydrate_concurrency(config.hydrate.download_concurrency)?;
         let mut hydrator = Self::with_concurrency(store, router, concurrency);
         hydrator.buffer_semaphore = hydrate_buffer_semaphore(config.hydrate.prefetch_budget);
         hydrator.file_concurrency = hydrate_file_concurrency(config.hydrate.download_concurrency);
@@ -1207,8 +1207,9 @@ impl ShardHydrator {
         let shared = Arc::new(std::sync::Mutex::new(buffer));
         let writer = SharedCursorWriter(shared.clone());
 
+        let xet_context = new_xet_context()?;
         let reconstructor =
-            xet_data::file_reconstruction::FileReconstructor::new(&client, file_hash)
+            xet_data::file_reconstruction::FileReconstructor::new(&xet_context, &client, file_hash)
                 .with_buffer_semaphore(Arc::clone(&self.buffer_semaphore));
         // Chunk cache and prefetch share the same concurrency
         // controller via `StoreClient::acquire_download_permit`. The
@@ -1347,8 +1348,9 @@ impl ShardHydrator {
             shared: tap_state.clone(),
         };
 
+        let xet_context = new_xet_context()?;
         let reconstructor =
-            xet_data::file_reconstruction::FileReconstructor::new(&client, file_hash)
+            xet_data::file_reconstruction::FileReconstructor::new(&xet_context, &client, file_hash)
                 .with_buffer_semaphore(Arc::clone(&self.buffer_semaphore));
         let reconstructor = match self.chunk_cache.clone() {
             Some(cache) => reconstructor.with_chunk_cache(cache),
@@ -1474,8 +1476,9 @@ impl ShardHydrator {
             shared: tap_state.clone(),
         };
 
+        let xet_context = new_xet_context()?;
         let reconstructor =
-            xet_data::file_reconstruction::FileReconstructor::new(&client, file_hash)
+            xet_data::file_reconstruction::FileReconstructor::new(&xet_context, &client, file_hash)
                 .with_buffer_semaphore(Arc::clone(&self.buffer_semaphore))
                 .with_cancellation_token(cancel.clone());
         let reconstructor = match self.chunk_cache.clone() {
@@ -1624,8 +1627,9 @@ impl ShardHydrator {
         let writer = SharedCursorWriter(shared.clone());
 
         let range = xet_client::cas_types::FileRange::new(start, end);
+        let xet_context = new_xet_context()?;
         let reconstructor =
-            xet_data::file_reconstruction::FileReconstructor::new(&client, file_hash)
+            xet_data::file_reconstruction::FileReconstructor::new(&xet_context, &client, file_hash)
                 .with_buffer_semaphore(Arc::clone(&self.buffer_semaphore))
                 .with_byte_range(range);
         let reconstructor = match self.chunk_cache.clone() {
@@ -1860,12 +1864,22 @@ impl ShardHydrator {
     }
 }
 
+fn new_xet_context() -> Result<xet_runtime::core::XetContext> {
+    xet_runtime::core::XetContext::default().map_err(|error| {
+        error::CrabError::Internal(format!("failed to initialize xet context: {error}"))
+    })
+}
+
 fn fixed_hydrate_concurrency(
     concurrency: usize,
-) -> Arc<xet_client::cas_client::adaptive_concurrency::AdaptiveConcurrencyController> {
-    xet_client::cas_client::adaptive_concurrency::AdaptiveConcurrencyController::new_fixed(
-        HYDRATE_CONCURRENCY_TAG,
-        concurrency,
+) -> Result<Arc<xet_client::cas_client::adaptive_concurrency::AdaptiveConcurrencyController>> {
+    let context = new_xet_context()?;
+    Ok(
+        xet_client::cas_client::adaptive_concurrency::AdaptiveConcurrencyController::new_fixed(
+            context,
+            HYDRATE_CONCURRENCY_TAG,
+            concurrency,
+        ),
     )
 }
 

--- a/crab/src/git/prefetch.rs
+++ b/crab/src/git/prefetch.rs
@@ -42,6 +42,7 @@ use tracing::{debug, warn};
 use xet_client::cas_client::Client;
 use xet_client::chunk_cache::ChunkCache;
 use xet_data::file_reconstruction::FileReconstructor;
+use xet_runtime::core::XetContext;
 use xet_runtime::utils::adjustable_semaphore::AdjustableSemaphore;
 
 use crate::core::error::{CrabError, Result};
@@ -211,7 +212,11 @@ impl PrefetchQueue {
                 m.inc_prefetch_started();
             }
 
-            let mut reconstructor = FileReconstructor::new(&client, file_hash)
+            let xet_context = match XetContext::default() {
+                Ok(context) => context,
+                Err(error) => return Err(format!("failed to initialize xet context: {error}")),
+            };
+            let mut reconstructor = FileReconstructor::new(&xet_context, &client, file_hash)
                 .with_buffer_semaphore(semaphore)
                 .with_cancellation_token(cancel);
             if let Some(cache) = chunk_cache {
@@ -464,11 +469,13 @@ mod tests {
     use bytes::Bytes;
     use crab_xet::shard::MDBFileInfo;
     use crab_xet::xorb::format::SerializedXorbObject;
+    use xet_client::cas_client::ShardUploadProgressCallback;
     use xet_client::cas_client::adaptive_concurrency::ConnectionPermit;
     use xet_client::cas_client::progress_tracked_streams::ProgressCallback;
     use xet_client::cas_client::{Client, URLProvider};
     use xet_client::cas_types::{
-        BatchQueryReconstructionResponse, FileRange, QueryReconstructionResponseV2,
+        BatchQueryReconstructionResponse, FileChunkHashesResponse, FileRange,
+        QueryReconstructionResponseV2,
     };
     use xet_client::error::{ClientError, Result as ClientResult};
 
@@ -532,7 +539,16 @@ mod tests {
             &self,
             _shard_data: Bytes,
             _upload_permit: ConnectionPermit,
-        ) -> ClientResult<bool> {
+            _progress_callback: Option<ShardUploadProgressCallback>,
+        ) -> ClientResult<()> {
+            Err(ClientError::Other("read-only".to_string()))
+        }
+
+        async fn get_file_chunk_hashes(
+            &self,
+            _file_id: &MerkleHash,
+            _dirty_ranges: Vec<FileRange>,
+        ) -> ClientResult<FileChunkHashesResponse> {
             Err(ClientError::Other("read-only".to_string()))
         }
 

--- a/crab/src/git/progress.rs
+++ b/crab/src/git/progress.rs
@@ -22,8 +22,8 @@ use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use xet_data::deduplication::DeduplicationMetrics;
-use xet_data::progress_tracking::GroupProgress;
 use xet_data::progress_tracking::upload_tracking::CompletionTracker;
+use xet_data::progress_tracking::{GroupProgress, UploadGroupProgress};
 
 use crate::core::output::event_payloads::ProgressPayload;
 use crate::core::output::{JsonlStream, OutputMode};
@@ -602,8 +602,9 @@ impl NativePushProgress {
     /// Prefer [`NativePushProgress::with_mode`] for new call sites.
     #[must_use]
     pub fn new(enabled: bool, color: bool, verbose: bool) -> Self {
-        let group_progress = GroupProgress::new();
-        let completion_tracker = Arc::new(CompletionTracker::new(Arc::clone(&group_progress)));
+        let upload_progress = UploadGroupProgress::new();
+        let group_progress = Arc::clone(&upload_progress.file_data);
+        let completion_tracker = Arc::new(CompletionTracker::new(upload_progress));
         let backend = if !enabled {
             ProgressBackend::Silent
         } else if is_tty() {
@@ -654,8 +655,9 @@ impl NativePushProgress {
         mode: OutputMode,
         stream: Option<Arc<Mutex<JsonlStream<Stdout>>>>,
     ) -> Self {
-        let group_progress = GroupProgress::new();
-        let completion_tracker = Arc::new(CompletionTracker::new(Arc::clone(&group_progress)));
+        let upload_progress = UploadGroupProgress::new();
+        let group_progress = Arc::clone(&upload_progress.file_data);
+        let completion_tracker = Arc::new(CompletionTracker::new(upload_progress));
         let (enabled, backend) = match mode {
             OutputMode::Text => {
                 let backend = if is_tty() {
@@ -717,8 +719,9 @@ impl NativePushProgress {
         mode: OutputMode,
         stream: Option<Arc<Mutex<JsonlStream<Stderr>>>>,
     ) -> Self {
-        let group_progress = GroupProgress::new();
-        let completion_tracker = Arc::new(CompletionTracker::new(Arc::clone(&group_progress)));
+        let upload_progress = UploadGroupProgress::new();
+        let group_progress = Arc::clone(&upload_progress.file_data);
+        let completion_tracker = Arc::new(CompletionTracker::new(upload_progress));
         let (enabled, backend) = match mode {
             OutputMode::Text => {
                 let backend = if is_tty() {

--- a/crab/src/git/store_client.rs
+++ b/crab/src/git/store_client.rs
@@ -27,15 +27,16 @@ use std::sync::{Arc, RwLock};
 
 use bytes::Bytes;
 use tracing::{debug, warn};
+use xet_client::cas_client::ShardUploadProgressCallback;
 use xet_client::cas_client::adaptive_concurrency::{
     AdaptiveConcurrencyController, ConnectionPermit,
 };
 use xet_client::cas_client::progress_tracked_streams::ProgressCallback;
 use xet_client::cas_client::{Client, URLProvider};
 use xet_client::cas_types::{
-    BatchQueryReconstructionResponse, ChunkRange, FileRange, HexMerkleHash, HttpRange,
-    QueryReconstructionResponseV2, XorbMultiRangeFetch, XorbRangeDescriptor,
-    XorbReconstructionFetchInfo, XorbReconstructionTerm,
+    BatchQueryReconstructionResponse, ChunkRange, FileChunkHashesResponse, FileRange,
+    HexMerkleHash, HttpRange, QueryReconstructionResponseV2, XorbMultiRangeFetch,
+    XorbRangeDescriptor, XorbReconstructionFetchInfo, XorbReconstructionTerm,
 };
 use xet_client::error::{ClientError, Result as ClientResult};
 
@@ -690,9 +691,21 @@ impl Client for StoreClient {
         &self,
         _shard_data: Bytes,
         _upload_permit: ConnectionPermit,
-    ) -> ClientResult<bool> {
+        _progress_callback: Option<ShardUploadProgressCallback>,
+    ) -> ClientResult<()> {
         Err(ClientError::Other(
             "StoreClient is read-only; shard uploads go through the crab push pipeline".into(),
+        ))
+    }
+
+    async fn get_file_chunk_hashes(
+        &self,
+        _file_id: &MerkleHash,
+        _dirty_ranges: Vec<FileRange>,
+    ) -> ClientResult<FileChunkHashesResponse> {
+        Err(ClientError::Other(
+            "StoreClient is read-only; file chunk hash queries go through the crab push pipeline"
+                .into(),
         ))
     }
 
@@ -754,7 +767,10 @@ mod tests {
                 .expect("CachingStore builds with default config");
         let router = StoreLayout::new(caching.origin().clone(), "org/test".to_string());
 
-        let concurrency = AdaptiveConcurrencyController::new_download("crab-hydrate-test");
+        let concurrency = AdaptiveConcurrencyController::new_download(
+            xet_runtime::core::XetContext::default().expect("xet context"),
+            "crab-hydrate-test",
+        );
         let client = StoreClient::new(caching, router, concurrency);
         (client, cache_dir)
     }
@@ -771,7 +787,10 @@ mod tests {
                 .expect("caching store");
         let expected = Arc::clone(caching.local_cache());
         let router = StoreLayout::new(caching.origin().clone(), "org/cache-owner".to_owned());
-        let concurrency = AdaptiveConcurrencyController::new_download("crab-cache-owner-test");
+        let concurrency = AdaptiveConcurrencyController::new_download(
+            xet_runtime::core::XetContext::default().expect("xet context"),
+            "crab-cache-owner-test",
+        );
 
         let client = StoreClient::new(caching, router, concurrency);
 
@@ -1081,7 +1100,7 @@ mod tests {
 
         let permit = client.acquire_download_permit().await.unwrap();
         let err = client
-            .upload_shard(Bytes::new(), permit)
+            .upload_shard(Bytes::new(), permit, None)
             .await
             .expect_err("upload_shard must report unsupported");
         assert!(matches!(err, ClientError::Other(_)));
@@ -1202,7 +1221,11 @@ mod tests {
             CachingStore::new_with_local_cache(origin, &CacheConfig::default(), local_cache)
                 .expect("CachingStore builds with default config");
         let router = StoreLayout::new(caching.origin().clone(), "org/test".to_string());
-        let concurrency = AdaptiveConcurrencyController::new_fixed("crab-term-test", 1);
+        let concurrency = AdaptiveConcurrencyController::new_fixed(
+            xet_runtime::core::XetContext::default().expect("xet context"),
+            "crab-term-test",
+            1,
+        );
 
         let xorb_path = router.xorb_path(&xorb.hash);
         caching
@@ -1286,8 +1309,11 @@ mod tests {
                 .expect("CachingStore builds with default config");
         let store_cache = Arc::clone(caching.local_cache());
         let router = StoreLayout::new(caching.origin().clone(), "org/test".to_string());
-        let concurrency =
-            AdaptiveConcurrencyController::new_fixed("crab-term-cache-repair-test", 1);
+        let concurrency = AdaptiveConcurrencyController::new_fixed(
+            xet_runtime::core::XetContext::default().expect("xet context"),
+            "crab-term-cache-repair-test",
+            1,
+        );
 
         let xorb_path = router.xorb_path(&xorb.hash);
         caching

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -3599,9 +3599,12 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                                             "would clean shard cache (dry-run)"
                                         );
                                     } else {
+                                        let shard_file_cache =
+                                            crab_xet::shard::new_shard_file_cache();
                                         match crab_xet::shard::MDBShardFile::clean_shard_cache(
                                             &shards_dir,
                                             expiration_secs,
+                                            &shard_file_cache,
                                         ) {
                                             Ok(()) => {
                                                 tracing::debug!(

--- a/crab/src/metadata/shard_sync.rs
+++ b/crab/src/metadata/shard_sync.rs
@@ -33,7 +33,7 @@ use crab_metadata::chunk_index::ChunkIndex;
 use crab_metadata::manifests::ShardList;
 use crab_metadata::persistent_chunk_index::PersistentChunkIndex;
 use crab_xet::hash::compute_data_hash;
-use crab_xet::shard::{MDBMinimalShard, MDBShardFile};
+use crab_xet::shard::{MDBMinimalShard, MDBShardFile, new_shard_file_cache};
 use crab_xet::xorb::format::{MerkleHash, XorbRef};
 
 static SHARD_GEN_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -858,7 +858,9 @@ impl ShardSynchronizer {
         }
 
         let mut cursor = std::io::Cursor::new(strip_v2_trailer(data));
-        let shard_file = MDBShardFile::write_out_from_reader(dir, &mut cursor).map_err(|e| {
+        let shard_file_cache = new_shard_file_cache();
+        let shard_file = MDBShardFile::write_out_from_reader(dir, &mut cursor, &shard_file_cache)
+            .map_err(|e| {
             CrabError::Internal(format!("failed to write shard {} to disk: {e}", hash.hex()))
         })?;
 

--- a/crates/crab-read/Cargo.toml
+++ b/crates/crab-read/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 xet-client = { workspace = true }
 xet-data = { workspace = true }
+xet-runtime = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/crab-read/src/hydrator.rs
+++ b/crates/crab-read/src/hydrator.rs
@@ -6,6 +6,7 @@ use crab_types::pointer::Pointer;
 use crab_xet::hash::MerkleHash;
 use xet_client::cas_client::adaptive_concurrency::AdaptiveConcurrencyController;
 use xet_client::cas_types::FileRange;
+use xet_runtime::core::XetContext;
 
 use crate::{ReadError, Result, StoreClient};
 
@@ -220,8 +221,11 @@ impl ShardHydrator {
     where
         W: Write + Send + 'static,
     {
+        let xet_context = XetContext::default().map_err(|error| {
+            ReadError::internal(format!("failed to initialize xet context: {error}"))
+        })?;
         let reconstructor =
-            xet_data::file_reconstruction::FileReconstructor::new(&client, file_hash);
+            xet_data::file_reconstruction::FileReconstructor::new(&xet_context, &client, file_hash);
         let reconstructor = match range {
             Some(range) => reconstructor.with_byte_range(range),
             None => reconstructor,
@@ -277,7 +281,11 @@ impl ShardHydrator {
 }
 
 pub fn fixed_hydrate_concurrency(concurrency: usize) -> Result<Arc<AdaptiveConcurrencyController>> {
+    let context = XetContext::default().map_err(|error| {
+        ReadError::internal(format!("failed to initialize xet context: {error}"))
+    })?;
     Ok(AdaptiveConcurrencyController::new_fixed(
+        context,
         HYDRATE_CONCURRENCY_TAG,
         concurrency,
     ))

--- a/crates/crab-read/src/store_client.rs
+++ b/crates/crab-read/src/store_client.rs
@@ -11,15 +11,16 @@ use crab_xet::hash::MerkleHash;
 use crab_xet::shard::{MDBFileInfo, ShardReader};
 use crab_xet::xorb::format::SerializedXorbObject;
 use tracing::{debug, warn};
+use xet_client::cas_client::ShardUploadProgressCallback;
 use xet_client::cas_client::adaptive_concurrency::{
     AdaptiveConcurrencyController, ConnectionPermit,
 };
 use xet_client::cas_client::progress_tracked_streams::ProgressCallback;
 use xet_client::cas_client::{Client, URLProvider};
 use xet_client::cas_types::{
-    BatchQueryReconstructionResponse, ChunkRange, FileRange, HexMerkleHash, HttpRange,
-    QueryReconstructionResponseV2, XorbMultiRangeFetch, XorbRangeDescriptor,
-    XorbReconstructionFetchInfo, XorbReconstructionTerm,
+    BatchQueryReconstructionResponse, ChunkRange, FileChunkHashesResponse, FileRange,
+    HexMerkleHash, HttpRange, QueryReconstructionResponseV2, XorbMultiRangeFetch,
+    XorbRangeDescriptor, XorbReconstructionFetchInfo, XorbReconstructionTerm,
 };
 use xet_client::error::{ClientError, Result as ClientResult};
 
@@ -520,9 +521,21 @@ impl Client for StoreClient {
         &self,
         _shard_data: Bytes,
         _upload_permit: ConnectionPermit,
-    ) -> ClientResult<bool> {
+        _progress_callback: Option<ShardUploadProgressCallback>,
+    ) -> ClientResult<()> {
         Err(ClientError::Other(
             "StoreClient is read-only; shard uploads go through the crab push pipeline".into(),
+        ))
+    }
+
+    async fn get_file_chunk_hashes(
+        &self,
+        _file_id: &MerkleHash,
+        _dirty_ranges: Vec<FileRange>,
+    ) -> ClientResult<FileChunkHashesResponse> {
+        Err(ClientError::Other(
+            "StoreClient is read-only; file chunk hash queries go through the crab push pipeline"
+                .into(),
         ))
     }
 

--- a/crates/crab-xet/src/shard.rs
+++ b/crates/crab-xet/src/shard.rs
@@ -22,7 +22,9 @@ pub use xet_core_structures::metadata_shard::file_structs::{
 };
 pub use xet_core_structures::metadata_shard::session_directory::merge_shards;
 pub use xet_core_structures::metadata_shard::set_operations::shard_set_union;
-pub use xet_core_structures::metadata_shard::shard_file_handle::MDBShardFile;
+pub use xet_core_structures::metadata_shard::shard_file_handle::{
+    MDBShardFile, ShardFileCache, new_shard_file_cache,
+};
 pub use xet_core_structures::metadata_shard::shard_format::MDBShardInfo;
 use xet_core_structures::metadata_shard::shard_in_memory::MDBInMemoryShard;
 pub use xet_core_structures::metadata_shard::streaming_shard::MDBMinimalShard;


### PR DESCRIPTION
## Summary

- Upgrade `xet-client`, `xet-core-structures`, `xet-data`, and `xet-runtime` from 1.5.2 to 1.6.0.
- Adapt Crab integrations for the Xet 1.6.0 runtime-context, shard-cache, client-trait, upload-progress, and file-chunk-hash APIs.
- Keep the dependency graph on the coordinated public Xet 1.6.0 release.

## Validation

- `cargo metadata --format-version 1 --locked`
- `cargo metadata --format-version 1 --locked --all-features`
- `cargo tree` checks confirm all Xet packages resolve to 1.6.0.
- Targeted Rust formatting checks pass.
- `git diff --check` passes.
- Full Cargo compilation/tests were not run because `/Volumes/Workspace` is unavailable; repository policy requires Cargo build artifacts there.