### PR TITLE
perf: harden protocol-v2 clone planning

### DIFF
--- a/crab/docs/architecture/git-protocol-v2.md
+++ b/crab/docs/architecture/git-protocol-v2.md
@@ -58,6 +58,18 @@ The support matrix is:
 A client request for an unsupported form receives a protocol error; Crab never
 acknowledges it and downloads a complete pack as a substitute.
 
+Fresh, unfiltered fetches of exact visible ref targets use the visibility
+proof's complete per-ref closure directly. Requests with haves, shallow or
+depth semantics, filters, tag expansion, or a want that is not an exact ref
+target use the bounded traversal planner. Pack generation reads up to the
+operation's default 10,000-object bound as one locator batch so adjacent pack
+ranges can be coalesced; fetched-byte and inflated-byte budgets remain the
+memory and I/O bounds.
+
+Failures detected before the `packfile` response section use Git's terminal
+`ERR` packet. Failures after that section begins use sideband channel 3. This
+keeps request rejections distinguishable from truncated pack generation.
+
 Every requested OID is admitted from the immutable visibility proof before the
 remote reader obtains object bytes. The proof and locator are tied to the same
 manifest generation and pack-index hash. Invalid or missing proof suppresses

--- a/crab/docs/design/adr-git-protocol-v2-local-helper.md
+++ b/crab/docs/design/adr-git-protocol-v2-local-helper.md
@@ -42,6 +42,12 @@ pack-index hash. Every want, traversal child, and lazy raw OID is admitted
 before its bytes are read. The standard Git process owns promisor pack
 installation and configuration on the local repository.
 
+An unfiltered fresh fetch of exact visible ref targets may plan directly from
+the proof's complete per-ref closure. Negotiated, shallow, filtered, tag-expanded,
+and arbitrary-object requests retain bounded traversal. Pack generation batches
+the default operation object bound for range coalescing while preserving the
+existing aggregate byte budgets.
+
 ## Consequences
 
 - Direct object-store operation remains the canonical and complete topology.

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -119,14 +119,23 @@ where
     let mut negotiation_rounds = 0u32;
     loop {
         tracing::debug!("waiting for protocol-v2 command request");
-        let Some(request) = read_command_request(reader, cancellation).await? else {
-            tracing::debug!("protocol-v2 client closed the session");
-            return Ok(());
+        let request = match read_command_request(reader, cancellation).await {
+            Ok(Some(request)) => request,
+            Ok(None) => {
+                tracing::debug!("protocol-v2 client closed the session");
+                return Ok(());
+            }
+            Err(error) => return reject_protocol_request(writer, error, cancellation).await,
         };
         tracing::debug!(command = %request.command, args = request.args.len(), "protocol-v2 command request received");
         match request.command.as_str() {
             "ls-refs" => {
-                let args = parse_ls_refs(&request.args)?;
+                let args = match parse_ls_refs(&request.args) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return reject_protocol_request(writer, error, cancellation).await;
+                    }
+                };
                 write_ls_refs(
                     writer,
                     &repository,
@@ -139,7 +148,12 @@ where
             }
             "fetch" => {
                 negotiation_rounds = negotiation_rounds.saturating_add(1);
-                let fetch = parse_fetch(&request.args)?;
+                let fetch = match parse_fetch(&request.args) {
+                    Ok(fetch) => fetch,
+                    Err(error) => {
+                        return reject_protocol_request(writer, error, cancellation).await;
+                    }
+                };
                 if !fetch.done {
                     let common_haves = common_haves(&fetch, &visibility, &visible_ref_names);
                     if common_haves.is_empty() {
@@ -174,9 +188,9 @@ where
                 .await?;
             }
             other => {
-                return Err(CrabError::Protocol(format!(
-                    "unsupported protocol-v2 command: {other}"
-                )));
+                let error =
+                    CrabError::Protocol(format!("unsupported protocol-v2 command: {other}"));
+                return reject_protocol_request(writer, error, cancellation).await;
             }
         }
     }
@@ -612,12 +626,8 @@ async fn write_fetch_response<W: AsyncWrite + Unpin>(
                 },
                 "protocol-v2 upload-pack request rejected"
             );
-            write_packet(writer, error.to_string().as_bytes(), Some(3), cancellation).await?;
-            write_flush(writer, cancellation).await?;
-            write_response_end(writer, cancellation).await?;
-            return Err(CrabError::Protocol(format!(
-                "upload-pack request rejected: {error}"
-            )));
+            let error = CrabError::Protocol(format!("upload-pack request rejected: {error}"));
+            return reject_protocol_request(writer, error, cancellation).await;
         }
     };
 
