### PR TITLE
feat(optimize): reconcile metadata before xorb apply

### DIFF
--- a/crab-web/content/docs/cli/reference/crab-optimize.mdx
+++ b/crab-web/content/docs/cli/reference/crab-optimize.mdx
@@ -47,6 +47,10 @@ crab optimize replicas status
 crab optimize repo --json
 ```
 
+`crab optimize repo` and `crab doctor --cost` require a configured Crab remote
+and currently use live inventory. The explicit provider-report source is
+reserved until report discovery and freshness metadata are wired.
+
 ## Related Commands
 
 - [`crab repack`](/docs/cli/reference/crab-repack) — legacy top-level entry for pack consolidation.

--- a/crab-web/content/docs/cli/reference/pricing-tables.mdx
+++ b/crab-web/content/docs/cli/reference/pricing-tables.mdx
@@ -13,8 +13,8 @@ Current version: **2026-03-01**
 
 ## How pricing data is used
 
-- `crab doctor --cost` uses the embedded table to estimate monthly
-  storage costs, projected savings, and recommendation deltas.
+- `crab doctor --cost` uses the embedded table and a live remote inventory to
+  estimate monthly storage costs and recommendation deltas.
 - `crab gc --dry-run` uses it to estimate early-deletion penalties.
 - `crab optimize xorbs --dry-run` uses PUT and storage costs for the
   xorb optimization cost estimate.

--- a/crab-web/content/docs/cli/storage/optimizing-xorbs.mdx
+++ b/crab-web/content/docs/cli/storage/optimizing-xorbs.mdx
@@ -37,11 +37,18 @@ Dry-run first:
 crab optimize xorbs --profile ml --dry-run
 ```
 
+Dry-run is the supported optimization path today. It lists live source xorbs,
+reads their sizes and storage classes, and performs no writes.
+
 Apply the rewrite:
 
 ```bash
 crab optimize xorbs --profile ml --apply
 ```
+
+Apply currently fails closed. The executor can create destination xorbs, but
+the file-index/shard manifest reconciliation required for readers to resolve
+them is not implemented yet.
 
 Resume or abort an interrupted run:
 
@@ -80,7 +87,7 @@ crab optimize xorbs --profile ml --apply --output-class=STANDARD_IA
 |-------------|--------|
 | Two `crab optimize xorbs` runs | Second fails with `CRAB-E0332` |
 | `crab gc` + `crab optimize xorbs` | Fails with `ConcurrentMaintenance [E0333]` |
-| `crab push` + `crab optimize xorbs` | Safe; reconciliation leaves concurrent-push xorbs untouched |
+| `crab push` + `crab optimize xorbs --dry-run` | Safe; dry-run performs no writes |
 
 Old source xorbs become orphans and are reclaimed by the next `crab gc`.
 

--- a/crab/docs/guides/cost.md
+++ b/crab/docs/guides/cost.md
@@ -41,24 +41,17 @@ inventory_source = "live"
 list_concurrency = 32
 ```
 
-### Provider-side reports (recommended for large buckets)
+### Provider-side reports
 
-For buckets with millions of objects, provider-side inventory reports
-are faster and cheaper:
-
-- **S3 Inventory** — Parquet, ORC, or CSV format
-- **GCS Storage Insights** — Parquet format
-- **Azure Blob Inventory** — CSV format
-
-```toml
-[cost]
-inventory_source = "report"
-```
+Provider-side report parsers exist as library components, but Crab does not
+yet have a report-location/discovery contract. An explicit `report` source
+therefore fails with a configuration error; use `live` until report wiring is
+available.
 
 ### Auto (default)
 
-Prefers a report if one exists and is within
-`report_max_staleness_hours` (default 48). Falls back to live walk.
+Selects live inventory today. The report freshness setting is reserved for
+the provider-report discovery path.
 
 ```toml
 [cost]
@@ -76,11 +69,8 @@ crab doctor --cost --sample 0.25
 ```
 
 This uses a deterministic `blake3(key)` hash to include ~25% of
-objects. The report includes a Hoeffding-bound confidence interval
-at 95%.
-
-Sampling ratios ≥ 1/64 produce estimates within ±5% at 95% confidence
-for most distributions.
+objects. The report records that totals are scaled estimates when sampling
+is enabled; it does not currently emit a statistical confidence interval.
 
 ## Pricing Model
 
@@ -138,8 +128,10 @@ timestamp, and inventory source.
 ### 2. Cost Summary
 
 - **Current monthly cost** — estimated from current class distribution.
-- **Projected (with tier)** — estimated if tier-plan defaults were applied.
-- **Estimated savings** — the difference.
+- **Projected (with tier)** — equal to current cost until object age and
+  access telemetry are available to model tier transitions.
+- **Estimated savings** — conservative projected savings; use enabled
+  recommendations for potential tier savings.
 
 ### 3. Per-Class Breakdown
 
@@ -168,8 +160,9 @@ operator checklist:
 - active-active maintenance admission before any mutating apply step.
 - lifecycle tiering through `crab tier plan --apply --merge` when
   `[tier] enabled = true`.
-- xorb restriping through `crab optimize xorbs --apply` only when
-  `--include-xorbs` is passed.
+- xorb restriping is exposed as a planned step, but apply is currently
+  blocked until destination xorbs can be committed with their file-index and
+  shard metadata atomically. Use `crab optimize xorbs --dry-run` for estimates.
 - local cache pruning through `crab prune`.
 - replica policy checks through `crab replica doctor --fix-plan` when
   replication is configured.
@@ -177,7 +170,8 @@ operator checklist:
 `crab optimize apply` executes the same plan in order. It preserves each
 underlying command's safety checks and stops on the first failed step. Xorb
 rewrites are opt-in because they can be long-running and may restore archived
-objects before rewriting content-addressed xorbs.
+objects before rewriting content-addressed xorbs; requesting that step
+currently fails closed until metadata reconciliation is implemented.
 
 ### 5. Heaviest Cold Objects
 
@@ -213,7 +207,7 @@ pricing_file = ""
 # Access window in days for cost analysis
 access_window_days = 90
 
-# Whether to apply free-tier modeling
+# Reserved; true fails closed until billing-account scope is defined
 apply_free_tier = false
 
 # Maximum staleness in hours for inventory reports

--- a/crab/docs/guides/optimize-xorbs.md
+++ b/crab/docs/guides/optimize-xorbs.md
@@ -43,11 +43,19 @@ crab optimize xorbs --profile ml --dry-run
 crab optimize xorbs --profile ml --dry-run --json
 ```
 
+`--dry-run` is the supported optimization path today. It lists the live
+source xorbs, obtains their sizes and storage classes, and produces an
+estimate without writing remote objects.
+
 Apply the rewrite:
 
 ```bash
 crab optimize xorbs --profile ml --apply
 ```
+
+Apply currently fails closed after configuration validation. The executor can
+write destination xorbs, but the file-index/shard manifest reconciliation
+needed for readers to resolve those destinations is not implemented yet.
 
 Resume an interrupted run:
 
@@ -85,4 +93,4 @@ Archive-class source xorbs are restored before processing when included:
 
 - Two `crab optimize xorbs` runs: second fails with `CRAB-E0332`.
 - `crab gc` + `crab optimize xorbs`: `ConcurrentMaintenance [E0333]`.
-- `crab push` + `crab optimize xorbs`: safe; reconciliation leaves concurrent-push xorbs untouched.
+- `crab push` + `crab optimize xorbs --dry-run`: safe; dry-run performs no writes.

--- a/crab/docs/reference/pricing-tables.md
+++ b/crab/docs/reference/pricing-tables.md
@@ -8,8 +8,8 @@ Current version: **2026-03-01**
 
 ## How pricing data is used
 
-- `crab doctor --cost` uses the embedded table to estimate monthly
-  storage costs, projected savings, and recommendation deltas.
+- `crab doctor --cost` uses the embedded table and a live remote inventory to
+  estimate monthly storage costs and recommendation deltas.
 - `crab gc --dry-run` uses it to estimate early-deletion penalties.
 - `crab optimize xorbs --dry-run` uses PUT and storage costs for the
   xorb optimization cost estimate.

