### PR TITLE
test: make protocol v2 RustFS smoke identity deterministic

### DIFF
--- a/crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py
@@ -209,6 +209,10 @@ class ProtocolV2PartialCloneSmoke:
                 "AWS_VIRTUAL_HOSTED_STYLE_REQUEST": "false",
                 "VIRTUAL_HOSTED_STYLE_REQUEST": "false",
                 "GIT_TERMINAL_PROMPT": "0",
+                "GIT_AUTHOR_NAME": "Crab protocol smoke",
+                "GIT_AUTHOR_EMAIL": "smoke@example.invalid",
+                "GIT_COMMITTER_NAME": "Crab protocol smoke",
+                "GIT_COMMITTER_EMAIL": "smoke@example.invalid",
                 "CRAB_LOG": "crab=debug,crab_remote_git=debug",
             }
         )


### PR DESCRIPTION
## Summary

- Make the protocol-v2 RustFS smoke test provide a deterministic synthetic Git author and committer identity.
- Keep the qualification independent of host-global Git configuration, which is absent in clean Linux containers.

## Why

The incomplete-promisor push fixture uses `git commit-tree`. On a clean Linux runner it failed before exercising Crab because Git could not infer an identity. The host run masked this by inheriting a developer's global Git configuration.

## Validation

- `python3 -m py_compile crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py`
- Native Linux/aarch64 RustFS qualification: run `plan013-linux-aarch64-e51-20260818`, Git 2.47.3, Crab 1.0.14, source/binary revision `e51e0499`.
- 76 checks and 265 commands passed; hidden-only, dangling, and unknown OID security checks recorded zero range reads.

This follow-up contains only the qualification-harness fix. The production protocol-v2 framing change was merged separately in PR #11.
