### PR TITLE
fix: adapt chunk cache to Xet 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "toml",
  "tracing",
  "xet-client",
+ "xet-runtime",
 ]
 
 [[package]]

--- a/crab/Makefile
+++ b/crab/Makefile
@@ -318,7 +318,7 @@ all: build
 # --- Build ---
 
 build:
-	@if [ "$(UNAME_S)" = "Darwin" ]; then \
+	@set -e; if [ "$(UNAME_S)" = "Darwin" ]; then \
 		$(CARGO) build $(RELEASE_FLAGS) -p crab --bin $(BINARY_NAME) --no-default-features --features "$(CRAB_CLI_FEATURES_WITH_FUSE)"; \
 		cp "$(RELEASE_BIN)" "$(FUSE_MOUNT_RELEASE_BIN)"; \
 		$(CARGO) build $(RELEASE_FLAGS) -p crab --bin $(BINARY_NAME) --no-default-features --features "$(CRAB_CLI_FEATURES_NO_FUSE)"; \

--- a/crates/crab-cache/Cargo.toml
+++ b/crates/crab-cache/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 active-probe = ["dep:reqwest"]
 local-cache = ["dep:filetime", "dep:rusqlite", "dep:tokio"]
 remote-client = ["active-probe", "dep:tokio"]
-xet-chunk-cache = ["dep:tokio", "dep:xet-client"]
+xet-chunk-cache = ["dep:tokio", "dep:xet-client", "dep:xet-runtime"]
 
 [dependencies]
 blake3 = { workspace = true, features = ["rayon"] }
@@ -33,6 +33,7 @@ tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt", 
 toml = { workspace = true }
 tracing = { workspace = true }
 xet-client = { workspace = true, optional = true }
+xet-runtime = { workspace = true, optional = true }
 
 [dev-dependencies]
 axum = { version = "0.8", features = ["json", "matched-path"] }

--- a/crates/crab-cache/src/xet_chunk_cache.rs
+++ b/crates/crab-cache/src/xet_chunk_cache.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use tracing::{debug, warn};
 use xet_client::chunk_cache::{CacheConfig, ChunkCache, DiskCache, get_cache};
+use xet_runtime::config::XetConfig;
 
 use crate::{CacheError, Result};
 
@@ -69,10 +70,12 @@ impl XetChunkCacheHandle {
             cache_size: size_bytes,
         };
 
-        let cache = get_cache(&cache_config).map_err(|source| CacheError::XetChunkCache {
-            path: directory.display().to_string(),
-            source: Box::new(source),
-        })?;
+        let xet_config = XetConfig::new();
+        let cache =
+            get_cache(&xet_config, &cache_config).map_err(|source| CacheError::XetChunkCache {
+                path: directory.display().to_string(),
+                source: Box::new(source),
+            })?;
 
         debug!(
             directory = %directory.display(),
@@ -98,7 +101,8 @@ impl XetChunkCacheHandle {
             cache_size: self.size_bytes,
         };
 
-        match DiskCache::initialize(&config) {
+        let xet_config = XetConfig::new();
+        match DiskCache::initialize(&xet_config, &config) {
             Ok(disk) => XetChunkCacheStats {
                 entries: disk.num_items().await,
                 total_bytes: disk.total_bytes().await,

--- a/crates/crab-vfs/Cargo.toml
+++ b/crates/crab-vfs/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 async-trait = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }
-crab-cache = { workspace = true, features = ["local-cache"] }
+crab-cache = { workspace = true, features = ["local-cache", "xet-chunk-cache"] }
 crab-cache-store = { workspace = true }
 crab-git = { workspace = true }
 crab-read = { workspace = true }

--- a/crates/crab-vfs/src/chunk_cache.rs
+++ b/crates/crab-vfs/src/chunk_cache.rs
@@ -23,7 +23,7 @@ use bytes::Bytes;
 use tokio::runtime::Handle;
 use tracing::{debug, warn};
 use xet_client::cas_types::{ChunkRange, Key};
-use xet_client::chunk_cache::{CacheConfig, ChunkCache as XetChunkCacheTrait, get_cache};
+use xet_client::chunk_cache::ChunkCache as XetChunkCacheTrait;
 
 use crate::core::error::{CrabError, Result};
 use crab_xet::xorb::format::MerkleHash;
@@ -82,24 +82,14 @@ impl ChunkCache {
     pub fn open(dir: PathBuf, max_bytes: Option<u64>) -> Result<Self> {
         let max_bytes = max_bytes.unwrap_or(DEFAULT_MAX_BYTES);
 
-        std::fs::create_dir_all(&dir).map_err(|e| {
-            CrabError::Internal(format!(
-                "failed to create chunk cache directory {}: {e}",
-                dir.display(),
-            ))
-        })?;
-
-        let config = CacheConfig {
-            cache_directory: dir.clone(),
-            cache_size: max_bytes,
-        };
-
-        let inner = get_cache(&config).map_err(|e| {
-            CrabError::Internal(format!(
-                "failed to initialize chunk cache at {}: {e}",
-                dir.display(),
-            ))
-        })?;
+        let inner = crab_cache::XetChunkCacheHandle::open(dir.clone(), max_bytes)
+            .map_err(|e| {
+                CrabError::Internal(format!(
+                    "failed to initialize chunk cache at {}: {e}",
+                    dir.display(),
+                ))
+            })?
+            .cache;
 
         debug!(
             dir = %dir.display(),


### PR DESCRIPTION
## Summary

- Pass the required `XetConfig` to Xet 1.6.0 chunk-cache initialization APIs.
- Enable the optional `xet-runtime` dependency only with `crab-cache/xet-chunk-cache`.
- Route `crab-vfs` through the shared Crab Xet chunk-cache handle so cache construction has one owner.
- Make the multi-artifact `make install` build stop immediately when any Cargo build or artifact copy fails.

## Root cause

Xet 1.6.0 changed `get_cache` and `DiskCache::initialize` to accept an `&XetConfig`. Crab still called the Xet 1.5.x one-argument forms, so `make install` failed while compiling `crab-cache`.

The Makefile recipe also used semicolon-separated commands without fail-fast shell behavior. A failed Crab build could therefore continue into later builds and potentially install a stale executable.

## Validation

- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/crab-main make install`
  - built the FUSE and non-FUSE Crab variants
  - built `crab-cache-server`
  - installed all binaries and the `git-remote-crab` symlink
- Installed `crab version`: `crab 1.0.14 (4cb549e4)`
- `cargo test -p crab-cache --features xet-chunk-cache xet_chunk_cache` - 3 passed
- `cargo test -p crab-vfs chunk_cache` - 6 passed
- Deliberately failing `make CARGO=false build` exits 2 at the first build
- `cargo fmt --all -- --check`
- `git diff --check`

## Known repository gate state

`make architecture-check` remains red because its checked-in policy is already out of sync with current `main` (including Xet 1.5.2 and object_store 0.12 expectations plus missing current workspace crates). This change also exposes the required Xet 1.6 `xet-runtime` feature cost that the stale budget does not yet admit. The architecture documentation already confines direct `xet-client`/`xet-runtime` imports to `crab-cache/src/xet_chunk_cache.rs` behind `xet-chunk-cache`; the policy baseline was not edited as part of this build repair.