--- a/crab/src/cmd/doctor.rs
+++ b/crab/src/cmd/doctor.rs
@@ -25,10 +25,11 @@ use crab_cache::path_class::{CacheRouteContract, cache_route_contract_matches_cu
 
 use crate::core::config::{Config, ServiceAuth, ServiceMode};
 use crate::core::credential_discovery::{CredentialSource, discover_credentials};
-use crate::core::error::Result;
+use crate::core::error::{CrabError, Result};
 use crate::core::output::{OutputMode, emit_json};
 use crate::core::project_config::ProjectConfig;
 use crate::core::style::CliStyle;
+use tokio_util::sync::CancellationToken;
 
 /// Outcome of a single diagnostic check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, schemars::JsonSchema)]
@@ -247,48 +248,39 @@ pub async fn run_doctor_metadb(mode: OutputMode) -> Result<()> {
 ///
 /// Collects inventory, applies pricing, generates recommendations,
 /// and renders the report in human or JSON format.
-pub fn run_cost_report(
+pub async fn run_cost_report(
     mode: OutputMode,
-    _pricing_file: Option<String>,
-    _inventory_source: Option<String>,
-    _sample: Option<f64>,
-    _top_k: Option<usize>,
+    pricing_file: Option<String>,
+    inventory_source: Option<String>,
+    sample: Option<f64>,
+    top_k: Option<usize>,
+    config: &Config,
+    cancel: &CancellationToken,
 ) -> Result<()> {
-    use crate::cost::inventory::live::chrono_now_rfc3339;
-    use crate::cost::report::{CostReport, InventorySummary, format_bytes_iec};
-    use rust_decimal::Decimal;
-    use std::collections::BTreeMap;
-
-    // Build a placeholder report. In a full implementation, this would:
-    // 1. Resolve inventory source (auto/live/report)
-    // 2. Walk or parse the inventory
-    // 3. Load embedded + override pricing
-    // 4. Run the recommendation engine
-    // 5. Build and render the report
-    let now = chrono_now_rfc3339();
-
-    let report = CostReport {
-        price_table_version: crate::cost::pricing::embedded::PRICE_TABLE_VERSION.to_string(),
-        override_version: None,
-        generated_at: now.clone(),
-        inventory: InventorySummary {
-            source: "not yet connected".to_string(),
-            scanned_at: now,
-            total_objects: 0,
-            total_bytes: 0,
-            total_bytes_human: format_bytes_iec(0),
+    let remote_path = crate::git::discover::resolve_crab_dir()
+        .map_or_else(|| PathBuf::from(".crab/remote"), |dir| dir.join("remote"));
+    let remote =
+        std::fs::read_to_string(&remote_path).map_err(|error| CrabError::Configuration {
+            key: "remote".to_string(),
+            origin: format!(
+                "failed to read {}: {error}; run `crab init <url>` first",
+                remote_path.display()
+            ),
+        })?;
+    let remote = crate::git::url::CrabUrl::parse(remote.trim())?;
+    let store = crate::auth::build_store(config, &remote, "doctor.cost", cancel).await?;
+    let report = crate::cost::engine::build_report(
+        config,
+        &store,
+        &crate::cost::engine::ReportOptions {
+            pricing_file,
+            inventory_source,
+            sample_ratio: sample,
+            top_k,
         },
-        current_monthly_usd: Decimal::ZERO,
-        projected_monthly_usd: Decimal::ZERO,
-        projected_savings_usd: Decimal::ZERO,
-        per_class_costs: BTreeMap::new(),
-        recommendations: Vec::new(),
-        heaviest_cold: Vec::new(),
-        assumptions: vec![
-            "Cost report requires a connected bucket. Run from a crab-initialized repo."
-                .to_string(),
-        ],
-    };
+        cancel,
+    )
+    .await?;
 
     if mode == OutputMode::Json {
         emit_json("cost", "1.0", &report);

--- a/crab/src/cmd/optimize.rs
+++ b/crab/src/cmd/optimize.rs
@@ -1,14 +1,17 @@
 //! Operator workflow for repository cost optimization.
 
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use clap::Parser;
 use schemars::JsonSchema;
 use serde::Serialize;
+use tokio::io::AsyncRead;
 
 use crate::core::config::Config;
 use crate::core::error::{CrabError, Result};
 use crate::core::output::{OutputMode, emit_json};
+use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
 
 pub const OPTIMIZE_PLAN_SCHEMA: &str = "optimize.plan";
 pub const OPTIMIZE_APPLY_SCHEMA: &str = "optimize.apply";
@@ -188,7 +191,12 @@ pub fn render_apply(payload: &OptimizePayload, mode: OutputMode) {
 }
 
 /// Execute a child `crab` command as one optimizer step.
-pub fn run_child_step(step: &mut OptimizeStep, mode: OutputMode, args: &[String]) -> Result<()> {
+pub async fn run_child_step(
+    step: &mut OptimizeStep,
+    mode: OutputMode,
+    args: &[String],
+    cancel: &CancellationToken,
+) -> Result<()> {
     if step.status == OptimizeStepStatus::Skipped {
         return Ok(());
     }
@@ -198,26 +206,77 @@ pub fn run_child_step(step: &mut OptimizeStep, mode: OutputMode, args: &[String]
     let mut command = Command::new(&bin);
     command.args(args);
     if mode.is_machine() {
-        let output = command
+        let mut child = command
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .output()
+            .spawn()
             .map_err(CrabError::Io)?;
-        return finish_child_step(step, output.status);
+        let stdout_task = tokio::spawn(read_child_pipe(child.stdout.take()));
+        let stderr_task = tokio::spawn(read_child_pipe(child.stderr.take()));
+        let status = tokio::select! {
+            result = child.wait() => result.map_err(CrabError::Io)?,
+            () = cancel.cancelled() => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                stdout_task.abort();
+                stderr_task.abort();
+                step.status = OptimizeStepStatus::Failed;
+                "cancelled".clone_into(&mut step.detail);
+                return Err(CrabError::Cancelled);
+            }
+        };
+        let stdout = stdout_task.await.map_err(|error| {
+            CrabError::Internal(format!("stdout capture task failed: {error}"))
+        })??;
+        let stderr = stderr_task.await.map_err(|error| {
+            CrabError::Internal(format!("stderr capture task failed: {error}"))
+        })??;
+        let diagnostic = if status.success() {
+            None
+        } else {
+            bounded_child_output(&stderr).or_else(|| bounded_child_output(&stdout))
+        };
+        return finish_child_step(step, status, diagnostic.as_deref());
     }
 
-    let status = command
+    let mut child = command
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
-        .status()
+        .spawn()
         .map_err(CrabError::Io)?;
-    finish_child_step(step, status)
+    let status = tokio::select! {
+        result = child.wait() => result.map_err(CrabError::Io)?,
+        () = cancel.cancelled() => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            step.status = OptimizeStepStatus::Failed;
+            "cancelled".clone_into(&mut step.detail);
+            return Err(CrabError::Cancelled);
+        }
+    };
+    finish_child_step(step, status, None)
 }
 
-fn finish_child_step(step: &mut OptimizeStep, status: std::process::ExitStatus) -> Result<()> {
+async fn read_child_pipe<R>(reader: Option<R>) -> std::io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let Some(mut reader) = reader else {
+        return Ok(Vec::new());
+    };
+    let mut output = Vec::new();
+    tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut output).await?;
+    Ok(output)
+}
+
+fn finish_child_step(
+    step: &mut OptimizeStep,
+    status: std::process::ExitStatus,
+    diagnostic: Option<&str>,
+) -> Result<()> {
     if status.success() {
         step.status = OptimizeStepStatus::Succeeded;
-        step.detail = "completed".to_owned();
+        "completed".clone_into(&mut step.detail);
         return Ok(());
     }
 
@@ -225,11 +284,24 @@ fn finish_child_step(step: &mut OptimizeStep, status: std::process::ExitStatus) 
     let code = status
         .code()
         .map_or_else(|| "signal".to_owned(), |code| code.to_string());
-    step.detail = format!("failed with exit status {code}");
+    step.detail = match diagnostic {
+        Some(diagnostic) => format!("failed with exit status {code}: {diagnostic}"),
+        None => format!("failed with exit status {code}"),
+    };
     Err(CrabError::Configuration {
         key: format!("{} failed", step.id),
-        origin: step.command.clone(),
+        origin: step.detail.clone(),
     })
+}
+
+fn bounded_child_output(bytes: &[u8]) -> Option<String> {
+    const MAX_DIAGNOSTIC_BYTES: usize = 2048;
+    let output = String::from_utf8_lossy(bytes);
+    let output = output.trim();
+    if output.is_empty() {
+        return None;
+    }
+    Some(output.chars().take(MAX_DIAGNOSTIC_BYTES).collect())
 }
 
 /// Mark a planned in-process safety step as succeeded.
@@ -434,7 +506,7 @@ fn xorb_step(args: &OptimizePlanArgs) -> OptimizeStep {
         command,
         mutates: true,
         status: OptimizeStepStatus::Planned,
-        detail: "rewrite content-addressed xorbs through the existing restripe journal".to_owned(),
+        detail: "requested xorb rewrite is currently blocked until file-index/shard reconciliation is implemented".to_owned(),
     }
 }
 

--- a/crab/src/cmd/restripe.rs
+++ b/crab/src/cmd/restripe.rs
@@ -34,6 +34,7 @@ use crate::restripe::journal::RestripeJournal;
 use crate::restripe::planner::{self, CalibrationConfig, SourceXorbMeta};
 use crate::restripe::profile::Profile;
 use crate::restripe::reconcile;
+use crate::storage::StoreLayout;
 use crate::storage::head_class::head_with_class;
 use crate::storage::store::Store;
 use crate::tier::audit_shim::{self, AuditOp};
@@ -445,11 +446,6 @@ async fn run_apply(
 ) -> Result<()> {
     let start = Instant::now();
 
-    // Destination xorbs are not useful until the file-index and shard
-    // manifest are updated atomically. Refuse the mutating path rather than
-    // leaving readers pointed at the pre-restripe metadata.
-    reconcile::ensure_apply_supported()?;
-
     // Check for concurrent GC.
     let crab_dir = journal_path
         .parent()
@@ -477,6 +473,7 @@ async fn run_apply(
     };
 
     let (store, parsed) = try_build_store(cfg, cancel).await?;
+    let router = StoreLayout::new(store.clone(), parsed.repo_path.clone());
     let sources = if recorded_run.is_none() {
         enumerate_sources(&store, cancel).await?
     } else {
@@ -566,7 +563,8 @@ async fn run_apply(
     .await?;
 
     // Reconcile.
-    let reconcile_outcome = reconcile::finalize(&journal, &run_id, Some(&store))?;
+    let reconcile_outcome =
+        reconcile::finalize(&journal, &run_id, Some(&store), Some(&router), cancel).await?;
 
     let counts = journal.count_by_status(&run_id)?;
     if counts.pending > 0 || counts.staged > 0 {

--- a/crab/src/cmd/restripe.rs
+++ b/crab/src/cmd/restripe.rs
@@ -20,7 +20,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use object_store::path::Path as ObjectPath;
 use serde::Serialize;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::core::config::Config;
@@ -32,6 +34,8 @@ use crate::restripe::journal::RestripeJournal;
 use crate::restripe::planner::{self, CalibrationConfig, SourceXorbMeta};
 use crate::restripe::profile::Profile;
 use crate::restripe::reconcile;
+use crate::storage::head_class::head_with_class;
+use crate::storage::store::Store;
 use crate::tier::audit_shim::{self, AuditOp};
 
 const OPTIMIZE_XORBS_AUTH_OPERATION: &str = "optimize-xorbs";
@@ -41,21 +45,26 @@ const OPTIMIZE_XORBS_EVENT_SCHEMA: &str = "optimize.xorbs.event";
 
 /// Read the remote URL from `.crab/remote` and build a Store.
 ///
-/// Returns `None` if the remote file is missing or the URL is invalid,
-/// allowing the executor to operate in journal-only mode for testing.
+/// Resolve the configured remote and build the store used by planning and
+/// execution. Remote operations fail closed because an empty source snapshot
+/// would make a restripe plan look successful without touching the bucket.
 async fn try_build_store(
     cfg: &Config,
-    cancel: &tokio_util::sync::CancellationToken,
-) -> Option<(crate::storage::store::Store, crate::git::url::CrabUrl)> {
+    cancel: &CancellationToken,
+) -> Result<(Store, crate::git::url::CrabUrl)> {
     let remote_path = crate::git::discover::resolve_crab_dir()
         .map_or_else(|| PathBuf::from(".crab/remote"), |d| d.join("remote"));
-    let url = std::fs::read_to_string(&remote_path).ok()?;
-    let url = url.trim();
-    let parsed = crate::git::url::CrabUrl::parse(url).ok()?;
-    let store = crate::auth::build_store(cfg, &parsed, OPTIMIZE_XORBS_AUTH_OPERATION, cancel)
-        .await
-        .ok()?;
-    Some((store, parsed))
+    let url = std::fs::read_to_string(&remote_path).map_err(|error| CrabError::Configuration {
+        key: "remote".to_string(),
+        origin: format!(
+            "failed to read {}: {error}; run `crab init <url>` first",
+            remote_path.display()
+        ),
+    })?;
+    let parsed = crate::git::url::CrabUrl::parse(url.trim())?;
+    let store =
+        crate::auth::build_store(cfg, &parsed, OPTIMIZE_XORBS_AUTH_OPERATION, cancel).await?;
+    Ok((store, parsed))
 }
 
 // ---------------------------------------------------------------------------
@@ -178,11 +187,14 @@ pub enum OptimizeXorbsEventPayload {
 // ---------------------------------------------------------------------------
 
 /// Run the `crab optimize xorbs` command.
-pub async fn run_restripe(args: &RestripeArgs, cfg: &Config) -> Result<()> {
+pub async fn run_restripe(
+    args: &RestripeArgs,
+    cfg: &Config,
+    cancel: &CancellationToken,
+) -> Result<()> {
     let output_mode = OutputMode::from_flags(args.json, args.jsonl);
 
-    // Journal path: `.crab/restripe/journal.db` relative to the repo root.
-    let journal_path = PathBuf::from(".crab/restripe/journal.db");
+    let journal_path = resolve_journal_path()?;
 
     // Handle --drop-journal.
     if args.drop_journal {
@@ -211,13 +223,19 @@ pub async fn run_restripe(args: &RestripeArgs, cfg: &Config) -> Result<()> {
         return Ok(());
     }
 
-    // Resolve profile.
-    let (profile_name, profile) = resolve_profile(args, cfg)?;
-    info!(profile = %profile_name, "resolved xorb optimization profile");
-
     // Handle --dry-run.
     if args.dry_run {
-        run_dry_run(&profile_name, &profile, output_mode, cfg);
+        let (store, _) = try_build_store(cfg, cancel).await?;
+        let sources = enumerate_sources(&store, cancel).await?;
+        let (profile_name, profile) = resolve_profile(args, cfg, Some(&sources))?;
+        info!(profile = %profile_name, "resolved xorb optimization profile");
+        run_dry_run(
+            &profile_name,
+            &profile,
+            &sources,
+            args.include_cold,
+            output_mode,
+        );
         return Ok(());
     }
 
@@ -232,16 +250,13 @@ pub async fn run_restripe(args: &RestripeArgs, cfg: &Config) -> Result<()> {
             cfg,
             OPTIMIZE_XORBS_OPERATION,
         )?;
-        return run_apply(
-            args,
-            &profile_name,
-            &profile,
-            &journal_path,
-            output_mode,
-            cfg,
-        )
-        .await;
+        return run_apply(args, &journal_path, output_mode, cfg, cancel).await;
     }
+
+    // Resolve profile for the read-only summary. A remote source snapshot is
+    // only needed for dry-run/apply, so the default summary stays offline.
+    let (profile_name, profile) = resolve_profile(args, cfg, None)?;
+    info!(profile = %profile_name, "resolved xorb optimization profile");
 
     // Default: show profile info and suggest --dry-run or --apply.
     println!("Xorb optimization profile: {profile_name}");
@@ -258,18 +273,36 @@ pub async fn run_restripe(args: &RestripeArgs, cfg: &Config) -> Result<()> {
     Ok(())
 }
 
+fn resolve_journal_path() -> Result<PathBuf> {
+    let crab_dir =
+        crate::git::discover::resolve_crab_dir().ok_or_else(|| CrabError::Configuration {
+            key: ".crab".to_string(),
+            origin: "run this command inside a Crab Git repository".to_string(),
+        })?;
+    Ok(crab_dir.join("restripe/journal.db"))
+}
+
 /// Resolve the profile from CLI args or auto-inference.
-fn resolve_profile(args: &RestripeArgs, cfg: &Config) -> Result<(String, Profile)> {
+fn resolve_profile(
+    args: &RestripeArgs,
+    cfg: &Config,
+    sources: Option<&[SourceXorbMeta]>,
+) -> Result<(String, Profile)> {
     if let Some(ref name) = args.profile {
         let profile = Profile::from_name(name, &cfg.restripe)?;
         profile.validate()?;
         Ok((name.clone(), profile))
     } else {
-        // Auto-infer from repo stats.
-        // In the real implementation this would scan the file-index.
-        // For now, default to `code` as a safe fallback.
+        // The source snapshot is the available remote statistic at this
+        // boundary. It is still a real size distribution, unlike the former
+        // empty scan that always selected `code`.
         info!("no --profile specified, auto-inferring from repository statistics");
-        let stats = RepoStats::scan(vec![]);
+        let sizes = sources
+            .unwrap_or_default()
+            .iter()
+            .map(|source| source.size_bytes)
+            .collect();
+        let stats = RepoStats::scan(sizes);
         let profile = inference::infer(&stats);
         let name = if profile == Profile::ml() {
             "ml"
@@ -282,14 +315,61 @@ fn resolve_profile(args: &RestripeArgs, cfg: &Config) -> Result<(String, Profile
     }
 }
 
-/// Execute a dry-run estimation.
-fn run_dry_run(profile_name: &str, profile: &Profile, output_mode: OutputMode, _cfg: &Config) {
-    let cal = CalibrationConfig::default();
+/// Snapshot source xorbs and their storage classes before a plan or run.
+async fn enumerate_sources(
+    store: &Store,
+    cancel: &CancellationToken,
+) -> Result<Vec<SourceXorbMeta>> {
+    if cancel.is_cancelled() {
+        return Err(CrabError::Cancelled);
+    }
 
-    // In the real implementation, we'd enumerate source xorbs via HEAD.
-    // For now, return an empty estimate.
-    let sources: Vec<SourceXorbMeta> = Vec::new();
-    let estimate = planner::estimate(profile_name, profile, &sources, &cal, true);
+    let prefix = ObjectPath::from(".crab/xorbs/");
+    let objects = store.list_prefix(&prefix).await?;
+    let mut sources = Vec::with_capacity(objects.len());
+
+    for object in objects {
+        if cancel.is_cancelled() {
+            return Err(CrabError::Cancelled);
+        }
+
+        let key = object.location.to_string();
+        let hash = key
+            .strip_prefix(".crab/xorbs/")
+            .ok_or_else(|| CrabError::Configuration {
+                key: format!("remote xorb key {key}"),
+                origin: "xorb listing returned an object outside .crab/xorbs/".to_string(),
+            })?;
+        if hash.is_empty() || hash.contains('/') {
+            return Err(CrabError::Configuration {
+                key: format!("remote xorb key {key}"),
+                origin: "expected one content hash directly below .crab/xorbs/".to_string(),
+            });
+        }
+
+        let head = head_with_class(store, &object.location).await?;
+        sources.push(SourceXorbMeta {
+            hash: hash.to_string(),
+            size_bytes: object.size,
+            storage_class: head.class.to_string(),
+            is_archive: head.class.is_archive_class(),
+        });
+    }
+
+    sources.sort_unstable_by(|left, right| left.hash.cmp(&right.hash));
+    Ok(sources)
+}
+
+/// Execute a dry-run estimation.
+fn run_dry_run(
+    profile_name: &str,
+    profile: &Profile,
+    sources: &[SourceXorbMeta],
+    include_cold: bool,
+    output_mode: OutputMode,
+) {
+    let cal = CalibrationConfig::default();
+    let estimate = planner::estimate(profile_name, profile, sources, &cal, include_cold);
 
     match output_mode {
         OutputMode::Json => {
@@ -358,54 +438,78 @@ fn run_abort(journal_path: &Path, output_mode: OutputMode) -> Result<()> {
 /// Execute or resume a xorb optimization run.
 async fn run_apply(
     args: &RestripeArgs,
-    profile_name: &str,
-    profile: &Profile,
     journal_path: &Path,
     output_mode: OutputMode,
     cfg: &Config,
+    cancel: &CancellationToken,
 ) -> Result<()> {
     let start = Instant::now();
 
+    // Destination xorbs are not useful until the file-index and shard
+    // manifest are updated atomically. Refuse the mutating path rather than
+    // leaving readers pointed at the pre-restripe metadata.
+    reconcile::ensure_apply_supported()?;
+
     // Check for concurrent GC.
-    let crab_dir = PathBuf::from(".crab");
-    executor::check_gc_not_running(&crab_dir)?;
+    let crab_dir = journal_path
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| CrabError::Configuration {
+            key: "restripe journal".to_string(),
+            origin: "journal path has no .crab parent".to_string(),
+        })?;
+    executor::check_gc_not_running(crab_dir)?;
 
     // Open journal (acquires exclusive lock).
     let journal = RestripeJournal::open(journal_path)?;
 
-    // Check for existing run.
-    let run_id = if args.resume {
-        match journal.active_run()? {
-            Some(run) => {
-                info!(run_id = %run.run_id, "resuming xorb optimization run");
-                run.run_id
-            }
-            None => {
-                return Err(CrabError::Configuration {
+    let recorded_run = if args.resume {
+        Some(
+            journal
+                .active_run()?
+                .ok_or_else(|| CrabError::Configuration {
                     key: "--resume".to_string(),
                     origin: "no active xorb optimization run to resume".to_string(),
-                });
-            }
-        }
+                })?,
+        )
     } else {
-        // Start a new run.
-        let run_id = uuid::Uuid::now_v7().to_string();
-        let profile_json = profile.to_json();
-        journal.start_run(&run_id, &profile_json)?;
-        info!(run_id = %run_id, profile = %profile_name, "started new xorb optimization run");
-        run_id
+        None
     };
 
-    // Set up cancellation for graceful SIGINT/SIGTERM.
-    let cancel = tokio_util::sync::CancellationToken::new();
+    let (store, parsed) = try_build_store(cfg, cancel).await?;
+    let sources = if recorded_run.is_none() {
+        enumerate_sources(&store, cancel).await?
+    } else {
+        Vec::new()
+    };
 
-    // Build the object store for xorb I/O. Falls back to journal-only
-    // mode when the remote is not configured (e.g. in tests).
-    let store_and_url = try_build_store(cfg, &cancel).await;
-    let store = store_and_url.as_ref().map(|(store, _)| store.clone());
-    if store.is_none() {
-        info!("no remote configured; running in journal-only mode");
-    }
+    let (run_id, profile_name, profile) = if let Some(run) = recorded_run {
+        let recorded_profile = Profile::from_json(&run.profile)?;
+        let profile_name = if let Some(name) = args.profile.as_deref() {
+            let requested = Profile::from_name(name, &cfg.restripe)?;
+            if requested != recorded_profile {
+                return Err(CrabError::Configuration {
+                    key: "--profile".to_string(),
+                    origin: "resume profile does not match the profile recorded in the journal"
+                        .to_string(),
+                });
+            }
+            name.to_string()
+        } else {
+            profile_label(&recorded_profile)
+        };
+        info!(run_id = %run.run_id, profile = %profile_name, "resuming xorb optimization run");
+        (run.run_id, profile_name, recorded_profile)
+    } else {
+        let (profile_name, profile) = resolve_profile(args, cfg, Some(&sources))?;
+        let run_id = uuid::Uuid::now_v7().to_string();
+        journal.start_run(&run_id, &profile.to_json())?;
+        for source in &sources {
+            journal.insert_source(&run_id, &source.hash)?;
+        }
+        info!(run_id = %run_id, profile = %profile_name, sources = sources.len(), "started new xorb optimization run");
+        (run_id, profile_name, profile)
+    };
 
     // Execute the pipeline.
     let exec_cfg = ExecutorConfig {
@@ -433,23 +537,19 @@ async fn run_apply(
     );
 
     let restore_orchestrator = if args.include_cold && cfg.tier.enabled {
-        if let Some((_, parsed)) = &store_and_url {
-            let mut options = crate::tier::runtime::restore_options_from_config(cfg)?;
-            if let Some(tier) = &args.restore_tier {
-                options.tier = crate::tier::runtime::parse_restore_tier(tier)?;
-            }
-            let backend = crate::tier::runtime::build_restore_backend(cfg, parsed).await?;
-            Some(Arc::new(
-                crate::tier::restore::RestoreOrchestrator::with_options(
-                    backend,
-                    cfg.tier.restore_max_concurrency,
-                    Duration::from_secs(cfg.tier.restore_timeout_secs),
-                    options,
-                ),
-            ))
-        } else {
-            None
+        let mut options = crate::tier::runtime::restore_options_from_config(cfg)?;
+        if let Some(tier) = &args.restore_tier {
+            options.tier = crate::tier::runtime::parse_restore_tier(tier)?;
         }
+        let backend = crate::tier::runtime::build_restore_backend(cfg, &parsed).await?;
+        Some(Arc::new(
+            crate::tier::restore::RestoreOrchestrator::with_options(
+                backend,
+                cfg.tier.restore_max_concurrency,
+                Duration::from_secs(cfg.tier.restore_timeout_secs),
+                options,
+            ),
+        ))
     } else {
         None
     };
@@ -457,16 +557,27 @@ async fn run_apply(
     let outcome = executor::execute(
         &journal,
         &run_id,
-        profile,
+        &profile,
         &exec_cfg,
-        &cancel,
-        store.as_ref(),
+        cancel,
+        Some(&store),
         restore_orchestrator.as_deref(),
     )
     .await?;
 
     // Reconcile.
-    let reconcile_outcome = reconcile::finalize(&journal, &run_id, store.as_ref()).await?;
+    let reconcile_outcome = reconcile::finalize(&journal, &run_id, Some(&store))?;
+
+    let counts = journal.count_by_status(&run_id)?;
+    if counts.pending > 0 || counts.staged > 0 {
+        return Err(CrabError::Configuration {
+            key: "restripe run pending sources".to_string(),
+            origin: format!(
+                "{} source(s) remain incomplete; rerun with --resume",
+                counts.pending + counts.staged
+            ),
+        });
+    }
 
     // Complete the run.
     journal.complete_run(&run_id)?;
@@ -489,12 +600,12 @@ async fn run_apply(
     // Emit summary.
     let summary = RestripeSummary {
         run_id: run_id.clone(),
-        profile: profile_name.to_string(),
+        profile: profile_name.clone(),
         counts: RestripeCounts {
-            done: outcome.sources_done,
-            corrupt: outcome.sources_corrupt,
-            skipped: outcome.sources_skipped,
-            pending: 0,
+            done: counts.done,
+            corrupt: counts.corrupt,
+            skipped: counts.skipped,
+            pending: counts.pending + counts.staged,
         },
         bytes_read: outcome.bytes_read,
         bytes_written: outcome.bytes_written,
@@ -532,4 +643,16 @@ async fn run_apply(
     }
 
     Ok(())
+}
+
+fn profile_label(profile: &Profile) -> String {
+    if *profile == Profile::ml() {
+        "ml".to_string()
+    } else if *profile == Profile::dataset() {
+        "dataset".to_string()
+    } else if *profile == Profile::code() {
+        "code".to_string()
+    } else {
+        "recorded".to_string()
+    }
 }

--- a/crab/src/cost/engine.rs
+++ b/crab/src/cost/engine.rs
@@ -1,0 +1,357 @@
+//! Runtime cost-report pipeline.
+//!
+//! This module owns the read-only path from a configured Crab store to a
+//! priced report. CLI modules only resolve the remote and render the result.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use rust_decimal::Decimal;
+use tokio_util::sync::CancellationToken;
+
+use crate::core::config::Config;
+use crate::core::error::{CrabError, Result};
+use crate::storage::Store;
+use crate::tier::provider::Provider;
+use crate::tier::runtime;
+
+use super::inventory::live::{self, LiveWalkConfig};
+use super::inventory::{self, InventorySource};
+use super::pricing::embedded::PRICE_TABLE_VERSION;
+use super::pricing::override_file::{self, ResolvedTable};
+use super::recommendations::{RuleContext, RuleSet};
+use super::report::{self, ClassCost, CostReport};
+
+const BYTES_PER_GIB: u64 = 1_073_741_824;
+const DEFAULT_TOP_K_COLD: usize = 100;
+const MAX_LIST_CONCURRENCY: u32 = 128;
+
+/// CLI overrides for a cost report.
+#[derive(Debug, Clone, Default)]
+pub struct ReportOptions {
+    /// Optional pricing override path.
+    pub pricing_file: Option<String>,
+    /// Optional inventory source selector.
+    pub inventory_source: Option<String>,
+    /// Optional deterministic live-walk sample ratio.
+    pub sample_ratio: Option<f64>,
+    /// Optional number of cold objects to retain in the report.
+    pub top_k: Option<usize>,
+}
+
+/// Collect and price a live inventory for the configured Crab store.
+pub async fn build_report(
+    config: &Config,
+    store: &Store,
+    options: &ReportOptions,
+    cancel: &CancellationToken,
+) -> Result<CostReport> {
+    check_cancelled(cancel)?;
+
+    let requested_source = options
+        .inventory_source
+        .as_deref()
+        .unwrap_or(&config.cost.inventory_source)
+        .parse::<InventorySource>()
+        .map_err(|error| CrabError::Configuration {
+            key: "cost.inventory_source".to_string(),
+            origin: error.to_string(),
+        })?;
+    let source = inventory::resolve_source(
+        &requested_source,
+        false,
+        None,
+        config.cost.report_max_staleness_hours,
+    );
+    if source == InventorySource::Report {
+        return Err(CrabError::Configuration {
+            key: "cost.inventory_source=report".to_string(),
+            origin:
+                "provider inventory report discovery is not configured; use --inventory-source live"
+                    .to_string(),
+        });
+    }
+
+    let list_concurrency = config.cost.list_concurrency;
+    if !(1..=MAX_LIST_CONCURRENCY).contains(&list_concurrency) {
+        return Err(CrabError::Configuration {
+            key: format!("cost.list_concurrency={list_concurrency}"),
+            origin: format!("expected a value from 1 through {MAX_LIST_CONCURRENCY}"),
+        });
+    }
+
+    let sample_ratio = options.sample_ratio.unwrap_or(config.cost.sample_ratio);
+    validate_sample_ratio(sample_ratio)?;
+    if config.cost.apply_free_tier {
+        return Err(CrabError::Configuration {
+            key: "cost.apply_free_tier".to_string(),
+            origin: "free-tier modeling has no account-age or billing-account contract; unset it for a list-price report".to_string(),
+        });
+    }
+
+    let pricing_path = options
+        .pricing_file
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+        .or_else(|| {
+            (!config.cost.pricing_file.trim().is_empty())
+                .then_some(config.cost.pricing_file.as_str())
+        })
+        .map(crab_auth::token_cache::expand_token_cache_path);
+    let price_table = override_file::load_resolved_table(pricing_path.as_deref())?;
+    validate_price_table_version(config, &price_table)?;
+
+    let provider = runtime::resolve_provider(config);
+    let inventory = live::walk_live(
+        Arc::clone(store.inner()),
+        LiveWalkConfig {
+            list_concurrency,
+            sample_ratio: (sample_ratio < 1.0).then_some(sample_ratio),
+            top_k_cold: options.top_k.unwrap_or(DEFAULT_TOP_K_COLD),
+            provider,
+        },
+        cancel,
+    )
+    .await?;
+    check_cancelled(cancel)?;
+
+    let region = pricing_region(config, provider);
+    let provider_name = provider_name(provider);
+    let (per_class_costs, current_monthly_usd) =
+        price_inventory(&inventory, &price_table, provider_name, &region)?;
+
+    let applied_rules = Vec::new();
+    let recommendations = RuleSet::builtin().run(&RuleContext {
+        inventory: &inventory,
+        price_table: &price_table,
+        provider: provider_name.to_string(),
+        region,
+        applied_rules: &applied_rules,
+    });
+
+    let mut report = report::build_report(
+        &inventory,
+        &price_table.embedded_version,
+        price_table.override_version.as_deref(),
+        per_class_costs,
+        current_monthly_usd,
+        current_monthly_usd,
+        recommendations,
+    );
+    report.assumptions.extend([
+        "Live inventory infers each provider's standard storage class because object_store list metadata does not expose storage class consistently; retrieval charges are omitted without access telemetry.".to_string(),
+        "Projected cost equals current cost until age/access data is available to model tier transitions.".to_string(),
+    ]);
+    if sample_ratio < 1.0 {
+        report.assumptions.push(format!(
+            "Inventory is a deterministic {sample_ratio:.4} sample; object and byte totals are scaled estimates."
+        ));
+    }
+    Ok(report)
+}
+
+fn check_cancelled(cancel: &CancellationToken) -> Result<()> {
+    if cancel.is_cancelled() {
+        Err(CrabError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_sample_ratio(ratio: f64) -> Result<()> {
+    if !(ratio.is_finite() && 0.0 < ratio && ratio <= 1.0) {
+        return Err(CrabError::Configuration {
+            key: format!("cost.sample_ratio={ratio}"),
+            origin: "expected a finite value greater than 0 and no greater than 1".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_price_table_version(config: &Config, table: &ResolvedTable) -> Result<()> {
+    if !config.cost.price_table_version.is_empty()
+        && config.cost.price_table_version != PRICE_TABLE_VERSION
+    {
+        return Err(CrabError::Configuration {
+            key: format!(
+                "cost.price_table_version={}",
+                config.cost.price_table_version
+            ),
+            origin: format!(
+                "this binary embeds price table {PRICE_TABLE_VERSION}; rebuild Crab to select another table"
+            ),
+        });
+    }
+    if table.embedded_version != PRICE_TABLE_VERSION {
+        return Err(CrabError::Internal(format!(
+            "resolved price table version {} does not match embedded version {PRICE_TABLE_VERSION}",
+            table.embedded_version
+        )));
+    }
+    Ok(())
+}
+
+fn price_inventory(
+    inventory: &super::inventory::Inventory,
+    table: &ResolvedTable,
+    provider: &str,
+    region: &str,
+) -> Result<(BTreeMap<String, ClassCost>, Decimal)> {
+    let mut per_class = BTreeMap::new();
+    let mut current_monthly_usd = Decimal::ZERO;
+
+    for (display_class, stats) in &inventory.per_class {
+        let pricing_class =
+            pricing_class(provider, display_class).ok_or_else(|| CrabError::Configuration {
+                key: format!("storage class {display_class}"),
+                origin: format!("no {provider} price exists for this live inventory class"),
+            })?;
+        let schedule = table
+            .lookup(provider, region, pricing_class)
+            .ok_or_else(|| CrabError::Configuration {
+                key: format!("pricing {provider}/{region}/{pricing_class}"),
+                origin: "price table has no matching storage class".to_string(),
+            })?;
+
+        let storage_gib = Decimal::from(stats.bytes) / Decimal::from(BYTES_PER_GIB);
+        let monthly_storage_usd = storage_gib * schedule.gb_month_usd;
+        let monthly_retrieval_usd = Decimal::ZERO;
+        let monthly_total_usd = monthly_storage_usd + monthly_retrieval_usd;
+        current_monthly_usd += monthly_total_usd;
+
+        let share_pct = if inventory.total_bytes == 0 {
+            Decimal::ZERO
+        } else {
+            Decimal::from(stats.bytes) * Decimal::from(100u64)
+                / Decimal::from(inventory.total_bytes)
+        };
+        per_class.insert(
+            display_class.clone(),
+            ClassCost {
+                objects: stats.objects,
+                bytes: stats.bytes,
+                bytes_human: report::format_bytes_iec(stats.bytes),
+                share_pct,
+                monthly_storage_usd,
+                monthly_retrieval_usd,
+                monthly_total_usd,
+            },
+        );
+    }
+
+    Ok((per_class, current_monthly_usd))
+}
+
+fn provider_name(provider: Provider) -> &'static str {
+    match provider {
+        Provider::S3 => "aws",
+        Provider::Gcs => "gcs",
+        Provider::Azure => "azure",
+    }
+}
+
+fn pricing_region(config: &Config, provider: Provider) -> String {
+    match provider {
+        Provider::S3 => config
+            .remote_region
+            .clone()
+            .or_else(|| config.auth.aws.region.clone())
+            .or_else(|| std::env::var("AWS_REGION").ok())
+            .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
+            .unwrap_or_else(|| "us-east-1".to_string()),
+        Provider::Gcs => std::env::var("GOOGLE_CLOUD_REGION")
+            .ok()
+            .filter(|region| !region.is_empty())
+            .unwrap_or_else(|| "us-central1".to_string()),
+        Provider::Azure => std::env::var("AZURE_REGION")
+            .ok()
+            .filter(|region| !region.is_empty())
+            .unwrap_or_else(|| "eastus".to_string()),
+    }
+}
+
+fn pricing_class(provider: &str, display_class: &str) -> Option<&'static str> {
+    match provider {
+        "aws" => match display_class {
+            "S3 Standard" => Some("Standard"),
+            "S3 Standard-IA" => Some("Standard-IA"),
+            "S3 One Zone-IA" => Some("One-Zone-IA"),
+            "S3 Glacier Instant Retrieval" => Some("Glacier-Instant-Retrieval"),
+            "S3 Glacier Flexible Retrieval" => Some("Glacier-Flexible-Retrieval"),
+            "S3 Glacier Deep Archive" => Some("Glacier-Deep-Archive"),
+            _ => None,
+        },
+        "gcs" => match display_class {
+            "GCS Standard" => Some("Standard"),
+            "GCS Nearline" => Some("Nearline"),
+            "GCS Coldline" => Some("Coldline"),
+            "GCS Archive" => Some("Archive"),
+            _ => None,
+        },
+        "azure" => match display_class {
+            "Azure Hot" => Some("Hot"),
+            "Azure Cool" => Some("Cool"),
+            "Azure Cold" => Some("Cold"),
+            "Azure Archive" => Some("Archive"),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::cost::inventory::{ClassStats, InventorySourceInfo};
+
+    #[test]
+    fn pricing_classes_match_embedded_names() {
+        assert_eq!(pricing_class("aws", "S3 Standard"), Some("Standard"));
+        assert_eq!(
+            pricing_class("aws", "S3 Glacier Deep Archive"),
+            Some("Glacier-Deep-Archive")
+        );
+        assert_eq!(pricing_class("gcs", "GCS Nearline"), Some("Nearline"));
+        assert_eq!(pricing_class("azure", "Azure Hot"), Some("Hot"));
+    }
+
+    #[test]
+    fn sample_ratio_must_be_positive_and_bounded() {
+        assert!(validate_sample_ratio(0.0).is_err());
+        assert!(validate_sample_ratio(f64::NAN).is_err());
+        assert!(validate_sample_ratio(1.0).is_ok());
+        assert!(validate_sample_ratio(0.25).is_ok());
+        assert!(validate_sample_ratio(1.01).is_err());
+    }
+
+    #[test]
+    fn prices_live_standard_inventory_from_embedded_table() {
+        let inventory = super::super::inventory::Inventory {
+            source: InventorySourceInfo::Live {
+                list_concurrency: 1,
+                sample_ratio: None,
+            },
+            scanned_at: "2026-01-01T00:00:00Z".to_owned(),
+            total_objects: 1,
+            total_bytes: BYTES_PER_GIB,
+            per_class: BTreeMap::from([(
+                "S3 Standard".to_owned(),
+                ClassStats {
+                    objects: 1,
+                    bytes: BYTES_PER_GIB,
+                },
+            )]),
+            per_prefix: BTreeMap::new(),
+            heaviest_cold: Vec::new(),
+        };
+        let table = override_file::load_resolved_table(None).unwrap();
+
+        let (costs, total) = price_inventory(&inventory, &table, "aws", "us-east-1").unwrap();
+
+        assert_eq!(total, Decimal::from_str("0.023").unwrap());
+        assert_eq!(costs["S3 Standard"].monthly_total_usd, total);
+    }
+}

--- a/crab/src/cost/inventory/live.rs
+++ b/crab/src/cost/inventory/live.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 use object_store::ObjectStore;
 use object_store::path::Path as ObjectPath;
 use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
 use super::{
@@ -100,6 +101,7 @@ async fn walk_prefix(
     prefix: &str,
     config: &LiveWalkConfig,
     progress: &WalkProgress,
+    cancel: &CancellationToken,
 ) -> Result<PrefixWalkResult> {
     use futures_util::StreamExt;
 
@@ -108,12 +110,19 @@ async fn walk_prefix(
 
     let mut stream = store.list(Some(&obj_prefix));
 
-    while let Some(meta_result) = stream.next().await {
+    loop {
+        let Some(meta_result) = (tokio::select! {
+            () = cancel.cancelled() => return Err(crate::core::error::CrabError::Cancelled),
+            next = stream.next() => next,
+        }) else {
+            break;
+        };
+
         let meta = match meta_result {
             Ok(m) => m,
             Err(e) => {
-                debug!(prefix, error = %e, "skipping object due to list error");
-                continue;
+                debug!(prefix, error = %e, "live inventory list failed");
+                return Err(crate::core::error::CrabError::Storage(e));
             }
         };
 
@@ -207,7 +216,11 @@ fn infer_default_class(provider: Provider) -> StorageClass {
 /// Uses `Semaphore`-gated concurrency to bound the number of
 /// simultaneous LIST requests. Returns a complete `Inventory` with
 /// per-class and per-prefix breakdowns.
-pub async fn walk_live(store: Arc<dyn ObjectStore>, config: LiveWalkConfig) -> Result<Inventory> {
+pub async fn walk_live(
+    store: Arc<dyn ObjectStore>,
+    config: LiveWalkConfig,
+    cancel: &CancellationToken,
+) -> Result<Inventory> {
     let semaphore = Arc::new(Semaphore::new(config.list_concurrency as usize));
     let progress = Arc::new(WalkProgress::new());
     let config = Arc::new(config);
@@ -225,10 +238,11 @@ pub async fn walk_live(store: Arc<dyn ObjectStore>, config: LiveWalkConfig) -> R
         let sem = Arc::clone(&semaphore);
         let prog = Arc::clone(&progress);
         let cfg = Arc::clone(&config);
+        let cancel = cancel.clone();
 
         let handle = tokio::spawn(async move {
             let _permit = sem.acquire().await;
-            walk_prefix(store.as_ref(), prefix, &cfg, &prog).await
+            walk_prefix(store.as_ref(), prefix, &cfg, &prog, &cancel).await
         });
 
         handles.push((prefix.to_string(), handle));
@@ -269,13 +283,22 @@ pub async fn walk_live(store: Arc<dyn ObjectStore>, config: LiveWalkConfig) -> R
         }
     }
 
-    // Apply sample ratio scaling if sampling was used.
+    // Apply sample-ratio scaling to every aggregate, not only the totals.
+    // Per-class costs and prefix shares must describe the same estimated
+    // population as the headline totals.
     let (adjusted_objects, adjusted_bytes) = if let Some(ratio) = config.sample_ratio {
         if ratio > 0.0 && ratio < 1.0 {
-            let scale = 1.0 / ratio;
+            for stats in per_class.values_mut() {
+                stats.objects = scale_sample_value(stats.objects, ratio);
+                stats.bytes = scale_sample_value(stats.bytes, ratio);
+            }
+            for stats in per_prefix.values_mut() {
+                stats.objects = scale_sample_value(stats.objects, ratio);
+                stats.bytes = scale_sample_value(stats.bytes, ratio);
+            }
             (
-                (total_objects as f64 * scale) as u64,
-                (total_bytes as f64 * scale) as u64,
+                scale_sample_value(total_objects, ratio),
+                scale_sample_value(total_bytes, ratio),
             )
         } else {
             (total_objects, total_bytes)
@@ -307,6 +330,10 @@ pub async fn walk_live(store: Arc<dyn ObjectStore>, config: LiveWalkConfig) -> R
         per_prefix,
         heaviest_cold: all_heaviest_cold,
     })
+}
+
+fn scale_sample_value(value: u64, ratio: f64) -> u64 {
+    ((value as f64) / ratio).round() as u64
 }
 
 /// Returns the current UTC time as an RFC 3339 string.
@@ -412,6 +439,12 @@ mod tests {
             StorageClass::GcsStandard
         );
         assert_eq!(infer_default_class(Provider::Azure), StorageClass::AzureHot);
+    }
+
+    #[test]
+    fn sample_scaling_rounds_aggregate_values() {
+        assert_eq!(scale_sample_value(25, 0.25), 100);
+        assert_eq!(scale_sample_value(1, 0.3), 3);
     }
 
     #[test]

--- a/crab/src/cost/mod.rs
+++ b/crab/src/cost/mod.rs
@@ -14,6 +14,7 @@
 //! - `recommendations` — rule engine and built-in rules.
 //! - `report` — human (`comfy-table`) and JSON formatters.
 
+pub mod engine;
 pub mod inventory;
 pub mod pricing;
 pub mod recommendations;

--- a/crab/src/cost/pricing/override_file.rs
+++ b/crab/src/cost/pricing/override_file.rs
@@ -16,6 +16,7 @@
 
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::str::FromStr;
 
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -259,6 +260,97 @@ pub fn from_embedded_only(
         override_version: None,
         entries: map,
     }
+}
+
+/// Load the generated price table and optionally apply a user override.
+pub fn load_resolved_table(path: Option<&Path>) -> Result<ResolvedTable> {
+    let mut entries = Vec::new();
+
+    for entry in super::embedded::embedded_price_table() {
+        let schedule = &entry.schedule;
+        entries.push((
+            entry.provider.to_string(),
+            entry.region.to_string(),
+            entry.class.to_string(),
+            ResolvedPriceSchedule {
+                gb_month_usd: parse_embedded_decimal(
+                    entry.provider,
+                    entry.region,
+                    entry.class,
+                    "gb_month_usd",
+                    schedule.gb_month_usd,
+                )?,
+                put_per_k_ops_usd: parse_embedded_decimal(
+                    entry.provider,
+                    entry.region,
+                    entry.class,
+                    "put_per_k_ops_usd",
+                    schedule.put_per_k_ops_usd,
+                )?,
+                get_per_k_ops_usd: parse_embedded_decimal(
+                    entry.provider,
+                    entry.region,
+                    entry.class,
+                    "get_per_k_ops_usd",
+                    schedule.get_per_k_ops_usd,
+                )?,
+                list_per_k_ops_usd: parse_embedded_decimal(
+                    entry.provider,
+                    entry.region,
+                    entry.class,
+                    "list_per_k_ops_usd",
+                    schedule.list_per_k_ops_usd,
+                )?,
+                head_per_k_ops_usd: parse_embedded_decimal(
+                    entry.provider,
+                    entry.region,
+                    entry.class,
+                    "head_per_k_ops_usd",
+                    schedule.head_per_k_ops_usd,
+                )?,
+                retrieval_per_gb_usd: parse_embedded_decimal(
+                    entry.provider,
+                    entry.region,
+                    entry.class,
+                    "retrieval_per_gb_usd",
+                    schedule.retrieval_per_gb_usd,
+                )?,
+                min_retention_days: schedule.min_retention_days,
+                min_object_size_bytes: schedule.min_object_size_bytes,
+                egress_per_gb_usd: parse_embedded_decimal(
+                    entry.provider,
+                    entry.region,
+                    entry.class,
+                    "egress_per_gb_usd",
+                    schedule.egress_per_gb_usd,
+                )?,
+            },
+        ));
+    }
+
+    let mut table = match path {
+        Some(path) => {
+            let override_file = load_override(path)?;
+            merge_tables(&entries, &override_file)
+        }
+        None => from_embedded_only(&entries, super::embedded::PRICE_TABLE_VERSION),
+    };
+    table.embedded_version = super::embedded::PRICE_TABLE_VERSION.to_string();
+    Ok(table)
+}
+
+fn parse_embedded_decimal(
+    provider: &str,
+    region: &str,
+    class: &str,
+    field: &str,
+    value: &str,
+) -> Result<Decimal> {
+    Decimal::from_str(value).map_err(|error| {
+        CrabError::Internal(format!(
+            "invalid embedded price {provider}/{region}/{class}.{field}: {error}"
+        ))
+    })
 }
 
 #[cfg(test)]

--- a/crab/src/cost/report.rs
+++ b/crab/src/cost/report.rs
@@ -281,8 +281,8 @@ pub fn build_report(
         heaviest_cold,
         assumptions: vec![
             "Pricing based on list prices; negotiated discounts not modeled.".to_string(),
-            "Retrieval costs estimated from current access patterns.".to_string(),
-            "Free-tier not applied unless cost.apply_free_tier = true.".to_string(),
+            "Retrieval costs require access telemetry and are not included in a live inventory report.".to_string(),
+            "Free-tier modeling is not included because account age and billing scope are not part of the Crab configuration contract.".to_string(),
         ],
     }
 }

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -3416,13 +3416,17 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
             .entered();
             let mode = OutputMode::from_flags(json, false);
             if cost {
+                let config = Config::resolve_local()?;
                 crab::cmd::doctor::run_cost_report(
                     mode,
                     pricing_file,
                     inventory_source,
                     sample,
                     top_k,
-                )?;
+                    &config,
+                    &cancel,
+                )
+                .await?;
             } else if metadb {
                 crab::cmd::doctor::run_doctor_metadb(mode).await?;
             } else if support_bundle {
@@ -4967,16 +4971,13 @@ async fn run_optimize_command(
         OptimizeCmd::Plan(args) => {
             let _span = tracing::info_span!("optimize_plan").entered();
             let mode = OutputMode::from_flags(args.json, false);
-            let config = Config::resolve_local().unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "failed to load config for optimize plan, using defaults");
-                Config::default()
-            });
+            let config = Config::resolve_local()?;
             crab::cmd::optimize::run_plan(&args, &config, mode);
             Ok(ExitCode::SUCCESS)
         }
         OptimizeCmd::Apply(args) => {
             let _span = tracing::info_span!("optimize_apply").entered();
-            run_optimize_apply(args)
+            run_optimize_apply(args, cancel).await
         }
         OptimizeCmd::Xorbs(args) => {
             let _span = tracing::info_span!("optimize_xorbs").entered();
@@ -4988,7 +4989,7 @@ async fn run_optimize_command(
             );
 
             let config = Config::resolve_local()?;
-            crab::cmd::restripe::run_restripe(&args, &config).await?;
+            crab::cmd::restripe::run_restripe(&args, &config, cancel).await?;
             Ok(ExitCode::SUCCESS)
         }
         OptimizeCmd::Packs {
@@ -5183,61 +5184,94 @@ async fn run_optimize_command(
         OptimizeCmd::Repo(args) => {
             let _span = tracing::info_span!("optimize_repo").entered();
             let mode = OutputMode::from_flags(args.json, false);
+            let config = Config::resolve_local()?;
             crab::cmd::doctor::run_cost_report(
                 mode,
                 args.pricing_file,
                 args.inventory_source,
                 args.sample,
                 args.top_k,
-            )?;
+                &config,
+                cancel,
+            )
+            .await?;
             Ok(ExitCode::SUCCESS)
         }
     }
 }
 
-fn run_optimize_apply(args: crab::cmd::optimize::OptimizeApplyArgs) -> Result<ExitCode> {
+async fn run_optimize_apply(
+    args: crab::cmd::optimize::OptimizeApplyArgs,
+    cancel: &CancellationToken,
+) -> Result<ExitCode> {
     let mode = OutputMode::from_flags(args.json, false);
     let config = Config::resolve_local()?;
     let mut payload = crab::cmd::optimize::build_apply_payload(&args, &config);
 
-    for step in &mut payload.steps {
-        if !mode.is_machine() && step.status != crab::cmd::optimize::OptimizeStepStatus::Skipped {
-            eprintln!("optimize: running {}", step.title);
+    for index in 0..payload.steps.len() {
+        if cancel.is_cancelled() {
+            let step = &mut payload.steps[index];
+            step.status = crab::cmd::optimize::OptimizeStepStatus::Failed;
+            "cancelled".clone_into(&mut step.detail);
+            crab::cmd::optimize::refresh_summary(&mut payload);
+            crab::cmd::optimize::render_apply(&payload, mode);
+            return Ok(ExitCode::FAILURE);
         }
-
-        match step.kind {
-            crab::cmd::optimize::OptimizeStepKind::CostReport => {
-                let cmd = crab::cmd::optimize::cost_command_args(&args);
-                crab::cmd::optimize::run_child_step(step, mode, &cmd)?;
+        let result = {
+            let step = &mut payload.steps[index];
+            if !mode.is_machine() && step.status != crab::cmd::optimize::OptimizeStepStatus::Skipped
+            {
+                eprintln!("optimize: running {}", step.title);
             }
-            crab::cmd::optimize::OptimizeStepKind::SafetyChecks => {
-                if step.status != crab::cmd::optimize::OptimizeStepStatus::Skipped {
-                    crab::replication::ensure_active_active_maintenance_admitted(
-                        &config,
-                        "cost optimization",
-                    )?;
-                    crab::cmd::optimize::mark_succeeded(
-                        step,
-                        "active-active maintenance admission passed",
-                    );
+
+            match step.kind {
+                crab::cmd::optimize::OptimizeStepKind::CostReport => {
+                    let cmd = crab::cmd::optimize::cost_command_args(&args);
+                    crab::cmd::optimize::run_child_step(step, mode, &cmd, cancel).await
+                }
+                crab::cmd::optimize::OptimizeStepKind::SafetyChecks => {
+                    if step.status == crab::cmd::optimize::OptimizeStepStatus::Skipped {
+                        Ok(())
+                    } else {
+                        crab::replication::ensure_active_active_maintenance_admitted(
+                            &config,
+                            "cost optimization",
+                        )
+                        .map(|()| {
+                            crab::cmd::optimize::mark_succeeded(
+                                step,
+                                "active-active maintenance admission passed",
+                            );
+                        })
+                    }
+                }
+                crab::cmd::optimize::OptimizeStepKind::LifecycleTiering => {
+                    let cmd = crab::cmd::optimize::tier_apply_command_args();
+                    crab::cmd::optimize::run_child_step(step, mode, &cmd, cancel).await
+                }
+                crab::cmd::optimize::OptimizeStepKind::XorbRestripe => {
+                    let cmd = crab::cmd::optimize::xorb_apply_command_args(&args);
+                    crab::cmd::optimize::run_child_step(step, mode, &cmd, cancel).await
+                }
+                crab::cmd::optimize::OptimizeStepKind::CachePrune => {
+                    let cmd = crab::cmd::optimize::cache_prune_command_args();
+                    crab::cmd::optimize::run_child_step(step, mode, &cmd, cancel).await
+                }
+                crab::cmd::optimize::OptimizeStepKind::ReplicaPolicy => {
+                    let cmd = crab::cmd::optimize::replica_policy_command_args();
+                    crab::cmd::optimize::run_child_step(step, mode, &cmd, cancel).await
                 }
             }
-            crab::cmd::optimize::OptimizeStepKind::LifecycleTiering => {
-                let cmd = crab::cmd::optimize::tier_apply_command_args();
-                crab::cmd::optimize::run_child_step(step, mode, &cmd)?;
+        };
+        if let Err(error) = result {
+            let step = &mut payload.steps[index];
+            if step.status != crab::cmd::optimize::OptimizeStepStatus::Failed {
+                step.status = crab::cmd::optimize::OptimizeStepStatus::Failed;
+                step.detail = error.to_string();
             }
-            crab::cmd::optimize::OptimizeStepKind::XorbRestripe => {
-                let cmd = crab::cmd::optimize::xorb_apply_command_args(&args);
-                crab::cmd::optimize::run_child_step(step, mode, &cmd)?;
-            }
-            crab::cmd::optimize::OptimizeStepKind::CachePrune => {
-                let cmd = crab::cmd::optimize::cache_prune_command_args();
-                crab::cmd::optimize::run_child_step(step, mode, &cmd)?;
-            }
-            crab::cmd::optimize::OptimizeStepKind::ReplicaPolicy => {
-                let cmd = crab::cmd::optimize::replica_policy_command_args();
-                crab::cmd::optimize::run_child_step(step, mode, &cmd)?;
-            }
+            crab::cmd::optimize::refresh_summary(&mut payload);
+            crab::cmd::optimize::render_apply(&payload, mode);
+            return Ok(ExitCode::FAILURE);
         }
     }
 

--- a/crab/src/restripe/mod.rs
+++ b/crab/src/restripe/mod.rs
@@ -12,9 +12,9 @@
 //! - [`inference`] — auto-select profile from `RepoStats`.
 //! - [`planner`] — dry-run estimator (destination count, bytes,
 //!   wall-clock, API cost).
-//! - [`executor`] — streaming source-xorb → dest-xorb pipeline (stub).
+//! - [`executor`] — streaming source-xorb → dest-xorb pipeline.
 //! - [`journal`] — WAL-mode SQLite journal for crash-safe resume.
-//! - [`reconcile`] — online reconciliation with concurrent pushes (stub).
+//! - [`reconcile`] — atomic file-index and shard-manifest reconciliation.
 
 pub mod executor;
 pub mod inference;

--- a/crab/src/restripe/profile.rs
+++ b/crab/src/restripe/profile.rs
@@ -185,6 +185,29 @@ impl Profile {
     pub fn to_json(&self) -> String {
         serde_json::to_string(&ProfileJson::from(self)).unwrap_or_else(|_| "{}".to_string())
     }
+
+    /// Restore a profile recorded in a restripe journal.
+    pub fn from_json(raw: &str) -> Result<Self> {
+        let stored: ProfileJson =
+            serde_json::from_str(raw).map_err(|error| CrabError::Configuration {
+                key: "restripe journal profile".to_string(),
+                origin: format!("invalid profile JSON: {error}"),
+            })?;
+        let group_by =
+            GroupBy::from_str_value(&stored.group_by).ok_or_else(|| CrabError::Configuration {
+                key: "restripe journal profile.group_by".to_string(),
+                origin: format!("unknown grouping strategy: {}", stored.group_by),
+            })?;
+        let compression = parse_compression_str(&stored.compression, "journal")?;
+        let profile = Self {
+            target_xorb_bytes: stored.target_xorb_bytes,
+            max_xorbs_per_file: stored.max_xorbs_per_file,
+            group_by,
+            compression,
+        };
+        profile.validate_with_name("journal")?;
+        Ok(profile)
+    }
 }
 
 /// Check whether a profile name is reserved (built-in).
@@ -311,6 +334,25 @@ mod tests {
         assert_eq!(p.max_xorbs_per_file, u32::MAX);
         assert_eq!(p.group_by, GroupBy::Hash);
         assert_eq!(p.compression, CompressionConfig::Zstd { level: 9 });
+    }
+
+    #[test]
+    fn journal_profile_round_trips() {
+        let profile = Profile::dataset();
+
+        let restored = Profile::from_json(&profile.to_json()).unwrap();
+
+        assert_eq!(restored, profile);
+    }
+
+    #[test]
+    fn journal_profile_rejects_unknown_grouping() {
+        let error = Profile::from_json(
+            r#"{"target_xorb_bytes":67108864,"max_xorbs_per_file":4294967295,"group_by":"bucket","compression":"zstd:5"}"#,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("unknown grouping strategy"));
     }
 
     #[test]

--- a/crab/src/restripe/reconcile.rs
+++ b/crab/src/restripe/reconcile.rs
@@ -1,13 +1,13 @@
 //! Online reconciliation for concurrent pushes during restripe.
 //!
 //! At the end of a restripe run, [`finalize`] reads the journal's
-//! `src_xorb → dest_xorbs` mapping and builds a reconciliation shard
-//! that records the new xorb info for the destination xorbs. The shard
-//! is uploaded to `.crab/shards/` and the shard list is updated.
+//! `src_xorb → dest_xorbs` mapping and reports the work that a metadata
+//! reconciliation would need to apply.
 //!
-//! # Invariant (design B5)
+//! # Target invariant (design B5)
 //!
-//! For any file-index entry `E` present at the end of the restripe:
+//! The eventual implementation must prove that, for any file-index entry
+//! `E` present at the end of the restripe:
 //!
 //! 1. If `E` existed at `run.started_at` AND its xorbs were in the
 //!    source set, `E` now points at dest xorbs.
@@ -17,35 +17,23 @@
 //!    newly-written dest xorb or a xorb out of restripe scope).
 //!
 //! Concurrent pushes during the run produce new xorbs outside the
-//! restripe snapshot. Those xorbs' file-index entries are untouched
-//! by reconciliation. Old source xorbs become orphans and are
-//! reclaimed by a later `crab gc`.
+//! restripe snapshot. Those xorbs' file-index entries are untouched by
+//! reconciliation. Old source xorbs become orphans and are reclaimed by a
+//! later `crab gc` after the metadata commit is complete.
 //!
-//! # Shard upload
-//!
-//! When a `Store` is provided, the reconciliation builds a shard via
-//! `PushShardSession`, uploads it to `.crab/shards/{hash}`, and
-//! updates the shard list via the manifest CAS pipeline. The shard
-//! upload is content-addressed and idempotent — a CAS repeat after a
-//! transient failure is a no-op if the first attempt committed.
-//!
-//! When no `Store` is available (tests, journal-only mode), the
-//! reconciliation reports the mapping counts without uploading.
+//! A `Store` cannot be used safely yet: the file-index rewrite needs the
+//! original `MDBFileInfo` records and a manifest/file-index CAS update, not
+//! an advisory object. Apply callers therefore fail closed until that
+//! contract is implemented. Tests can pass `None` to inspect journal counts.
 
 use std::collections::HashMap;
 
-use bytes::Bytes;
-use object_store::path::Path as ObjectPath;
 use serde::Serialize;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
-use crate::core::error::Result;
+use crate::core::error::{CrabError, Result};
 use crate::restripe::journal::{RestripeJournal, SourceStatus};
 use crate::storage::store::Store;
-
-/// Maximum CAS retry attempts for shard-list update.
-#[expect(dead_code, reason = "reserved for full shard-list CAS retry loop")]
-const MAX_CAS_RETRIES: u32 = 3;
 
 // ---------------------------------------------------------------------------
 // Reconciliation outcome
@@ -98,82 +86,12 @@ fn build_mapping(
     Ok((src_to_dest, entries_updated, entries_unchanged))
 }
 
-// ---------------------------------------------------------------------------
-// Shard upload
-// ---------------------------------------------------------------------------
-
-/// Upload reconciliation shards to object storage.
-///
-/// For each destination xorb in the mapping, we need to record its
-/// existence in the shard so that the chunk index can resolve chunks
-/// to the new xorb locations. The shard is built using the same
-/// `PushShardSession` used by the push pipeline.
-///
-/// Returns `(shards_uploaded, shard_bytes, cas_first_attempt, cas_attempts)`.
-async fn upload_reconciliation_shards(
-    store: &Store,
-    src_to_dest: &HashMap<String, Vec<String>>,
-) -> Result<(u64, u64, bool, u32)> {
-    if src_to_dest.is_empty() {
-        return Ok((0, 0, true, 1));
-    }
-
-    // Build a minimal reconciliation shard that records the dest xorb
-    // hashes. The full shard with chunk-level metadata would require
-    // parsing each dest xorb — for now we upload a marker shard that
-    // the chunk index can discover during the next shard sync.
-    //
-    // The shard is content-addressed: uploading the same shard twice
-    // is a no-op (CAS put semantics).
-    let mut shards_uploaded: u64 = 0;
-    let mut shard_bytes: u64 = 0;
-
-    // Collect all unique dest xorb hashes for the reconciliation record.
-    let mut all_dest_hashes: Vec<String> = src_to_dest.values().flatten().cloned().collect();
-    all_dest_hashes.sort();
-    all_dest_hashes.dedup();
-
-    // Build a reconciliation manifest as a JSON document that records
-    // the src→dest mapping. This is uploaded alongside the shards so
-    // that `crab fsck` can verify the restripe was complete.
-    let manifest = serde_json::json!({
-        "type": "restripe_reconciliation",
-        "version": "1.0",
-        "mappings": src_to_dest.len(),
-        "dest_xorbs": all_dest_hashes.len(),
-    });
-    let manifest_bytes = serde_json::to_vec(&manifest).unwrap_or_else(|_| b"{}".to_vec());
-
-    // Upload the reconciliation record to a well-known path.
-    // This is idempotent: the content is deterministic for a given mapping.
-    let record_hash = blake3::hash(&manifest_bytes);
-    let record_path = ObjectPath::from(format!(".crab/shards/restripe-{}", record_hash.to_hex()));
-
-    match store
-        .put(&record_path, Bytes::from(manifest_bytes.clone()))
-        .await
-    {
-        Ok(()) => {
-            shards_uploaded += 1;
-            shard_bytes += manifest_bytes.len() as u64;
-            debug!(
-                path = %record_path,
-                bytes = manifest_bytes.len(),
-                "uploaded reconciliation shard"
-            );
-        }
-        Err(e) => {
-            // Non-fatal: the reconciliation record is advisory.
-            // The dest xorbs are already uploaded and the journal
-            // has the mapping — fsck can reconstruct from there.
-            warn!(
-                error = %e,
-                "failed to upload reconciliation shard; continuing"
-            );
-        }
-    }
-
-    Ok((shards_uploaded, shard_bytes, true, 1))
+/// Reject xorb apply until the file-index reconciliation contract is real.
+pub fn ensure_apply_supported() -> Result<()> {
+    Err(CrabError::Configuration {
+        key: "optimize xorbs --apply".to_string(),
+        origin: "xorb apply is unavailable until it can rewrite MDBFileInfo records and commit the file-index/shard manifest atomically; use --dry-run".to_string(),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -183,15 +101,14 @@ async fn upload_reconciliation_shards(
 /// Finalize a restripe run by reconciling the file-index.
 ///
 /// Reads the journal's completed source entries to build the
-/// `src_xorb → dest_xorbs` mapping, uploads reconciliation shards
-/// when a Store is available, and returns the outcome.
+/// `src_xorb → dest_xorbs` mapping and returns the outcome.
 ///
 /// The reconciliation is scoped to the pre-run xorb snapshot:
 /// - Entries whose xorbs were in the source set are updated.
 /// - Entries added by concurrent pushes during the run are unchanged.
 /// - Every chunk reference in the final file-index resolves to a live
 ///   xorb (dest xorb or out-of-scope xorb).
-pub async fn finalize(
+pub fn finalize(
     journal: &RestripeJournal,
     run_id: &str,
     store: Option<&Store>,
@@ -206,14 +123,15 @@ pub async fn finalize(
         "reconciliation mapping built"
     );
 
-    // Step 2: Upload reconciliation shards (when store is available).
-    let (shards_uploaded, shard_bytes, cas_first_attempt, cas_attempts) = if let Some(store) = store
-    {
-        upload_reconciliation_shards(store, &src_to_dest).await?
-    } else {
-        debug!("no store available; skipping shard upload");
-        (0, 0, true, 1)
-    };
+    if store.is_some() && !src_to_dest.is_empty() {
+        return Err(CrabError::Configuration {
+            key: "restripe reconciliation".to_string(),
+            origin: "file-index reconciliation is not implemented; refusing to publish destination xorbs that readers cannot resolve".to_string(),
+        });
+    }
+
+    debug!("no file-index write performed; reporting reconciliation counts only");
+    let (shards_uploaded, shard_bytes, cas_first_attempt, cas_attempts) = (0, 0, true, 1);
 
     info!(
         entries_updated,
@@ -274,8 +192,8 @@ mod tests {
         assert!(!is_cas_repeat_noop(&outcome));
     }
 
-    #[tokio::test]
-    async fn finalize_with_completed_sources_reports_counts() {
+    #[test]
+    fn finalize_with_completed_sources_reports_counts() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("journal.db");
         let journal = RestripeJournal::open(&path).unwrap();
@@ -305,7 +223,7 @@ mod tests {
             .update_source_status("test-reconcile", "xorb-003", SourceStatus::Skipped, None)
             .unwrap();
 
-        let outcome = finalize(&journal, "test-reconcile", None).await.unwrap();
+        let outcome = finalize(&journal, "test-reconcile", None).unwrap();
 
         assert_eq!(outcome.entries_updated, 2);
         assert_eq!(outcome.entries_unchanged, 1);
@@ -313,8 +231,8 @@ mod tests {
         assert!(outcome.cas_first_attempt);
     }
 
-    #[tokio::test]
-    async fn finalize_with_empty_dest_lists_counts_zero_updates() {
+    #[test]
+    fn finalize_with_empty_dest_lists_counts_zero_updates() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("journal.db");
         let journal = RestripeJournal::open(&path).unwrap();
@@ -325,7 +243,7 @@ mod tests {
             .update_source_status("test-empty", "xorb-aaa", SourceStatus::Done, Some("[]"))
             .unwrap();
 
-        let outcome = finalize(&journal, "test-empty", None).await.unwrap();
+        let outcome = finalize(&journal, "test-empty", None).unwrap();
 
         assert_eq!(outcome.entries_updated, 0);
         assert_eq!(outcome.entries_unchanged, 0);

--- a/crab/src/restripe/reconcile.rs
+++ b/crab/src/restripe/reconcile.rs
@@ -1,39 +1,39 @@
 //! Online reconciliation for concurrent pushes during restripe.
 //!
-//! At the end of a restripe run, [`finalize`] reads the journal's
-//! `src_xorb → dest_xorbs` mapping and reports the work that a metadata
-//! reconciliation would need to apply.
-//!
-//! # Target invariant (design B5)
-//!
-//! The eventual implementation must prove that, for any file-index entry
-//! `E` present at the end of the restripe:
-//!
-//! 1. If `E` existed at `run.started_at` AND its xorbs were in the
-//!    source set, `E` now points at dest xorbs.
-//! 2. If `E` was added during the run by a concurrent push, `E` is
-//!    byte-identical to what the push wrote.
-//! 3. Every chunk `E` references resolves to a live xorb (either a
-//!    newly-written dest xorb or a xorb out of restripe scope).
-//!
-//! Concurrent pushes during the run produce new xorbs outside the
-//! restripe snapshot. Those xorbs' file-index entries are untouched by
-//! reconciliation. Old source xorbs become orphans and are reclaimed by a
-//! later `crab gc` after the metadata commit is complete.
-//!
-//! A `Store` cannot be used safely yet: the file-index rewrite needs the
-//! original `MDBFileInfo` records and a manifest/file-index CAS update, not
-//! an advisory object. Apply callers therefore fail closed until that
-//! contract is implemented. Tests can pass `None` to inspect journal counts.
+//! A restripe writes destination xorbs before it can know which file versions
+//! are still current. This module turns the completed journal mapping into a
+//! new immutable shard snapshot, generation-pins the file-index acceleration
+//! rows to that snapshot, and then publishes the snapshot through the
+//! repository manifest CAS. The manifest CAS is the visibility boundary:
+//! readers anchored to the previous generation continue to use the old shard
+//! set, while rows written for a failed attempt are ignored by their anchor
+//! validation.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
+use std::sync::Arc;
 
+use bytes::Bytes;
 use serde::Serialize;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
+use crate::metadata::manifest;
 use crate::restripe::journal::{RestripeJournal, SourceStatus};
+use crate::storage::StoreLayout;
 use crate::storage::store::Store;
+
+use crab_staging::recipe::{ChunkingPolicyId, FileRecipe};
+use crab_xet::shard::{
+    FileDataSequenceEntry, MDBFileInfo, MDBXorbInfo, ShardReader, ShardWriter,
+    XorbChunkSequenceEntry, XorbChunkSequenceHeader,
+};
+use crab_xet::shard_parse::extract_file_recipes;
+use crab_xet::xorb::format::{MerkleHash, XorbRef};
+use crab_xet::xorb::parser::XorbParser;
+
+const MAX_CAS_ATTEMPTS: u32 = 8;
 
 // ---------------------------------------------------------------------------
 // Reconciliation outcome
@@ -73,7 +73,11 @@ fn build_mapping(
 
     for source in &done_sources {
         if let Some(ref dest_json) = source.dest_xorbs {
-            let dests: Vec<String> = serde_json::from_str(dest_json).unwrap_or_default();
+            let dests: Vec<String> =
+                serde_json::from_str(dest_json).map_err(|error| CrabError::CorruptObject {
+                    path: format!("restripe journal source {}", source.src_xorb),
+                    reason: format!("invalid destination xorb list: {error}"),
+                })?;
             if !dests.is_empty() {
                 entries_updated += 1;
                 src_to_dest.insert(source.src_xorb.clone(), dests);
@@ -86,34 +90,612 @@ fn build_mapping(
     Ok((src_to_dest, entries_updated, entries_unchanged))
 }
 
-/// Reject xorb apply until the file-index reconciliation contract is real.
-pub fn ensure_apply_supported() -> Result<()> {
-    Err(CrabError::Configuration {
-        key: "optimize xorbs --apply".to_string(),
-        origin: "xorb apply is unavailable until it can rewrite MDBFileInfo records and commit the file-index/shard manifest atomically; use --dry-run".to_string(),
+#[derive(Debug, Clone, Copy)]
+struct SourceChunk {
+    hash: MerkleHash,
+    size: u32,
+}
+
+#[derive(Debug, Clone)]
+struct SourcePlacement {
+    chunks: Vec<SourceChunk>,
+    refs: HashMap<MerkleHash, XorbRef>,
+}
+
+#[derive(Debug, Default)]
+struct LoadedMapping {
+    sources: HashMap<MerkleHash, SourcePlacement>,
+    destination_infos: HashMap<MerkleHash, Arc<MDBXorbInfo>>,
+}
+
+/// Parse a journal hash and retain the error as a corrupt-object report.
+fn parse_hash(value: &str, path: &str) -> Result<MerkleHash> {
+    MerkleHash::from_hex(value).map_err(|error| CrabError::CorruptObject {
+        path: path.to_owned(),
+        reason: format!("invalid Merkle hash {value}: {error}"),
     })
+}
+
+/// Read and validate one xorb before using its chunk metadata in a shard.
+async fn load_xorb(store: &Store, router: &StoreLayout, hash: MerkleHash) -> Result<XorbParser> {
+    let path = router.xorb_path(&hash);
+    let (bytes, _) = store.get_with_etag(&path).await?;
+    let parser = XorbParser::parse(bytes).map_err(CrabError::from)?;
+    if parser.hash() != hash {
+        return Err(CrabError::CorruptObject {
+            path: path.to_string(),
+            reason: format!("xorb content hash is {}, expected {}", parser.hash(), hash),
+        });
+    }
+    parser.verify_payload_digest().map_err(CrabError::from)?;
+    parser.verify_all_chunks().map_err(CrabError::from)?;
+    Ok(parser)
+}
+
+fn source_chunks(parser: &XorbParser, path: &str) -> Result<Vec<SourceChunk>> {
+    let mut chunks = Vec::with_capacity(parser.num_chunks() as usize);
+    for index in 0..parser.num_chunks() {
+        let chunk = parser
+            .chunk_meta(index)
+            .map_err(|error| CrabError::CorruptObject {
+                path: path.to_owned(),
+                reason: error.to_string(),
+            })?;
+        chunks.push(SourceChunk {
+            hash: chunk.hash,
+            size: chunk.uncompressed_len,
+        });
+    }
+    Ok(chunks)
+}
+
+/// Convert a parsed xorb's ordered chunk metadata to xet-core shard metadata.
+fn xorb_info(hash: MerkleHash, parser: &XorbParser, path: &str) -> Result<Arc<MDBXorbInfo>> {
+    let mut chunks = Vec::with_capacity(parser.num_chunks() as usize);
+    let mut uncompressed_offset = 0u64;
+
+    for index in 0..parser.num_chunks() {
+        let chunk = parser.chunk_meta(index).map_err(CrabError::from)?;
+        let offset = u32::try_from(uncompressed_offset).map_err(|_| CrabError::CorruptObject {
+            path: path.to_owned(),
+            reason: "uncompressed xorb offset exceeds the shard format".to_owned(),
+        })?;
+        chunks.push(XorbChunkSequenceEntry::new(
+            chunk.hash,
+            chunk.uncompressed_len,
+            offset,
+        ));
+        uncompressed_offset = uncompressed_offset
+            .checked_add(u64::from(chunk.uncompressed_len))
+            .ok_or_else(|| CrabError::CorruptObject {
+                path: path.to_owned(),
+                reason: "uncompressed xorb size overflows".to_owned(),
+            })?;
+    }
+
+    let num_entries = u32::try_from(chunks.len()).map_err(|_| CrabError::CorruptObject {
+        path: path.to_owned(),
+        reason: "xorb chunk count exceeds the shard format".to_owned(),
+    })?;
+    let num_bytes = u32::try_from(uncompressed_offset).map_err(|_| CrabError::CorruptObject {
+        path: path.to_owned(),
+        reason: "uncompressed xorb size exceeds the shard format".to_owned(),
+    })?;
+
+    Ok(Arc::new(MDBXorbInfo {
+        metadata: XorbChunkSequenceHeader::new(hash, num_entries, num_bytes),
+        chunks,
+    }))
+}
+
+/// Load source chunk sequences and the destination xorb metadata referenced by
+/// a completed journal. This is done once; immutable xorb objects do not need
+/// to be reread after a manifest CAS conflict.
+async fn load_mapping(
+    store: &Store,
+    router: &StoreLayout,
+    mapping: &HashMap<String, Vec<String>>,
+    cancel: &CancellationToken,
+) -> Result<LoadedMapping> {
+    let mut loaded = LoadedMapping::default();
+
+    for (source_text, destination_texts) in mapping {
+        check_cancelled(cancel)?;
+        let source_hash = parse_hash(source_text, "restripe journal source")?;
+        let source_path = router.xorb_path(&source_hash).to_string();
+        let source_parser = load_xorb(store, router, source_hash).await?;
+        let chunks = source_chunks(&source_parser, &source_path)?;
+        let source_hashes: HashSet<MerkleHash> = chunks.iter().map(|chunk| chunk.hash).collect();
+        let mut refs = HashMap::new();
+
+        for destination_text in destination_texts {
+            check_cancelled(cancel)?;
+            let destination_hash = parse_hash(destination_text, "restripe journal destination")?;
+            let info = if let Some(info) = loaded.destination_infos.get(&destination_hash) {
+                Arc::clone(info)
+            } else {
+                let destination_path = router.xorb_path(&destination_hash).to_string();
+                let destination_parser = load_xorb(store, router, destination_hash).await?;
+                let info = xorb_info(destination_hash, &destination_parser, &destination_path)?;
+                loaded
+                    .destination_infos
+                    .insert(destination_hash, Arc::clone(&info));
+                info
+            };
+
+            for (index, chunk) in info.chunks.iter().enumerate() {
+                if !source_hashes.contains(&chunk.chunk_hash) {
+                    return Err(CrabError::CorruptObject {
+                        path: router.xorb_path(&destination_hash).to_string(),
+                        reason: format!(
+                            "destination xorb contains chunk {} absent from source {}",
+                            chunk.chunk_hash, source_hash
+                        ),
+                    });
+                }
+                let chunk_index = u32::try_from(index).map_err(|_| CrabError::CorruptObject {
+                    path: router.xorb_path(&destination_hash).to_string(),
+                    reason: "destination chunk index exceeds the shard format".to_owned(),
+                })?;
+                let destination_ref = XorbRef {
+                    xorb_hash: destination_hash,
+                    chunk_index,
+                    uncompressed_size: chunk.unpacked_segment_bytes,
+                };
+                if let Some(previous) = refs.insert(chunk.chunk_hash, destination_ref)
+                    && previous != destination_ref
+                {
+                    return Err(CrabError::CorruptObject {
+                        path: router.xorb_path(&destination_hash).to_string(),
+                        reason: format!(
+                            "source {} maps chunk {} to multiple destination locations",
+                            source_hash, chunk.chunk_hash
+                        ),
+                    });
+                }
+            }
+        }
+
+        for chunk in &chunks {
+            let destination_ref =
+                refs.get(&chunk.hash)
+                    .ok_or_else(|| CrabError::CorruptObject {
+                        path: source_path.clone(),
+                        reason: format!("source chunk {} has no destination placement", chunk.hash),
+                    })?;
+            if destination_ref.uncompressed_size != chunk.size {
+                return Err(CrabError::CorruptObject {
+                    path: source_path.clone(),
+                    reason: format!(
+                        "chunk {} changes size from {} to {} during restripe",
+                        chunk.hash, chunk.size, destination_ref.uncompressed_size
+                    ),
+                });
+            }
+        }
+
+        loaded
+            .sources
+            .insert(source_hash, SourcePlacement { chunks, refs });
+    }
+
+    Ok(loaded)
+}
+
+// ---------------------------------------------------------------------------
+// Shard rewriting
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct FileIndexEntry {
+    file_hash: MerkleHash,
+    recipe_hash: [u8; 32],
+    shard_hash: MerkleHash,
+}
+
+#[derive(Debug)]
+struct ShardRewrite {
+    new_hash: MerkleHash,
+    bytes: Bytes,
+    file_entries: Vec<FileIndexEntry>,
+}
+
+#[derive(Debug, Default)]
+struct ReconcilePlan {
+    replacements: Vec<ShardRewrite>,
+    final_shards: Vec<MerkleHash>,
+    file_entries: Vec<FileIndexEntry>,
+}
+
+fn corrupt_shard(reason: impl Into<String>) -> CrabError {
+    CrabError::CorruptObject {
+        path: "restripe shard reconciliation".to_owned(),
+        reason: reason.into(),
+    }
+}
+
+fn append_destination_segment(
+    segments: &mut Vec<FileDataSequenceEntry>,
+    destination: XorbRef,
+) -> Result<()> {
+    let chunk_index_end = destination
+        .chunk_index
+        .checked_add(1)
+        .ok_or_else(|| corrupt_shard("destination chunk index overflows"))?;
+
+    if let Some(previous) = segments.last_mut()
+        && previous.xorb_hash == destination.xorb_hash
+        && previous.xorb_flags == 0
+        && previous.chunk_index_end == destination.chunk_index
+    {
+        previous.unpacked_segment_bytes = previous
+            .unpacked_segment_bytes
+            .checked_add(destination.uncompressed_size)
+            .ok_or_else(|| corrupt_shard("file segment byte count overflows"))?;
+        previous.chunk_index_end = chunk_index_end;
+        return Ok(());
+    }
+
+    segments.push(FileDataSequenceEntry::new(
+        destination.xorb_hash,
+        destination.uncompressed_size,
+        destination.chunk_index,
+        chunk_index_end,
+    ));
+    Ok(())
+}
+
+fn rewrite_file_info(file: &MDBFileInfo, mapping: &LoadedMapping) -> Result<(MDBFileInfo, bool)> {
+    let mut segments = Vec::new();
+
+    for segment in &file.segments {
+        let Some(source) = mapping.sources.get(&segment.xorb_hash) else {
+            segments.push(segment.clone());
+            continue;
+        };
+
+        let start = usize::try_from(segment.chunk_index_start)
+            .map_err(|_| corrupt_shard("source chunk range start cannot be represented"))?;
+        let end = usize::try_from(segment.chunk_index_end)
+            .map_err(|_| corrupt_shard("source chunk range end cannot be represented"))?;
+        let source_chunks = source
+            .chunks
+            .get(start..end)
+            .ok_or_else(|| corrupt_shard("source file segment exceeds xorb bounds"))?;
+        let source_bytes = source_chunks.iter().try_fold(0u64, |total, chunk| {
+            total
+                .checked_add(u64::from(chunk.size))
+                .ok_or_else(|| corrupt_shard("source file segment byte count overflows"))
+        })?;
+        if source_bytes != u64::from(segment.unpacked_segment_bytes) {
+            return Err(corrupt_shard(format!(
+                "source file segment covers {source_bytes} bytes, expected {}",
+                segment.unpacked_segment_bytes
+            )));
+        }
+
+        for chunk in source_chunks {
+            let destination = source.refs.get(&chunk.hash).ok_or_else(|| {
+                corrupt_shard(format!(
+                    "source chunk {} has no destination placement",
+                    chunk.hash
+                ))
+            })?;
+            append_destination_segment(&mut segments, *destination)?;
+        }
+    }
+
+    if segments == file.segments {
+        return Ok((file.clone(), false));
+    }
+
+    if file.metadata.contains_verification() {
+        return Err(CrabError::Configuration {
+            key: "restripe reconciliation".to_owned(),
+            origin: format!(
+                "cannot rewrite verification-bearing MDBFileInfo for {} without preserving its per-segment proofs",
+                file.metadata.file_hash
+            ),
+        });
+    }
+
+    let mut rewritten = file.clone();
+    rewritten.metadata.num_entries = u32::try_from(segments.len())
+        .map_err(|_| corrupt_shard("rewritten file segment count exceeds the shard format"))?;
+    rewritten.segments = segments;
+    Ok((rewritten, true))
+}
+
+fn recipe_hashes(body: &Bytes) -> Result<HashMap<MerkleHash, [u8; 32]>> {
+    let recipes = extract_file_recipes(body).map_err(CrabError::from)?;
+    recipes
+        .into_iter()
+        .map(|recipe| {
+            let file_size = recipe.chunks.iter().try_fold(0u64, |total, (_, size)| {
+                total
+                    .checked_add(*size)
+                    .ok_or_else(|| corrupt_shard("file recipe size overflows"))
+            })?;
+            let hash = FileRecipe::from_staged_chunks(
+                ChunkingPolicyId::XetGearV1_64KiB,
+                recipe.file_hash,
+                file_size,
+                &recipe.chunks,
+            )?
+            .hash();
+            Ok((recipe.file_hash, hash))
+        })
+        .collect()
+}
+
+fn rewrite_shard(
+    body: &Bytes,
+    old_hash: MerkleHash,
+    mapping: &LoadedMapping,
+) -> Result<Option<ShardRewrite>> {
+    let reader = ShardReader::from_bytes(body.clone(), old_hash);
+    let shard_data = reader.v1_data();
+    let shard_info = reader.shard_info_public().map_err(CrabError::from)?;
+    let mut cursor = Cursor::new(shard_data);
+    let files = shard_info
+        .read_all_file_info_sections(&mut cursor)
+        .map_err(|error| corrupt_shard(format!("read file-info section: {error}")))?;
+    let original_xorbs = shard_info
+        .read_all_xorb_blocks_full(&mut cursor)
+        .map_err(|error| corrupt_shard(format!("read xorb-info section: {error}")))?;
+    if files.is_empty() {
+        return Ok(None);
+    }
+
+    let recipes = recipe_hashes(body)?;
+    let original_xorbs: HashMap<MerkleHash, Arc<MDBXorbInfo>> = original_xorbs
+        .into_iter()
+        .map(|info| (info.metadata.xorb_hash, Arc::new(info)))
+        .collect();
+
+    let mut rewritten_files = Vec::with_capacity(files.len());
+    let mut files_changed = false;
+    let mut file_entries = Vec::with_capacity(files.len());
+    for file in &files {
+        let (rewritten, changed) = rewrite_file_info(file, mapping)?;
+        files_changed |= changed;
+        let recipe_hash = recipes
+            .get(&file.metadata.file_hash)
+            .copied()
+            .ok_or_else(|| {
+                corrupt_shard(format!("missing recipe for {}", file.metadata.file_hash))
+            })?;
+        file_entries.push(FileIndexEntry {
+            file_hash: file.metadata.file_hash,
+            recipe_hash,
+            shard_hash: MerkleHash::default(),
+        });
+        rewritten_files.push(rewritten);
+    }
+
+    let referenced_xorbs: HashSet<MerkleHash> = rewritten_files
+        .iter()
+        .flat_map(|file| file.segments.iter().map(|segment| segment.xorb_hash))
+        .collect();
+    let original_xorb_hashes: HashSet<MerkleHash> = original_xorbs.keys().copied().collect();
+    let needs_rewrite = files_changed || original_xorb_hashes != referenced_xorbs;
+    if !needs_rewrite {
+        return Ok(None);
+    }
+
+    let mut writer = ShardWriter::new();
+    for xorb_hash in &referenced_xorbs {
+        let info = mapping
+            .destination_infos
+            .get(xorb_hash)
+            .or_else(|| original_xorbs.get(xorb_hash))
+            .ok_or_else(|| {
+                corrupt_shard(format!(
+                    "rewritten file references xorb {} without shard metadata",
+                    xorb_hash
+                ))
+            })?;
+        writer.add_xorb(Arc::clone(info)).map_err(CrabError::from)?;
+    }
+    for file in rewritten_files {
+        writer.add_file(file).map_err(CrabError::from)?;
+    }
+    let (bytes, new_hash) = writer.finalize().map_err(CrabError::from)?;
+    for entry in &mut file_entries {
+        entry.shard_hash = new_hash;
+    }
+
+    Ok(Some(ShardRewrite {
+        new_hash,
+        bytes: Bytes::from(bytes),
+        file_entries,
+    }))
+}
+
+async fn read_shard(store: &Store, router: &StoreLayout, hash: MerkleHash) -> Result<Bytes> {
+    let path = router.shard_path(&hash);
+    let (body, _) = store.get_with_etag(&path).await?;
+    let actual_hash = crab_xet::hash::compute_data_hash(&body);
+    if actual_hash != hash {
+        return Err(CrabError::CorruptObject {
+            path: path.to_string(),
+            reason: format!("shard content hash is {actual_hash}, expected {hash}"),
+        });
+    }
+    Ok(body)
+}
+
+async fn build_plan(
+    store: &Store,
+    router: &StoreLayout,
+    shard_hashes: &[MerkleHash],
+    mapping: &LoadedMapping,
+    cancel: &CancellationToken,
+) -> Result<ReconcilePlan> {
+    let mut plan = ReconcilePlan::default();
+    let mut replacements_by_old = HashMap::new();
+    let mut seen_shards = HashSet::new();
+
+    for &shard_hash in shard_hashes {
+        if !seen_shards.insert(shard_hash) {
+            continue;
+        }
+        check_cancelled(cancel)?;
+        let body = read_shard(store, router, shard_hash).await?;
+        if let Some(rewrite) = rewrite_shard(&body, shard_hash, mapping)? {
+            replacements_by_old.insert(shard_hash, rewrite.new_hash);
+            plan.file_entries
+                .extend(rewrite.file_entries.iter().cloned());
+            plan.replacements.push(rewrite);
+        }
+    }
+
+    let mut final_seen = HashSet::new();
+    for &shard_hash in shard_hashes {
+        let replacement = replacements_by_old
+            .get(&shard_hash)
+            .copied()
+            .unwrap_or(shard_hash);
+        if final_seen.insert(replacement) {
+            plan.final_shards.push(replacement);
+        }
+    }
+
+    let mut entries_by_file = HashMap::new();
+    for entry in plan.file_entries.drain(..) {
+        if let Some((previous_recipe, _)) =
+            entries_by_file.insert(entry.file_hash, (entry.recipe_hash, entry.shard_hash))
+            && previous_recipe != entry.recipe_hash
+        {
+            return Err(corrupt_shard(format!(
+                "file {} has conflicting recipes in the canonical shard set",
+                entry.file_hash
+            )));
+        }
+    }
+    plan.file_entries = entries_by_file
+        .into_iter()
+        .map(|(file_hash, (recipe_hash, shard_hash))| FileIndexEntry {
+            file_hash,
+            recipe_hash,
+            shard_hash,
+        })
+        .collect();
+
+    Ok(plan)
+}
+
+async fn upload_replacements(
+    store: &Store,
+    router: &StoreLayout,
+    replacements: &[ShardRewrite],
+    cancel: &CancellationToken,
+) -> Result<(u64, u64)> {
+    let mut uploaded = 0;
+    let mut bytes = 0;
+    for replacement in replacements {
+        check_cancelled(cancel)?;
+        let path = router.shard_path(&replacement.new_hash);
+        store.put(&path, replacement.bytes.clone()).await?;
+        let (verified, _) = store.get_with_etag(&path).await?;
+        let actual_hash = crab_xet::hash::compute_data_hash(&verified);
+        if actual_hash != replacement.new_hash {
+            return Err(CrabError::CorruptObject {
+                path: path.to_string(),
+                reason: format!(
+                    "rewritten shard content hash is {actual_hash}, expected {}",
+                    replacement.new_hash
+                ),
+            });
+        }
+        uploaded += 1;
+        bytes += replacement.bytes.len() as u64;
+    }
+    Ok((uploaded, bytes))
+}
+
+async fn publish_file_index(
+    store: &Store,
+    router: &StoreLayout,
+    entries: &[FileIndexEntry],
+    generation: u64,
+    shard_index_hash: MerkleHash,
+) -> Result<()> {
+    let committed = entries
+        .iter()
+        .map(|entry| {
+            (
+                entry.file_hash,
+                crab_metadata::value_codec::CommittedFileRecord {
+                    recipe_hash: entry.recipe_hash,
+                    shard_hash: entry.shard_hash,
+                    committed_generation: generation,
+                    shard_index_hash,
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    let config = crab_metadata::remote_index::RemoteIndexConfig::for_repo_with_global_prefix(
+        router.repo_prefix(),
+        router.global_prefix(),
+    );
+    crab_metadata::remote_index::write_index_entries(
+        Arc::clone(store.inner()),
+        &config,
+        &committed,
+        &[],
+    )
+    .await
+    .map_err(CrabError::from)
+}
+
+fn now_iso8601() -> String {
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_else(|_| std::time::Duration::ZERO);
+    let seconds = duration.as_secs();
+    let days = seconds / 86_400;
+    let time_of_day = seconds % 86_400;
+    let hours = time_of_day / 3_600;
+    let minutes = (time_of_day % 3_600) / 60;
+    let seconds = time_of_day % 60;
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_part = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_part + 2) / 5 + 1;
+    let month = month_part + if month_part < 10 { 3 } else { 9 };
+    let year = year + u64::from(month <= 2);
+    (year, month, day)
 }
 
 // ---------------------------------------------------------------------------
 // Finalize
 // ---------------------------------------------------------------------------
 
-/// Finalize a restripe run by reconciling the file-index.
+/// Finalize a restripe run by reconciling the file-index and shard manifest.
 ///
-/// Reads the journal's completed source entries to build the
-/// `src_xorb → dest_xorbs` mapping and returns the outcome.
-///
-/// The reconciliation is scoped to the pre-run xorb snapshot:
-/// - Entries whose xorbs were in the source set are updated.
-/// - Entries added by concurrent pushes during the run are unchanged.
-/// - Every chunk reference in the final file-index resolves to a live
-///   xorb (dest xorb or out-of-scope xorb).
-pub fn finalize(
+/// Destination xorbs are immutable. For each CAS attempt this function reads
+/// the current canonical shard set, rewrites every affected `MDBFileInfo`,
+/// uploads the replacement shards and generation-pinned file-index rows, and
+/// finally advances the manifest. A concurrent push causes a bounded retry
+/// against the new manifest, so files added during the run are included.
+pub async fn finalize(
     journal: &RestripeJournal,
     run_id: &str,
     store: Option<&Store>,
+    router: Option<&StoreLayout>,
+    cancel: &CancellationToken,
 ) -> Result<ReconcileOutcome> {
-    // Step 1: Build the src → dest mapping.
     let (src_to_dest, entries_updated, entries_unchanged) = build_mapping(journal, run_id)?;
 
     debug!(
@@ -123,32 +705,150 @@ pub fn finalize(
         "reconciliation mapping built"
     );
 
-    if store.is_some() && !src_to_dest.is_empty() {
-        return Err(CrabError::Configuration {
-            key: "restripe reconciliation".to_string(),
-            origin: "file-index reconciliation is not implemented; refusing to publish destination xorbs that readers cannot resolve".to_string(),
+    let Some(store) = store else {
+        return Ok(ReconcileOutcome {
+            entries_updated,
+            entries_unchanged,
+            shards_uploaded: 0,
+            shard_bytes: 0,
+            cas_first_attempt: true,
+            cas_attempts: 1,
+        });
+    };
+    let router = router.ok_or_else(|| CrabError::Configuration {
+        key: "restripe reconciliation".to_owned(),
+        origin: "a store layout is required to publish the reconciled metadata".to_owned(),
+    })?;
+    if src_to_dest.is_empty() {
+        return Ok(ReconcileOutcome {
+            entries_updated,
+            entries_unchanged,
+            shards_uploaded: 0,
+            shard_bytes: 0,
+            cas_first_attempt: true,
+            cas_attempts: 1,
         });
     }
 
-    debug!("no file-index write performed; reporting reconciliation counts only");
-    let (shards_uploaded, shard_bytes, cas_first_attempt, cas_attempts) = (0, 0, true, 1);
+    let loaded_mapping = load_mapping(store, router, &src_to_dest, cancel).await?;
+    let mut total_uploaded = 0;
+    let mut total_bytes = 0;
 
-    info!(
-        entries_updated,
-        entries_unchanged,
-        shards_uploaded,
-        shard_bytes,
-        cas_attempts,
-        "restripe reconciliation complete"
-    );
+    for attempt in 1..=MAX_CAS_ATTEMPTS {
+        check_cancelled(cancel)?;
+        let (manifest_before, etag) = manifest::read_manifest(store, router).await?;
+        if manifest_before.shard_index_hash.is_empty() {
+            return Err(CrabError::Configuration {
+                key: "restripe reconciliation".to_owned(),
+                origin: "the repository manifest has no canonical shard index".to_owned(),
+            });
+        }
 
-    Ok(ReconcileOutcome {
-        entries_updated,
-        entries_unchanged,
-        shards_uploaded,
-        shard_bytes,
-        cas_first_attempt,
-        cas_attempts,
+        let shard_texts =
+            manifest::read_bulk_shard_list(store, router, &manifest_before.shard_index_hash)
+                .await?;
+        let shard_hashes = shard_texts
+            .iter()
+            .map(|hash| parse_hash(hash, "manifest shard index"))
+            .collect::<Result<Vec<_>>>()?;
+        let plan = build_plan(store, router, &shard_hashes, &loaded_mapping, cancel).await?;
+
+        if plan.replacements.is_empty() {
+            info!(
+                entries_updated,
+                entries_unchanged,
+                cas_attempts = attempt,
+                "restripe reconciliation found no canonical file entries using source xorbs"
+            );
+            return Ok(ReconcileOutcome {
+                entries_updated,
+                entries_unchanged,
+                shards_uploaded: total_uploaded,
+                shard_bytes: total_bytes,
+                cas_first_attempt: attempt == 1,
+                cas_attempts: attempt,
+            });
+        }
+
+        let next_generation =
+            manifest_before
+                .generation
+                .checked_add(1)
+                .ok_or_else(|| CrabError::Configuration {
+                    key: "restripe reconciliation".to_owned(),
+                    origin: "manifest generation overflow".to_owned(),
+                })?;
+        let final_shards = plan
+            .final_shards
+            .iter()
+            .map(MerkleHash::hex)
+            .collect::<Vec<_>>();
+        let (shard_index_hash_text, _, shard_index_write) =
+            manifest::compact_shard_index(next_generation, &final_shards)?;
+        manifest::upload_segmented_bulk(
+            store,
+            router,
+            &crab_metadata::manifests::BulkData {
+                shard_index: shard_index_write,
+                pack_index: crab_metadata::segmented::SegmentWrite::default(),
+            },
+        )
+        .await?;
+        let (uploaded, bytes) =
+            upload_replacements(store, router, &plan.replacements, cancel).await?;
+        total_uploaded += uploaded;
+        total_bytes += bytes;
+
+        let shard_index_hash = parse_hash(&shard_index_hash_text, "reconciled shard index")?;
+        publish_file_index(
+            store,
+            router,
+            &plan.file_entries,
+            next_generation,
+            shard_index_hash,
+        )
+        .await?;
+        check_cancelled(cancel)?;
+
+        let mut candidate = manifest_before;
+        candidate.generation = next_generation;
+        candidate.created_at = now_iso8601();
+        candidate.session_id = format!("restripe-{run_id}");
+        candidate.shard_index_hash = shard_index_hash_text;
+        candidate.seal_git_validation();
+
+        match manifest::write_manifest_cas(store, router, &candidate, &etag).await {
+            Ok(_) => {
+                info!(
+                    entries_updated,
+                    entries_unchanged,
+                    shards_uploaded = total_uploaded,
+                    shard_bytes = total_bytes,
+                    cas_attempts = attempt,
+                    "restripe reconciliation complete"
+                );
+                return Ok(ReconcileOutcome {
+                    entries_updated,
+                    entries_unchanged,
+                    shards_uploaded: total_uploaded,
+                    shard_bytes: total_bytes,
+                    cas_first_attempt: attempt == 1,
+                    cas_attempts: attempt,
+                });
+            }
+            Err(CrabError::CasConflict { .. }) if attempt < MAX_CAS_ATTEMPTS => {
+                debug!(
+                    attempt,
+                    "manifest changed during restripe reconciliation; retrying"
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(CrabError::CasConflict {
+        path: router.manifest_path().to_string(),
+        expected_etag: None,
     })
 }
 
@@ -165,6 +865,35 @@ pub fn is_cas_repeat_noop(first_outcome: &ReconcileOutcome) -> bool {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    fn hash(seed: u8) -> MerkleHash {
+        MerkleHash::from([seed; 32])
+    }
+
+    fn xorb_info(xorb_hash: MerkleHash, chunks: &[(MerkleHash, u32)]) -> Arc<MDBXorbInfo> {
+        let mut offset = 0;
+        let entries = chunks
+            .iter()
+            .map(|(chunk_hash, size)| {
+                let entry = XorbChunkSequenceEntry::new(*chunk_hash, *size, offset);
+                offset += *size;
+                entry
+            })
+            .collect::<Vec<_>>();
+        Arc::new(MDBXorbInfo {
+            metadata: XorbChunkSequenceHeader::new(xorb_hash, entries.len(), offset),
+            chunks: entries,
+        })
+    }
+
+    fn file_info(file_hash: MerkleHash, xorb_hash: MerkleHash, size: u32) -> MDBFileInfo {
+        MDBFileInfo {
+            metadata: crab_xet::shard::FileDataSequenceHeader::new(file_hash, 1, false, false),
+            segments: vec![FileDataSequenceEntry::new(xorb_hash, size, 0, 1)],
+            verification: Vec::new(),
+            metadata_ext: None,
+        }
+    }
 
     #[test]
     fn cas_repeat_noop_when_first_succeeded() {
@@ -192,8 +921,8 @@ mod tests {
         assert!(!is_cas_repeat_noop(&outcome));
     }
 
-    #[test]
-    fn finalize_with_completed_sources_reports_counts() {
+    #[tokio::test]
+    async fn finalize_without_store_reports_counts() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("journal.db");
         let journal = RestripeJournal::open(&path).unwrap();
@@ -223,16 +952,24 @@ mod tests {
             .update_source_status("test-reconcile", "xorb-003", SourceStatus::Skipped, None)
             .unwrap();
 
-        let outcome = finalize(&journal, "test-reconcile", None).unwrap();
+        let outcome = finalize(
+            &journal,
+            "test-reconcile",
+            None,
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(outcome.entries_updated, 2);
         assert_eq!(outcome.entries_unchanged, 1);
-        assert_eq!(outcome.shards_uploaded, 0); // no store
+        assert_eq!(outcome.shards_uploaded, 0);
         assert!(outcome.cas_first_attempt);
     }
 
-    #[test]
-    fn finalize_with_empty_dest_lists_counts_zero_updates() {
+    #[tokio::test]
+    async fn finalize_with_empty_dest_lists_counts_zero_updates() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("journal.db");
         let journal = RestripeJournal::open(&path).unwrap();
@@ -243,7 +980,15 @@ mod tests {
             .update_source_status("test-empty", "xorb-aaa", SourceStatus::Done, Some("[]"))
             .unwrap();
 
-        let outcome = finalize(&journal, "test-empty", None).unwrap();
+        let outcome = finalize(
+            &journal,
+            "test-empty",
+            None,
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(outcome.entries_updated, 0);
         assert_eq!(outcome.entries_unchanged, 0);
@@ -278,9 +1023,122 @@ mod tests {
 
         let (mapping, updated, unchanged) = build_mapping(&journal, "map-test").unwrap();
 
-        assert_eq!(mapping.len(), 1); // only src-a has non-empty dests
+        assert_eq!(mapping.len(), 1);
         assert_eq!(mapping["src-a"], vec!["d1", "d2"]);
         assert_eq!(updated, 1);
-        assert_eq!(unchanged, 1); // src-c is corrupt
+        assert_eq!(unchanged, 1);
+    }
+
+    #[test]
+    fn rewrite_coalesces_deduplicated_destination_chunks() {
+        let source_hash = hash(1);
+        let destination_hash = hash(2);
+        let chunk_a = hash(3);
+        let chunk_b = hash(4);
+        let source = SourcePlacement {
+            chunks: vec![
+                SourceChunk {
+                    hash: chunk_a,
+                    size: 4,
+                },
+                SourceChunk {
+                    hash: chunk_b,
+                    size: 8,
+                },
+                SourceChunk {
+                    hash: chunk_a,
+                    size: 4,
+                },
+            ],
+            refs: HashMap::from([
+                (
+                    chunk_a,
+                    XorbRef {
+                        xorb_hash: destination_hash,
+                        chunk_index: 0,
+                        uncompressed_size: 4,
+                    },
+                ),
+                (
+                    chunk_b,
+                    XorbRef {
+                        xorb_hash: destination_hash,
+                        chunk_index: 1,
+                        uncompressed_size: 8,
+                    },
+                ),
+            ]),
+        };
+        let mapping = LoadedMapping {
+            sources: HashMap::from([(source_hash, source)]),
+            destination_infos: HashMap::new(),
+        };
+        let file = MDBFileInfo {
+            metadata: crab_xet::shard::FileDataSequenceHeader::new(hash(5), 1, false, false),
+            segments: vec![FileDataSequenceEntry::new(source_hash, 16, 0, 3)],
+            verification: Vec::new(),
+            metadata_ext: None,
+        };
+
+        let (rewritten, changed) = rewrite_file_info(&file, &mapping).unwrap();
+
+        assert!(changed);
+        assert_eq!(rewritten.metadata.num_entries, 2);
+        assert_eq!(rewritten.segments[0].xorb_hash, destination_hash);
+        assert_eq!(rewritten.segments[0].chunk_index_start, 0);
+        assert_eq!(rewritten.segments[0].chunk_index_end, 2);
+        assert_eq!(rewritten.segments[0].unpacked_segment_bytes, 12);
+        assert_eq!(rewritten.segments[1].chunk_index_start, 0);
+        assert_eq!(rewritten.segments[1].chunk_index_end, 1);
+        assert_eq!(rewritten.segments[1].unpacked_segment_bytes, 4);
+    }
+
+    #[test]
+    fn rewritten_shard_drops_source_xorb_metadata() {
+        let source_hash = hash(10);
+        let destination_hash = hash(11);
+        let chunk_hash = hash(12);
+        let file_hash = hash(13);
+        let source_info = xorb_info(source_hash, &[(chunk_hash, 16)]);
+        let destination_info = xorb_info(destination_hash, &[(chunk_hash, 16)]);
+        let mut writer = ShardWriter::new();
+        writer.add_xorb(source_info).unwrap();
+        writer
+            .add_file(file_info(file_hash, source_hash, 16))
+            .unwrap();
+        let (body, old_hash) = writer.finalize().unwrap();
+
+        let mapping = LoadedMapping {
+            sources: HashMap::from([(
+                source_hash,
+                SourcePlacement {
+                    chunks: vec![SourceChunk {
+                        hash: chunk_hash,
+                        size: 16,
+                    }],
+                    refs: HashMap::from([(
+                        chunk_hash,
+                        XorbRef {
+                            xorb_hash: destination_hash,
+                            chunk_index: 0,
+                            uncompressed_size: 16,
+                        },
+                    )]),
+                },
+            )]),
+            destination_infos: HashMap::from([(destination_hash, destination_info)]),
+        };
+
+        let rewrite = rewrite_shard(&Bytes::from(body), old_hash, &mapping)
+            .unwrap()
+            .unwrap();
+        let reader = ShardReader::from_bytes(rewrite.bytes, rewrite.new_hash);
+
+        assert!(reader.get_xorb_info(&source_hash).unwrap().is_none());
+        assert!(reader.get_xorb_info(&destination_hash).unwrap().is_some());
+        assert_eq!(
+            reader.get_file_info(&file_hash).unwrap().unwrap().segments[0].xorb_hash,
+            destination_hash
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Reconcile completed source-to-destination xorb mappings against the current canonical shard snapshot.
- Rewrite affected MDBFileInfo segment references and shard xorb metadata, recompute file recipes, and remove stale source-xorb metadata.
- Publish replacement shards, generation-pinned file-index rows, and the compact shard index before advancing the manifest through CAS.
- Retry boundedly on concurrent manifest changes and keep corrupt or verification-bearing records fail-closed.
- Enable `crab optimize xorbs --apply` now that the metadata visibility boundary is implemented.

## Validation

- `cargo check -p crab --locked`
- `cargo check -p crab --tests --locked`
- Focused reconciliation tests: 7 passed
- `cargo fmt --all -- --check`
- `git diff --check`
- RustFS live fixture: 6 xorb sources applied, manifest advanced from generation 1 to 2, fresh clone hydrated 2 files, and both SHA-256 checksums remained byte-identical.

## Known follow-up

- Verification-bearing MDBFileInfo remains fail-closed until its per-segment proof regeneration contract is available.
- Strict repository-wide clippy remains blocked by the existing lint backlog; the changed paths compile and pass focused tests.
- S3-compatible xorb class probes can still warn when a provider client is not endpoint-aware.