### PR TITLE
perf: scale protocol-v2 clone and concurrent pushes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,6 +2196,7 @@ dependencies = [
  "tokio",
  "tracing",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/crab/src/cmd/metadb.rs
+++ b/crab/src/cmd/metadb.rs
@@ -1437,7 +1437,7 @@ async fn rebuild_git_object_locators(
         crab_coordination::GIT_OBJECT_LOCATOR_RESOURCE,
     )
     .await?;
-    let write_result = crate::git::push::while_renewing_locator_lock(&lock, async {
+    let write_result = crate::git::push::while_renewing_internal_lock(&lock, async {
         let (current, _) = crab_metadata::manifest_store::read_manifest(store, router).await?;
         if current.generation != manifest.generation
             || current.pack_index_hash != manifest.pack_index_hash

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -2415,8 +2415,10 @@ const MANIFEST_LOCK_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(50);
 const MANIFEST_LOCK_WAIT_BACKOFF_CAP: Duration = Duration::from_millis(500);
 const PUSH_ADMISSION_SLOTS: usize = 5;
 const PUSH_ADMISSION_WAIT_TTL_MULTIPLIER: u32 = 2;
-const PUSH_ADMISSION_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(500);
+const PUSH_ADMISSION_QUEUED_TTL: Duration = Duration::from_secs(120);
+const PUSH_ADMISSION_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(100);
 const PUSH_ADMISSION_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(5);
+const PUSH_ADMISSION_WAIT_PER_WAVE: Duration = Duration::from_millis(250);
 const MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS: u64 = 100_000;
 
 /// Multipart threshold: xorbs larger than this use multipart upload.
@@ -2976,15 +2978,23 @@ fn manifest_lock_wait_delay(attempt: u32, remaining: Duration) -> Duration {
     Duration::from_nanos(pick)
 }
 
-fn push_admission_wait_delay(attempt: u32, remaining: Duration) -> Duration {
+fn push_admission_wait_delay(attempt: u32, writers_ahead: usize, remaining: Duration) -> Duration {
     let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
     let exp = PUSH_ADMISSION_WAIT_BACKOFF_BASE.saturating_mul(shift);
-    let bound = exp.min(PUSH_ADMISSION_WAIT_BACKOFF_CAP).min(remaining);
+    let waves_ahead = writers_ahead / PUSH_ADMISSION_SLOTS;
+    let rank_floor = PUSH_ADMISSION_WAIT_PER_WAVE
+        .saturating_mul(u32::try_from(waves_ahead).unwrap_or(u32::MAX))
+        .min(PUSH_ADMISSION_WAIT_BACKOFF_CAP.saturating_sub(PUSH_ADMISSION_WAIT_BACKOFF_BASE));
+    let bound = exp
+        .max(rank_floor.saturating_add(PUSH_ADMISSION_WAIT_BACKOFF_BASE))
+        .min(PUSH_ADMISSION_WAIT_BACKOFF_CAP)
+        .min(remaining);
     let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
     if bound_nanos == 0 {
         return Duration::ZERO;
     }
-    let pick = rand::rng().random_range(1..=bound_nanos);
+    let floor_nanos = u64::try_from(rank_floor.min(bound).as_nanos()).unwrap_or(bound_nanos);
+    let pick = rand::rng().random_range(floor_nanos.max(1)..=bound_nanos);
     Duration::from_nanos(pick)
 }
 
@@ -3701,6 +3711,9 @@ pub struct PushPipeline {
     manifest_etag: tokio::sync::Mutex<Option<String>>,
     /// Generation and shard-index hash returned by a successful manifest CAS.
     committed_manifest_anchor: tokio::sync::Mutex<Option<CommittedManifestAnchor>>,
+    /// Whether this generation has the complete bounded visibility proof that
+    /// protocol-v2 admission requires alongside exact locator coverage.
+    git_visibility_published: std::sync::atomic::AtomicBool,
     /// Base-bound dependency receipt rebuilt whenever manifest CAS replans.
     push_commit_receipt: tokio::sync::Mutex<Option<crab_metadata::receipts::PushCommitReceipt>>,
     /// Current pre-commit ref decisions. Dependency discovery reads this so
@@ -3714,6 +3727,8 @@ pub struct PushPipeline {
     /// [`Self::evaluate_decisions`] to short-circuit rejected pushes
     /// before any S3 write happens.
     receive_config: ReceiveConfig,
+    #[cfg(test)]
+    cas_dependency_replans: std::sync::atomic::AtomicU64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4711,38 +4726,57 @@ async fn acquire_push_admission_lock(
     prefix: &str,
     ttl: Duration,
     cancel: &CancellationToken,
-) -> Result<PushLock> {
+) -> Result<crab_coordination::PushAdmissionTicket> {
     // Admission is a capacity queue, not a correctness lease. Give queued
     // writers more than one lease lifetime so a healthy long push cannot
     // make an unrelated branch fail only because all slots remained busy.
     let deadline = Instant::now() + ttl.saturating_mul(PUSH_ADMISSION_WAIT_TTL_MULTIPLIER);
+    let mut ticket = crab_coordination::PushAdmissionTicket::enqueue(
+        store.inner(),
+        prefix,
+        PUSH_ADMISSION_SLOTS,
+        ttl,
+        PUSH_ADMISSION_QUEUED_TTL,
+    )
+    .await
+    .map_err(CrabError::from)?;
     let mut attempt = 0;
     loop {
-        check_cancelled(cancel)?;
-        let slot = rand::rng().random_range(0..PUSH_ADMISSION_SLOTS);
-        let resource = format!("push-admission-{slot}");
-        match PushLock::acquire_internal(store.inner(), prefix, &resource, ttl)
-            .await
-            .map_err(CrabError::from)
-        {
-            Ok(lock) => return Ok(lock),
-            Err(CrabError::PushLockHeld { .. }) => {
+        if let Err(error) = check_cancelled(cancel) {
+            if let Err(release_error) = ticket.release().await {
+                warn!(error = %release_error, "cancelled push admission ticket release failed");
+            }
+            return Err(error);
+        }
+        match ticket.try_admit().await.map_err(CrabError::from) {
+            Ok(true) => return Ok(ticket),
+            Ok(false) => {
                 let now = Instant::now();
                 if now >= deadline {
+                    if let Err(error) = ticket.release().await {
+                        warn!(error = %error, "timed-out push admission ticket release failed");
+                    }
                     return Err(CrabError::Throttled { retry_after: None });
                 }
-                let delay =
-                    push_admission_wait_delay(attempt, deadline.saturating_duration_since(now));
+                let delay = push_admission_wait_delay(
+                    attempt,
+                    ticket.writers_ahead(),
+                    deadline.saturating_duration_since(now),
+                );
                 attempt = attempt.saturating_add(1);
                 debug!(
-                    slot,
                     attempt,
                     delay_ms = delay.as_millis(),
-                    "push admission is full, waiting before retry"
+                    "push admission ticket is queued"
                 );
                 tokio::select! {
                     () = tokio::time::sleep(delay) => {}
-                    () = cancel.cancelled() => return Err(CrabError::Cancelled),
+                    () = cancel.cancelled() => {
+                        if let Err(error) = ticket.release().await {
+                            warn!(error = %error, "cancelled push admission ticket release failed");
+                        }
+                        return Err(CrabError::Cancelled);
+                    },
                 }
             }
             Err(error) => return Err(error),
@@ -4792,11 +4826,11 @@ pub(crate) async fn while_renewing_internal_lock<T>(
 }
 
 async fn while_admitted_until_commit<T>(
-    lock: PushLock,
+    permit: crab_coordination::PushAdmissionTicket,
     operation: impl Future<Output = Result<T>>,
     mut committed: tokio::sync::oneshot::Receiver<()>,
 ) -> Result<T> {
-    let renewal_interval = (lock.ttl() / 3).max(Duration::from_secs(1));
+    let renewal_interval = (permit.ttl() / 3).max(Duration::from_secs(1));
     let mut ticker = tokio::time::interval(renewal_interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     ticker.tick().await;
@@ -4807,8 +4841,8 @@ async fn while_admitted_until_commit<T>(
     loop {
         tokio::select! {
             result = &mut operation => {
-                if let Err(error) = lock.release().await {
-                    warn!(error = %error, "push admission lock release failed");
+                if let Err(error) = permit.release().await {
+                    warn!(error = %error, "push admission ticket release failed");
                 }
                 return match (result, renewal_error) {
                     (Ok(_), Some(error)) => Err(CrabError::from(error)),
@@ -4820,15 +4854,15 @@ async fn while_admitted_until_commit<T>(
                     commit_signal_open = false;
                     continue;
                 }
-                if let Err(error) = lock.release().await {
-                    warn!(error = %error, "push admission lock release failed after commit");
+                if let Err(error) = permit.release().await {
+                    warn!(error = %error, "push admission ticket release failed after commit");
                 }
                 // Derived indexes and cache warming are repairable and must
                 // not retain scarce write capacity after the ref is visible.
                 return operation.await;
             }
             _ = ticker.tick(), if renewal_error.is_none() => {
-                if let Err(error) = lock.renew().await {
+                if let Err(error) = permit.renew().await {
                     renewal_error = Some(error);
                 }
             }
@@ -5148,10 +5182,13 @@ impl PushPipeline {
             base_commit_graph_loaded: tokio::sync::Mutex::new(false),
             manifest_etag: tokio::sync::Mutex::new(None),
             committed_manifest_anchor: tokio::sync::Mutex::new(None),
+            git_visibility_published: std::sync::atomic::AtomicBool::new(false),
             push_commit_receipt: tokio::sync::Mutex::new(None),
             planned_ref_decisions: tokio::sync::Mutex::new(None),
             dependency_plan: tokio::sync::Mutex::new(None),
             receive_config,
+            #[cfg(test)]
+            cas_dependency_replans: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -6510,6 +6547,10 @@ impl PushPipeline {
                     false
                 }
             };
+        self.git_visibility_published.store(
+            visibility_proof_published,
+            std::sync::atomic::Ordering::Relaxed,
+        );
         let plan = if visibility_proof_published {
             self.active_active_commit_plan(manifest, bulk, decisions, sha_map, true)
                 .await?
@@ -6707,15 +6748,22 @@ impl PushPipeline {
                 if let Some(committed) = admission_commit.take() {
                     let _ = committed.send(());
                 }
-                if let Err(error) = self
+                match self
                     .publish_git_visibility_index(&committed_manifest, store)
                     .await
                 {
-                    warn!(
-                        error = %error,
-                        generation = committed_manifest.generation,
-                        "Git visibility proof publication failed; v2 remains gated"
-                    );
+                    Ok(()) => self
+                        .git_visibility_published
+                        .store(true, std::sync::atomic::Ordering::Relaxed),
+                    Err(error) => {
+                        self.git_visibility_published
+                            .store(false, std::sync::atomic::Ordering::Relaxed);
+                        warn!(
+                            error = %error,
+                            generation = committed_manifest.generation,
+                            "Git visibility proof publication failed; v2 remains gated"
+                        );
+                    }
                 }
                 Ok(value)
             }
@@ -6929,8 +6977,19 @@ impl PushPipeline {
                         });
                     }
                     *self.planned_ref_decisions.lock().await = Some(retry_decisions.clone());
-                    self.replan_base_bound_dependencies_after_cas_conflict()
-                        .await?;
+                    if retry_decisions != decisions {
+                        // A changed proceeding set invalidates ref-scoped
+                        // packs, shards, and connectivity. An unrelated ref
+                        // advance keeps those immutable proofs valid; the
+                        // candidate builder below rebinds their receipt to the
+                        // refreshed manifest without repeating preparation.
+                        self.replan_base_bound_dependencies_after_cas_conflict()
+                            .await?;
+                    } else {
+                        info!(
+                            "manifest advanced only on unrelated refs; reusing prepared immutable dependencies"
+                        );
+                    }
                     let (merged, merged_bulk) = self
                         .apply_decisions_with_sha_map(&retry_decisions, self.config.atomic, sha_map)
                         .await?;
@@ -11100,13 +11159,8 @@ impl PushPipeline {
 
     /// Install a [`MetaDbGuard`] for the duration of this pipeline run.
     ///
-    /// Callers (`run_push_batch`, `run_push_batch_with_locks`, the
-    /// native push orchestrator) construct the guard at the outer
-    /// command boundary, hand it to the pipeline here, and let the
-    /// pipeline drive `commit` + `close` for every exit path. Tests
-    /// that don't care about metadata can simply skip this call —
-    /// step 2 and step 9b both preserve their legacy behaviour when
-    /// no guard is installed.
+    /// Pointer-bearing production pushes construct the guard lazily after
+    /// discovery. Tests can install one directly when exercising metadata.
     ///
     /// [`MetaDbGuard`]: crate::metadata::MetaDbGuard
     fn install_metadb(&self, guard: crate::metadata::MetaDbGuard) {
@@ -11130,6 +11184,31 @@ impl PushPipeline {
                 drop(guard);
             }
         }
+    }
+
+    async fn install_metadb_for_pointer_work_if_needed(&self) {
+        if self.config.protected_push.is_some()
+            || self.pointers.lock().await.is_empty()
+            || self.metadb.lock().await.is_some()
+        {
+            return;
+        }
+        let Some(store) = self.store.as_ref() else {
+            return;
+        };
+        let metadb_object_store = self
+            .caching_store
+            .as_ref()
+            .map(crab_cache_store::CachingStore::object_store);
+        let guard = build_push_metadb_guard_with_object_store(
+            store,
+            metadb_object_store,
+            &self.router,
+            self.metrics.clone(),
+            &self.config.metadb,
+            true,
+        );
+        self.install_metadb(guard);
     }
 
     /// Close the installed MetaDb guard on every exit path.
@@ -11653,6 +11732,9 @@ impl PushPipeline {
     }
 
     async fn replan_base_bound_dependencies_after_cas_conflict(&self) -> Result<()> {
+        #[cfg(test)]
+        self.cas_dependency_replans
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         // The surviving non-atomic ref set is a strict subset of the initial
         // plan. Rewalk and rebuild all ref-scoped large-file state so shards,
         // receipts, acceleration writes, and cleanup describe that exact set.
@@ -13347,7 +13429,9 @@ impl PushPipeline {
         // and releases the handle. On the error path, `on_failure`
         // still runs below (releasing the push lock, etc.) — the
         // MetaDb close is additive and independent.
+        let metadb_close_phase = PhaseTimer::start("push", "metadb_close");
         self.close_metadb().await;
+        self.emit_perf_phase(metadb_close_phase.finish(0, 0, 0));
 
         match result {
             Ok(outcomes) => {
@@ -13439,11 +13523,14 @@ impl PushPipeline {
             None
         };
 
-        self.check_chunk_index_cache_gc_drift().await;
-
         // Steps 1–4: data preparation (classify phase)
         async {
             self.enumerate_pointers().await?;
+            // Pure Git pushes never consult file/chunk metadata. Avoid
+            // opening and draining shared SlateDB readers for every branch
+            // writer when pointer discovery proved there is no metadata work.
+            self.install_metadb_for_pointer_work_if_needed().await;
+            self.check_chunk_index_cache_gc_drift().await;
             // Retirement uses shared staging handles and is coordinated by
             // marker files. Publish our reader marker before the first recipe
             // or payload lookup so a sibling push cannot retire rows in the
@@ -13715,7 +13802,12 @@ impl PushPipeline {
 
             let uploaded_packs = self.uploaded_packs.lock().await.clone();
             let mut git_indexed = true;
-            if let (Some(anchor), Some(store)) = (anchor, self.store.as_ref()) {
+            let visibility_published = self
+                .git_visibility_published
+                .load(std::sync::atomic::Ordering::Relaxed);
+            if visibility_published
+                && let (Some(anchor), Some(store)) = (anchor, self.store.as_ref())
+            {
                 match publish_uploaded_pack_locators(
                     store,
                     &self.router,
@@ -13753,6 +13845,11 @@ impl PushPipeline {
                         );
                     }
                 }
+            } else if anchor.is_some() && self.store.is_some() {
+                git_indexed = false;
+                info!(
+                    "skipping synchronous Git locator publication until the visibility proof is repairable"
+                );
             }
             if file_indexed
                 && git_indexed
@@ -13863,7 +13960,7 @@ pub(crate) async fn run_push_batch_with_prepopulated(
         return reject_batch_for_error(specs, &error);
     }
 
-    let Some(store_ref) = store.as_ref() else {
+    let Some(_) = store.as_ref() else {
         return reject_batch_for_error(
             specs,
             &CrabError::Configuration {
@@ -13879,7 +13976,6 @@ pub(crate) async fn run_push_batch_with_prepopulated(
         "starting push pipeline"
     );
 
-    let metadb_object_store = caching_store.as_ref().map(|cache| cache.object_store());
     let pipeline = PushPipeline::new(
         config.clone(),
         specs.to_vec(),
@@ -13894,17 +13990,6 @@ pub(crate) async fn run_push_batch_with_prepopulated(
     );
     if let Some(prepopulated) = prepopulated {
         pipeline.install_prepopulated_walk(prepopulated).await;
-    }
-    if config.protected_push.is_none() {
-        let guard = build_push_metadb_guard_with_object_store(
-            store_ref,
-            metadb_object_store,
-            &router,
-            metrics.clone(),
-            &config.metadb,
-            true,
-        );
-        pipeline.install_metadb(guard);
     }
     Box::pin(pipeline.execute()).await
 }
@@ -13952,7 +14037,7 @@ pub(crate) async fn run_push_batch_with_locks(
         return reject_batch_for_error(specs, &error);
     }
 
-    let Some(store_ref) = store.as_ref() else {
+    let Some(_) = store.as_ref() else {
         release_push_lock_leases(leases).await;
         return reject_batch_for_error(
             specs,
@@ -13971,7 +14056,6 @@ pub(crate) async fn run_push_batch_with_locks(
         "starting push pipeline with pre-acquired locks"
     );
 
-    let metadb_object_store = caching_store.as_ref().map(|cache| cache.object_store());
     let pipeline = PushPipeline::new(
         config.clone(),
         specs.to_vec(),
@@ -13987,17 +14071,6 @@ pub(crate) async fn run_push_batch_with_locks(
     pipeline.install_locks(leases).await;
     if let Some(pre) = prepopulated {
         pipeline.install_prepopulated_walk(pre).await;
-    }
-    if config.protected_push.is_none() {
-        let guard = build_push_metadb_guard_with_object_store(
-            store_ref,
-            metadb_object_store,
-            &router,
-            metrics.clone(),
-            &config.metadb,
-            true,
-        );
-        pipeline.install_metadb(guard);
     }
     Box::pin(pipeline.execute()).await
 }
@@ -16601,6 +16674,19 @@ mod tests {
         }
     }
 
+    #[test]
+    fn push_admission_backoff_scales_with_fifo_distance() {
+        let front = push_admission_wait_delay(0, PUSH_ADMISSION_SLOTS, Duration::from_secs(60));
+        let tail = push_admission_wait_delay(0, 95, Duration::from_secs(60));
+        let bounded = push_admission_wait_delay(32, 95, Duration::from_secs(1));
+
+        assert!(front >= PUSH_ADMISSION_WAIT_PER_WAVE);
+        assert!(front <= PUSH_ADMISSION_WAIT_PER_WAVE + PUSH_ADMISSION_WAIT_BACKOFF_BASE);
+        assert!(tail >= Duration::from_millis(4_750));
+        assert!(tail <= PUSH_ADMISSION_WAIT_BACKOFF_CAP);
+        assert!(bounded <= Duration::from_secs(1));
+    }
+
     #[tokio::test]
     async fn prepopulated_walk_is_reusable_for_manifest_cas_replan() {
         let mut config = PushConfig::default();
@@ -17002,6 +17088,92 @@ mod tests {
             sha_map.get("refs/heads/dev"),
             "the unconflicted sibling must commit in non-atomic mode"
         );
+        assert_eq!(
+            pipeline
+                .cas_dependency_replans
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "a changed proceeding set must rebuild ref-scoped dependencies"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cas_retry_reuses_dependencies_when_only_unrelated_ref_advanced() {
+        let _guard = GitDirGuard::new();
+        let (store, router) = test_store_router("cas-retry-unrelated-ref");
+        let initial = Manifest::default_for_repo("refs/heads/main");
+        create_manifest_with_etag(&store, &router, &initial)
+            .await
+            .expect("create initial manifest");
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            vec![make_spec("refs/heads/dev")],
+            Some(store.clone()),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router.clone(),
+            None,
+            CancellationToken::new(),
+            None,
+        );
+        pipeline.read_base_manifest().await.expect("read base");
+        let sha_map = pipeline.resolve_src_ref_map().expect("resolve refs");
+        let decisions = pipeline
+            .evaluate_decisions_with_sha_map(&sha_map)
+            .await
+            .expect("evaluate refs");
+        *pipeline.planned_ref_decisions.lock().await = Some(decisions.clone());
+        pipeline.prepare_git_pack().await.expect("prepare pack");
+        pipeline.upload_packs().await.expect("upload pack");
+        let (candidate, bulk) = pipeline
+            .apply_decisions_with_sha_map(&decisions, false, &sha_map)
+            .await
+            .expect("build candidate");
+
+        let (mut concurrent, etag) = read_manifest(&store, &router)
+            .await
+            .expect("read concurrent base");
+        let concurrent_main = "f".repeat(40);
+        concurrent.generation += 1;
+        concurrent
+            .refs
+            .insert("refs/heads/main".to_owned(), concurrent_main.clone());
+        concurrent.seal_git_validation();
+        write_manifest_cas(&store, &router, &concurrent, &etag)
+            .await
+            .expect("commit concurrent main update");
+
+        let mut admission_commit = None;
+        let committed_decisions = pipeline
+            .unified_manifest_cas(candidate, bulk, &sha_map, decisions, &mut admission_commit)
+            .await
+            .expect("retry should merge the unrelated ref update");
+
+        assert!(matches!(
+            committed_decisions.get("refs/heads/dev"),
+            Some(RefUpdateDecision::Proceed { .. })
+        ));
+        let (committed, _) = read_manifest(&store, &router)
+            .await
+            .expect("read committed manifest");
+        assert_eq!(
+            committed.refs.get("refs/heads/main"),
+            Some(&concurrent_main),
+            "the concurrent unrelated ref must be preserved"
+        );
+        assert_eq!(
+            committed.refs.get("refs/heads/dev"),
+            sha_map.get("refs/heads/dev"),
+            "the planned ref must commit after rebinding to the current manifest"
+        );
+        assert_eq!(
+            pipeline
+                .cas_dependency_replans
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "an unrelated ref advance must reuse immutable dependencies"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -17239,17 +17411,18 @@ mod tests {
             Arc::new(object_store::memory::InMemory::new());
         let store = Store::new(inner);
         let mut blockers = Vec::new();
-        for slot in 0..PUSH_ADMISSION_SLOTS {
-            blockers.push(
-                PushLock::acquire_internal(
-                    store.inner(),
-                    "repo",
-                    &format!("push-admission-{slot}"),
-                    Duration::from_secs(60),
-                )
-                .await
-                .unwrap(),
-            );
+        for _ in 0..PUSH_ADMISSION_SLOTS {
+            let mut blocker = crab_coordination::PushAdmissionTicket::enqueue(
+                store.inner(),
+                "repo",
+                PUSH_ADMISSION_SLOTS,
+                Duration::from_secs(60),
+                PUSH_ADMISSION_QUEUED_TTL,
+            )
+            .await
+            .unwrap();
+            assert!(blocker.try_admit().await.unwrap());
+            blockers.push(blocker);
         }
         let release = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
@@ -17278,16 +17451,21 @@ mod tests {
         let inner: Arc<dyn object_store::ObjectStore> =
             Arc::new(object_store::memory::InMemory::new());
         let store = Store::new(inner);
-        let resource = "push-admission-0";
-        let lock =
-            PushLock::acquire_internal(store.inner(), "repo", resource, Duration::from_secs(60))
-                .await
-                .unwrap();
+        let mut permit = crab_coordination::PushAdmissionTicket::enqueue(
+            store.inner(),
+            "repo",
+            1,
+            Duration::from_secs(60),
+            PUSH_ADMISSION_QUEUED_TTL,
+        )
+        .await
+        .unwrap();
+        assert!(permit.try_admit().await.unwrap());
         let (committed_tx, committed_rx) = tokio::sync::oneshot::channel();
         let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
         let operation = tokio::spawn(async move {
             while_admitted_until_commit(
-                lock,
+                permit,
                 async move {
                     committed_tx.send(()).unwrap();
                     finish_rx.await.unwrap();
@@ -17299,21 +17477,20 @@ mod tests {
         });
 
         let contender = tokio::time::timeout(Duration::from_secs(1), async {
+            let mut ticket = crab_coordination::PushAdmissionTicket::enqueue(
+                store.inner(),
+                "repo",
+                1,
+                Duration::from_secs(60),
+                PUSH_ADMISSION_QUEUED_TTL,
+            )
+            .await
+            .unwrap();
             loop {
-                match PushLock::acquire_internal(
-                    store.inner(),
-                    "repo",
-                    resource,
-                    Duration::from_secs(60),
-                )
-                .await
-                {
-                    Ok(lock) => break lock,
-                    Err(crab_coordination::CoordinationError::PushLockHeld { .. }) => {
-                        tokio::time::sleep(Duration::from_millis(5)).await;
-                    }
-                    Err(error) => panic!("unexpected admission error: {error}"),
+                if ticket.try_admit().await.unwrap() {
+                    break ticket;
                 }
+                tokio::time::sleep(Duration::from_millis(5)).await;
             }
         })
         .await
@@ -17603,6 +17780,37 @@ mod tests {
         );
         assert_eq!(pipeline.specs.len(), 1);
         assert_eq!(pipeline.config.upload_concurrency, 16);
+    }
+
+    #[tokio::test]
+    async fn metadb_is_opened_only_after_pointer_discovery_finds_work() {
+        use crate::git::walk::PointerBlob;
+
+        let (store, router) = test_store_router("lazy-pointer-metadb");
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            vec![],
+            Some(store),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router,
+            None,
+            CancellationToken::new(),
+            None,
+        );
+
+        pipeline.install_metadb_for_pointer_work_if_needed().await;
+        assert!(pipeline.metadb.lock().await.is_none());
+
+        pipeline.pointers.lock().await.push(PointerBlob {
+            oid: [0; 20],
+            file_hash: [1; 32],
+            size: 1,
+        });
+        pipeline.install_metadb_for_pointer_work_if_needed().await;
+        assert!(pipeline.metadb.lock().await.is_some());
+        pipeline.close_metadb().await;
     }
 
     #[test]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6517,18 +6517,6 @@ impl PushPipeline {
             check_cancelled(&self.cancel)?;
             self.validate_push_commit_receipt(&manifest).await?;
 
-            // Publish the complete ref-rooted object proof before exposing the
-            // manifest. Missing proof disables protocol-v2 advertisement, but
-            // must not turn an otherwise valid legacy push into a data loss
-            // event; repair can rebuild this immutable artifact later.
-            if let Err(error) = self.publish_git_visibility_index(&manifest, store).await {
-                warn!(
-                    error = %error,
-                    generation = manifest.generation,
-                    "Git visibility proof publication failed; v2 remains gated"
-                );
-            }
-
             let etag_guard = self.manifest_etag.lock().await;
             let current_etag = etag_guard.clone();
             drop(etag_guard);
@@ -6550,6 +6538,17 @@ impl PushPipeline {
                     // Success — update the stored ETag.
                     *self.manifest_etag.lock().await =
                         Some(self.manifest_etag_or_read_current(store, new_etag).await);
+
+                    // Visibility is derived acceleration. Build it only for
+                    // the generation that won CAS; losing candidates would
+                    // repeat a full repository walk before every retry.
+                    if let Err(error) = self.publish_git_visibility_index(&manifest, store).await {
+                        warn!(
+                            error = %error,
+                            generation = manifest.generation,
+                            "Git visibility proof publication failed; v2 remains gated"
+                        );
+                    }
 
                     let span = tracing::Span::current();
                     span.record("generation", manifest.generation);

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -2411,6 +2411,14 @@ const PUSH_LOCK_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(250);
 /// Cap for opt-in push-lock wait polling.
 const PUSH_LOCK_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(2);
 
+const MANIFEST_LOCK_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(50);
+const MANIFEST_LOCK_WAIT_BACKOFF_CAP: Duration = Duration::from_millis(500);
+const PUSH_ADMISSION_SLOTS: usize = 5;
+const PUSH_ADMISSION_WAIT_TTL_MULTIPLIER: u32 = 2;
+const PUSH_ADMISSION_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(500);
+const PUSH_ADMISSION_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(5);
+const MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS: u64 = 100_000;
+
 /// Multipart threshold: xorbs larger than this use multipart upload.
 const XORB_MULTIPART_THRESHOLD: usize = 8 * 1024 * 1024;
 
@@ -2948,6 +2956,30 @@ fn push_lock_wait_delay(attempt: u32, remaining: Duration) -> Duration {
     let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
     let exp = PUSH_LOCK_WAIT_BACKOFF_BASE.saturating_mul(shift);
     let bound = exp.min(PUSH_LOCK_WAIT_BACKOFF_CAP).min(remaining);
+    let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
+    if bound_nanos == 0 {
+        return Duration::ZERO;
+    }
+    let pick = rand::rng().random_range(1..=bound_nanos);
+    Duration::from_nanos(pick)
+}
+
+fn manifest_lock_wait_delay(attempt: u32, remaining: Duration) -> Duration {
+    let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
+    let exp = MANIFEST_LOCK_WAIT_BACKOFF_BASE.saturating_mul(shift);
+    let bound = exp.min(MANIFEST_LOCK_WAIT_BACKOFF_CAP).min(remaining);
+    let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
+    if bound_nanos == 0 {
+        return Duration::ZERO;
+    }
+    let pick = rand::rng().random_range(1..=bound_nanos);
+    Duration::from_nanos(pick)
+}
+
+fn push_admission_wait_delay(attempt: u32, remaining: Duration) -> Duration {
+    let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
+    let exp = PUSH_ADMISSION_WAIT_BACKOFF_BASE.saturating_mul(shift);
+    let bound = exp.min(PUSH_ADMISSION_WAIT_BACKOFF_CAP).min(remaining);
     let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
     if bound_nanos == 0 {
         return Duration::ZERO;
@@ -4633,6 +4665,91 @@ pub(crate) async fn acquire_push_lock_leases(
     }
 }
 
+async fn acquire_internal_push_lock_with_wait(
+    store: &Store,
+    prefix: &str,
+    resource: &str,
+    ttl: Duration,
+    wait: Duration,
+    cancel: &CancellationToken,
+) -> Result<PushLock> {
+    let deadline = Instant::now() + wait;
+    let mut attempt = 0;
+    loop {
+        check_cancelled(cancel)?;
+        match PushLock::acquire_internal(store.inner(), prefix, resource, ttl)
+            .await
+            .map_err(CrabError::from)
+        {
+            Ok(lock) => return Ok(lock),
+            Err(error @ CrabError::PushLockHeld { .. }) => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(error);
+                }
+                let delay =
+                    manifest_lock_wait_delay(attempt, deadline.saturating_duration_since(now));
+                attempt = attempt.saturating_add(1);
+                debug!(
+                    resource,
+                    attempt,
+                    delay_ms = delay.as_millis(),
+                    "internal push lock held, waiting before retry"
+                );
+                tokio::select! {
+                    () = tokio::time::sleep(delay) => {}
+                    () = cancel.cancelled() => return Err(CrabError::Cancelled),
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+async fn acquire_push_admission_lock(
+    store: &Store,
+    prefix: &str,
+    ttl: Duration,
+    cancel: &CancellationToken,
+) -> Result<PushLock> {
+    // Admission is a capacity queue, not a correctness lease. Give queued
+    // writers more than one lease lifetime so a healthy long push cannot
+    // make an unrelated branch fail only because all slots remained busy.
+    let deadline = Instant::now() + ttl.saturating_mul(PUSH_ADMISSION_WAIT_TTL_MULTIPLIER);
+    let mut attempt = 0;
+    loop {
+        check_cancelled(cancel)?;
+        let slot = rand::rng().random_range(0..PUSH_ADMISSION_SLOTS);
+        let resource = format!("push-admission-{slot}");
+        match PushLock::acquire_internal(store.inner(), prefix, &resource, ttl)
+            .await
+            .map_err(CrabError::from)
+        {
+            Ok(lock) => return Ok(lock),
+            Err(CrabError::PushLockHeld { .. }) => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(CrabError::Throttled { retry_after: None });
+                }
+                let delay =
+                    push_admission_wait_delay(attempt, deadline.saturating_duration_since(now));
+                attempt = attempt.saturating_add(1);
+                debug!(
+                    slot,
+                    attempt,
+                    delay_ms = delay.as_millis(),
+                    "push admission is full, waiting before retry"
+                );
+                tokio::select! {
+                    () = tokio::time::sleep(delay) => {}
+                    () = cancel.cancelled() => return Err(CrabError::Cancelled),
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 pub(crate) async fn release_push_lock_leases(mut leases: Vec<PushLockLease>) {
     while let Some(PushLockLease { lock, heartbeat }) = leases.pop() {
         if let Some(hb) = heartbeat {
@@ -4645,7 +4762,7 @@ pub(crate) async fn release_push_lock_leases(mut leases: Vec<PushLockLease>) {
     }
 }
 
-pub(crate) async fn while_renewing_locator_lock<T>(
+pub(crate) async fn while_renewing_internal_lock<T>(
     lock: &PushLock,
     operation: impl Future<Output = Result<T>>,
 ) -> Result<T> {
@@ -4664,6 +4781,51 @@ pub(crate) async fn while_renewing_locator_lock<T>(
                         None => Ok(value),
                     },
                 };
+            }
+            _ = ticker.tick(), if renewal_error.is_none() => {
+                if let Err(error) = lock.renew().await {
+                    renewal_error = Some(error);
+                }
+            }
+        }
+    }
+}
+
+async fn while_admitted_until_commit<T>(
+    lock: PushLock,
+    operation: impl Future<Output = Result<T>>,
+    mut committed: tokio::sync::oneshot::Receiver<()>,
+) -> Result<T> {
+    let renewal_interval = (lock.ttl() / 3).max(Duration::from_secs(1));
+    let mut ticker = tokio::time::interval(renewal_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ticker.tick().await;
+    let mut operation = std::pin::pin!(operation);
+    let mut renewal_error = None;
+    let mut commit_signal_open = true;
+
+    loop {
+        tokio::select! {
+            result = &mut operation => {
+                if let Err(error) = lock.release().await {
+                    warn!(error = %error, "push admission lock release failed");
+                }
+                return match (result, renewal_error) {
+                    (Ok(_), Some(error)) => Err(CrabError::from(error)),
+                    (result, _) => result,
+                };
+            }
+            signal = &mut committed, if commit_signal_open => {
+                if signal.is_err() {
+                    commit_signal_open = false;
+                    continue;
+                }
+                if let Err(error) = lock.release().await {
+                    warn!(error = %error, "push admission lock release failed after commit");
+                }
+                // Derived indexes and cache warming are repairable and must
+                // not retain scarce write capacity after the ref is visible.
+                return operation.await;
             }
             _ = ticker.tick(), if renewal_error.is_none() => {
                 if let Err(error) = lock.renew().await {
@@ -4725,6 +4887,16 @@ pub(crate) async fn publish_committed_pack_locators(
         ));
     }
 
+    // Most fanout writers are stale by the time they reach derived indexing.
+    // Reject them before lock traffic or opening SlateDB; the check under the
+    // lock remains authoritative against a concurrent manifest advance.
+    let (current, _) = read_manifest(store, router).await?;
+    if current.generation != anchor.generation
+        || current.pack_index_hash != anchor.pack_index_hash.hex()
+    {
+        return Ok(crab_metadata::git_object_locator::LocatorWriteStats::default());
+    }
+
     let lock = PushLock::acquire_internal(
         store.inner(),
         router.repo_prefix(),
@@ -4733,7 +4905,7 @@ pub(crate) async fn publish_committed_pack_locators(
     )
     .await?;
     let publication_started = Instant::now();
-    let write_result = Box::pin(while_renewing_locator_lock(&lock, async {
+    let write_result = Box::pin(while_renewing_internal_lock(&lock, async {
         let (current, _) = read_manifest(store, router).await?;
         if current.generation != anchor.generation
             || current.pack_index_hash != anchor.pack_index_hash.hex()
@@ -6487,10 +6659,11 @@ impl PushPipeline {
     )]
     async fn unified_manifest_cas(
         &self,
-        mut manifest: Manifest,
+        manifest: Manifest,
         bulk: BulkData,
         sha_map: &HashMap<String, String>,
-        mut decisions: HashMap<String, RefUpdateDecision>,
+        decisions: HashMap<String, RefUpdateDecision>,
+        admission_commit: &mut Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<HashMap<String, RefUpdateDecision>> {
         let t0 = Instant::now();
         let store = self.store.as_ref().ok_or_else(|| {
@@ -6501,6 +6674,62 @@ impl PushPipeline {
         // manifest pointer exposes them.
         upload_segmented_bulk(store, &self.router, &bulk).await?;
 
+        // Pack/chunk uploads remain concurrent, while the single manifest
+        // pointer has one repository-wide writer. Queue this short commit
+        // phase to avoid O(writers²) CAS retries under branch fanout.
+        let manifest_lock = acquire_internal_push_lock_with_wait(
+            store,
+            self.router.repo_prefix(),
+            crab_coordination::GIT_MANIFEST_RESOURCE,
+            self.config.lock_ttl,
+            self.config.lock_ttl,
+            &self.cancel,
+        )
+        .await?;
+        let result = while_renewing_internal_lock(
+            &manifest_lock,
+            self.unified_manifest_cas_under_lock(t0, manifest, sha_map, decisions, store),
+        )
+        .await;
+        let release = manifest_lock.release().await.map_err(CrabError::from);
+        match result {
+            Err(error) => {
+                if let Err(release_error) = release {
+                    warn!(
+                        error = %release_error,
+                        "manifest publication failed and its lock release also failed"
+                    );
+                }
+                Err(error)
+            }
+            Ok((value, committed_manifest)) => {
+                release?;
+                if let Some(committed) = admission_commit.take() {
+                    let _ = committed.send(());
+                }
+                if let Err(error) = self
+                    .publish_git_visibility_index(&committed_manifest, store)
+                    .await
+                {
+                    warn!(
+                        error = %error,
+                        generation = committed_manifest.generation,
+                        "Git visibility proof publication failed; v2 remains gated"
+                    );
+                }
+                Ok(value)
+            }
+        }
+    }
+
+    async fn unified_manifest_cas_under_lock(
+        &self,
+        t0: Instant,
+        mut manifest: Manifest,
+        sha_map: &HashMap<String, String>,
+        mut decisions: HashMap<String, RefUpdateDecision>,
+        store: &Store,
+    ) -> Result<(HashMap<String, RefUpdateDecision>, Manifest)> {
         let max_retries = self.config.max_cas_retries;
         // A retry may only shrink the planned ref set. Promoting a ref that
         // preflight rejected would commit it without the dependency walk,
@@ -6539,17 +6768,6 @@ impl PushPipeline {
                     *self.manifest_etag.lock().await =
                         Some(self.manifest_etag_or_read_current(store, new_etag).await);
 
-                    // Visibility is derived acceleration. Build it only for
-                    // the generation that won CAS; losing candidates would
-                    // repeat a full repository walk before every retry.
-                    if let Err(error) = self.publish_git_visibility_index(&manifest, store).await {
-                        warn!(
-                            error = %error,
-                            generation = manifest.generation,
-                            "Git visibility proof publication failed; v2 remains gated"
-                        );
-                    }
-
                     let span = tracing::Span::current();
                     span.record("generation", manifest.generation);
                     span.record("refs_count", manifest.refs.len());
@@ -6566,7 +6784,7 @@ impl PushPipeline {
                     );
                     let anchor = committed_manifest_anchor(&manifest)?;
                     *self.committed_manifest_anchor.lock().await = anchor;
-                    return Ok(decisions);
+                    return Ok((decisions, manifest));
                 }
                 Err(CrabError::CasConflict { .. }) => {
                     // Bump the CAS conflict counter.
@@ -6768,6 +6986,16 @@ impl PushPipeline {
         manifest: &Manifest,
         store: &crate::storage::store::Store,
     ) -> Result<()> {
+        let packs = read_bulk_pack_list(store, &self.router, &manifest.pack_index_hash).await?;
+        let packed_objects = packs
+            .iter()
+            .try_fold(0u64, |total, pack| total.checked_add(pack.object_count))
+            .ok_or_else(|| CrabError::Internal("Git pack object count overflow".to_owned()))?;
+        if packed_objects > MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS {
+            return Err(CrabError::Internal(format!(
+                "Git visibility proof deferred: {packed_objects} packed objects exceed the synchronous push budget of {MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS}"
+            )));
+        }
         let git_dir = self
             .git_dir_override()
             .map(Path::to_path_buf)
@@ -13084,7 +13312,34 @@ impl PushPipeline {
     /// level. Ref-level errors (non-fast-forward, connectivity
     /// missing) are already surfaced per-ref during their own steps.
     async fn execute(&self) -> PushResult {
-        let result = Box::pin(self.execute_inner()).await;
+        let admission_lock = if self.config.active_active_replication.is_none() {
+            match self.store.as_ref() {
+                Some(store) => acquire_push_admission_lock(
+                    store,
+                    self.router.repo_prefix(),
+                    self.config.lock_ttl,
+                    &self.cancel,
+                )
+                .await
+                .map(Some),
+                None => Ok(None),
+            }
+        } else {
+            Ok(None)
+        };
+        let result = match admission_lock {
+            Ok(Some(lock)) => {
+                let (committed_tx, committed_rx) = tokio::sync::oneshot::channel();
+                while_admitted_until_commit(
+                    lock,
+                    self.execute_inner(Some(committed_tx)),
+                    committed_rx,
+                )
+                .await
+            }
+            Ok(None) => Box::pin(self.execute_inner(None)).await,
+            Err(error) => Err(error),
+        };
 
         // Close the MetaDb guard before returning on either path.
         // On the happy path, step 9b already committed every SlateDB
@@ -13140,7 +13395,10 @@ impl PushPipeline {
         (bytes, pointers.len() as u64)
     }
 
-    async fn execute_inner(&self) -> Result<PushResult> {
+    async fn execute_inner(
+        &self,
+        mut admission_commit: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<PushResult> {
         // Cancellation wins over configuration or remote preflight errors so
         // callers receive the stable cancellation contract even when no
         // network operation has started yet.
@@ -13392,8 +13650,14 @@ impl PushPipeline {
                 active_active_commit = self.protected_push_finalize(manifest, bulk).await?;
                 decisions
             } else {
-                self.unified_manifest_cas(manifest, bulk, &sha_map, decisions)
-                    .await?
+                self.unified_manifest_cas(
+                    manifest,
+                    bulk,
+                    &sha_map,
+                    decisions,
+                    &mut admission_commit,
+                )
+                .await?
             };
             self.emit_perf_phase(manifest_phase.finish(0, manifest_bytes_out, manifest_item_count));
             Some(committed_decisions)
@@ -13401,6 +13665,10 @@ impl PushPipeline {
             debug!("steps 11-12: no store, skipping manifest build and CAS");
             None
         };
+
+        if let Some(committed) = admission_commit.take() {
+            let _ = committed.send(());
+        }
 
         if decisions.is_some() && self.config.protected_push.is_none() {
             let file_index_plan = self.pending_file_index_plan.lock().await.clone();
@@ -16706,8 +16974,9 @@ mod tests {
             .await
             .expect("commit concurrent main update");
 
+        let mut admission_commit = None;
         let committed_decisions = pipeline
-            .unified_manifest_cas(candidate, bulk, &sha_map, decisions)
+            .unified_manifest_cas(candidate, bulk, &sha_map, decisions, &mut admission_commit)
             .await
             .expect("retry should commit unconflicted dev ref");
         assert!(matches!(
@@ -16927,6 +17196,132 @@ mod tests {
         .expect("partial acquisition must be released after later contention");
         lock.release().await.unwrap();
         blocker.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn manifest_publication_waits_for_current_writer() {
+        let inner: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let store = Store::new(inner);
+        let blocker = PushLock::acquire_internal(
+            store.inner(),
+            "repo",
+            crab_coordination::GIT_MANIFEST_RESOURCE,
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        let release = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            blocker.release().await.unwrap();
+        });
+
+        let started = Instant::now();
+        let lock = acquire_internal_push_lock_with_wait(
+            &store,
+            "repo",
+            crab_coordination::GIT_MANIFEST_RESOURCE,
+            Duration::from_secs(60),
+            Duration::from_secs(1),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("queued manifest writer should acquire the released lease");
+
+        assert!(started.elapsed() >= Duration::from_millis(50));
+        lock.release().await.unwrap();
+        release.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn push_admission_waits_when_every_slot_is_occupied() {
+        let inner: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let store = Store::new(inner);
+        let mut blockers = Vec::new();
+        for slot in 0..PUSH_ADMISSION_SLOTS {
+            blockers.push(
+                PushLock::acquire_internal(
+                    store.inner(),
+                    "repo",
+                    &format!("push-admission-{slot}"),
+                    Duration::from_secs(60),
+                )
+                .await
+                .unwrap(),
+            );
+        }
+        let release = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            for blocker in blockers {
+                blocker.release().await.unwrap();
+            }
+        });
+
+        let started = Instant::now();
+        let lock = acquire_push_admission_lock(
+            &store,
+            "repo",
+            Duration::from_secs(3),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("queued push should enter after an admission slot is released");
+
+        assert!(started.elapsed() >= Duration::from_millis(50));
+        lock.release().await.unwrap();
+        release.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn push_admission_releases_after_canonical_commit() {
+        let inner: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let store = Store::new(inner);
+        let resource = "push-admission-0";
+        let lock =
+            PushLock::acquire_internal(store.inner(), "repo", resource, Duration::from_secs(60))
+                .await
+                .unwrap();
+        let (committed_tx, committed_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let operation = tokio::spawn(async move {
+            while_admitted_until_commit(
+                lock,
+                async move {
+                    committed_tx.send(()).unwrap();
+                    finish_rx.await.unwrap();
+                    Ok(())
+                },
+                committed_rx,
+            )
+            .await
+        });
+
+        let contender = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match PushLock::acquire_internal(
+                    store.inner(),
+                    "repo",
+                    resource,
+                    Duration::from_secs(60),
+                )
+                .await
+                {
+                    Ok(lock) => break lock,
+                    Err(crab_coordination::CoordinationError::PushLockHeld { .. }) => {
+                        tokio::time::sleep(Duration::from_millis(5)).await;
+                    }
+                    Err(error) => panic!("unexpected admission error: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("canonical commit should release admission before repair finishes");
+
+        finish_tx.send(()).unwrap();
+        operation.await.unwrap().unwrap();
+        contender.release().await.unwrap();
     }
 
     #[tokio::test]
@@ -25733,8 +26128,15 @@ mod tests {
             .rebuild_push_commit_receipt(&manifest, &HashMap::new(), &HashMap::new(), 1, &[])
             .await
             .unwrap();
+        let mut admission_commit = None;
         pipeline
-            .unified_manifest_cas(manifest.clone(), bulk, &HashMap::new(), HashMap::new())
+            .unified_manifest_cas(
+                manifest.clone(),
+                bulk,
+                &HashMap::new(),
+                HashMap::new(),
+                &mut admission_commit,
+            )
             .await
             .unwrap();
 

--- a/crates/crab-coordination/Cargo.toml
+++ b/crates/crab-coordination/Cargo.toml
@@ -8,7 +8,7 @@ description = "Coordination contracts for Crab active-active writes."
 
 [features]
 default = []
-object-store-lock = ["dep:bytes", "dep:futures-util", "dep:object_store", "dep:tracing", "tokio/rt"]
+object-store-lock = ["dep:bytes", "dep:futures-util", "dep:object_store", "dep:tracing", "dep:uuid", "tokio/rt", "tokio/time"]
 coordinator-dynamodb = ["dep:aws-config", "dep:aws-sdk-dynamodb"]
 coordinator-spanner = ["dep:google-cloud-storage", "dep:google-cloud-token", "dep:reqwest"]
 coordinator-cosmosdb = ["dep:azure_core", "dep:azure_identity", "dep:reqwest", "dep:urlencoding"]
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-dynamodb = { workspace = true, optional = true }
 azure_core = { workspace = true, optional = true }

--- a/crates/crab-coordination/README.md
+++ b/crates/crab-coordination/README.md
@@ -20,12 +20,11 @@ There are two complementary coordination paths:
 ```text
 Single repository mutation                 Active-active mutation
         │                                          │
-        ▼                                          ▼
-PushLock: short-TTL CAS lease          WriteCoordinator: durable state machine
-        │                                          │
-        └── object-store lock                      ├─ Pending
-                                                   ├─ ObjectsUploaded
-                                                   ├─ Committed
+        ├─ PushLock: short-TTL CAS lease           ▼
+        │                              WriteCoordinator: durable state machine
+        └─ PushAdmissionTicket: FIFO queue          ├─ Pending
+                   │                                ├─ ObjectsUploaded
+                   └─ object-store CAS              ├─ Committed
                                                    ├─ Materialized
                                                    └─ Aborted
 ```
@@ -33,6 +32,12 @@ PushLock: short-TTL CAS lease          WriteCoordinator: durable state machine
 `PushLock` protects a Git ref or internal resource under a repository prefix.
 It has a default five-minute TTL, holder-checked release, renewal, and
 expired-lease reclamation. Enable it with `object-store-lock`.
+
+`PushAdmissionTicket` bounds expensive single-repository push pipelines without
+random slot selection or a shared mutable queue object. Each writer creates one
+time-ordered ticket object, the oldest live tickets enter first, and writers
+refresh only their own short lease. Observers ignore expired tickets and remove
+a bounded number per poll, so enqueue and renewal do not contend on one hot key.
 
 `WriteCoordinator` exposes health, begin/upload/commit/materialize/abort,
 ref lookup, GC safety snapshots, repair snapshots, and write fencing. The

--- a/crates/crab-coordination/src/lib.rs
+++ b/crates/crab-coordination/src/lib.rs
@@ -6,6 +6,8 @@ pub mod cosmosdb_coordinator;
 pub mod dynamodb_coordinator;
 pub mod error;
 #[cfg(feature = "object-store-lock")]
+pub mod push_admission;
+#[cfg(feature = "object-store-lock")]
 pub mod push_lock;
 pub mod spanner_coordinator;
 pub mod write_coordinator;
@@ -16,6 +18,8 @@ mod active_active_tests;
 pub use active_active::*;
 pub use active_active_runtime::*;
 pub use error::{CoordinationError, Result};
+#[cfg(feature = "object-store-lock")]
+pub use push_admission::*;
 #[cfg(feature = "object-store-lock")]
 pub use push_lock::*;
 pub use write_coordinator::*;

--- a/crates/crab-coordination/src/push_admission.rs
+++ b/crates/crab-coordination/src/push_admission.rs
@@ -1,0 +1,480 @@
+//! Fair object-store admission for repository push pipelines.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures_util::StreamExt;
+use object_store::path::Path;
+use object_store::{ObjectStore, ObjectStoreExt};
+use tracing::warn;
+
+use crate::error::{CoordinationError, Result};
+use crate::push_lock::{
+    create_strict, generate_holder_id, get_with_version, push_locks_prefix, store_error, unix_now,
+    update,
+};
+
+const MAX_TICKET_CREATE_ATTEMPTS: usize = 8;
+const MAX_ADMISSION_RETRIES: usize = 16;
+const MAX_EXPIRED_CLEANUP_PER_OBSERVATION: usize = 2;
+
+/// Durable FIFO ticket that becomes a bounded push-admission permit.
+pub struct PushAdmissionTicket {
+    store: Arc<dyn ObjectStore>,
+    prefix: String,
+    path: String,
+    holder: String,
+    capacity: usize,
+    lease_ttl: Duration,
+    writers_ahead: usize,
+    admitted: bool,
+    released: bool,
+}
+
+impl PushAdmissionTicket {
+    /// Creates one independently writable ticket in the repository queue.
+    pub async fn enqueue(
+        store: &Arc<dyn ObjectStore>,
+        prefix: &str,
+        capacity: usize,
+        active_ttl: Duration,
+        queued_ttl: Duration,
+    ) -> Result<Self> {
+        if capacity == 0 {
+            return Err(CoordinationError::Configuration {
+                key: capacity.to_string(),
+                origin: "push admission capacity must be positive".to_owned(),
+            });
+        }
+        validate_ttl(active_ttl, "active")?;
+        validate_ttl(queued_ttl, "queued")?;
+
+        let prefix = push_admission_prefix(prefix)?;
+        let lease_ttl = active_ttl.min(queued_ttl);
+        for _ in 0..MAX_TICKET_CREATE_ATTEMPTS {
+            let holder = generate_holder_id();
+            let path = format!("{prefix}/{}", uuid::Uuid::now_v7());
+            match create_strict(
+                store,
+                &Path::from(path.as_str()),
+                Bytes::from(holder.clone()),
+            )
+            .await
+            {
+                Ok(_) => {
+                    return Ok(Self {
+                        store: Arc::clone(store),
+                        prefix,
+                        path,
+                        holder,
+                        capacity,
+                        lease_ttl,
+                        writers_ahead: usize::MAX,
+                        admitted: false,
+                        released: false,
+                    });
+                }
+                Err(error) if is_cas_conflict(&error) => {}
+                Err(source) => return Err(store_error(&path, source)),
+            }
+        }
+        Err(CoordinationError::CasConflict {
+            path: prefix,
+            expected_etag: None,
+        })
+    }
+
+    /// Attempts to convert this FIFO ticket into an active bounded permit.
+    pub async fn try_admit(&mut self) -> Result<bool> {
+        if self.admitted {
+            return Ok(true);
+        }
+        for _ in 0..MAX_ADMISSION_RETRIES {
+            let now = unix_now();
+            let mut live = Vec::new();
+            let mut expired = Vec::new();
+            let mut stream = self.store.list(Some(&Path::from(self.prefix.as_str())));
+            while let Some(item) = stream.next().await {
+                let meta = item.map_err(|source| store_error(&self.prefix, source))?;
+                let modified = u64::try_from(meta.last_modified.timestamp()).unwrap_or(0);
+                if modified.saturating_add(self.lease_ttl.as_secs().max(1)) <= now {
+                    expired.push(meta);
+                } else {
+                    live.push(meta);
+                }
+            }
+            // Renewal changes object metadata, so queue order must live in the
+            // immutable UUIDv7 key rather than the mutable last-modified time.
+            live.sort_unstable_by(|left, right| left.location.cmp(&right.location));
+            self.cleanup_expired(expired).await;
+
+            let Some(position) = live
+                .iter()
+                .position(|meta| meta.location.as_ref() == self.path)
+            else {
+                return Err(expired_ticket(&self.path));
+            };
+            self.writers_ahead = position;
+            let admitted = position < self.capacity;
+            let own = &live[position];
+            let modified = u64::try_from(own.last_modified.timestamp()).unwrap_or(0);
+            let refresh_margin = self.lease_ttl.as_secs().max(1).div_ceil(4).min(30);
+            let needs_refresh = admitted
+                || modified.saturating_add(self.lease_ttl.as_secs().max(1))
+                    <= now.saturating_add(refresh_margin);
+            if !needs_refresh {
+                return Ok(false);
+            }
+            let (body, version) = get_with_version(&self.store, &own.location)
+                .await
+                .map_err(|source| store_error(&self.path, source))?;
+            if body.as_ref() != self.holder.as_bytes() {
+                return Err(expired_ticket(&self.path));
+            }
+            match update(
+                &self.store,
+                &own.location,
+                Bytes::from(self.holder.clone()),
+                version,
+            )
+            .await
+            {
+                Ok(_) => {
+                    self.admitted = admitted;
+                    return Ok(admitted);
+                }
+                Err(error) if is_cas_conflict(&error) => continue,
+                Err(source) => return Err(store_error(&self.path, source)),
+            }
+        }
+        Err(CoordinationError::CasConflict {
+            path: self.path.clone(),
+            expected_etag: None,
+        })
+    }
+
+    /// Extends an active permit's lease.
+    pub async fn renew(&self) -> Result<()> {
+        if !self.admitted {
+            return Err(CoordinationError::Configuration {
+                key: self.path.clone(),
+                origin: "cannot renew a queued push admission ticket".to_owned(),
+            });
+        }
+        let path = Path::from(self.path.as_str());
+        let (body, version) = get_with_version(&self.store, &path)
+            .await
+            .map_err(|source| store_error(&self.path, source))?;
+        if body.as_ref() != self.holder.as_bytes() {
+            return Err(expired_ticket(&self.path));
+        }
+        update(
+            &self.store,
+            &path,
+            Bytes::from(self.holder.clone()),
+            version,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|source| store_error(&self.path, source))
+    }
+
+    /// Removes this writer from the queue and hands capacity to its successor.
+    pub async fn release(mut self) -> Result<()> {
+        let result = delete_ticket(&self.store, &self.path).await;
+        self.released = true;
+        result
+    }
+
+    /// Returns the permit lifetime used for active renewal.
+    #[must_use]
+    pub fn ttl(&self) -> Duration {
+        self.lease_ttl
+    }
+
+    /// Returns the last observed number of live writers ahead in FIFO order.
+    #[must_use]
+    pub fn writers_ahead(&self) -> usize {
+        self.writers_ahead
+    }
+
+    async fn cleanup_expired(&self, expired: Vec<object_store::ObjectMeta>) {
+        for meta in expired
+            .into_iter()
+            .filter(|meta| meta.location.as_ref() != self.path)
+            .take(MAX_EXPIRED_CLEANUP_PER_OBSERVATION)
+        {
+            let version = object_store::UpdateVersion {
+                e_tag: meta.e_tag,
+                version: meta.version,
+            };
+            match update(
+                &self.store,
+                &meta.location,
+                Bytes::from_static(b"expired"),
+                version,
+            )
+            .await
+            {
+                Ok(_) => {
+                    if let Err(error) = self.store.delete(&meta.location).await {
+                        warn!(path = %meta.location, %error, "failed to delete expired push admission ticket");
+                    }
+                }
+                Err(error) if is_cas_conflict(&error) => {}
+                Err(error) => {
+                    warn!(path = %meta.location, %error, "failed to claim expired push admission ticket");
+                }
+            }
+        }
+    }
+}
+
+impl Drop for PushAdmissionTicket {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        let store = Arc::clone(&self.store);
+        let path = self.path.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                if let Err(error) = delete_ticket(&store, &path).await {
+                    warn!(path, %error, "failed to release push admission ticket on drop");
+                }
+            });
+        }
+    }
+}
+
+/// Canonical object-key prefix for one repository's FIFO admission tickets.
+pub fn push_admission_prefix(prefix: &str) -> Result<String> {
+    Ok(format!(
+        "{}/internal/push-admission/tickets",
+        push_locks_prefix(prefix)?
+    ))
+}
+
+async fn delete_ticket(store: &Arc<dyn ObjectStore>, path: &str) -> Result<()> {
+    match store.delete(&Path::from(path)).await {
+        Ok(()) | Err(object_store::Error::NotFound { .. }) => Ok(()),
+        Err(source) => Err(store_error(path, source)),
+    }
+}
+
+fn validate_ttl(ttl: Duration, kind: &str) -> Result<()> {
+    if !ttl.is_zero() {
+        return Ok(());
+    }
+    Err(CoordinationError::Configuration {
+        key: ttl.as_secs().to_string(),
+        origin: format!("push admission {kind} TTL must be positive"),
+    })
+}
+
+fn expired_ticket(path: &str) -> CoordinationError {
+    CoordinationError::NotFound {
+        path: path.to_owned(),
+    }
+}
+
+fn is_cas_conflict(error: &object_store::Error) -> bool {
+    matches!(
+        error,
+        object_store::Error::AlreadyExists { .. } | object_store::Error::Precondition { .. }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+
+    fn memory_store() -> Arc<dyn ObjectStore> {
+        Arc::new(InMemory::new())
+    }
+
+    #[tokio::test]
+    async fn one_hundred_tickets_complete_in_fifo_capacity_windows() {
+        let store = memory_store();
+        let mut tickets = Vec::new();
+        for _ in 0..100 {
+            tickets.push(
+                PushAdmissionTicket::enqueue(
+                    &store,
+                    "org/repo",
+                    5,
+                    Duration::from_secs(60),
+                    Duration::from_secs(60),
+                )
+                .await
+                .unwrap(),
+            );
+        }
+        let expected = tickets
+            .iter()
+            .map(|ticket| ticket.path.clone())
+            .collect::<Vec<_>>();
+        let (admitted_tx, mut admitted_rx) = tokio::sync::mpsc::channel(100);
+        let workers = tickets
+            .into_iter()
+            .map(|mut ticket| {
+                let admitted_tx = admitted_tx.clone();
+                tokio::spawn(async move {
+                    loop {
+                        if ticket.try_admit().await.unwrap() {
+                            admitted_tx.send(ticket).await.unwrap();
+                            return;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        drop(admitted_tx);
+
+        for window in 0..20 {
+            let mut admitted = Vec::new();
+            for _ in 0..5 {
+                admitted.push(admitted_rx.recv().await.unwrap());
+            }
+            tokio::task::yield_now().await;
+            assert!(
+                admitted_rx.try_recv().is_err(),
+                "more than five tickets entered in window {window}"
+            );
+            admitted.sort_by(|left, right| left.path.cmp(&right.path));
+            assert_eq!(
+                admitted
+                    .iter()
+                    .map(|ticket| ticket.path.clone())
+                    .collect::<Vec<_>>(),
+                expected[(window * 5)..(window * 5 + 5)]
+            );
+            for ticket in admitted {
+                ticket.release().await.unwrap();
+            }
+        }
+        for worker in workers {
+            worker.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn expired_front_ticket_does_not_block_its_successor() {
+        let store = memory_store();
+        let abandoned = PushAdmissionTicket::enqueue(
+            &store,
+            "org/repo",
+            1,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        std::mem::forget(abandoned);
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        let mut successor = PushAdmissionTicket::enqueue(
+            &store,
+            "org/repo",
+            1,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+
+        assert!(successor.try_admit().await.unwrap());
+        successor.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn release_removes_ticket_object() {
+        let store = memory_store();
+        let ticket = PushAdmissionTicket::enqueue(
+            &store,
+            "org/repo",
+            1,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        let path = Path::from(ticket.path.as_str());
+
+        ticket.release().await.unwrap();
+
+        assert!(matches!(
+            store.head(&path).await,
+            Err(object_store::Error::NotFound { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn stale_cleanup_does_not_delete_a_renewed_ticket() {
+        let store = memory_store();
+        let mut active = PushAdmissionTicket::enqueue(
+            &store,
+            "org/repo",
+            1,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        assert!(active.try_admit().await.unwrap());
+        let cleaner = PushAdmissionTicket::enqueue(
+            &store,
+            "org/repo",
+            1,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        let path = Path::from(active.path.as_str());
+        let stale = store.head(&path).await.unwrap();
+
+        active.renew().await.unwrap();
+        cleaner.cleanup_expired(vec![stale]).await;
+
+        store.head(&path).await.unwrap();
+        active.release().await.unwrap();
+        cleaner.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn claimed_expired_ticket_cannot_be_renewed() {
+        let store = memory_store();
+        let mut ticket = PushAdmissionTicket::enqueue(
+            &store,
+            "org/repo",
+            1,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        assert!(ticket.try_admit().await.unwrap());
+        let path = Path::from(ticket.path.as_str());
+        let (_, version) = get_with_version(&store, &path).await.unwrap();
+        update(&store, &path, Bytes::from_static(b"expired"), version)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ticket.renew().await,
+            Err(CoordinationError::NotFound { .. })
+        ));
+        ticket.release().await.unwrap();
+    }
+
+    #[test]
+    fn queue_prefix_is_repository_scoped() {
+        assert_eq!(
+            push_admission_prefix("org/repo").unwrap(),
+            "org/repo/locks/internal/push-admission/tickets"
+        );
+    }
+}

--- a/crates/crab-coordination/src/push_lock.rs
+++ b/crates/crab-coordination/src/push_lock.rs
@@ -524,7 +524,7 @@ async fn expire_stale_lock_at(
     }
 }
 
-async fn create_strict(
+pub(crate) async fn create_strict(
     store: &Arc<dyn ObjectStore>,
     path: &Path,
     body: Bytes,
@@ -535,7 +535,7 @@ async fn create_strict(
         .map(Into::into)
 }
 
-async fn get_with_version(
+pub(crate) async fn get_with_version(
     store: &Arc<dyn ObjectStore>,
     path: &Path,
 ) -> object_store::Result<(Bytes, UpdateVersion)> {
@@ -547,7 +547,7 @@ async fn get_with_version(
     Ok((result.bytes().await?, version))
 }
 
-async fn update(
+pub(crate) async fn update(
     store: &Arc<dyn ObjectStore>,
     path: &Path,
     body: Bytes,
@@ -563,7 +563,7 @@ async fn update(
         .map(Into::into)
 }
 
-fn store_error(path: &str, source: object_store::Error) -> CoordinationError {
+pub(crate) fn store_error(path: &str, source: object_store::Error) -> CoordinationError {
     CoordinationError::ObjectStore {
         path: path.to_owned(),
         source,
@@ -587,7 +587,7 @@ fn deserialize_payload(path: &str, body: &[u8]) -> Result<PushLockPayload> {
     })
 }
 
-fn generate_holder_id() -> String {
+pub(crate) fn generate_holder_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
     static HOLDER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
     let nanos = SystemTime::now()

--- a/crates/crab-coordination/src/push_lock.rs
+++ b/crates/crab-coordination/src/push_lock.rs
@@ -17,6 +17,8 @@ pub const DEFAULT_PUSH_LOCK_TTL: Duration = Duration::from_secs(300);
 
 /// Internal resource serializing Git object-locator publication.
 pub const GIT_OBJECT_LOCATOR_RESOURCE: &str = "git-object-locator";
+/// Internal resource serializing unified manifest publication.
+pub const GIT_MANIFEST_RESOURCE: &str = "git-manifest";
 /// Internal resource serializing repository repacks.
 pub const REPACK_RESOURCE: &str = "repack";
 /// Internal resource used when a push has no destination ref.
@@ -756,6 +758,10 @@ mod tests {
         assert_eq!(
             internal_lock_path("org/repo", GIT_OBJECT_LOCATOR_RESOURCE).unwrap(),
             "org/repo/locks/internal/git-object-locator/lock"
+        );
+        assert_eq!(
+            internal_lock_path("org/repo", GIT_MANIFEST_RESOURCE).unwrap(),
+            "org/repo/locks/internal/git-manifest/lock"
         );
         assert_eq!(push_locks_prefix("org/repo").unwrap(), "org/repo/locks");
     }

--- a/crates/crab-git/src/walk.rs
+++ b/crates/crab-git/src/walk.rs
@@ -243,6 +243,38 @@ fn walk_reachable_by_ref_with_limit(
     peeled_refs: &BTreeMap<String, String>,
     maximum: Option<usize>,
 ) -> Result<BTreeMap<String, ReachableSet>> {
+    let objects_dir = git_dir.join("objects");
+    if !objects_dir.is_dir() {
+        return Err(WalkError::ObjectsDirectoryNotFound {
+            path: objects_dir.display().to_string(),
+        });
+    }
+    let odb = gix_odb::at(&objects_dir).map_err(|source| WalkError::Git {
+        operation: format!("failed to open git ODB at {}", objects_dir.display()),
+        source: Box::new(source),
+    })?;
+
+    // A push client may not have tips concurrently published by another
+    // writer. Prove every root is locally available before walking any large
+    // closure so an incomplete ODB fails in O(refs), not O(repository size).
+    for (_, oid) in refs {
+        let root = ObjectId::from_hex(oid.as_bytes()).map_err(|source| WalkError::Git {
+            operation: format!("invalid ref object {oid}"),
+            source: Box::new(source),
+        })?;
+        let mut buf = Vec::new();
+        if odb
+            .try_find(&root, &mut buf)
+            .map_err(|source| WalkError::Git {
+                operation: format!("failed to read ref object {root}"),
+                source,
+            })?
+            .is_none()
+        {
+            return Err(WalkError::BeyondShallowBoundary { oid: oid.clone() });
+        }
+    }
+
     let mut closures = BTreeMap::new();
     let mut total_objects = 0usize;
     for (name, oid) in refs {
@@ -261,11 +293,6 @@ fn walk_reachable_by_ref_with_limit(
                 operation: format!("invalid ref object {traversal_tip}"),
                 source: Box::new(source),
             })?;
-        let objects_dir = git_dir.join("objects");
-        let odb = gix_odb::at(&objects_dir).map_err(|source| WalkError::Git {
-            operation: format!("failed to open git ODB at {}", objects_dir.display()),
-            source: Box::new(source),
-        })?;
         let mut buf = Vec::new();
         let data = odb
             .try_find(&root, &mut buf)
@@ -678,7 +705,7 @@ mod tests {
 
         let bounded = walk_reachable_bounded(
             &git_dir_path,
-            &[("refs/heads/main".to_owned(), head_sha)],
+            &[("refs/heads/main".to_owned(), head_sha.clone())],
             1,
         )
         .unwrap_err();
@@ -688,6 +715,22 @@ mod tests {
                 actual: 2,
                 maximum: 1
             }
+        ));
+
+        let missing_tip = "f".repeat(40);
+        let per_ref = walk_reachable_by_ref_bounded(
+            &git_dir_path,
+            &[
+                ("refs/heads/main".to_owned(), head_sha),
+                ("refs/heads/concurrent".to_owned(), missing_tip.clone()),
+            ],
+            &BTreeMap::new(),
+            1,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            per_ref,
+            WalkError::BeyondShallowBoundary { oid } if oid == missing_tip
         ));
     }
 


### PR DESCRIPTION
## Summary

- fix protocol-v2 traversal deduplication and dense locator scans so large-file clones remain bounded and exact
- preflight visibility roots and publish proofs only for winning manifest generations
- skip synchronous locator publication when the bounded visibility proof cannot make protocol v2 readable
- avoid opening SlateDB for pure Git pushes and reuse immutable push dependencies when only unrelated refs advance
- replace random admission slots and the single mutable CAS queue with independent UUIDv7 FIFO ticket objects
- cap expensive repository push pipelines at five, release admission at canonical manifest commit, and use rank-aware polling
- conditionally claim expired tickets before deletion so stale cleanup cannot delete a renewed owner or revive a claimed lease

## Verification

- cargo fmt --all -- --check
- cargo check -p crab --locked
- cargo check -p crab-coordination --no-default-features --locked
- cargo test -p crab-coordination --features object-store-lock push_admission --locked
- focused Crab admission, CAS-retry, lazy-MetaDB, and single-ref push tests
- cargo clippy -p crab-coordination --features object-store-lock --locked -- -D warnings
- make install using the dedicated external release target
- live Kubernetes source repository fanout against local MinIO

Final exact-binary results on one growing repository:

- 10 writers: 10/10, 23.236s
- 100 writers: 100/100, 213.295s
- all 100 remote branch OIDs exactly matched their unique local commits
- zero remaining admission-ticket objects
- all 100 ref-lock objects released with expires_at zero
- 99 expected unrelated-ref manifest CAS retries

The earlier per-ticket run completed 100/100 in 166.376s at generation 399. The final run completed 100/100 in 213.295s at generation 509, showing that admission hot-key failures are fixed while whole-manifest CAS work now dominates as ref count grows. The previous single mutable queue completed only 71/100 in 172.184s; the random-slot baseline took 373.528s.

Full Crab clippy currently stops on the pre-existing manual_is_multiple_of warning in crates/crab-remote-git/src/snapshot.rs:1226; the touched coordination crate is lint-clean. GitHub jobs are failing during startup in 2-5 seconds without logs, consistent with the existing Actions account/billing block rather than test execution.