@@ -775,6 +785,54 @@ async fn write_data<W: AsyncWrite + Unpin>(
     write_packet(writer, data, None, cancellation).await
 }
 
+fn protocol_error_payload(message: &str) -> Vec<u8> {
+    const PREFIX: &[u8] = b"ERR ";
+    const NEWLINE_BYTES: usize = 1;
+    let maximum = MAX_PACKET_BYTES - 4;
+    let mut payload = Vec::with_capacity(message.len().min(maximum));
+    payload.extend_from_slice(PREFIX);
+    for character in message.chars() {
+        let character = if character.is_control() {
+            ' '
+        } else {
+            character
+        };
+        let mut encoded = [0; 4];
+        let encoded = character.encode_utf8(&mut encoded).as_bytes();
+        if payload
+            .len()
+            .saturating_add(encoded.len())
+            .saturating_add(NEWLINE_BYTES)
+            > maximum
+        {
+            break;
+        }
+        payload.extend_from_slice(encoded);
+    }
+    payload.push(b'\n');
+    payload
+}
+
+async fn write_protocol_error<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    message: &str,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    write_data(writer, &protocol_error_payload(message), cancellation).await?;
+    flush_cancellable(writer, cancellation).await
+}
+
+async fn reject_protocol_request<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    error: CrabError,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    if let Err(write_error) = write_protocol_error(writer, &error.to_string(), cancellation).await {
+        tracing::warn!(error = %write_error, "failed to write protocol-v2 ERR packet");
+    }
+    Err(error)
+}
+
 async fn write_packet<W: AsyncWrite + Unpin>(
     writer: &mut W,
     data: &[u8],
@@ -900,6 +958,37 @@ mod tests {
                 .expect("a terminal line feed should be accepted"),
             "want aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
+    }
+
+    #[test]
+    fn protocol_error_payload_uses_err_framing_and_sanitizes_controls() {
+        assert_eq!(
+            protocol_error_payload("request\nfailed\tcleanly"),
+            b"ERR request failed cleanly\n"
+        );
+    }
+
+    #[test]
+    fn protocol_error_payload_respects_the_packet_line_bound() {
+        let payload = protocol_error_payload(&"x".repeat(MAX_PACKET_BYTES));
+
+        assert_eq!(payload.len() + 4, MAX_PACKET_BYTES);
+        assert!(payload.starts_with(b"ERR "));
+        assert!(payload.ends_with(b"\n"));
+    }
+
+    #[tokio::test]
+    async fn rejected_request_writes_one_terminal_err_packet() {
+        let mut writer = Vec::new();
+        let cancellation = CancellationToken::new();
+        let error = protocol("request rejected");
+        let expected = packet(&protocol_error_payload(&error.to_string()));
+
+        reject_protocol_request(&mut writer, error, &cancellation)
+            .await
+            .expect_err("the semantic request error must remain terminal");
+
+        assert_eq!(writer, expected);
     }
 
     #[test]

--- a/crates/crab-read/src/upload_pack.rs
+++ b/crates/crab-read/src/upload_pack.rs
@@ -6,7 +6,7 @@ use bstr::ByteSlice;
 use crab_metadata::git_visibility::GitVisibilityIndex;
 use crab_remote_git::{
     CorruptionStage, Error as RemoteGitError, OperationContext, OperationKind, RemoteGitObject,
-    RemoteGitRepository,
+    RemoteGitRepository, RepositoryRef, RepositoryStateError,
 };
 use gix_hash::ObjectId;
 use tokio_util::sync::CancellationToken;
@@ -403,6 +403,21 @@ async fn plan_with_operation(
     request: &UploadPackRequest,
     cancellation: &CancellationToken,
 ) -> crab_remote_git::Result<PackPlan> {
+    let maximum_objects = operation.max_logical_objects();
+    if let Some(plan) = plan_from_visibility(
+        &repository.refs().entries,
+        visible_ref_names,
+        visibility,
+        request,
+        maximum_objects,
+    )? {
+        tracing::debug!(
+            planned_objects = plan.object_ids.len(),
+            "planned full ref closure from visibility proof"
+        );
+        return Ok(plan);
+    }
+
     let common_haves = request
         .haves
         .iter()
@@ -415,7 +430,6 @@ async fn plan_with_operation(
         .copied()
         .collect::<HashSet<_>>();
     let existing_shallow = request.shallow.iter().copied().collect::<HashSet<_>>();
-    let maximum_objects = operation.max_logical_objects();
     let deduplicate_by_oid = request.deepen.is_none()
         && !request.deepen_relative
         && !filter_requires_traversal_context(&request.filter);
@@ -604,6 +618,87 @@ async fn plan_with_operation(
         shallow,
         unshallow,
     })
+}
+
+fn plan_from_visibility(
+    references: &[RepositoryRef],
+    visible_ref_names: &[String],
+    visibility: &GitVisibilityIndex,
+    request: &UploadPackRequest,
+    maximum_objects: u64,
+) -> crab_remote_git::Result<Option<PackPlan>> {
+    if request.wants.is_empty()
+        || !request.haves.is_empty()
+        || !request.shallow.is_empty()
+        || request.deepen.is_some()
+        || request.deepen_relative
+        || request.include_tags
+        || !matches!(request.filter, UploadPackFilter::None)
+    {
+        return Ok(None);
+    }
+
+    let visible = visible_ref_names
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let selected_refs = request
+        .wants
+        .iter()
+        .map(|want| {
+            references
+                .iter()
+                .find(|reference| {
+                    visible.contains(reference.name.as_str()) && reference.target == *want
+                })
+                .map(|reference| reference.name.as_str())
+        })
+        .collect::<Option<Vec<_>>>();
+    let Some(selected_refs) = selected_refs else {
+        return Ok(None);
+    };
+
+    for (reference_name, want) in selected_refs.iter().zip(&request.wants) {
+        let target = want.to_hex().to_string();
+        if visibility
+            .refs
+            .get(*reference_name)
+            .is_none_or(|objects| objects.binary_search(&target).is_err())
+        {
+            return Err(RemoteGitError::RepositoryState {
+                reason: RepositoryStateError::VisibilityProofMismatch,
+            });
+        }
+    }
+
+    let objects = visibility.objects_for_refs(selected_refs.iter().copied());
+    let actual = u64::try_from(objects.len()).unwrap_or(u64::MAX);
+    if actual > maximum_objects {
+        return Err(RemoteGitError::LimitExceeded {
+            limit: "upload-pack planned objects",
+            actual,
+            maximum: maximum_objects,
+        });
+    }
+    let object_ids = objects
+        .into_iter()
+        .map(|oid| {
+            ObjectId::from_hex(oid.as_bytes()).map_err(|_| RemoteGitError::RepositoryState {
+                reason: RepositoryStateError::VisibilityProofMismatch,
+            })
+        })
+        .collect::<crab_remote_git::Result<Vec<_>>>()?;
+
+    Ok(Some(PackPlan {
+        wants: request.wants.clone(),
+        common_haves: Vec::new(),
+        filter: request.filter.clone(),
+        include_tags: false,
+        object_ids,
+        required_bases: Vec::new(),
+        shallow: Vec::new(),
+        unshallow: Vec::new(),
+    }))
 }
 
 #[derive(Debug, Clone)]
@@ -1085,6 +1180,8 @@ fn enqueue(
 
 #[cfg(test)]
 mod tests {
+    use crab_remote_git::RepositoryRef;
+
     use super::*;
 
     fn oid(value: char) -> ObjectId {
@@ -1108,6 +1205,143 @@ mod tests {
             .into_iter()
             .collect(),
         )
+    }
+
+    fn references() -> Vec<RepositoryRef> {
+        vec![
+            RepositoryRef {
+                name: "refs/heads/main".to_owned(),
+                target: oid('1'),
+                peeled: None,
+            },
+            RepositoryRef {
+                name: "refs/heads/secret".to_owned(),
+                target: oid('2'),
+                peeled: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn full_ref_visibility_plan_deduplicates_duplicate_wants() {
+        let request = UploadPackRequest {
+            wants: vec![oid('1'), oid('1')],
+            ..UploadPackRequest::default()
+        };
+        let plan = plan_from_visibility(
+            &references(),
+            &["refs/heads/main".to_owned()],
+            &visibility(),
+            &request,
+            10,
+        )
+        .expect("valid visibility closure")
+        .expect("fresh full ref fetch should use the visibility plan");
+
+        assert_eq!(plan.object_ids, [oid('1'), oid('3')]);
+        assert_eq!(plan.wants, request.wants);
+        assert!(plan.common_haves.is_empty());
+        assert!(plan.shallow.is_empty());
+        assert!(plan.unshallow.is_empty());
+    }
+
+    #[test]
+    fn visibility_plan_falls_back_when_request_semantics_need_traversal() {
+        let cases = [
+            UploadPackRequest {
+                wants: vec![oid('3')],
+                ..UploadPackRequest::default()
+            },
+            UploadPackRequest {
+                wants: vec![oid('1')],
+                haves: vec![oid('3')],
+                ..UploadPackRequest::default()
+            },
+            UploadPackRequest {
+                wants: vec![oid('1')],
+                shallow: vec![oid('3')],
+                ..UploadPackRequest::default()
+            },
+            UploadPackRequest {
+                wants: vec![oid('1')],
+                deepen: Some(1),
+                ..UploadPackRequest::default()
+            },
+            UploadPackRequest {
+                wants: vec![oid('1')],
+                include_tags: true,
+                ..UploadPackRequest::default()
+            },
+            UploadPackRequest {
+                wants: vec![oid('1')],
+                filter: UploadPackFilter::BlobNone,
+                ..UploadPackRequest::default()
+            },
+        ];
+
+        for request in cases {
+            assert!(
+                plan_from_visibility(
+                    &references(),
+                    &["refs/heads/main".to_owned()],
+                    &visibility(),
+                    &request,
+                    10,
+                )
+                .expect("fallback decision")
+                .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn visibility_plan_enforces_the_operation_object_bound() {
+        let request = UploadPackRequest {
+            wants: vec![oid('1')],
+            ..UploadPackRequest::default()
+        };
+        let error = plan_from_visibility(
+            &references(),
+            &["refs/heads/main".to_owned()],
+            &visibility(),
+            &request,
+            1,
+        )
+        .expect_err("two-object closure must exceed a one-object operation bound");
+
+        assert!(matches!(
+            error,
+            RemoteGitError::LimitExceeded {
+                actual: 2,
+                maximum: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn visibility_plan_rejects_a_closure_missing_its_ref_target() {
+        let proof = GitVisibilityIndex::new(
+            7,
+            "a".repeat(64),
+            [("refs/heads/main".to_owned(), vec![oid('3').to_string()])]
+                .into_iter()
+                .collect(),
+        );
+        let request = UploadPackRequest {
+            wants: vec![oid('1')],
+            ..UploadPackRequest::default()
+        };
+        let error = plan_from_visibility(
+            &references(),
+            &["refs/heads/main".to_owned()],
+            &proof,
+            &request,
+            10,
+        )
+        .expect_err("a visibility closure must contain its exact ref target");
+
+        assert!(matches!(error, RemoteGitError::RepositoryState { .. }));
     }
 
     #[test]

--- a/crates/crab-remote-git/src/pack.rs
+++ b/crates/crab-remote-git/src/pack.rs
@@ -12,7 +12,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{BudgetDimension, Error, OperationKind, RemoteGitObject, RemoteGitRepository, Result};
 
-const OBJECT_BATCH_SIZE: usize = 32;
+// Large locator batches let the reader coalesce adjacent pack ranges across the
+// whole batch. The operation's object and byte budgets still bound residency.
+const OBJECT_BATCH_SIZE: usize = 10_000;
 const SIDEBAND_PAYLOAD: usize = 65_515;
 
 /// A temporary, checksummed Git pack generated from one pinned snapshot.
@@ -473,5 +475,13 @@ mod tests {
         };
         let result = writer.write_objects(vec![object], &CancellationToken::new());
         assert!(matches!(result, Err(Error::LimitExceeded { .. })));
+    }
+
+    #[test]
+    fn generation_batch_covers_the_default_operation_object_bound() {
+        let maximum = usize::try_from(crate::OperationLimits::default().max_logical_objects)
+            .expect("default logical-object bound fits usize");
+
+        assert!(OBJECT_BATCH_SIZE >= maximum);
     }
 }


### PR DESCRIPTION
## Summary

- Plan fresh, unfiltered fetches of exact visible ref targets directly from the generation-pinned visibility closure.
- Preserve bounded traversal for haves, shallow/depth negotiation, filters, tag expansion, and arbitrary object wants.
- Generate packs in one operation-bounded locator batch so object-store ranges can coalesce across the complete default 10,000-object budget.
- Emit a terminal Git `ERR` packet for pre-pack request rejection; retain sideband channel 3 only after the `packfile` section starts.
- Document the planning, batching, and failure-framing contracts.

The 10,000 value is a logical-object safety bound, not 10,000 network requests.

## Performance proof

Real macOS Git 2.50.1 clones of `crab://crabbuild/bbolt`, which has 7,830 reachable objects:

| Metric | Before | After |
| --- | ---: | ---: |
| Logged locator operations | 2,415 | 1 |
| Pack range GETs | 7,118 | 2 |
| Upload-pack latency | 22.169 s | 10.090 s |
| Clone wall time | about 23 s | about 11 s |

The final clone passed `git fsck --full`. Running `crab hydrate --all` from the clone reconstructed `Zed-aarch64.dmg` at 143,534,626 bytes with SHA-256 `ed414ec3276f42c6272958823e1b669ce9a63f929d067a0dd3b12f0bf8bd087e`, identical to the source checkout.

The retained RustFS protocol-v2 qualification passed all 76 checks. Its fresh full clone used one locator lookup and one coalesced range GET. Filtered incremental fetch remained on bounded traversal and passed shallow, filter-matrix, promisor, lazy-OID, authorization, disconnect-cleanup, and byte-identity checks.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p crab-read --lib` — 50 passed
- `cargo test --locked -p crab-remote-git --lib` — 74 passed
- `cargo test --locked -p crab-remote-git --test remote_repository` — 44 passed
- `cargo test --locked -p crab --lib git::upload_pack_wire::tests` — 16 passed
- `cargo test --locked -p crab --test remote_helper_transcript` — 42 passed
- `cargo check --locked -p crab-auth-server`
- Release build of `crab`
- RustFS protocol-v2 partial-clone smoke — 76 checks passed
- Real `bbolt` clone, Git fsck, full hydration, size comparison, and SHA-256 comparison

Strict Clippy is currently blocked by pre-existing Rust 1.97 lints in untouched `crates/crab-remote-git/src/snapshot.rs` and `crates/crab-remote-git/src/repository.rs`; this PR does not modify those files.
