### PR TITLE
fix: support minimum Git pack indexing

### DIFF
--- a/crab/src/cmd/repack.rs
+++ b/crab/src/cmd/repack.rs
@@ -433,16 +433,17 @@ fn build_and_validate_pack(
     run_git(
         Command::new("git")
             .arg("index-pack")
-            .arg("--rev-index")
             .arg("-o")
             .arg(&index_path)
             .arg(&pack_path)
             .stdout(Stdio::null()),
         "index replacement pack",
     )?;
+    write_pack_reverse_index(&index_path, &reverse_index_path)
+        .map_err(crab_git::pack::PackError::from)?;
     if !reverse_index_path.is_file() {
         return Err(CrabError::Internal(
-            "git index-pack did not create the canonical reverse index".to_owned(),
+            "reverse-index generation did not create the canonical reverse index".to_owned(),
         ));
     }
     let pack_size = std::fs::metadata(&pack_path)?.len();

--- a/crab/src/git/pack.rs
+++ b/crab/src/git/pack.rs
@@ -1580,18 +1580,14 @@ fn install_pack_blocking(
     #[cfg(not(feature = "gix-pack-native"))]
     let output = std::process::Command::new("git")
         .arg("index-pack")
-        .arg("--rev-index")
         .arg("-o")
         .arg(&idx_tmp_path)
         .arg(&pack_tmp_path)
         .output()
         .map_err(CrabError::Io)?;
 
-    // git index-pack 2.31+ also writes a `.rev` reverse-index sidecar
-    // alongside the `-o` output. Its name is derived from the -o path
-    // (strip `.idx`, append `.rev`), so it lives under our tempfile
-    // name and needs to be renamed into place too — or cleaned up on
-    // older gits where the file doesn't exist at all.
+    // Generate the reverse-index sidecar ourselves below. This keeps the
+    // install path compatible with Git 2.30, which predates `--rev-index`.
     let rev_tmp_path = idx_tmp_path.with_extension("rev");
     let final_rev = final_idx.with_extension("rev");
 

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -14303,7 +14303,6 @@ mod tests {
         run(
             &[
                 "index-pack",
-                "--rev-index",
                 "-o",
                 idx_path.to_str().expect("idx path UTF-8"),
                 pack_path.to_str().expect("pack path UTF-8"),
@@ -14311,6 +14310,8 @@ mod tests {
             None,
         );
         let rev_path = idx_path.with_extension("rev");
+        crab_git::pack_locator::write_pack_reverse_index(&idx_path, &rev_path)
+            .expect("write reverse index");
         let index =
             gix_pack::index::File::at(&idx_path, gix_hash::Kind::Sha1).expect("open fixture index");
         let git_sha1 = index.pack_checksum().to_string();

--- a/crates/crab-auth-server/src/receive/git_workspace.rs
+++ b/crates/crab-auth-server/src/receive/git_workspace.rs
@@ -361,12 +361,7 @@ impl<'a> GitReceiveWorkspace<'a> {
         let verify_path = temp_root.join(format!("pack-{pack_id}.pack"));
         fs::write(&verify_path, &pack_bytes)?;
         run_git(
-            [
-                "index-pack",
-                "--strict",
-                "--rev-index",
-                path_str(&verify_path)?,
-            ],
+            ["index-pack", "--strict", path_str(&verify_path)?],
             Some(git_dir),
         )?;
         Ok(PackManifestEntry {

--- a/crates/crab-auth-server/src/view/git_workspace.rs
+++ b/crates/crab-auth-server/src/view/git_workspace.rs
@@ -162,7 +162,6 @@ pub(super) fn generate_view_pack(filtered_git: &Path) -> Result<Vec<u8>> {
             path_str(filtered_git)?,
             "index-pack",
             "--strict",
-            "--rev-index",
             path_str(&validation_pack)?,
         ],
         None,

--- a/crates/crab-git/src/pack.rs
+++ b/crates/crab-git/src/pack.rs
@@ -308,7 +308,10 @@ fn install_pack_file_blocking(
         // packs. Bind it to the owning repository instead of ambient cwd.
         index_pack.arg("--git-dir").arg(git_dir);
     }
-    index_pack.arg("index-pack").arg("--rev-index");
+    // Git 2.30, the minimum supported version, predates `--rev-index`.
+    // Crab writes its own reverse index below, so indexing must not depend
+    // on that newer optional Git sidecar.
+    index_pack.arg("index-pack");
     if fsck_objects {
         // Validate object bodies during the indexing pass. Broken links are
         // checked separately by the reachability owner after all packs land.

--- a/crates/crab-git/src/pack_locator.rs
+++ b/crates/crab-git/src/pack_locator.rs
@@ -518,17 +518,9 @@ mod tests {
                 .to_owned();
             let pack = temp.path().join(format!("fixture-{pack_hash}.pack"));
             let idx = temp.path().join("fixture.idx");
-            git(
-                &[
-                    "index-pack",
-                    "--rev-index",
-                    "-o",
-                    path_str(&idx),
-                    path_str(&pack),
-                ],
-                None,
-            );
+            git(&["index-pack", "-o", path_str(&idx), path_str(&pack)], None);
             let rev = idx.with_extension("rev");
+            write_pack_reverse_index(&idx, &rev).expect("write reverse index");
             assert!(pack.exists());
             assert!(idx.exists());
             assert!(rev.exists());

--- a/crates/crab-git/src/repack.rs
+++ b/crates/crab-git/src/repack.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::pack::{PackError, install_pack_file_from_path};
-use crate::pack_locator::{PackLocationIter, PackLocatorError};
+use crate::pack_locator::{PackLocationIter, PackLocatorError, write_pack_reverse_index};
 
 /// A downloaded canonical pack selected by a pinned repository manifest.
 #[derive(Debug, Clone)]
@@ -157,17 +157,17 @@ pub fn repack_repository(
     run_git(
         Command::new("git")
             .arg("index-pack")
-            .arg("--rev-index")
             .arg("-o")
             .arg(&index_path)
             .arg(&pack_path)
             .stdout(Stdio::null()),
         "index replacement pack",
     )?;
+    write_pack_reverse_index(&index_path, &reverse_index_path)?;
     if !reverse_index_path.is_file() {
         return Err(RepackError::SourceIntegrity {
             pack_id: "replacement".to_owned(),
-            reason: "git index-pack produced no reverse index".to_owned(),
+            reason: "reverse-index generation produced no reverse index".to_owned(),
         });
     }
     run_git(


### PR DESCRIPTION
## Summary

- Remove the `--rev-index` flag from Crab's Git pack-indexing and validation paths.
- Generate the reverse index with Crab's existing writer so the minimum supported Git version, 2.30, remains compatible.
- Keep the deterministic author/committer setup from the merged protocol-v2 RustFS smoke fix on `main`.

## Root cause

Git 2.30.9 rejects `git index-pack --rev-index` with a usage error. That made a real RustFS push fail while constructing the source pack, before protocol-v2 clone and lazy-fetch qualification could begin. Crab already owns reverse-index generation, so the fix removes the newer Git-only flag and makes the sidecar generation explicit in both repack implementations.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p crab-git --lib` — 163 passed, 0 failed, 1 ignored
- `cargo test --locked -p crab --lib git::pack -- --nocapture` — 32 passed
- `cargo check --locked -p crab-auth-server`
- Real RustFS protocol-v2 qualification on Linux/macOS fixtures passed the existing 76-check matrix on Git 2.47.3 before this compatibility change.
- A targeted real RustFS run with Git 2.30.9 reached and passed the previously failing source-pack push path after this fix. The remaining full-matrix stop is Git 2.30's own rejection of the unsupported `object:type=tag` filter syntax, before Crab receives that request.

## Scope

This PR contains the eight production/test-helper files required for minimum-Git pack indexing. The deterministic RustFS identity fix is already merged in PR #12.

Remaining release qualification gates are the complete supported-filter matrix for the minimum Git client, AWS S3, Windows, and released-artifact verification.
