### PR TITLE
fix: keep locator readers refreshable

### DIFF
--- a/crates/crab-metadata/src/git_object_locator/reader.rs
+++ b/crates/crab-metadata/src/git_object_locator/reader.rs
@@ -67,7 +67,9 @@ impl GitObjectLocatorSession {
             checkpoint_lifetime,
             ..locator_reader_options()
         };
-        Self::open_with_options(store, repo_prefix, options).await
+        let path = git_object_locator_path(repo_prefix);
+        let checkpoint = reader_checkpoint_id(Arc::clone(&store), &path).await?;
+        Self::open_with_checkpoint(store, repo_prefix, options, checkpoint).await
     }
 
     async fn open_with_options(
@@ -75,8 +77,16 @@ impl GitObjectLocatorSession {
         repo_prefix: &str,
         options: DbReaderOptions,
     ) -> Result<Self> {
+        Self::open_with_checkpoint(store, repo_prefix, options, None).await
+    }
+
+    async fn open_with_checkpoint(
+        store: Arc<dyn ObjectStore>,
+        repo_prefix: &str,
+        options: DbReaderOptions,
+        checkpoint: Option<slatedb::Checkpoint>,
+    ) -> Result<Self> {
         let path = git_object_locator_path(repo_prefix);
-        let checkpoint = reader_checkpoint_id(Arc::clone(&store), &path).await?;
         let mut builder = slatedb::DbReader::builder(ObjectPath::from(path.as_str()), store)
             .with_options(options);
         if let Some(checkpoint) = checkpoint {


### PR DESCRIPTION
## What changed

Keep ordinary Git object locator readers on SlateDB's refreshable-reader path, while operation-scoped readers remain pinned to the published checkpoint.

## Why

The merged Plan013 path always discovered and passed an existing checkpoint to `DbReader`. SlateDB treats an explicit checkpoint as immutable and disables periodic refresh, so a long-lived ordinary session could miss newly published locator rows.

## Validation

- Focused regression and package suites: metadata 176, read 44, remote-git 73, remote-repository 44; all passed.
- Full workspace test compiled and ran 3,495 passing tests; 15 unrelated pre-existing snapshot/classification tests remain failing and no baselines were changed.
- Targeted clippy completed with existing warnings outside this change.
- Release binary built from commit `d0c7412c`.
- Real RustFS end-to-end protocol-v2 partial-clone smoke passed: 76 checks, zero failed checks, Git 2.50.1, clean committed source, RustFS healthy.
