### PR TITLE
Auto-detect Crab remotes for ship

### DIFF
--- a/crab-web/README.md
+++ b/crab-web/README.md
@@ -1,21 +1,329 @@
-# Next.js template
+# crab-web
 
-This is a Next.js template with shadcn/ui.
+`crab-web` is Crab’s public website and documentation app. It serves the marketing site at [crab.build](https://crab.build), the Crab CLI documentation, technical blog, changelog, pricing calculator, integration pages, and public CLI installer scripts.
 
-## Adding components
+This package contains the web experience and its content pipeline. The Crab CLI and Git remote helper live in [`crab/`](../crab/), while shared Rust libraries live in [`crates/`](../crates/).
 
-To add components to your app, run the following command:
+## What this app contains
+
+The site combines several content and product surfaces:
+
+- **Marketing pages**: Product overviews, use cases, pricing, integrations, remote services, authentication, and cache service pages
+- **CLI documentation**: Fumadocs-powered MDX guides, workflows, command reference, diagnostics, automation, storage, and authentication content
+- **Technical blog**: MDX articles with learning paths, categories, tags, diagrams, and related-post navigation
+- **Release communication**: A source-backed changelog rendered from typed data in `lib/changelog.ts`
+- **Public installers**: Shell and PowerShell scripts in `public/`, exposed through `/install.sh` and `/install.ps1`
+- **Search and discovery**: CLI documentation search at `/api/search` and a generated sitemap at `/sitemap.xml`
+
+The app renders content through Next.js App Router routes. Most pages are server components. Client components are reserved for browser interactions such as animations, filters, theme switching, and interactive demos.
+
+## Public routes
+
+The main routes are implemented under `app/`:
+
+| Route               | Purpose                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| `/`                 | Crab product landing page                                                          |
+| `/cli`              | Crab CLI product page with installation examples and the push pipeline walkthrough |
+| `/docs`             | Documentation landing page                                                         |
+| `/docs/cli/...`     | Fumadocs-rendered CLI documentation                                                |
+| `/blog`             | Blog index with learning paths, categories, levels, tags, and search               |
+| `/blog/[slug]`      | Individual blog posts                                                              |
+| `/changelog`        | Published or repository-backed release entries                                     |
+| `/pricing`          | Storage provider pricing calculator                                                |
+| `/integrations`     | Cloud, CI/CD, machine learning, and version-control integrations                   |
+| `/use-cases`        | Product workflows and use cases                                                    |
+| `/remote-services`  | Remote-helper and cloud object-storage architecture                                |
+| `/auth`             | Crab Auth and credential-vending architecture                                      |
+| `/cache`            | Crab Cache service and cache topology                                              |
+| `/about-us`         | Company information                                                                |
+| `/privacy`          | Privacy policy                                                                     |
+| `/terms-of-service` | Terms of service                                                                   |
+| `/api/search`       | Fumadocs search endpoint for CLI docs                                              |
+| `/api/install`      | Returns the shell installer from `public/install.sh`                               |
+| `/api/install-ps1`  | Returns the PowerShell installer from `public/install.ps1`                         |
+| `/sitemap.xml`      | Generated sitemap for static pages, blog posts, and CLI docs                       |
+
+`next.config.mjs` also owns canonical redirects for older company, installer, and documentation URLs. Update those redirects when moving a public route so existing links continue to resolve.
+
+## Technology stack
+
+- **Framework**: Next.js 16 with the App Router and React Server Components
+- **Language**: TypeScript with strict compiler settings
+- **UI**: React 19, Tailwind CSS v4, `tw-animate-css`, and shadcn/ui primitives
+- **Documentation**: Fumadocs, `fumadocs-mdx`, MDX, Mermaid, and custom MDX components
+- **Icons**: Lucide React and Hugeicons for the shadcn configuration
+- **Testing**: Vitest with Fast-check available for property-based tests
+- **Quality**: ESLint, Prettier, TypeScript, and a production link crawler
+- **Hosting**: Vercel, configured by `vercel.json`
+
+The project uses the `@/*` TypeScript alias for local imports and the `collections/*` alias for generated Fumadocs collections. Prefer those aliases over long relative import paths.
+
+## Prerequisites
+
+Install the following before working in this directory:
+
+- Node.js 20.9 or newer, which matches the Next.js runtime requirement
+- npm, which matches the package lockfile and the Vercel install configuration
+- Git, if you are cloning the repository or testing links to Git-backed content
+
+The site does not currently require a `.env.local` file for normal local development. The link checker accepts the optional `CRAB_WEB_LINK_CHECK_PORT` variable when port `3210` is already in use.
+
+## Start the site locally
+
+Run these commands from the `crab-web/` directory:
+
+```bash
+npm install
+npm run dev
+```
+
+The development server uses Turbopack. Open [http://localhost:3000](http://localhost:3000) after the server starts.
+
+To run the production server locally, build first and then start Next.js:
+
+```bash
+npm run build
+npm run start
+```
+
+`next start` serves the previously generated `.next/` output. It does not compile the app for you.
+
+## npm scripts
+
+Run these commands from `crab-web/`:
+
+| Command                  | Purpose                                                               |
+| ------------------------ | --------------------------------------------------------------------- |
+| `npm run dev`            | Start the Turbopack development server                                |
+| `npm run build`          | Build the production Next.js app and generate the MDX collections     |
+| `npm run start`          | Serve the last production build                                       |
+| `npm run typecheck`      | Run TypeScript without emitting files                                 |
+| `npm run lint`           | Run ESLint with the Next.js Core Web Vitals and TypeScript presets    |
+| `npm run test`           | Run the Vitest suite once                                             |
+| `npm run check:links`    | Crawl the production server and check internal pages and fragments    |
+| `npm run format`         | Format TypeScript and TSX files with Prettier and the Tailwind plugin |
+| `npm run deploy:preview` | Create a Vercel preview deployment                                    |
+| `npm run deploy`         | Create a Vercel production deployment                                 |
+
+The link checker starts `next start` on `127.0.0.1:3210` by default. Build before running it, and set a different port when necessary:
+
+```bash
+npm run build
+CRAB_WEB_LINK_CHECK_PORT=3211 npm run check:links
+```
+
+The current test setup uses Vitest. Browser end-to-end testing is not defined in `package.json`, so use the production build and link checker to validate route reachability in addition to unit tests.
+
+## Recommended validation order
+
+Run the narrow checks first, then the checks that exercise the built site:
+
+```bash
+npm run typecheck
+npm run lint
+npm run test
+npm run build
+npm run check:links
+```
+
+Run `npm run format` before handing off TypeScript or TSX changes. It does not format Markdown or MDX files, so review README and content changes separately.
+
+## Repository layout
+
+| Path                      | Responsibility                                                                                      |
+| ------------------------- | --------------------------------------------------------------------------------------------------- |
+| `app/`                    | App Router pages, layouts, API routes, diagrams, loading states, and the sitemap                    |
+| `components/marketing/`   | Reusable marketing sections, product demonstrations, and visual storytelling components             |
+| `components/docs/`        | Documentation layout, code blocks, callouts, sidebar icons, and copy controls                       |
+| `components/navigation/`  | Header, footer, menus, skip links, and navigation behavior                                          |
+| `components/ui/`          | shadcn/ui primitives and small reusable interface components                                        |
+| `content/docs/cli/`       | CLI documentation written in MDX, organized by category                                             |
+| `content/blog/`           | Blog posts written in MDX                                                                           |
+| `lib/`                    | Fumadocs loaders, blog transforms, pricing data, integrations, changelog data, and shared utilities |
+| `public/`                 | Static images, icons, and the shell and PowerShell installer scripts                                |
+| `scripts/check-links.mjs` | Production-server crawler for internal links and URL fragments                                      |
+| `source.config.ts`        | Fumadocs collections, frontmatter schemas, Mermaid support, and code highlighting                   |
+| `next.config.mjs`         | MDX integration, installer rewrites, and permanent redirects                                        |
+| `vercel.json`             | Vercel framework, install, build, and output settings                                               |
+| `.source/`                | Generated Fumadocs collection output; do not edit by hand                                           |
+| `.next/`                  | Generated Next.js build output; do not edit by hand                                                 |
+
+## How content becomes a page
+
+The app has two MDX collections and one static-data layer:
+
+1. `content/docs/cli/**/*.mdx` is loaded by `source.config.ts` as the `cliDocs` collection.
+2. `lib/source.ts` creates the `/docs/cli` loader, attaches sidebar icons, and removes internal `design` content from the public sidebar.
+3. `app/docs/cli/[[...slug]]/page.tsx` resolves a documentation slug and renders its MDX body through `mdx-components.tsx`.
+4. `app/api/search/route.ts` builds a Fumadocs search index from the same CLI page source.
+5. `content/blog/*.mdx` is loaded as the `blog` collection and transformed by `lib/blog-posts.ts` for filtering, learning paths, reading time, and related posts.
+6. `lib/integrations.ts`, `lib/pricing-data.ts`, and `lib/changelog.ts` provide typed, build-time data for their corresponding product pages.
+
+Fumadocs generates collection artifacts under `.source/`. Change the source MDX, schema, or loader instead of editing generated files.
+
+## Author CLI documentation
+
+CLI documentation lives under `content/docs/cli/`. Each document uses MDX and normally starts with `title` and `description` frontmatter:
+
+```mdx
+---
+title: "Configure a Crab repository"
+description: "Set the remote, tracking rules, and local options for a Crab repository."
+---
+
+# Configure a Crab repository
+
+Explain the task, required credentials, expected result, and failure behavior.
+```
+
+Follow these conventions:
+
+- **Use the existing category**: Put the file in the directory that matches its task, such as `getting-started`, `daily-workflow`, `authentication`, `storage`, or `reference`
+- **Register navigation order**: Add the filename to the nearest `meta.json`; the metadata tree controls the sidebar order and grouping
+- **Use canonical links**: Link to `/docs/cli/...` paths rather than legacy command URLs, which exist only as redirects
+- **Explain commands in context**: Introduce each code block, state prerequisites, and describe the expected result
+- **Use shared MDX components**: `Callout`, `Steps`, `Step`, `Tabs`, `Tab`, `Accordion`, `Accordions`, `Card`, `Cards`, and `Mermaid` are available through `mdx-components.tsx`
+- **Use Mermaid for diagrams**: Fence a diagram as `mermaid`; `source.config.ts` and the custom MDX renderer convert it to the site’s Mermaid component
+- **Escape prose syntax when needed**: Angle brackets and curly braces can be interpreted by MDX, so escape them when they are literal text
+
+The top-level order is defined in `content/docs/cli/meta.json`. When you add a new top-level category, update that file and add a matching icon in `components/docs/docs-sidebar-icons.tsx` if the section needs a custom sidebar icon.
+
+## Author blog posts
+
+Blog posts live in `content/blog/` as individual `.mdx` files. The schema is defined in `source.config.ts`, and `lib/blog-posts.ts` maps the lowercase frontmatter values to the display labels used by the blog UI.
+
+Use frontmatter like this:
+
+```mdx
+---
+title: "A useful Crab article title"
+description: "State what the reader will learn and why it matters."
+date: "2026-08-18"
+author: "Crab Team"
+category: "tutorial"
+tags: ["getting-started", "workflow"]
+excerpt: "A short summary for cards and search results."
+level: "beginner"
+path: "first-workflow"
+order: 1
+concepts: ["installation", "push", "hydration"]
+prerequisites: ["What is Crab"]
+outcome: "Install Crab and complete a first push workflow."
+diagramType: "Command flow"
+---
+
+# A useful Crab article title
+
+Write the article body in MDX.
+```
+
+The accepted values are:
+
+- **Categories**: `product`, `tutorial`, `architecture`, `use-case`, `release`
+- **Levels**: `beginner`, `intermediate`, `deep-dive`
+- **Learning paths**: `start-here`, `first-workflow`, `core-internals`, `advanced-operations`
+
+The blog loader discovers `.mdx` files automatically. You do not need a separate registration file, but each post needs complete frontmatter so cards, filters, navigation, search, and the sitemap remain useful.
+
+## Update product data
+
+Several pages use typed data modules instead of remote APIs:
+
+- `lib/integrations.ts` defines integration names, descriptions, categories, icons, and destinations
+- `lib/pricing-data.ts` contains the provider, region, storage-class, request, and egress values used by the calculator
+- `lib/changelog.ts` contains release entries and source links; keep entries tied to published release notes, source tags, or repository changelog material
+- `public/install.sh` and `public/install.ps1` are the installer sources returned by the public installer routes
+
+When changing one of these surfaces, update its data and the page that consumes it. For installer changes, verify both the source file and the deployed response because the public URL is a documented installation path.
+
+## UI and component conventions
+
+Keep new UI code aligned with the existing structure:
+
+- **Server-first rendering**: Use a server component unless the feature needs browser APIs, event handlers, local state, or animation lifecycle hooks
+- **Client boundaries**: Add `"use client"` only at the smallest component that needs it
+- **Styling**: Use Tailwind classes and `cn()` from `lib/utils.ts` for conditional class merging
+- **Marketing components**: Put reusable landing-page sections in `components/marketing/`
+- **Documentation components**: Put docs-specific controls and presentation in `components/docs/`
+- **Diagrams**: Add reusable SVG diagrams as React components under `app/diagrams/`
+- **UI primitives**: Keep shadcn/ui primitives in `components/ui/`
+- **Accessibility**: Preserve keyboard access, semantic headings, visible focus states, reduced-motion behavior, and useful labels when extending interactive components
+
+To add a shadcn/ui primitive, use the project’s configured generator from `crab-web/`:
 
 ```bash
 npx shadcn@latest add button
 ```
 
-This will place the ui components in the `components` directory.
-
-## Using components
-
-To use the components in your app, import them as follows:
+Import generated primitives through the configured alias:
 
 ```tsx
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
 ```
+
+Prefer an existing component or pattern before adding a new abstraction. Keep product-specific composition in the marketing or docs component directories instead of making `components/ui/` carry page policy.
+
+## Installer routes and public assets
+
+The installer URLs are wired in two layers:
+
+1. `next.config.mjs` rewrites `/install.sh` to `/api/install` and `/install.ps1` to `/api/install-ps1`.
+2. Each route reads the matching file from `public/` and returns it as plain text with cache headers.
+
+The scripts download release artifacts from the Crab release repository and verify checksums before installation. Keep the scripts self-contained, review changes carefully, and never place credentials in them.
+
+Check the local responses after a build with:
+
+```bash
+curl -fsSL http://localhost:3000/install.sh
+curl -fsSL http://localhost:3000/install.ps1
+```
+
+## Deployment
+
+Vercel reads the settings in `vercel.json`:
+
+- Framework: `nextjs`
+- Install command: `npm install`
+- Build command: `npm run build`
+- Output directory: `.next`
+
+The package scripts wrap the Vercel CLI:
+
+```bash
+npm run deploy:preview
+npm run deploy
+```
+
+Use the preview command for review deployments and the production command only after the validation sequence passes. These commands require an authenticated Vercel CLI and a linked project. The local `.vercel/` directory is ignored and must not be committed.
+
+## Troubleshooting
+
+### The production server will not start
+
+Run `npm run build` first. `npm run start` requires a completed `.next/` production build.
+
+### A documentation page is missing from the sidebar
+
+Check that the MDX file is under `content/docs/cli/` and that its filename appears in the nearest `meta.json`. Check the generated URL against the folder structure and use `/docs/cli/getting-started` as the canonical starting route.
+
+### MDX syntax fails during a build
+
+Check frontmatter types, escape literal angle brackets or curly braces, and confirm that custom components are exported from `mdx-components.tsx`. Restart the development server after changing collection configuration so Fumadocs can regenerate its collection output.
+
+### The link checker reports a failure
+
+Build first, then run `npm run check:links`. The checker follows internal HTML links and validates fragments. Inspect the failing source route, confirm the target route returns HTML, and update stale anchors or redirects. If port `3210` is busy, set `CRAB_WEB_LINK_CHECK_PORT`.
+
+### A new sidebar section has no icon
+
+Add its slug to `components/docs/docs-sidebar-icons.tsx`. The loader attaches icons to top-level pages and folders when a mapping exists.
+
+## Related resources
+
+- [Crab repository overview](../README.md)
+- [Crab CLI documentation](https://crab.build/docs/cli/getting-started)
+- [Crab website](https://crab.build)
+- [Crab GitHub repository](https://github.com/crabbuild/crab-oss)
+- [Apache-2.0 license](../LICENSE)

--- a/crab-web/content/docs/cli/reference/crab-push.mdx
+++ b/crab-web/content/docs/cli/reference/crab-push.mdx
@@ -9,6 +9,10 @@ Push committed pointer blobs, backing objects, and Git refs. `crab push` uses
 the same repository outcome as `git push` through `git-remote-crab`, while its
 native pipeline can upload independent objects concurrently.
 
+When `REMOTE` is omitted, Crab prefers the current branch's Crab-compatible
+upstream, then a remote named `crab`, then the only other Crab-compatible
+remote. If several Crab remotes remain, pass the remote name explicitly.
+
 ## Synopsis
 
 ```text
@@ -19,7 +23,7 @@ crab push [OPTIONS] [REMOTE] [REFSPECS]...
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `REMOTE` | No | Remote name or URL; defaults to the upstream remote or `origin` |
+| `REMOTE` | No | Remote name or URL; auto-detects a Crab-compatible remote before falling back to the upstream remote or `origin` |
 | `REFSPECS` | No | Refspecs to push; defaults to the current branch |
 
 ## Managed push

--- a/crab-web/content/docs/cli/reference/crab-ship.mdx
+++ b/crab-web/content/docs/cli/reference/crab-ship.mdx
@@ -41,7 +41,7 @@ behavior as `crab add`.
 |--------|---------|-------------|
 | `-m, --message` | (required) | Commit message |
 | `-j, --jobs` | `16` | Maximum concurrent file-processing tasks |
-| `--remote` | `origin` | Git remote to push to |
+| `--remote` | Auto-detected | Git remote name or `crab://` URL; pass this option to choose a specific Crab remote |
 | `-b, --branch` | current branch | Branch to push |
 | `--rebase-on-non-fast-forward` | `false` | Integrate the current branch and retry after a non-fast-forward or lock conflict |
 | `--rebase-retry-limit` | `256` | Maximum integration retries when rebasing is enabled |
@@ -82,6 +82,11 @@ means xorb uploads happen concurrently (default 16 parallel uploads) and the
 push bypasses git's serial remote helper protocol. For repositories with many
 large files, this can be significantly faster than the equivalent
 `crab add && git commit && git push` sequence.
+
+When `--remote` is omitted, Crab selects the current branch's Crab-compatible
+upstream, then a remote named `crab`, then the only other Crab-compatible
+remote. If more than one remains, choose one explicitly with
+`--remote <name>`.
 
 ## When to Use `crab ship` vs Individual Commands
 

--- a/crab/docs/guides/ship.md
+++ b/crab/docs/guides/ship.md
@@ -29,7 +29,7 @@ Uses the native `crab push` pipeline for concurrent xorb uploads rather than
 |--------|---------|-------------|
 | `-m, --message` | (required) | Commit message |
 | `-j, --jobs` | `16` | Maximum concurrent file-processing tasks |
-| `--remote` | `origin` | Git remote to push to |
+| `--remote` | Auto-detected | Git remote name or `crab://` URL; pass this option to choose a specific Crab remote |
 | `-b, --branch` | current branch | Branch to push |
 | `--rebase-on-non-fast-forward` | `false` | On a single current-branch non-fast-forward, run `git pull --rebase --autostash` and retry; retry transient push-lock contention in the same loop |
 | `--rebase-retry-limit` | `64` | Maximum integration retry attempts |
@@ -48,6 +48,11 @@ Uses the native `crab push` pipeline for concurrent xorb uploads rather than
 If no tracking patterns exist in `.gitattributes`, `crab ship` auto-detects
 large file extensions and tracks them before staging — the same auto-track
 behavior as `crab add`.
+
+When `--remote` is omitted, Crab selects the current branch's Crab-compatible
+upstream, then a remote named `crab`, then the only other Crab-compatible
+remote. If more than one remains, choose one explicitly with
+`--remote <name>`.
 
 ## JSON Output
 

--- a/crab/src/cmd/add_push_plan.rs
+++ b/crab/src/cmd/add_push_plan.rs
@@ -227,7 +227,7 @@ async fn open_remote_plan_context(
     repo_root: &Path,
     cancel: &CancellationToken,
 ) -> Option<RemotePlanContext> {
-    let remote_name = crate::cmd::push::resolve_remote_name(None);
+    let remote_name = crate::cmd::push::resolve_remote_name(None).ok()?;
     let remote_url = match crate::cmd::push::git_config_value(&format!("remote.{remote_name}.url"))
     {
         Some(url) if url.starts_with("crab://") => url,

--- a/crab/src/cmd/push.rs
+++ b/crab/src/cmd/push.rs
@@ -170,6 +170,12 @@ struct PushTarget {
     parsed_url: CrabUrl,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConfiguredRemote {
+    name: String,
+    url: String,
+}
+
 enum PushAttempt {
     Done(PushSummaryPayload),
     Failed(Box<PushAttemptFailure>),
@@ -1071,27 +1077,103 @@ fn build_push_summary(
     }
 }
 
-/// Resolve the remote name from the user argument or git config.
+/// Resolve the remote name from the user argument or Git configuration.
 ///
-/// When no remote is specified, tries `git config branch.<current>.remote`,
-/// falling back to `"origin"`.
-pub(crate) fn resolve_remote_name(explicit: Option<&str>) -> String {
+/// When no remote is specified, a Crab-compatible upstream is preferred,
+/// followed by a remote named `crab` or the only other Crab-compatible
+/// remote. Non-Crab upstream/origin fallback is retained so the final target
+/// validation can provide the existing actionable error.
+pub(crate) fn resolve_remote_name(explicit: Option<&str>) -> Result<String> {
     if let Some(name) = explicit {
-        return name.to_owned();
+        return Ok(name.to_owned());
     }
 
-    // Try the current branch's configured remote.
-    if let Some(branch) = current_branch()
-        && let Some(remote) = git_config_value(&format!("branch.{branch}.remote"))
+    let branch_remote =
+        current_branch().and_then(|branch| git_config_value(&format!("branch.{branch}.remote")));
+    let configured_remotes = configured_git_remotes();
+    if let Some(remote) = select_default_crab_remote(branch_remote.as_deref(), &configured_remotes)?
     {
-        return remote;
+        return Ok(remote);
     }
 
-    "origin".to_owned()
+    Ok(branch_remote.unwrap_or_else(|| "origin".to_owned()))
+}
+
+/// Resolve and validate the target used by a higher-level command before it
+/// performs local mutations such as staging or committing.
+pub(crate) fn resolve_push_remote(explicit: Option<&str>) -> Result<String> {
+    Ok(resolve_push_target(explicit)?.remote)
+}
+
+fn configured_git_remotes() -> Vec<ConfiguredRemote> {
+    let output = match Command::new("git")
+        .args(["remote"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return Vec::new(),
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let name = line.trim();
+            if name.is_empty() {
+                return None;
+            }
+            let url = git_config_value(&format!("remote.{name}.url"))?;
+            Some(ConfiguredRemote {
+                name: name.to_owned(),
+                url,
+            })
+        })
+        .collect()
+}
+
+fn select_default_crab_remote(
+    branch_remote: Option<&str>,
+    configured_remotes: &[ConfiguredRemote],
+) -> Result<Option<String>> {
+    let crab_remotes: Vec<&ConfiguredRemote> = configured_remotes
+        .iter()
+        .filter(|remote| remote.url.starts_with("crab://"))
+        .collect();
+
+    if let Some(branch_remote) = branch_remote
+        && crab_remotes
+            .iter()
+            .any(|remote| remote.name == branch_remote)
+    {
+        return Ok(Some(branch_remote.to_owned()));
+    }
+
+    if let Some(remote) = crab_remotes.iter().find(|remote| remote.name == "crab") {
+        return Ok(Some(remote.name.clone()));
+    }
+
+    match crab_remotes.as_slice() {
+        [] => Ok(None),
+        [remote] => Ok(Some(remote.name.clone())),
+        _ => {
+            let names = crab_remotes
+                .iter()
+                .map(|remote| format!("'{}'", remote.name))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(CrabError::Configuration {
+                key: format!(
+                    "multiple Crab remotes detected ({names}); choose one with `--remote <name>`"
+                ),
+                origin: "git remotes".into(),
+            })
+        }
+    }
 }
 
 fn resolve_push_target(explicit: Option<&str>) -> Result<PushTarget> {
-    let remote = resolve_remote_name(explicit);
+    let remote = resolve_remote_name(explicit)?;
     if remote.contains("://") {
         let parsed_url = CrabUrl::parse(&remote)?;
         return Ok(PushTarget {
@@ -1580,6 +1662,80 @@ mod tests {
 
         assert!(matches!(err, CrabError::Configuration { .. }));
         assert!(!err.to_string().contains("remote.https://"));
+    }
+
+    fn configured_remote(name: &str, url: &str) -> ConfiguredRemote {
+        ConfiguredRemote {
+            name: name.to_owned(),
+            url: url.to_owned(),
+        }
+    }
+
+    #[test]
+    fn default_remote_prefers_crab_compatible_upstream() {
+        let remotes = vec![
+            configured_remote("origin", "https://github.com/example/repo.git"),
+            configured_remote("backup", "crab://bucket/backup"),
+        ];
+
+        assert_eq!(
+            select_default_crab_remote(Some("backup"), &remotes).unwrap(),
+            Some("backup".to_owned())
+        );
+    }
+
+    #[test]
+    fn default_remote_prefers_named_crab_when_upstream_is_not_compatible() {
+        let remotes = vec![
+            configured_remote("origin", "https://github.com/example/repo.git"),
+            configured_remote("crab", "crab://bucket/repo"),
+            configured_remote("backup", "crab://bucket/backup"),
+        ];
+
+        assert_eq!(
+            select_default_crab_remote(Some("origin"), &remotes).unwrap(),
+            Some("crab".to_owned())
+        );
+    }
+
+    #[test]
+    fn default_remote_detects_the_only_crab_compatible_remote() {
+        let remotes = vec![
+            configured_remote("origin", "https://github.com/example/repo.git"),
+            configured_remote("storage", "crab://bucket/repo"),
+        ];
+
+        assert_eq!(
+            select_default_crab_remote(Some("origin"), &remotes).unwrap(),
+            Some("storage".to_owned())
+        );
+    }
+
+    #[test]
+    fn default_remote_requires_explicit_choice_for_ambiguous_crab_remotes() {
+        let remotes = vec![
+            configured_remote("origin", "https://github.com/example/repo.git"),
+            configured_remote("primary", "crab://bucket/primary"),
+            configured_remote("backup", "crab://bucket/backup"),
+        ];
+
+        let err = select_default_crab_remote(Some("origin"), &remotes).unwrap_err();
+        assert!(err.to_string().contains("'primary'"));
+        assert!(err.to_string().contains("'backup'"));
+        assert!(err.to_string().contains("--remote <name>"));
+    }
+
+    #[test]
+    fn default_remote_returns_no_crab_match_for_non_crab_remotes() {
+        let remotes = vec![configured_remote(
+            "origin",
+            "https://github.com/example/repo.git",
+        )];
+
+        assert_eq!(
+            select_default_crab_remote(Some("origin"), &remotes).unwrap(),
+            None
+        );
     }
 
     fn test_push_args() -> PushArgs {

--- a/crab/src/cmd/ship.rs
+++ b/crab/src/cmd/ship.rs
@@ -15,7 +15,9 @@ use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
 use crate::cmd::add::{AddArgs, AddSummary, run_add_without_terminal_output};
-use crate::cmd::push::{PushArgs, PushSummaryPayload, run_push_without_terminal_output};
+use crate::cmd::push::{
+    PushArgs, PushSummaryPayload, resolve_push_remote, run_push_without_terminal_output,
+};
 use crate::core::error::{CrabError, Result};
 use crate::core::output::{OutputMode, emit_json};
 use crate::core::style::CliStyle;
@@ -101,8 +103,9 @@ pub struct ShipArgs {
     pub message: String,
     /// Maximum number of concurrent file-processing tasks.
     pub jobs: usize,
-    /// Push to this remote (default: origin).
-    pub remote: String,
+    /// Push to this Git remote name or crab:// URL; auto-detects a Crab remote
+    /// when omitted.
+    pub remote: Option<String>,
     /// Push to this branch (default: current branch).
     pub branch: Option<String>,
     /// Integrate the current branch and retry after non-fast-forward or lock contention.
@@ -121,10 +124,15 @@ pub struct ShipArgs {
 pub async fn run_ship(args: &ShipArgs, cancel: &CancellationToken) -> Result<()> {
     let start = Instant::now();
     let style = CliStyle::resolve(args.mode);
+    let resolved_remote = if args.no_push {
+        None
+    } else {
+        Some(resolve_push_remote(args.remote.as_deref())?)
+    };
 
     // Dry-run mode: show what would happen without making changes.
     if args.dry_run {
-        return run_ship_dry_run(args, cancel).await;
+        return run_ship_dry_run(args, resolved_remote.as_deref(), cancel).await;
     }
 
     // --- Phase 1: Staging (crab add) ---
@@ -214,7 +222,7 @@ pub async fn run_ship(args: &ShipArgs, cancel: &CancellationToken) -> Result<()>
         };
 
         let push_args = PushArgs {
-            remote: Some(args.remote.clone()),
+            remote: resolved_remote.clone(),
             refspecs: refspec,
             upload_concurrency: None,
             lock_wait_secs: None,
@@ -263,11 +271,15 @@ pub async fn run_ship(args: &ShipArgs, cancel: &CancellationToken) -> Result<()>
                     ))
                 );
             } else {
+                let remote_display = push_summary
+                    .as_ref()
+                    .map(|summary| summary.remote_url.as_str())
+                    .unwrap_or("(unknown remote)");
                 eprintln!(
                     "{}",
                     style.ok(&format!(
                         "Shipped to {} ({commit_word}) in {:.1}s — {}",
-                        args.remote,
+                        remote_display,
                         elapsed.as_secs_f64(),
                         timing_line
                     ))
@@ -340,7 +352,11 @@ fn resolve_head_oid(repo_root: &std::path::Path) -> Result<String> {
 }
 
 /// Dry-run mode: show what would be staged, committed, and pushed.
-async fn run_ship_dry_run(args: &ShipArgs, cancel: &CancellationToken) -> Result<()> {
+async fn run_ship_dry_run(
+    args: &ShipArgs,
+    resolved_remote: Option<&str>,
+    cancel: &CancellationToken,
+) -> Result<()> {
     // Run add in dry-run mode to show what would be staged.
     let add_args = AddArgs {
         patterns: args.patterns.clone(),
@@ -394,7 +410,10 @@ async fn run_ship_dry_run(args: &ShipArgs, cancel: &CancellationToken) -> Result
     // Show push target.
     eprintln!("\n=== Push target ===");
     let branch_display = args.branch.as_deref().unwrap_or("(current branch)");
-    eprintln!("  Remote: {}", args.remote);
+    let remote_display = resolved_remote
+        .or(args.remote.as_deref())
+        .unwrap_or("(not selected: --no-push)");
+    eprintln!("  Remote: {remote_display}");
     eprintln!("  Branch: {branch_display}");
 
     if args.no_push {

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -821,9 +821,10 @@ enum Cmd {
         /// Maximum number of concurrent file-processing tasks.
         #[arg(long, short = 'j', default_value_t = DEFAULT_FILE_PROCESSING_JOBS)]
         jobs: usize,
-        /// Push to this remote (default: origin).
-        #[arg(long, default_value = "origin")]
-        remote: String,
+        /// Push to this Git remote name or crab:// URL. Auto-detects a Crab
+        /// remote when omitted.
+        #[arg(long, value_name = "REMOTE")]
+        remote: Option<String>,
         /// Push to this branch (default: current branch).
         #[arg(long, short)]
         branch: Option<String>,
@@ -6672,8 +6673,13 @@ mod tests {
 
             match cli.cmd {
                 Some(Cmd::Ship {
-                    rebase_retry_limit, ..
-                }) => assert_eq!(rebase_retry_limit, 256),
+                    rebase_retry_limit,
+                    remote,
+                    ..
+                }) => {
+                    assert_eq!(rebase_retry_limit, 256);
+                    assert_eq!(remote, None);
+                }
                 _ => unreachable!("ship command should parse"),
             }
         });

--- a/crab/tests/add_ship_contract.rs
+++ b/crab/tests/add_ship_contract.rs
@@ -124,6 +124,80 @@ fn ship_json_emits_one_terminal_envelope() {
 }
 
 #[test]
+fn ship_dry_run_auto_detects_crab_remote_when_origin_is_git_remote() {
+    let dir = repository();
+    write_large_model(dir.path());
+    assert_success(
+        &git(
+            dir.path(),
+            &[
+                "remote",
+                "set-url",
+                "origin",
+                "https://github.com/example/repo.git",
+            ],
+        ),
+        "set Git origin",
+    );
+    assert_success(
+        &git(
+            dir.path(),
+            &["remote", "add", "crab", "crab://contract-test/repo"],
+        ),
+        "add Crab remote",
+    );
+
+    let output = crab(
+        dir.path(),
+        &[
+            "ship",
+            "model.bin",
+            "--message",
+            "preview ship",
+            "--dry-run",
+        ],
+    );
+    assert_success(&output, "crab ship --dry-run");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Remote: crab"),
+        "ship should select the Crab remote\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn ship_dry_run_accepts_explicit_crab_remote_choice() {
+    let dir = repository();
+    write_large_model(dir.path());
+    assert_success(
+        &git(
+            dir.path(),
+            &["remote", "add", "backup", "crab://contract-test/backup"],
+        ),
+        "add backup Crab remote",
+    );
+
+    let output = crab(
+        dir.path(),
+        &[
+            "ship",
+            "model.bin",
+            "--message",
+            "preview backup ship",
+            "--dry-run",
+            "--remote",
+            "backup",
+        ],
+    );
+    assert_success(&output, "crab ship --dry-run --remote backup");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Remote: backup"),
+        "ship should honor the selected Crab remote\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn ship_json_stops_when_metadata_staging_fails() {
     let dir = repository();
     let head_before = git(dir.path(), &["rev-parse", "HEAD"]);


### PR DESCRIPTION
## Summary

- auto-detect Crab-compatible Git remotes for `crab push` and `crab ship`
- allow an explicit `--remote` choice and report ambiguity when multiple Crab remotes are configured
- resolve and validate the ship target before staging or committing
- document and contract-test repositories with Git and Crab remotes side by side

## Why

`crab ship` supplied `origin` as a hard-coded default. In repositories with a normal Git `origin` and a Crab remote, the command selected the Git URL and failed before pushing.

## Selection order

1. Current branch's Crab-compatible upstream
2. Remote named `crab`
3. The only remaining Crab-compatible remote
4. Existing upstream/`origin` fallback so the current actionable non-Crab error remains available

When multiple Crab remotes match, the command asks the user to choose with `--remote <name>`.

## Validation

- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/crab-main cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/crab-main cargo test -p crab --locked cmd::push::tests::default_remote --lib`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/crab-main cargo test -p crab --locked --test add_ship_contract`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/crab-main cargo test -p crab --locked --bin crab ship_rebase_retry_default_supports_large_swarms`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/crab-main cargo clippy -p crab --locked --lib --no-deps` (passes with existing warnings)
