### PR TITLE
perf: publish concurrent refs independently

### DIFF
--- a/crab/src/cmd/fsck_store.rs
+++ b/crab/src/cmd/fsck_store.rs
@@ -17,7 +17,7 @@ use crate::core::error::{CrabError, Result};
 #[cfg(test)]
 use crate::metadata::manifest::PackManifestEntry;
 use crate::metadata::manifest::{
-    Manifest, read_bulk_pack_list, read_bulk_shard_list, read_manifest,
+    Manifest, read_bulk_pack_list, read_manifest, read_repository_snapshot,
 };
 use crate::storage::StoreLayout;
 use crate::storage::store::Store;
@@ -46,47 +46,36 @@ impl StoreChecker {
         }
     }
 
-    /// Load the current manifest-backed pack list from storage.
+    /// Load the current pack list from the compacted manifest and journal.
     async fn load_pack_list(&self) -> Result<PackList> {
-        let manifest = match read_manifest(&self.store, &self.router).await {
-            Ok((manifest, _etag)) => manifest,
+        let snapshot = match read_repository_snapshot(&self.store, &self.router).await {
+            Ok(snapshot) => snapshot,
             Err(CrabError::NotFound { .. }) => return Ok(PackList::default()),
             Err(e) => return Err(e),
         };
 
-        let entries = if manifest.pack_index_hash.is_empty() {
-            Vec::new()
-        } else {
-            read_bulk_pack_list(&self.store, &self.router, &manifest.pack_index_hash)
-                .await?
+        Ok(PackList {
+            generation: snapshot.manifest.generation,
+            entries: snapshot
+                .journal
+                .packs
                 .into_iter()
                 .map(|entry| PackEntry::with_ref_tips(entry.pack_id, entry.size, entry.ref_tips))
-                .collect()
-        };
-
-        Ok(PackList {
-            generation: manifest.generation,
-            entries,
+                .collect(),
         })
     }
 
-    /// Load the current manifest-backed shard list from storage.
+    /// Load the current shard list from the compacted manifest and journal.
     async fn load_shard_list(&self) -> Result<ShardList> {
-        let manifest = match read_manifest(&self.store, &self.router).await {
-            Ok((manifest, _etag)) => manifest,
+        let snapshot = match read_repository_snapshot(&self.store, &self.router).await {
+            Ok(snapshot) => snapshot,
             Err(CrabError::NotFound { .. }) => return Ok(ShardList::default()),
             Err(e) => return Err(e),
         };
 
-        let entries = if manifest.shard_index_hash.is_empty() {
-            Vec::new()
-        } else {
-            read_bulk_shard_list(&self.store, &self.router, &manifest.shard_index_hash).await?
-        };
-
         Ok(ShardList {
-            generation: manifest.generation,
-            entries,
+            generation: snapshot.manifest.generation,
+            entries: snapshot.journal.shards,
         })
     }
 
@@ -713,7 +702,13 @@ impl FsckRepairer for StoreRepairer {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
+    use crate::metadata::manifest::{
+        RefJournalEdit, RefJournalTransaction, commit_ref_journal_transaction,
+        read_ref_journal_head,
+    };
     use bytes::Bytes;
     use crab_xet::shard::{
         FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo, MDBXorbInfo,
@@ -963,6 +958,42 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn checker_reads_uncompacted_journal_lists() {
+        let (store, prefix) = test_store();
+        let router = StoreLayout::new(store.clone(), prefix.clone());
+        write_manifest(&store, &prefix, &[], &[]).await;
+        let pack_id = hash_from_seed(30).hex();
+        let shard_hash = hash_from_seed(31).hex();
+        let ref_name = "refs/heads/main";
+        let head = read_ref_journal_head(&store, &router, ref_name)
+            .await
+            .unwrap();
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([(ref_name.to_owned(), head.visible_transaction.clone())]),
+            vec![RefJournalEdit {
+                ref_name: ref_name.to_owned(),
+                old_oid: None,
+                new_oid: Some("a".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            vec![pack_entry(&pack_id, 4)],
+            vec![shard_hash.clone()],
+        )
+        .unwrap();
+        commit_ref_journal_transaction(&store, &router, &transaction, &[head])
+            .await
+            .unwrap();
+
+        let checker = StoreChecker::new(store, prefix);
+        let packs = checker.load_pack_list().await.unwrap();
+        let shards = checker.load_shard_list().await.unwrap();
+
+        assert_eq!(packs.entries[0].pack_id, pack_id);
+        assert_eq!(shards.entries, vec![shard_hash]);
     }
 
     #[tokio::test]

--- a/crab/src/cmd/gc/bucket.rs
+++ b/crab/src/cmd/gc/bucket.rs
@@ -618,17 +618,8 @@ pub async fn repair_ref_registry(store: &Store) -> Result<(usize, usize)> {
     let mut shard_count = 0usize;
     for repo_prefix in &repo_prefixes {
         let router = StoreLayout::new(store.clone(), repo_prefix.clone());
-        let (manifest, _) = crate::metadata::manifest::read_manifest(store, &router).await?;
-        let shards = if manifest.shard_index_hash.is_empty() {
-            Vec::new()
-        } else {
-            crate::metadata::manifest::read_bulk_shard_list(
-                store,
-                &router,
-                &manifest.shard_index_hash,
-            )
-            .await?
-        };
+        let snapshot = crate::metadata::manifest::read_repository_snapshot(store, &router).await?;
+        let shards = snapshot.journal.shards;
         shard_count = shard_count.checked_add(shards.len()).ok_or_else(|| {
             CrabError::Internal("ref-registry repair shard count overflow".to_owned())
         })?;

--- a/crab/src/cmd/gc/mod.rs
+++ b/crab/src/cmd/gc/mod.rs
@@ -894,6 +894,16 @@ pub async fn reachable_repo_objects_from_manifest(
     reachable.insert(router.manifest_path().as_ref().to_string());
 
     extend_reachable_pack_objects(store, router, &manifest, &mut reachable).await?;
+    let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
+    for pack in &snapshot.journal.packs {
+        insert_pack_objects(router, &pack.pack_id, &mut reachable);
+    }
+    // Journal metadata is the recovery root when publication succeeded but
+    // derived manifest compaction did not. GC may compact it only with the
+    // same frontier protocol as writers.
+    for object in store.list_prefix(&router.repo_path("refs/journal")).await? {
+        reachable.insert(object.location.as_ref().to_owned());
+    }
 
     let storage_router =
         crab_storage::StoreLayout::new(store.as_storage().clone(), router.repo_prefix().to_owned());
@@ -923,24 +933,18 @@ async fn extend_reachable_pack_objects(
         )
         .await?;
         for pack in packs {
-            reachable.insert(router.pack_path(&pack.pack_id).as_ref().to_string());
-            reachable.insert(router.pack_index_path(&pack.pack_id).as_ref().to_string());
-            reachable.insert(
-                router
-                    .pack_reverse_index_path(&pack.pack_id)
-                    .as_ref()
-                    .to_string(),
-            );
-            reachable.insert(
-                router
-                    .pack_metadata_path(&pack.pack_id)
-                    .as_ref()
-                    .to_string(),
-            );
+            insert_pack_objects(router, &pack.pack_id, reachable);
         }
     }
 
     Ok(())
+}
+
+fn insert_pack_objects(router: &StoreLayout, pack_id: &str, reachable: &mut HashSet<String>) {
+    reachable.insert(router.pack_path(pack_id).as_ref().to_owned());
+    reachable.insert(router.pack_index_path(pack_id).as_ref().to_owned());
+    reachable.insert(router.pack_reverse_index_path(pack_id).as_ref().to_owned());
+    reachable.insert(router.pack_metadata_path(pack_id).as_ref().to_owned());
 }
 
 /// Run remote repo-scope GC against the primary/write store.
@@ -961,7 +965,7 @@ pub async fn run_repo_remote_gc(
             .await?
             .into_iter(),
     );
-    let shard_snapshot = shard_snapshot_from_manifest(store, router, &manifest).await?;
+    let shard_snapshot = shard_snapshot_from_repository(store, router, &manifest).await?;
     let (listed_objects, list_outcome) = list_repo_gc_candidates(store, router).await?;
     let deleter = StoreObjectDeleter::new(store.clone());
 
@@ -979,6 +983,24 @@ pub async fn run_repo_remote_gc(
         jsonl_stream,
     )
     .await
+}
+
+async fn shard_snapshot_from_repository(
+    store: &Store,
+    router: &StoreLayout,
+    manifest: &crate::metadata::manifest::Manifest,
+) -> Result<ShardListSnapshot> {
+    let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
+    let shard_keys = snapshot
+        .journal
+        .shards
+        .iter()
+        .map(|hash| format!("shards/{}/{hash}", &hash[..2.min(hash.len())]))
+        .collect();
+    Ok(ShardListSnapshot {
+        generation: manifest.generation,
+        shard_keys,
+    })
 }
 
 /// Build a shard-list snapshot from the manifest for GC T0 safety.
@@ -1744,6 +1766,63 @@ mod tests {
         assert!(reachable.contains(&format!("org/repo/packs/pack-{pack_id}.idx")));
         assert!(reachable.contains(&format!("org/repo/packs/pack-{pack_id}.rev")));
         assert!(reachable.contains(&format!("org/repo/packs/pack-{pack_id}.meta")));
+    }
+
+    #[tokio::test]
+    async fn reachable_repo_objects_include_uncompacted_journal_pack_objects() {
+        use std::collections::BTreeMap;
+        use std::sync::Arc;
+
+        use object_store::memory::InMemory;
+
+        use crate::metadata::manifest::{
+            Manifest, PackManifestEntry, RefJournalEdit, RefJournalTransaction,
+            commit_ref_journal_transaction, create_manifest, read_ref_journal_head,
+        };
+        use crate::storage::StoreLayout;
+        use crate::storage::store::Store;
+
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(inner);
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest
+            .refs
+            .insert("refs/heads/main".to_owned(), "a".repeat(40));
+        manifest.seal_git_validation();
+        create_manifest(&store, &router, &manifest).await.unwrap();
+        let head = read_ref_journal_head(&store, &router, "refs/heads/side")
+            .await
+            .unwrap();
+        let pack_id = "c".repeat(64);
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([("refs/heads/side".to_owned(), None)]),
+            vec![RefJournalEdit {
+                ref_name: "refs/heads/side".to_owned(),
+                old_oid: None,
+                new_oid: Some("b".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            vec![PackManifestEntry {
+                pack_id: pack_id.clone(),
+                size: 1024,
+                content_hash: pack_id.clone(),
+                ref_tips: vec!["b".repeat(40)],
+                object_count: 1,
+            }],
+            Vec::new(),
+        )
+        .unwrap();
+        commit_ref_journal_transaction(&store, &router, &transaction, &[head])
+            .await
+            .unwrap();
+
+        let (_, reachable) = reachable_repo_objects_from_manifest(&store, &router)
+            .await
+            .unwrap();
+
+        assert!(reachable.contains(&format!("org/repo/packs/pack-{pack_id}.pack")));
     }
 
     #[tokio::test]

--- a/crab/src/cmd/push.rs
+++ b/crab/src/cmd/push.rs
@@ -272,12 +272,53 @@ async fn execute_push(
                 if emit_terminal || mode == OutputMode::Text {
                     emit_push_failure(&failure, mode);
                 }
-                return Err(CrabError::Internal(
-                    "push failed for one or more refs".into(),
-                ));
+                let source = push_failure_source(&failure.specs, &failure.result);
+                return Err(CrabError::PushPartialOutcome {
+                    outcomes: Box::new(failure.result),
+                    source: Box::new(source),
+                });
             }
         }
     }
+}
+
+fn push_failure_source(specs: &[PushSpec], result: &PushResult) -> CrabError {
+    for spec in specs {
+        let Some(outcome) = result.outcomes.get(&spec.dst) else {
+            continue;
+        };
+        #[expect(
+            deprecated,
+            reason = "preserves the deprecated outcome until its callers are migrated"
+        )]
+        match outcome {
+            RefPushOutcome::Ok => {}
+            RefPushOutcome::Error(message) => return CrabError::Internal(message.clone()),
+            RefPushOutcome::Rejected(PushRejectReason::NonFastForward { have, want }) => {
+                return CrabError::NonFastForward {
+                    ref_name: spec.dst.clone(),
+                    have: have.clone(),
+                    want: want.clone(),
+                };
+            }
+            RefPushOutcome::Rejected(PushRejectReason::StaleInfo) => {
+                return CrabError::CasConflict {
+                    path: spec.dst.clone(),
+                    expected_etag: None,
+                };
+            }
+            RefPushOutcome::Rejected(PushRejectReason::IntegrationFailed { command, message }) => {
+                return CrabError::PushIntegrationFailed {
+                    command: command.clone(),
+                    message: message.clone(),
+                };
+            }
+            RefPushOutcome::Rejected(reason) => {
+                return CrabError::Internal(reason.to_string());
+            }
+        }
+    }
+    CrabError::Internal("push failed without a per-ref failure outcome".to_owned())
 }
 
 /// Push explicit refspecs without emitting command output.
@@ -1516,6 +1557,33 @@ mod tests {
         let result = PushResult::new(outcomes);
 
         assert_eq!(rebase_retry_branch(&[spec], &result), Some("main"));
+    }
+
+    #[test]
+    fn push_failure_source_preserves_non_fast_forward_classification() {
+        use std::collections::HashMap;
+
+        let spec = PushSpec {
+            force: false,
+            src: "HEAD".to_owned(),
+            dst: "refs/heads/main".to_owned(),
+        };
+        let result = PushResult::new(HashMap::from([(
+            spec.dst.clone(),
+            RefPushOutcome::Rejected(PushRejectReason::NonFastForward {
+                have: "old".to_owned(),
+                want: "new".to_owned(),
+            }),
+        )]));
+
+        assert!(matches!(
+            push_failure_source(&[spec], &result),
+            CrabError::NonFastForward {
+                ref_name,
+                have,
+                want,
+            } if ref_name == "refs/heads/main" && have == "old" && want == "new"
+        ));
     }
 
     #[test]

--- a/crab/src/git/protected_push.rs
+++ b/crab/src/git/protected_push.rs
@@ -346,11 +346,12 @@ async fn protected_push_ref_updates_from_store(
 ) -> Result<Vec<PushRefUpdate>> {
     crate::core::error::check_cancelled(cancel)?;
     let router = StoreLayout::new(read_store.clone(), repository_prefix.to_owned());
-    let remote_refs = match crate::metadata::manifest::read_manifest(&read_store, &router).await {
-        Ok((manifest, _)) => manifest.refs,
-        Err(CrabError::NotFound { .. }) => BTreeMap::default(),
-        Err(e) => return Err(e),
-    };
+    let remote_refs =
+        match crate::metadata::manifest::read_repository_snapshot(&read_store, &router).await {
+            Ok(snapshot) => snapshot.journal.refs,
+            Err(CrabError::NotFound { .. }) => BTreeMap::default(),
+            Err(e) => return Err(e),
+        };
 
     let mut seen = BTreeSet::new();
     let mut updates = Vec::with_capacity(specs.len());

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -2409,8 +2409,6 @@ const PUSH_LOCK_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(250);
 /// Cap for opt-in push-lock wait polling.
 const PUSH_LOCK_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(2);
 
-const MANIFEST_LOCK_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(50);
-const MANIFEST_LOCK_WAIT_BACKOFF_CAP: Duration = Duration::from_millis(500);
 const PUSH_ADMISSION_SLOTS: usize = 5;
 const PUSH_ADMISSION_WAIT_TTL_MULTIPLIER: u32 = 2;
 const PUSH_ADMISSION_QUEUED_TTL: Duration = Duration::from_secs(120);
@@ -2945,18 +2943,6 @@ fn push_lock_wait_delay(attempt: u32, remaining: Duration) -> Duration {
     let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
     let exp = PUSH_LOCK_WAIT_BACKOFF_BASE.saturating_mul(shift);
     let bound = exp.min(PUSH_LOCK_WAIT_BACKOFF_CAP).min(remaining);
-    let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
-    if bound_nanos == 0 {
-        return Duration::ZERO;
-    }
-    let pick = rand::rng().random_range(1..=bound_nanos);
-    Duration::from_nanos(pick)
-}
-
-fn manifest_lock_wait_delay(attempt: u32, remaining: Duration) -> Duration {
-    let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
-    let exp = MANIFEST_LOCK_WAIT_BACKOFF_BASE.saturating_mul(shift);
-    let bound = exp.min(MANIFEST_LOCK_WAIT_BACKOFF_CAP).min(remaining);
     let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
     if bound_nanos == 0 {
         return Duration::ZERO;
@@ -4663,47 +4649,6 @@ pub(crate) async fn acquire_push_lock_leases(
         tokio::select! {
             () = tokio::time::sleep(delay) => {}
             () = cancel.cancelled() => return Err(CrabError::Cancelled),
-        }
-    }
-}
-
-async fn acquire_internal_push_lock_with_wait(
-    store: &Store,
-    prefix: &str,
-    resource: &str,
-    ttl: Duration,
-    wait: Duration,
-    cancel: &CancellationToken,
-) -> Result<PushLock> {
-    let deadline = Instant::now() + wait;
-    let mut attempt = 0;
-    loop {
-        check_cancelled(cancel)?;
-        match PushLock::acquire_internal(store.inner(), prefix, resource, ttl)
-            .await
-            .map_err(CrabError::from)
-        {
-            Ok(lock) => return Ok(lock),
-            Err(error @ CrabError::PushLockHeld { .. }) => {
-                let now = Instant::now();
-                if now >= deadline {
-                    return Err(error);
-                }
-                let delay =
-                    manifest_lock_wait_delay(attempt, deadline.saturating_duration_since(now));
-                attempt = attempt.saturating_add(1);
-                debug!(
-                    resource,
-                    attempt,
-                    delay_ms = delay.as_millis(),
-                    "internal push lock held, waiting before retry"
-                );
-                tokio::select! {
-                    () = tokio::time::sleep(delay) => {}
-                    () = cancel.cancelled() => return Err(CrabError::Cancelled),
-                }
-            }
-            Err(error) => return Err(error),
         }
     }
 }
@@ -6863,17 +6808,20 @@ impl PushPipeline {
         // Compaction is derived state. It runs after ref visibility and after
         // scarce push admission is released, while one repository writer
         // folds every transaction currently visible at its snapshot.
-        let manifest_lock = match acquire_internal_push_lock_with_wait(
-            store,
+        let manifest_lock = match PushLock::acquire_internal(
+            store.inner(),
             self.router.repo_prefix(),
             crab_coordination::GIT_MANIFEST_RESOURCE,
             self.config.lock_ttl,
-            self.config.lock_ttl,
-            &self.cancel,
         )
         .await
+        .map_err(CrabError::from)
         {
             Ok(lock) => lock,
+            Err(CrabError::PushLockHeld { .. }) => {
+                debug!("ref journal committed; another writer owns derived compaction");
+                return Ok(decisions);
+            }
             Err(error) => {
                 warn!(%error, "ref journal committed; compaction lock requires repair");
                 return Ok(decisions);
@@ -17047,6 +16995,74 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn journal_commit_does_not_wait_for_busy_compactor() {
+        let _guard = GitDirGuard::new();
+        let (store, router) = test_store_router("journal-busy-compactor");
+        let initial = Manifest::default_for_repo("refs/heads/main");
+        create_manifest_with_etag(&store, &router, &initial)
+            .await
+            .expect("create initial manifest");
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            vec![make_spec("refs/heads/main")],
+            Some(store.clone()),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router.clone(),
+            None,
+            CancellationToken::new(),
+            None,
+        );
+        pipeline.read_base_manifest().await.expect("read base");
+        let sha_map = pipeline.resolve_src_ref_map().expect("resolve refs");
+        let decisions = pipeline
+            .evaluate_decisions_with_sha_map(&sha_map)
+            .await
+            .expect("evaluate refs");
+        *pipeline.planned_ref_decisions.lock().await = Some(decisions.clone());
+        pipeline.prepare_git_pack().await.expect("prepare pack");
+        pipeline.upload_packs().await.expect("upload pack");
+        let (candidate, bulk) = pipeline
+            .apply_decisions_with_sha_map(&decisions, false, &sha_map)
+            .await
+            .expect("build candidate");
+        let blocker = PushLock::acquire_internal(
+            store.inner(),
+            router.repo_prefix(),
+            crab_coordination::GIT_MANIFEST_RESOURCE,
+            Duration::from_secs(60),
+        )
+        .await
+        .expect("hold compaction lock");
+
+        let mut admission_commit = None;
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            pipeline.commit_ref_journal(
+                candidate,
+                bulk,
+                &sha_map,
+                decisions,
+                &mut admission_commit,
+            ),
+        )
+        .await
+        .expect("journal publication must not queue behind compaction")
+        .expect("journal publication succeeds");
+        blocker.release().await.unwrap();
+
+        let snapshot = crate::metadata::manifest::read_repository_snapshot(&store, &router)
+            .await
+            .expect("read journal state");
+        assert_eq!(
+            snapshot.journal.refs.get("refs/heads/main"),
+            sha_map.get("refs/heads/main")
+        );
+        assert_eq!(snapshot.journal.transactions.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn cancellation_after_manifest_cas_reports_committed_success() {
         let _guard = GitDirGuard::new();
         let cancel = CancellationToken::new();
@@ -17238,41 +17254,6 @@ mod tests {
         .expect("partial acquisition must be released after later contention");
         lock.release().await.unwrap();
         blocker.release().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn manifest_publication_waits_for_current_writer() {
-        let inner: Arc<dyn object_store::ObjectStore> =
-            Arc::new(object_store::memory::InMemory::new());
-        let store = Store::new(inner);
-        let blocker = PushLock::acquire_internal(
-            store.inner(),
-            "repo",
-            crab_coordination::GIT_MANIFEST_RESOURCE,
-            Duration::from_secs(60),
-        )
-        .await
-        .unwrap();
-        let release = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            blocker.release().await.unwrap();
-        });
-
-        let started = Instant::now();
-        let lock = acquire_internal_push_lock_with_wait(
-            &store,
-            "repo",
-            crab_coordination::GIT_MANIFEST_RESOURCE,
-            Duration::from_secs(60),
-            Duration::from_secs(1),
-            &CancellationToken::new(),
-        )
-        .await
-        .expect("queued manifest writer should acquire the released lease");
-
-        assert!(started.elapsed() >= Duration::from_millis(50));
-        lock.release().await.unwrap();
-        release.await.unwrap();
     }
 
     #[tokio::test]
@@ -26152,85 +26133,6 @@ mod tests {
         );
         assert!(pipeline.base_commit_graph.lock().await.is_none());
         assert!(!*pipeline.base_commit_graph_loaded.lock().await);
-    }
-
-    #[tokio::test]
-    async fn unified_manifest_first_create_uses_put_etag_without_manifest_reread() {
-        let inner = Arc::new(object_store::memory::InMemory::new());
-        let reads = Arc::new(Mutex::new(Vec::new()));
-        let recording_store: Arc<dyn object_store::ObjectStore> = Arc::new(RecordingReadStore {
-            inner: Arc::clone(&inner),
-            reads: Arc::clone(&reads),
-        });
-        let store = crate::storage::store::Store::new(recording_store);
-        let router = StoreLayout::new(store.clone(), "org/repo".to_string());
-
-        let (shard_hash, _shard_index, shard_write) =
-            crate::metadata::manifest::compact_shard_index(1, &[]).unwrap();
-        let (pack_hash, _pack_index, pack_write) =
-            crate::metadata::manifest::compact_pack_index(1, &[]).unwrap();
-        let bulk = BulkData {
-            shard_index: shard_write,
-            pack_index: pack_write,
-        };
-        let mut manifest = Manifest {
-            version: 2,
-            generation: 1,
-            created_at: "2026-06-20T00:00:00Z".to_owned(),
-            pusher: None,
-            session_id: "session-1".to_owned(),
-            refs: std::collections::BTreeMap::new(),
-            peeled_refs: std::collections::BTreeMap::new(),
-            head: "refs/heads/main".to_owned(),
-            shard_index_hash: shard_hash,
-            pack_index_hash: pack_hash,
-            git_validation_digest: String::new(),
-            commit_graph_hash: None,
-            ref_registry_hash: None,
-        };
-        manifest.seal_git_validation();
-        let pipeline = PushPipeline::new(
-            PushConfig::default(),
-            vec![],
-            Some(store.clone()),
-            None,
-            None,
-            "org/repo".to_string(),
-            router.clone(),
-            None,
-            CancellationToken::new(),
-            None,
-        );
-
-        pipeline
-            .rebuild_push_commit_receipt(&manifest, &HashMap::new(), &HashMap::new(), 1, &[])
-            .await
-            .unwrap();
-        let mut admission_commit = None;
-        pipeline
-            .commit_ref_journal(
-                manifest.clone(),
-                bulk,
-                &HashMap::new(),
-                HashMap::new(),
-                &mut admission_commit,
-            )
-            .await
-            .unwrap();
-
-        let recorded = reads
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        assert!(
-            recorded.iter().all(|path| path != "org/repo/manifest"),
-            "first manifest create should cache the returned ETag without re-reading: {recorded:?}"
-        );
-        drop(recorded);
-        let cached_etag = pipeline.manifest_etag.lock().await.clone().unwrap();
-        assert!(!cached_etag.is_empty());
-
-        let (stored, _) = read_manifest(&store, &router).await.unwrap();
-        assert_eq!(stored, manifest);
     }
 
     #[tokio::test]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -1744,6 +1744,10 @@ fn manifest_connectivity_frontier(manifest: Option<&Manifest>, objects_dir: &Pat
     .collect()
 }
 
+fn should_probe_git_object_locator(candidate_count: usize) -> bool {
+    candidate_count >= GIT_LOCATOR_MIN_CANDIDATES
+}
+
 fn ref_tip_pack_basis_if_local(
     packs: &[PackManifestEntry],
     objects_dir: &Path,
@@ -2399,12 +2403,6 @@ const DEFAULT_BATCH_READ_SIZE: usize = 256;
 /// Default maximum CAS retry attempts for the unified manifest pointer.
 const DEFAULT_MAX_CAS_RETRIES: u32 = 64;
 
-/// Base delay for jittered unified-manifest CAS retries.
-const MANIFEST_CAS_BACKOFF_BASE: Duration = Duration::from_millis(50);
-
-/// Cap for jittered unified-manifest CAS retries.
-const MANIFEST_CAS_BACKOFF_CAP: Duration = Duration::from_millis(750);
-
 /// Base delay for opt-in push-lock wait polling.
 const PUSH_LOCK_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(250);
 
@@ -2420,6 +2418,7 @@ const PUSH_ADMISSION_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(100);
 const PUSH_ADMISSION_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(5);
 const PUSH_ADMISSION_WAIT_PER_WAVE: Duration = Duration::from_millis(250);
 const MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS: u64 = 100_000;
+const GIT_LOCATOR_MIN_CANDIDATES: usize = 256;
 
 /// Multipart threshold: xorbs larger than this use multipart upload.
 const XORB_MULTIPART_THRESHOLD: usize = 8 * 1024 * 1024;
@@ -2940,18 +2939,6 @@ pub fn lock_ttl_remaining(expires_at_unix: Option<u64>) -> u64 {
         .unwrap_or(0);
 
     expires_at.saturating_sub(now)
-}
-
-fn manifest_cas_backoff(attempt: u32) -> Duration {
-    let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
-    let exp = MANIFEST_CAS_BACKOFF_BASE.saturating_mul(shift);
-    let bound = exp.min(MANIFEST_CAS_BACKOFF_CAP);
-    let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
-    if bound_nanos == 0 {
-        return Duration::ZERO;
-    }
-    let pick = rand::rng().random_range(0..=bound_nanos);
-    Duration::from_nanos(pick)
 }
 
 fn push_lock_wait_delay(attempt: u32, remaining: Duration) -> Duration {
@@ -5394,15 +5381,19 @@ impl PushPipeline {
             return Ok(());
         };
 
-        match read_manifest(store, &self.router).await {
-            Ok((manifest, etag)) => {
+        match crate::metadata::manifest::read_repository_snapshot(store, &self.router).await {
+            Ok(snapshot) => {
+                let mut manifest = snapshot.manifest;
+                manifest.refs = snapshot.journal.refs;
+                manifest.peeled_refs = snapshot.journal.peeled_refs;
+                manifest.head = snapshot.journal.head;
                 debug!(
                     generation = manifest.generation,
                     refs = manifest.refs.len(),
                     "read base manifest"
                 );
                 *self.base_manifest.lock().await = Some(manifest);
-                *self.manifest_etag.lock().await = Some(etag);
+                *self.manifest_etag.lock().await = Some(snapshot.manifest_etag);
             }
             Err(CrabError::NotFound { .. }) => {
                 debug!("read_base_manifest: no manifest found, first push");
@@ -6677,18 +6668,10 @@ impl PushPipeline {
         )))
     }
 
-    /// Step 12 (new): Unified manifest CAS — uploads bulk data objects,
-    /// then CAS-writes the manifest pointer.
-    ///
-    /// Replaces the old two-phase commit (`manifest_cas` + `ref_cas`) with
-    /// a single atomic CAS on `{repo}/manifest`. On CAS conflict, re-reads
-    /// the current manifest, checks for ref conflicts, and retries with a
-    /// merged manifest if non-conflicting.
-    ///
-    /// Max retries: `config.max_cas_retries` (default 64).
+    /// Commit independently locked refs through one atomic journal transaction.
     #[tracing::instrument(
         level = "info",
-        name = "push.unified_manifest_cas",
+        name = "push.commit_ref_journal",
         skip_all,
         fields(
             generation = tracing::field::Empty,
@@ -6698,27 +6681,189 @@ impl PushPipeline {
             duration_ms = tracing::field::Empty,
         )
     )]
-    async fn unified_manifest_cas(
+    async fn commit_ref_journal(
         &self,
-        manifest: Manifest,
-        bulk: BulkData,
+        mut manifest: Manifest,
+        _bulk: BulkData,
         sha_map: &HashMap<String, String>,
-        decisions: HashMap<String, RefUpdateDecision>,
+        mut decisions: HashMap<String, RefUpdateDecision>,
         admission_commit: &mut Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<HashMap<String, RefUpdateDecision>> {
         let t0 = Instant::now();
-        let store = self.store.as_ref().ok_or_else(|| {
-            CrabError::Internal("unified_manifest_cas requires a store".to_owned())
-        })?;
+        let store = self
+            .store
+            .as_ref()
+            .ok_or_else(|| CrabError::Internal("commit_ref_journal requires a store".to_owned()))?;
+        self.validate_push_commit_receipt(&manifest).await?;
+        let base = self.base_manifest.lock().await.clone();
+        let current_snapshot =
+            match crate::metadata::manifest::read_repository_snapshot(store, &self.router).await {
+                Ok(snapshot) => snapshot,
+                Err(CrabError::NotFound { path })
+                    if path == self.router.manifest_path().as_ref() =>
+                {
+                    let initial = Manifest::default_for_repo(&manifest.head);
+                    match create_manifest_with_etag(store, &self.router, &initial).await {
+                        Ok(_) | Err(CrabError::CasConflict { .. }) => {}
+                        Err(error) => return Err(error),
+                    }
+                    crate::metadata::manifest::read_repository_snapshot(store, &self.router).await?
+                }
+                Err(error) => return Err(error),
+            };
+        let mut current = current_snapshot.manifest;
+        current.refs = current_snapshot.journal.refs;
+        current.peeled_refs = current_snapshot.journal.peeled_refs;
+        current.head = current_snapshot.journal.head;
+        let conflicts = ref_base_conflicts(&self.specs, &decisions, base.as_ref(), &current);
+        if self.config.atomic
+            && let Some(conflict) = conflicts.first()
+        {
+            let desired = self
+                .specs
+                .iter()
+                .find(|spec| spec.dst == conflict.dst)
+                .and_then(|spec| sha_map.get(&spec.src))
+                .cloned()
+                .unwrap_or_else(|| conflict.want.clone());
+            let reason = if conflict.is_delete {
+                PushRejectReason::StaleInfo
+            } else {
+                PushRejectReason::NonFastForward {
+                    have: conflict.have.clone(),
+                    want: desired,
+                }
+            };
+            return Err(self.partial_outcome_singling_out(
+                &conflict.dst,
+                reason,
+                CrabError::CasConflict {
+                    path: self.router.manifest_path().to_string(),
+                    expected_etag: None,
+                },
+            ));
+        }
+        let had_conflicts = !conflicts.is_empty();
+        for conflict in conflicts {
+            let reason = if conflict.is_delete {
+                PushRejectReason::StaleInfo
+            } else {
+                let desired = self
+                    .specs
+                    .iter()
+                    .find(|spec| spec.dst == conflict.dst)
+                    .and_then(|spec| sha_map.get(&spec.src))
+                    .cloned()
+                    .unwrap_or(conflict.want);
+                PushRejectReason::NonFastForward {
+                    have: conflict.have,
+                    want: desired,
+                }
+            };
+            decisions.insert(conflict.dst, RefUpdateDecision::Reject(reason));
+        }
+        if had_conflicts {
+            self.replan_base_bound_dependencies_after_cas_conflict()
+                .await?;
+            (manifest, _) = self
+                .apply_decisions_with_sha_map(&decisions, false, sha_map)
+                .await?;
+        }
+        let mut edits = Vec::new();
+        for spec in &self.specs {
+            if !matches!(
+                decisions.get(&spec.dst),
+                Some(RefUpdateDecision::Proceed { .. })
+            ) {
+                continue;
+            }
+            edits.push(crate::metadata::manifest::RefJournalEdit {
+                ref_name: spec.dst.clone(),
+                old_oid: base
+                    .as_ref()
+                    .and_then(|value| value.refs.get(&spec.dst).cloned()),
+                new_oid: if spec.src.is_empty() {
+                    None
+                } else {
+                    Some(sha_map.get(&spec.src).cloned().ok_or_else(|| {
+                        CrabError::Internal(format!(
+                            "journal commit is missing source ref {}",
+                            spec.src
+                        ))
+                    })?)
+                },
+                peeled_oid: manifest.peeled_refs.get(&spec.dst).cloned(),
+            });
+        }
+        edits.sort_unstable_by(|left, right| left.ref_name.cmp(&right.ref_name));
+        if edits.is_empty() {
+            return Err(CrabError::PushPartialOutcome {
+                outcomes: Box::new(PushResult::new(decisions_to_outcomes(&decisions))),
+                source: Box::new(CrabError::CasConflict {
+                    path: self.router.manifest_path().to_string(),
+                    expected_etag: None,
+                }),
+            });
+        }
+        let mut expected_heads = Vec::with_capacity(edits.len());
+        let mut parents = BTreeMap::new();
+        for edit in &edits {
+            let head = crate::metadata::manifest::read_ref_journal_head(
+                store,
+                &self.router,
+                &edit.ref_name,
+            )
+            .await?;
+            parents.insert(edit.ref_name.clone(), head.visible_transaction.clone());
+            expected_heads.push(head);
+        }
+        let packs = self
+            .uploaded_packs
+            .lock()
+            .await
+            .iter()
+            .map(|pack| pack.entry.clone())
+            .collect();
+        let shards = self
+            .uploaded_shard_hashes
+            .lock()
+            .await
+            .iter()
+            .map(MerkleHash::hex)
+            .collect();
+        let head = base
+            .as_ref()
+            .is_none_or(|value| value.head != manifest.head)
+            .then(|| manifest.head.clone());
+        let transaction = crate::metadata::manifest::RefJournalTransaction::new(
+            parents, edits, head, packs, shards,
+        )?;
+        let committed = crate::metadata::manifest::commit_ref_journal_transaction(
+            store,
+            &self.router,
+            &transaction,
+            &expected_heads,
+        )
+        .await?;
+        info!(
+            transaction_id = %committed.transaction_id,
+            refs_count = committed.edited_refs,
+            duration_ms = t0.elapsed().as_millis() as u64,
+            "ref journal transaction committed"
+        );
+        if let Some(signal) = admission_commit.take() {
+            let _ = signal.send(());
+        }
+        // Ref locks protect publication through the active marker. Derived
+        // manifest/index repair must not serialize later writers to that ref.
+        self.stop_heartbeat_and_release_lock().await;
+        self.git_visibility_published
+            .store(false, std::sync::atomic::Ordering::Relaxed);
 
-        // Upload immutable metadata segments and indexes before the
-        // manifest pointer exposes them.
-        upload_segmented_bulk(store, &self.router, &bulk).await?;
-
-        // Pack/chunk uploads remain concurrent, while the single manifest
-        // pointer has one repository-wide writer. Queue this short commit
-        // phase to avoid O(writers²) CAS retries under branch fanout.
-        let manifest_lock = acquire_internal_push_lock_with_wait(
+        // Compaction is derived state. It runs after ref visibility and after
+        // scarce push admission is released, while one repository writer
+        // folds every transaction currently visible at its snapshot.
+        let manifest_lock = match acquire_internal_push_lock_with_wait(
             store,
             self.router.repo_prefix(),
             crab_coordination::GIT_MANIFEST_RESOURCE,
@@ -6726,318 +6871,41 @@ impl PushPipeline {
             self.config.lock_ttl,
             &self.cancel,
         )
-        .await?;
-        let result = while_renewing_internal_lock(
+        .await
+        {
+            Ok(lock) => lock,
+            Err(error) => {
+                warn!(%error, "ref journal committed; compaction lock requires repair");
+                return Ok(decisions);
+            }
+        };
+        let compacted = while_renewing_internal_lock(
             &manifest_lock,
-            self.unified_manifest_cas_under_lock(t0, manifest, sha_map, decisions, store),
+            crate::metadata::manifest::compact_ref_journal(
+                store,
+                &self.router,
+                now_iso8601(),
+                manifest.pusher.clone(),
+                uuid::Uuid::now_v7().to_string(),
+            ),
         )
         .await;
-        let release = manifest_lock.release().await.map_err(CrabError::from);
-        match result {
+        if let Err(error) = manifest_lock.release().await {
+            warn!(%error, "ref journal committed; compaction lock release requires repair");
+        }
+        match compacted {
+            Ok(Some(compacted_manifest)) => match committed_manifest_anchor(&compacted_manifest) {
+                Ok(anchor) => *self.committed_manifest_anchor.lock().await = anchor,
+                Err(error) => {
+                    warn!(%error, "ref journal committed; compacted anchor requires repair")
+                }
+            },
+            Ok(None) => {}
             Err(error) => {
-                if let Err(release_error) = release {
-                    warn!(
-                        error = %release_error,
-                        "manifest publication failed and its lock release also failed"
-                    );
-                }
-                Err(error)
-            }
-            Ok((value, committed_manifest)) => {
-                release?;
-                if let Some(committed) = admission_commit.take() {
-                    let _ = committed.send(());
-                }
-                match self
-                    .publish_git_visibility_index(&committed_manifest, store)
-                    .await
-                {
-                    Ok(()) => self
-                        .git_visibility_published
-                        .store(true, std::sync::atomic::Ordering::Relaxed),
-                    Err(error) => {
-                        self.git_visibility_published
-                            .store(false, std::sync::atomic::Ordering::Relaxed);
-                        warn!(
-                            error = %error,
-                            generation = committed_manifest.generation,
-                            "Git visibility proof publication failed; v2 remains gated"
-                        );
-                    }
-                }
-                Ok(value)
+                warn!(%error, "ref journal committed; manifest compaction requires repair")
             }
         }
-    }
-
-    async fn unified_manifest_cas_under_lock(
-        &self,
-        t0: Instant,
-        mut manifest: Manifest,
-        sha_map: &HashMap<String, String>,
-        mut decisions: HashMap<String, RefUpdateDecision>,
-        store: &Store,
-    ) -> Result<(HashMap<String, RefUpdateDecision>, Manifest)> {
-        let max_retries = self.config.max_cas_retries;
-        // A retry may only shrink the planned ref set. Promoting a ref that
-        // preflight rejected would commit it without the dependency walk,
-        // staging snapshot, uploads, or connectivity proof built above.
-        let mut sticky_rejections: HashMap<String, PushRejectReason> = decisions
-            .iter()
-            .filter_map(|(dst, decision)| match decision {
-                RefUpdateDecision::Reject(reason) => Some((dst.clone(), reason.clone())),
-                RefUpdateDecision::Proceed { .. } => None,
-            })
-            .collect();
-
-        for attempt in 0..max_retries {
-            check_cancelled(&self.cancel)?;
-            self.validate_push_commit_receipt(&manifest).await?;
-
-            let etag_guard = self.manifest_etag.lock().await;
-            let current_etag = etag_guard.clone();
-            drop(etag_guard);
-
-            let pointer_bytes = serde_json::to_vec_pretty(&manifest)
-                .map_err(|e| CrabError::Internal(format!("manifest serialize: {e}")))?;
-            let pointer_len = pointer_bytes.len();
-
-            let cas_result = match &current_etag {
-                Some(etag) => write_manifest_cas(store, &self.router, &manifest, etag).await,
-                None => {
-                    // First push — no existing manifest, use create (If-None-Match: *).
-                    create_manifest_with_etag(store, &self.router, &manifest).await
-                }
-            };
-
-            match cas_result {
-                Ok(new_etag) => {
-                    // Success — update the stored ETag.
-                    *self.manifest_etag.lock().await =
-                        Some(self.manifest_etag_or_read_current(store, new_etag).await);
-
-                    let span = tracing::Span::current();
-                    span.record("generation", manifest.generation);
-                    span.record("refs_count", manifest.refs.len());
-                    span.record("pointer_bytes", pointer_len);
-                    span.record("retries", attempt);
-                    span.record("duration_ms", t0.elapsed().as_millis() as u64);
-
-                    info!(
-                        generation = manifest.generation,
-                        refs_count = manifest.refs.len(),
-                        pointer_bytes = pointer_len,
-                        attempt = attempt + 1,
-                        "manifest committed"
-                    );
-                    let anchor = committed_manifest_anchor(&manifest)?;
-                    *self.committed_manifest_anchor.lock().await = anchor;
-                    return Ok((decisions, manifest));
-                }
-                Err(CrabError::CasConflict { .. }) => {
-                    // Bump the CAS conflict counter.
-                    if let Some(metrics) = &self.metrics {
-                        metrics.inc_manifest_cas_conflicts_total();
-                    }
-
-                    // Re-read the current manifest pointer.
-                    let (current, new_etag) = read_manifest(store, &self.router).await?;
-
-                    // The old receipt and plan are base-bound. Discard them
-                    // before any retry decision or dependency proof is reused.
-                    *self.push_commit_receipt.lock().await = None;
-                    *self.dependency_plan.lock().await = None;
-
-                    // Check every proceeding ref against the exact value from
-                    // which this attempt planned. Deletes participate in the
-                    // same comparison as creates and updates.
-                    let base = self.base_manifest.lock().await;
-                    let conflicts =
-                        ref_base_conflicts(&self.specs, &decisions, base.as_ref(), &current);
-                    drop(base);
-                    if self.config.atomic
-                        && let Some(conflict) = conflicts.first()
-                    {
-                        if let Some(metrics) = &self.metrics {
-                            metrics.inc_manifest_cas_failures_total();
-                        }
-
-                        let span = tracing::Span::current();
-                        span.record("generation", manifest.generation);
-                        span.record("refs_count", manifest.refs.len());
-                        span.record("retries", attempt + 1);
-                        span.record("duration_ms", t0.elapsed().as_millis() as u64);
-
-                        let desired = self
-                            .specs
-                            .iter()
-                            .find(|spec| spec.dst == conflict.dst)
-                            .and_then(|spec| sha_map.get(&spec.src))
-                            .cloned()
-                            .unwrap_or_else(|| conflict.want.clone());
-                        let (reason, source) = if conflict.is_delete {
-                            (
-                                PushRejectReason::StaleInfo,
-                                CrabError::CasConflict {
-                                    path: self.router.manifest_path().to_string(),
-                                    expected_etag: current_etag.clone(),
-                                },
-                            )
-                        } else {
-                            (
-                                PushRejectReason::NonFastForward {
-                                    have: conflict.have.clone(),
-                                    want: desired.clone(),
-                                },
-                                CrabError::NonFastForward {
-                                    ref_name: conflict.dst.clone(),
-                                    have: conflict.have.clone(),
-                                    want: desired,
-                                },
-                            )
-                        };
-                        return Err(self.partial_outcome_singling_out(
-                            &conflict.dst,
-                            reason,
-                            source,
-                        ));
-                    }
-
-                    // Refresh canonical base state before rerunning ref and
-                    // dependency planning. Non-atomic conflicts become sticky
-                    // per-ref rejections while unaffected siblings may commit.
-                    *self.base_manifest.lock().await = Some(current);
-                    *self.manifest_etag.lock().await = Some(new_etag);
-                    *self.base_commit_graph.lock().await = None;
-                    *self.base_commit_graph_loaded.lock().await = false;
-
-                    // Re-evaluate decisions against the refreshed
-                    // base manifest. Concurrent ref updates or future
-                    // policy changes during the push window land
-                    // here, so pass 1 reruns before pass 2 rebuilds
-                    // the new manifest body.
-                    for conflict in conflicts {
-                        let reason = if conflict.is_delete {
-                            PushRejectReason::StaleInfo
-                        } else {
-                            let desired = self
-                                .specs
-                                .iter()
-                                .find(|spec| spec.dst == conflict.dst)
-                                .and_then(|spec| sha_map.get(&spec.src))
-                                .cloned()
-                                .unwrap_or(conflict.want);
-                            PushRejectReason::NonFastForward {
-                                have: conflict.have,
-                                want: desired,
-                            }
-                        };
-                        sticky_rejections.insert(conflict.dst, reason);
-                    }
-                    let mut retry_decisions = self.evaluate_decisions_with_sha_map(sha_map).await?;
-                    for (dst, reason) in &sticky_rejections {
-                        retry_decisions
-                            .insert(dst.clone(), RefUpdateDecision::Reject(reason.clone()));
-                    }
-                    sticky_rejections.extend(retry_decisions.iter().filter_map(
-                        |(dst, decision)| match decision {
-                            RefUpdateDecision::Reject(reason) => {
-                                Some((dst.clone(), reason.clone()))
-                            }
-                            RefUpdateDecision::Proceed { .. } => None,
-                        },
-                    ));
-                    if self.config.atomic
-                        && retry_decisions
-                            .values()
-                            .any(|decision| matches!(decision, RefUpdateDecision::Reject(_)))
-                    {
-                        return Err(CrabError::PushPartialOutcome {
-                            outcomes: Box::new(PushResult::new(aborted_batch_outcomes(
-                                &retry_decisions,
-                            ))),
-                            source: Box::new(CrabError::CasConflict {
-                                path: self.router.manifest_path().to_string(),
-                                expected_etag: current_etag,
-                            }),
-                        });
-                    }
-                    if !retry_decisions
-                        .values()
-                        .any(|decision| matches!(decision, RefUpdateDecision::Proceed { .. }))
-                    {
-                        return Err(CrabError::PushPartialOutcome {
-                            outcomes: Box::new(PushResult::new(decisions_to_outcomes(
-                                &retry_decisions,
-                            ))),
-                            source: Box::new(CrabError::CasConflict {
-                                path: self.router.manifest_path().to_string(),
-                                expected_etag: current_etag,
-                            }),
-                        });
-                    }
-                    *self.planned_ref_decisions.lock().await = Some(retry_decisions.clone());
-                    if retry_decisions != decisions {
-                        // A changed proceeding set invalidates ref-scoped
-                        // packs, shards, and connectivity. An unrelated ref
-                        // advance keeps those immutable proofs valid; the
-                        // candidate builder below rebinds their receipt to the
-                        // refreshed manifest without repeating preparation.
-                        self.replan_base_bound_dependencies_after_cas_conflict()
-                            .await?;
-                    } else {
-                        info!(
-                            "manifest advanced only on unrelated refs; reusing prepared immutable dependencies"
-                        );
-                    }
-                    let (merged, merged_bulk) = self
-                        .apply_decisions_with_sha_map(&retry_decisions, self.config.atomic, sha_map)
-                        .await?;
-
-                    // Upload any new segmented metadata from the rebuild.
-                    upload_segmented_bulk(store, &self.router, &merged_bulk).await?;
-
-                    manifest = merged;
-                    decisions = retry_decisions;
-
-                    if attempt + 1 < max_retries {
-                        let delay = manifest_cas_backoff(attempt);
-                        warn!(
-                            attempt = attempt + 1,
-                            delay_ms = delay.as_millis(),
-                            "manifest CAS conflict, merged and retrying"
-                        );
-                        tokio::select! {
-                            () = tokio::time::sleep(delay) => {}
-                            () = self.cancel.cancelled() => return Err(CrabError::Cancelled),
-                        }
-                    } else {
-                        warn!(
-                            attempt = attempt + 1,
-                            "manifest CAS conflict, retry budget exhausted"
-                        );
-                    }
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
-        // Max retries exceeded — permanent failure.
-        if let Some(metrics) = &self.metrics {
-            metrics.inc_manifest_cas_failures_total();
-        }
-
-        let span = tracing::Span::current();
-        span.record("generation", manifest.generation);
-        span.record("refs_count", manifest.refs.len());
-        span.record("retries", max_retries);
-        span.record("duration_ms", t0.elapsed().as_millis() as u64);
-
-        let expected_etag = self.manifest_etag.lock().await.clone();
-        Err(CrabError::CasConflict {
-            path: self.router.manifest_path().to_string(),
-            expected_etag,
-        })
+        Ok(decisions)
     }
 
     async fn publish_git_visibility_index(
@@ -10511,14 +10379,20 @@ impl PushPipeline {
         *self.git_object_candidates.lock().await = receipt_candidates;
 
         let indexed_basis = match candidate_objects.as_deref() {
-            Some(candidates) => match self.compute_git_object_locator_basis(candidates).await {
-                Ok(basis) => basis,
-                Err(error @ CrabError::CorruptObject { .. }) => return Err(error),
-                Err(error) => {
-                    warn!(error = %error, "Git object locator lookup failed; using committed ref-tip fallback");
-                    None
+            Some(candidates) if should_probe_git_object_locator(candidates.len()) => {
+                match self.compute_git_object_locator_basis(candidates).await {
+                    Ok(basis) => basis,
+                    Err(error @ CrabError::CorruptObject { .. }) => return Err(error),
+                    Err(error) => {
+                        warn!(error = %error, "Git object locator lookup failed; using committed ref-tip fallback");
+                        None
+                    }
                 }
-            },
+            }
+            // Candidate enumeration is bounded by committed connectivity
+            // tips. Sending this small superset is correct and avoids a
+            // fixed locator startup cost that dominates branch-only pushes.
+            Some(_) => Some(RemotePackBasis::ExactObjects(HashSet::new())),
             None => None,
         };
         let mut remote_pack_basis = match indexed_basis {
@@ -13339,7 +13213,7 @@ impl PushPipeline {
     ///
     /// Used by pipeline steps that fail the whole batch on one ref's
     /// behalf — `verify_connectivity` (a single missing object) and
-    /// `unified_manifest_cas` (a single non-fast-forward on CAS retry).
+    /// `commit_ref_journal` (a single concurrent ref conflict).
     /// Siblings report `AtomicAbort`: they passed their own checks but
     /// did not commit, so reporting `Ok` would be an optimistic lie.
     fn partial_outcome_singling_out(
@@ -13442,7 +13316,7 @@ impl PushPipeline {
                 outcomes
             }
             // `PushPartialOutcome` carries per-ref outcomes from the
-            // upstream step that failed (e.g. `unified_manifest_cas`
+            // upstream step that failed (e.g. `commit_ref_journal`
             // rejected one ref for NFF but the rest of the batch would
             // have committed). Preserve that map instead of overwriting
             // every ref with the aggregate error — otherwise a user
@@ -13723,7 +13597,7 @@ impl PushPipeline {
             let manifest_bytes = serde_json::to_vec_pretty(&manifest)
                 .map_err(|e| CrabError::Internal(format!("manifest serialize: {e}")))?
                 .len() as u64;
-            let manifest_phase = PhaseTimer::start("push", "manifest_cas");
+            let manifest_phase = PhaseTimer::start("push", "ref_journal_commit");
             let manifest_item_count = manifest.refs.len() as u64;
             let manifest_bytes_out = manifest_bytes + bulk_data_bytes(&bulk);
             let committed_decisions = if let Some(outcome) = self
@@ -13737,14 +13611,8 @@ impl PushPipeline {
                 active_active_commit = self.protected_push_finalize(manifest, bulk).await?;
                 decisions
             } else {
-                self.unified_manifest_cas(
-                    manifest,
-                    bulk,
-                    &sha_map,
-                    decisions,
-                    &mut admission_commit,
-                )
-                .await?
+                self.commit_ref_journal(manifest, bulk, &sha_map, decisions, &mut admission_commit)
+                    .await?
             };
             self.emit_perf_phase(manifest_phase.finish(0, manifest_bytes_out, manifest_item_count));
             Some(committed_decisions)
@@ -16236,6 +16104,15 @@ mod tests {
     }
 
     #[test]
+    fn locator_probe_is_reserved_for_candidate_sets_that_amortize_startup() {
+        assert!(!should_probe_git_object_locator(0));
+        assert!(!should_probe_git_object_locator(
+            GIT_LOCATOR_MIN_CANDIDATES - 1
+        ));
+        assert!(should_probe_git_object_locator(GIT_LOCATOR_MIN_CANDIDATES));
+    }
+
+    #[test]
     fn exact_locator_basis_packs_every_unproven_object_individually() {
         let commit = gix_hash::ObjectId::from_hex(b"1111111111111111111111111111111111111111")
             .expect("commit oid");
@@ -16668,13 +16545,6 @@ mod tests {
     }
 
     #[test]
-    fn manifest_cas_backoff_stays_within_cap() {
-        for attempt in 0..16 {
-            assert!(manifest_cas_backoff(attempt) <= MANIFEST_CAS_BACKOFF_CAP);
-        }
-    }
-
-    #[test]
     fn push_admission_backoff_scales_with_fifo_distance() {
         let front = push_admission_wait_delay(0, PUSH_ADMISSION_SLOTS, Duration::from_secs(60));
         let tail = push_admission_wait_delay(0, 95, Duration::from_secs(60));
@@ -17062,7 +16932,7 @@ mod tests {
 
         let mut admission_commit = None;
         let committed_decisions = pipeline
-            .unified_manifest_cas(candidate, bulk, &sha_map, decisions, &mut admission_commit)
+            .commit_ref_journal(candidate, bulk, &sha_map, decisions, &mut admission_commit)
             .await
             .expect("retry should commit unconflicted dev ref");
         assert!(matches!(
@@ -17146,7 +17016,7 @@ mod tests {
 
         let mut admission_commit = None;
         let committed_decisions = pipeline
-            .unified_manifest_cas(candidate, bulk, &sha_map, decisions, &mut admission_commit)
+            .commit_ref_journal(candidate, bulk, &sha_map, decisions, &mut admission_commit)
             .await
             .expect("retry should merge the unrelated ref update");
 
@@ -26338,7 +26208,7 @@ mod tests {
             .unwrap();
         let mut admission_commit = None;
         pipeline
-            .unified_manifest_cas(
+            .commit_ref_journal(
                 manifest.clone(),
                 bulk,
                 &HashMap::new(),

--- a/crab/src/git/push_native.rs
+++ b/crab/src/git/push_native.rs
@@ -25,7 +25,6 @@ use crate::git::push::{
 use crate::git::push_state::PushState;
 use crate::git::remote_helper::PushSpec;
 use crate::git::walk::PointerBlob;
-use crate::metadata::manifest::read_manifest;
 use crate::storage::StoreLayout;
 use crate::storage::store::Store;
 use crab_staging::StagingAreaReadOnly;
@@ -301,8 +300,8 @@ pub async fn run_native_push(
         // client; the protected upload store is not a canonical read handle.
         Some(prepared_ref_frontier(&session.ref_updates))
     } else {
-        match read_manifest(&store, &router).await {
-            Ok((manifest, _)) => Some(manifest.refs),
+        match crate::metadata::manifest::read_repository_snapshot(&store, &router).await {
+            Ok(snapshot) => Some(snapshot.journal.refs),
             Err(CrabError::NotFound { path })
                 if config.followtags && path == router.manifest_path().as_ref() =>
             {

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -2527,7 +2527,7 @@ fn linked_worktree_root_from_git_dir(git_dir: &std::path::Path) -> Option<std::p
 }
 
 ///
-/// Reads the pack count from the manifest's bulk pack-list. Uses the
+/// Reads the current pack count from the repository snapshot. Uses the
 /// session cache for config resolution. Falls back silently on errors.
 async fn check_repack_threshold(
     store: &crate::storage::store::Store,
@@ -2539,43 +2539,27 @@ async fn check_repack_threshold(
     let pack_count = if let Some(ref pl) = cache.pack_list {
         pl.entries.len()
     } else {
-        // Read the manifest to get the pack list hash, then read the bulk pack-list.
-        let Ok((manifest, _etag)) = crate::metadata::manifest::read_manifest(store, router).await
+        let Ok(snapshot) = crate::metadata::manifest::read_repository_snapshot(store, router).await
         else {
             return;
         };
-
-        if manifest.pack_index_hash.is_empty() {
-            return;
-        }
-
-        match crate::metadata::manifest::read_bulk_pack_list(
-            store,
-            router,
-            &manifest.pack_index_hash,
-        )
-        .await
-        {
-            Ok(entries) => {
-                let count = entries.len();
-                // Cache as a PackList for compatibility with the session cache.
-                cache.pack_list = Some(crab_metadata::manifests::PackList {
-                    generation: manifest.generation,
-                    entries: entries
-                        .iter()
-                        .map(|e| {
-                            crab_metadata::manifests::PackEntry::with_ref_tips(
-                                &e.pack_id,
-                                e.size,
-                                e.ref_tips.clone(),
-                            )
-                        })
-                        .collect(),
-                });
-                count
-            }
-            Err(_) => return,
-        }
+        let count = snapshot.journal.packs.len();
+        cache.pack_list = Some(crab_metadata::manifests::PackList {
+            generation: snapshot.manifest.generation,
+            entries: snapshot
+                .journal
+                .packs
+                .iter()
+                .map(|entry| {
+                    crab_metadata::manifests::PackEntry::with_ref_tips(
+                        &entry.pack_id,
+                        entry.size,
+                        entry.ref_tips.clone(),
+                    )
+                })
+                .collect(),
+        });
+        count
     };
 
     if pack_count > threshold {

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -26,7 +26,7 @@ use crate::git::push_native::{NativePushConfig, NativePushInputs, run_native_pus
 use crate::git::push_state::PushState;
 use crate::storage::StoreLayout;
 use crab_metadata::commit_graph::CommitGraphSummary;
-use crab_metadata::manifests::{Manifest, PackEntry, PackList};
+use crab_metadata::manifests::{PackEntry, PackList, PackManifestEntry};
 use crab_metadata::pack_metadata::PackMetadata;
 
 pub(crate) const AGENT_REBASE_FETCH_REF_FILTERING_ENV: &str =
@@ -1798,16 +1798,17 @@ pub fn format_capabilities_with_v2(has_commit_graph: bool, v2_ready: bool) -> St
     caps
 }
 
-/// Read refs from the unified manifest pointer.
-///
-/// Reads `{repo}/manifest` in one small GET, then delegates hidden-ref and
-/// HEAD fallback policy to the read-domain manifest advertisement helper.
+/// Read refs from the compacted manifest plus committed journal overlay.
 async fn read_remote_refs(
     store: &crate::storage::store::Store,
     router: &StoreLayout,
     hidden_ref_patterns: &[String],
 ) -> Result<ListOutput> {
-    let (manifest, _etag) = crate::metadata::manifest::read_manifest(store, router).await?;
+    let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
+    let mut manifest = snapshot.manifest;
+    manifest.refs = snapshot.journal.refs;
+    manifest.peeled_refs = snapshot.journal.peeled_refs;
+    manifest.head = snapshot.journal.head;
     let advertisement = crab_read::manifest_ref_advertisement(&manifest, hidden_ref_patterns);
 
     let refs = advertisement
@@ -1912,7 +1913,8 @@ fn map_fetch_admission_reject(
 struct RemoteFetchStore {
     store: crate::storage::store::Store,
     router: StoreLayout,
-    manifest: Manifest,
+    generation: u64,
+    packs: Vec<PackManifestEntry>,
     caching_store: Option<crab_cache_store::CachingStore>,
     pack_list: Arc<tokio::sync::Mutex<Option<PackList>>>,
     enrich_ref_tips: bool,
@@ -1923,7 +1925,8 @@ impl RemoteFetchStore {
     fn new(
         store: crate::storage::store::Store,
         router: StoreLayout,
-        manifest: Manifest,
+        generation: u64,
+        packs: Vec<PackManifestEntry>,
         caching_store: Option<crab_cache_store::CachingStore>,
         enrich_ref_tips: bool,
         metadata_concurrency: usize,
@@ -1931,7 +1934,8 @@ impl RemoteFetchStore {
         Self {
             store,
             router,
-            manifest,
+            generation,
+            packs,
             caching_store,
             pack_list: Arc::new(tokio::sync::Mutex::new(None)),
             enrich_ref_tips,
@@ -1948,19 +1952,12 @@ impl RemoteFetchStore {
             return Ok(cached);
         }
 
-        let entries = if self.manifest.pack_index_hash.is_empty() {
-            Vec::new()
-        } else {
-            crate::metadata::manifest::read_bulk_pack_list(
-                &self.store,
-                &self.router,
-                &self.manifest.pack_index_hash,
-            )
-            .await?
-            .into_iter()
+        let entries: Vec<PackEntry> = self
+            .packs
+            .iter()
+            .cloned()
             .map(|entry| PackEntry::with_ref_tips(entry.pack_id, entry.size, entry.ref_tips))
-            .collect()
-        };
+            .collect();
 
         let entries =
             if self.enrich_ref_tips && entries.iter().any(|entry| entry.ref_tips.is_none()) {
@@ -1970,7 +1967,7 @@ impl RemoteFetchStore {
             };
 
         let pack_list = PackList {
-            generation: self.manifest.generation,
+            generation: self.generation,
             entries,
         };
         *self.pack_list.lock().await = Some(pack_list.clone());
@@ -2120,13 +2117,17 @@ async fn fetch_packs(
     cancel: &tokio_util::sync::CancellationToken,
     check_connectivity: bool,
 ) -> Result<Option<std::path::PathBuf>> {
-    // Read the manifest to get the pack list hash.
-    let (manifest, _etag) = crate::metadata::manifest::read_manifest(store, router).await?;
+    let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
+    let mut manifest = snapshot.manifest;
+    manifest.refs = snapshot.journal.refs;
+    manifest.peeled_refs = snapshot.journal.peeled_refs;
+    manifest.head = snapshot.journal.head;
 
     let fetch_store = Arc::new(RemoteFetchStore::new(
         store.clone(),
         router.clone(),
-        manifest.clone(),
+        manifest.generation,
+        snapshot.journal.packs,
         caching_store.cloned(),
         config.fetch_ref_filtering,
         config.download_concurrency,
@@ -3166,7 +3167,8 @@ mod tests {
         let fetch_store = RemoteFetchStore::new(
             store.clone(),
             router.clone(),
-            admitted.clone(),
+            admitted.generation,
+            Vec::new(),
             None,
             false,
             1,
@@ -3196,8 +3198,15 @@ mod tests {
         let (manifest, _) = crate::metadata::manifest::read_manifest(&store, &router)
             .await
             .expect("read manifest");
-        let fetch_store =
-            RemoteFetchStore::new(store.clone(), router.clone(), manifest, None, false, 1);
+        let fetch_store = RemoteFetchStore::new(
+            store.clone(),
+            router.clone(),
+            manifest.generation,
+            Vec::new(),
+            None,
+            false,
+            1,
+        );
         let pack_id = "a".repeat(64);
 
         let missing = fetch_store

--- a/crab/src/metadata/manifest.rs
+++ b/crab/src/metadata/manifest.rs
@@ -1,7 +1,10 @@
 //! Compatibility Adapter for repository manifest helpers.
 
-pub use crab_metadata::manifest_store::ManifestHistoryEntry;
+pub use crab_metadata::manifest_store::{ManifestHistoryEntry, RepositorySnapshot};
 pub use crab_metadata::manifests::{BulkData, Manifest, PackManifestEntry};
+pub use crab_metadata::ref_journal::{
+    RefJournalCommitResult, RefJournalEdit, RefJournalHeadSnapshot, RefJournalTransaction,
+};
 
 use crate::core::error::{CrabError, Result};
 use crate::storage::StoreLayout;
@@ -23,6 +26,63 @@ pub async fn read_manifest(store: &Store, router: &StoreLayout) -> Result<(Manif
     crab_metadata::manifest_store::read_manifest(store.as_storage(), &router)
         .await
         .map_err(CrabError::from)
+}
+
+pub async fn read_repository_snapshot(
+    store: &Store,
+    router: &StoreLayout,
+) -> Result<RepositorySnapshot> {
+    let router = storage_layout(store, router);
+    crab_metadata::manifest_store::read_repository_snapshot(store.as_storage(), &router)
+        .await
+        .map_err(CrabError::from)
+}
+
+pub async fn read_ref_journal_head(
+    store: &Store,
+    router: &StoreLayout,
+    ref_name: &str,
+) -> Result<RefJournalHeadSnapshot> {
+    let router = storage_layout(store, router);
+    crab_metadata::ref_journal::read_ref_head(store.as_storage(), &router, ref_name)
+        .await
+        .map_err(CrabError::from)
+}
+
+pub async fn commit_ref_journal_transaction(
+    store: &Store,
+    router: &StoreLayout,
+    transaction: &RefJournalTransaction,
+    expected_heads: &[RefJournalHeadSnapshot],
+) -> Result<RefJournalCommitResult> {
+    let router = storage_layout(store, router);
+    crab_metadata::ref_journal::commit_ref_transaction(
+        store.as_storage(),
+        &router,
+        transaction,
+        expected_heads,
+    )
+    .await
+    .map_err(CrabError::from)
+}
+
+pub async fn compact_ref_journal(
+    store: &Store,
+    router: &StoreLayout,
+    created_at: String,
+    pusher: Option<String>,
+    session_id: String,
+) -> Result<Option<Manifest>> {
+    let router = storage_layout(store, router);
+    crab_metadata::manifest_store::compact_ref_journal(
+        store.as_storage(),
+        &router,
+        created_at,
+        pusher,
+        session_id,
+    )
+    .await
+    .map_err(CrabError::from)
 }
 
 pub async fn list_manifest_history(

--- a/crab/src/metadata/shard_sync.rs
+++ b/crab/src/metadata/shard_sync.rs
@@ -1036,7 +1036,7 @@ fn install_chunk_index_shard(
 /// Run a post-fetch shard sync to warm the local chunk-index cache.
 ///
 /// Invoked by clone, pull, and fetch after packs are on disk: reads
-/// the remote manifest's `shard_index_hash`, computes the delta against
+/// the current repository snapshot, computes the shard delta against
 /// locally installed shards via
 /// [`PersistentChunkIndex::installed_shards`], downloads the missing
 /// shards in parallel, and installs them into both local cache tiers.
@@ -1061,11 +1061,11 @@ pub async fn run_post_fetch_shard_sync(
     metrics: Option<Arc<Metrics>>,
     emit_progress: bool,
 ) -> Result<SyncStats> {
-    let (manifest, _etag) =
-        crate::metadata::manifest::read_manifest(router.store(), &router).await?;
+    let snapshot =
+        crate::metadata::manifest::read_repository_snapshot(router.store(), &router).await?;
 
-    if manifest.shard_index_hash.is_empty() {
-        debug!("post-fetch shard sync: manifest has empty shard_index_hash, nothing to sync");
+    if snapshot.journal.shards.is_empty() {
+        debug!("post-fetch shard sync: repository has no shards, nothing to sync");
         return Ok(SyncStats::default());
     }
 
@@ -1125,14 +1125,22 @@ pub async fn run_post_fetch_shard_sync(
 
     let mut synchronizer = ShardSynchronizer::new(router, local_cache, metrics)
         .with_persistent_index(Arc::clone(&persistent))
-        .with_repo_cache_dir(cache_dir, repo_hash)
         .with_shard_cache_dir(shard_cache_dir);
 
+    // The compacted manifest generation does not change until journal
+    // compaction. Do not cache an active journal shard set under that stale
+    // generation or a later fetch could incorrectly skip newly added shards.
+    if snapshot.journal.transactions.is_empty() {
+        synchronizer = synchronizer.with_repo_cache_dir(cache_dir, repo_hash);
+    }
+
     let stats = synchronizer
-        .sync_from_manifest(
+        .sync(
             &mut chunk_index,
-            &manifest.shard_index_hash,
-            manifest.generation,
+            &ShardList {
+                generation: snapshot.manifest.generation,
+                entries: snapshot.journal.shards,
+            },
         )
         .await?;
 
@@ -1160,7 +1168,13 @@ pub async fn run_post_fetch_shard_sync(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
+    use crate::metadata::manifest::{
+        Manifest, RefJournalEdit, RefJournalTransaction, commit_ref_journal_transaction,
+        create_manifest, read_ref_journal_head,
+    };
     use crate::storage::StoreLayout;
     use crate::storage::store::Store;
     use crab_metadata::manifests::ShardList;
@@ -1259,6 +1273,66 @@ mod tests {
         assert_eq!(stats.shards_downloaded, 1);
         assert!(idx.has_shard(&hash));
         assert!(cache.contains(&CacheKey::Shard(hash)).await);
+    }
+
+    #[tokio::test]
+    async fn post_fetch_sync_does_not_hide_journal_shards_behind_manifest_generation_cache() {
+        let (router, _cache, dir) = setup();
+        let manifest = Manifest::default_for_repo("refs/heads/main");
+        create_manifest(router.store(), &router, &manifest)
+            .await
+            .unwrap();
+
+        let shard_data = b"journal shard";
+        let shard_hash = compute_data_hash(shard_data);
+        router
+            .store()
+            .put(
+                &router.shard_path(&shard_hash),
+                Bytes::from_static(shard_data),
+            )
+            .await
+            .unwrap();
+
+        let ref_name = "refs/heads/main";
+        let head = read_ref_journal_head(router.store(), &router, ref_name)
+            .await
+            .unwrap();
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([(ref_name.to_owned(), head.visible_transaction.clone())]),
+            vec![RefJournalEdit {
+                ref_name: ref_name.to_owned(),
+                old_oid: None,
+                new_oid: Some("a".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            Vec::new(),
+            vec![shard_hash.hex()],
+        )
+        .unwrap();
+        commit_ref_journal_transaction(router.store(), &router, &transaction, &[head])
+            .await
+            .unwrap();
+
+        let generation_path = dir
+            .path()
+            .join("repos")
+            .join("repo-hash")
+            .join("shard-list-gen.json");
+        save_cached_generation(
+            &generation_path,
+            &CachedShardListGen {
+                generation: manifest.generation,
+                shard_hashes: Vec::new(),
+            },
+        );
+
+        let stats = run_post_fetch_shard_sync(router, "repo-hash", dir.path(), None, false)
+            .await
+            .unwrap();
+
+        assert_eq!(stats.shards_downloaded, 1);
     }
 
     #[tokio::test]

--- a/crab/src/read/mod.rs
+++ b/crab/src/read/mod.rs
@@ -412,15 +412,21 @@ impl Inner {
     }
 
     async fn remote_snapshot_git_dir(&self, rev: &str) -> Result<(String, PathBuf)> {
-        let manifest = self.read_remote_manifest().await?;
+        let snapshot = self.read_remote_snapshot().await?;
+        let mut manifest = snapshot.manifest;
+        manifest.refs = snapshot.journal.refs;
+        manifest.peeled_refs = snapshot.journal.peeled_refs;
+        manifest.head = snapshot.journal.head;
         let resolved = resolve_manifest_rev(&manifest, rev).ok_or_else(|| CrabError::NotFound {
             path: format!("revision:{rev}"),
         })?;
-        let git_dir = self.remote_git_dir_for_manifest(&manifest).await?;
+        let git_dir = self
+            .remote_git_dir_for_packs(&snapshot.journal.packs)
+            .await?;
         Ok((resolved, git_dir))
     }
 
-    async fn remote_git_dir_for_manifest(&self, manifest: &Manifest) -> Result<PathBuf> {
+    async fn remote_git_dir_for_packs(&self, packs: &[PackManifestEntry]) -> Result<PathBuf> {
         let git_dir = self
             .remote_git_dir
             .get_or_try_init(|| async {
@@ -432,27 +438,18 @@ impl Inner {
             .await?;
 
         let remote = self.remote().await?;
-        if !manifest.pack_index_hash.is_empty() {
-            let origin = crate::storage::Store::from_storage(remote.caching_store.origin().clone());
-            let packs = crate::metadata::manifest::read_bulk_pack_list(
-                &origin,
-                &remote.router,
-                &manifest.pack_index_hash,
-            )
-            .await?;
+        if !packs.is_empty() {
             let pack_dir = git_dir.join("objects").join("pack");
-            install_remote_git_packs(&remote, &pack_dir, &packs).await?;
+            install_remote_git_packs(&remote, &pack_dir, packs).await?;
         }
 
         Ok((**git_dir).clone())
     }
 
-    async fn read_remote_manifest(&self) -> Result<Manifest> {
+    async fn read_remote_snapshot(&self) -> Result<crate::metadata::manifest::RepositorySnapshot> {
         let remote = self.remote().await?;
         let origin = crate::storage::Store::from_storage(remote.caching_store.origin().clone());
-        let (manifest, _etag) =
-            crate::metadata::manifest::read_manifest(&origin, &remote.router).await?;
-        Ok(manifest)
+        crate::metadata::manifest::read_repository_snapshot(&origin, &remote.router).await
     }
 }
 

--- a/crates/crab-auth-server/src/view.rs
+++ b/crates/crab-auth-server/src/view.rs
@@ -45,6 +45,15 @@ async fn read_manifest(store: &Store, router: &StoreLayout) -> Result<(Manifest,
         .map_err(AuthServerError::from)
 }
 
+async fn read_repository_snapshot(
+    store: &Store,
+    router: &StoreLayout,
+) -> Result<manifest_store::RepositorySnapshot> {
+    manifest_store::read_repository_snapshot(store, router)
+        .await
+        .map_err(AuthServerError::from)
+}
+
 #[cfg(test)]
 async fn read_bulk_pack_list(
     store: &Store,
@@ -200,10 +209,9 @@ pub async fn materialize_view_with_store_and_credentials(
 
     let parsed = CrabUrl::parse(repo_url).map_err(AuthServerError::from)?;
     let source_router = StoreLayout::new(store.clone(), parsed.repo_path.clone());
-    let (manifest, _) = read_manifest(&store, &source_router).await?;
-    let manifest_bytes = serde_json::to_vec(&manifest)
-        .map_err(|e| AuthServerError::Internal(format!("manifest serialize: {e}")))?;
-    let source_manifest_hash = blake3::hash(&manifest_bytes).to_hex().to_string();
+    let snapshot = read_repository_snapshot(&store, &source_router).await?;
+    let manifest = snapshot.manifest;
+    let source_manifest_hash = snapshot.journal.state_digest;
     let repo_prefix = view_prefix(
         &parsed.repo_path,
         scope_hash,

--- a/crates/crab-metadata/src/file_index_lookup.rs
+++ b/crates/crab-metadata/src/file_index_lookup.rs
@@ -164,40 +164,42 @@ impl FileIndexLookupSession {
         use_acceleration: bool,
     ) -> Result<Self> {
         let router = crab_storage::StoreLayout::new(storage.clone(), repo_prefix.to_owned());
-        let anchor =
-            match crate::manifest_store::read_manifest(&storage, &router).await {
-                Ok((manifest, _)) if !manifest.shard_index_hash.is_empty() => {
-                    let shard_index_hash = MerkleHash::from_hex(&manifest.shard_index_hash)
-                        .map_err(|error| MetadataError::CorruptObject {
+        let anchor = match crate::manifest_store::read_repository_snapshot(&storage, &router).await
+        {
+            Ok(snapshot) if !snapshot.journal.shards.is_empty() => {
+                let shard_index_hash = if snapshot.manifest.shard_index_hash.is_empty() {
+                    MerkleHash::default()
+                } else {
+                    MerkleHash::from_hex(&snapshot.manifest.shard_index_hash).map_err(|error| {
+                        MetadataError::CorruptObject {
                             path: router.manifest_path().to_string(),
                             reason: format!("invalid shard-index hash: {error}"),
-                        })?;
-                    let shards = crate::manifest_store::read_bulk_shard_list(
-                        &storage,
-                        &router,
-                        &manifest.shard_index_hash,
-                    )
-                    .await?
+                        }
+                    })?
+                };
+                let shards = snapshot
+                    .journal
+                    .shards
                     .into_iter()
                     .map(|hash| {
                         MerkleHash::from_hex(&hash).map_err(|error| MetadataError::CorruptObject {
-                            path: "manifest shard index".to_owned(),
+                            path: "repository shard inventory".to_owned(),
                             reason: format!("invalid shard hash: {error}"),
                         })
                     })
                     .collect::<Result<HashSet<_>>>()?;
-                    Some(CommittedShardAnchor {
-                        generation: manifest.generation,
-                        shard_index_hash,
-                        shards,
-                    })
-                }
-                Ok(_) => None,
-                Err(MetadataError::Storage {
-                    source: crab_storage::StorageError::NotFound { .. },
-                }) => None,
-                Err(error) => return Err(error),
-            };
+                Some(CommittedShardAnchor {
+                    generation: snapshot.manifest.generation,
+                    shard_index_hash,
+                    shards,
+                })
+            }
+            Ok(_) => None,
+            Err(MetadataError::Storage {
+                source: crab_storage::StorageError::NotFound { .. },
+            }) => None,
+            Err(error) => return Err(error),
+        };
         let reader = if use_acceleration {
             let path = file_index_path(repo_prefix);
             match slatedb::DbReader::builder(
@@ -554,12 +556,38 @@ pub async fn resolve_file_hash_to_shard(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use bytes::Bytes;
     use object_store::memory::InMemory;
 
     fn hash_from_seed(seed: u64) -> MerkleHash {
         MerkleHash::from([seed, seed.wrapping_mul(31), seed.wrapping_mul(97), seed])
+    }
+
+    fn shard_with_file(file_hash: MerkleHash) -> (Vec<u8>, MerkleHash) {
+        use crab_xet::shard::{
+            FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo, MDBXorbInfo, ShardWriter,
+            XorbChunkSequenceEntry, XorbChunkSequenceHeader,
+        };
+
+        let chunk_hash = hash_from_seed(43);
+        let xorb_hash = hash_from_seed(44);
+        let xorb = Arc::new(MDBXorbInfo {
+            metadata: XorbChunkSequenceHeader::new(xorb_hash, 1, 16),
+            chunks: vec![XorbChunkSequenceEntry::new(chunk_hash, 16, 0)],
+        });
+        let file = MDBFileInfo {
+            metadata: FileDataSequenceHeader::new(file_hash, 1, false, false),
+            segments: vec![FileDataSequenceEntry::new(xorb_hash, 16, 0, 1)],
+            verification: Vec::new(),
+            metadata_ext: None,
+        };
+        let mut writer = ShardWriter::new();
+        writer.add_xorb(xorb).unwrap();
+        writer.add_file(file).unwrap();
+        writer.finalize().unwrap()
     }
 
     async fn seed_file_index(
@@ -712,31 +740,11 @@ mod tests {
 
     #[tokio::test]
     async fn manifest_shard_search_recovers_missing_file_index_entry() {
-        use crab_xet::shard::{
-            FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo, MDBXorbInfo, ShardWriter,
-            XorbChunkSequenceEntry, XorbChunkSequenceHeader,
-        };
-
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let storage = crab_storage::Store::new(Arc::clone(&store));
         let router = crab_storage::StoreLayout::new(storage.clone(), "org/recovery".to_owned());
         let file_hash = hash_from_seed(42);
-        let chunk_hash = hash_from_seed(43);
-        let xorb_hash = hash_from_seed(44);
-        let xorb = Arc::new(MDBXorbInfo {
-            metadata: XorbChunkSequenceHeader::new(xorb_hash, 1, 16),
-            chunks: vec![XorbChunkSequenceEntry::new(chunk_hash, 16, 0)],
-        });
-        let file = MDBFileInfo {
-            metadata: FileDataSequenceHeader::new(file_hash, 1, false, false),
-            segments: vec![FileDataSequenceEntry::new(xorb_hash, 16, 0, 1)],
-            verification: Vec::new(),
-            metadata_ext: None,
-        };
-        let mut writer = ShardWriter::new();
-        writer.add_xorb(xorb).unwrap();
-        writer.add_file(file).unwrap();
-        let (shard_bytes, shard_hash) = writer.finalize().unwrap();
+        let (shard_bytes, shard_hash) = shard_with_file(file_hash);
         storage
             .put(&router.shard_path(&shard_hash), Bytes::from(shard_bytes))
             .await
@@ -766,6 +774,49 @@ mod tests {
             .unwrap();
 
         let session = FileIndexLookupSession::open(store, "org/recovery")
+            .await
+            .unwrap();
+        assert_eq!(session.lookup(&file_hash).await.unwrap(), Some(shard_hash));
+        session.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn journal_shard_search_recovers_before_compaction() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let storage = crab_storage::Store::new(Arc::clone(&store));
+        let router = crab_storage::StoreLayout::new(storage.clone(), "org/journal".to_owned());
+        let file_hash = hash_from_seed(52);
+        let (shard_bytes, shard_hash) = shard_with_file(file_hash);
+        storage
+            .put(&router.shard_path(&shard_hash), Bytes::from(shard_bytes))
+            .await
+            .unwrap();
+        let manifest = crate::manifests::Manifest::default_for_repo("refs/heads/main");
+        crate::manifest_store::create_manifest(&storage, &router, &manifest)
+            .await
+            .unwrap();
+        let ref_name = "refs/heads/main";
+        let head = crate::ref_journal::read_ref_head(&storage, &router, ref_name)
+            .await
+            .unwrap();
+        let transaction = crate::ref_journal::RefJournalTransaction::new(
+            BTreeMap::from([(ref_name.to_owned(), head.visible_transaction.clone())]),
+            vec![crate::ref_journal::RefJournalEdit {
+                ref_name: ref_name.to_owned(),
+                old_oid: None,
+                new_oid: Some("a".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            Vec::new(),
+            vec![shard_hash.hex()],
+        )
+        .unwrap();
+        crate::ref_journal::commit_ref_transaction(&storage, &router, &transaction, &[head])
+            .await
+            .unwrap();
+
+        let session = FileIndexLookupSession::open(store, "org/journal")
             .await
             .unwrap();
         assert_eq!(session.lookup(&file_hash).await.unwrap(), Some(shard_hash));

--- a/crates/crab-metadata/src/lib.rs
+++ b/crates/crab-metadata/src/lib.rs
@@ -27,6 +27,8 @@ pub mod pack_origin;
 #[cfg(feature = "local-index")]
 pub mod persistent_chunk_index;
 pub mod receipts;
+#[cfg(feature = "storage")]
+pub mod ref_journal;
 pub mod ref_registry;
 #[cfg(feature = "remote-index")]
 pub mod remote_index;

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -10,7 +10,7 @@ use crate::manifests::{
 };
 use crate::ref_journal::{
     RefJournalSnapshot, cleanup_compacted_transactions, list_active_transactions,
-    materialize_ref_journal, write_ref_journal_frontier,
+    materialize_ref_journal, read_ref_journal_frontier, write_ref_journal_frontier,
 };
 use crate::segmented::{self, SegmentKind, ShardSegmentEntry};
 use crate::segmented_store;
@@ -393,6 +393,7 @@ pub async fn write_manifest_cas(
             expected_etag: Some(etag.to_owned()),
         });
     }
+    carry_ref_journal_frontier(store, router, &current, manifest).await?;
     archive_manifest(store, router, &current).await?;
     let path = router.manifest_path();
     let body = serialize_manifest(manifest)?;
@@ -404,6 +405,24 @@ pub async fn write_manifest_cas(
         .update(&path, Bytes::from(body), update_version)
         .await?;
     Ok(new_etag.e_tag.unwrap_or_default())
+}
+
+async fn carry_ref_journal_frontier(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    current: &Manifest,
+    next: &Manifest,
+) -> Result<()> {
+    if read_ref_journal_frontier(store, router, next)
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let Some(frontier) = read_ref_journal_frontier(store, router, current).await? else {
+        return Ok(());
+    };
+    write_ref_journal_frontier(store, router, next, &frontier.heads).await
 }
 
 /// PUT the manifest pointer with `If-None-Match: *` for first-time creation.
@@ -866,6 +885,45 @@ mod tests {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+
+        let (_, etag) = read_manifest(&store, &router).await.unwrap();
+        let rewritten = next_manifest(&compacted);
+        write_manifest_cas(&store, &router, &rewritten, &etag)
+            .await
+            .unwrap();
+        let head = read_ref_head(&store, &router, "refs/heads/main")
+            .await
+            .unwrap();
+        let second = RefJournalTransaction::new(
+            BTreeMap::from([(
+                "refs/heads/main".to_owned(),
+                head.visible_transaction.clone(),
+            )]),
+            vec![RefJournalEdit {
+                ref_name: "refs/heads/main".to_owned(),
+                old_oid: Some("b".repeat(40)),
+                new_oid: Some("c".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        commit_ref_transaction(&store, &router, &second, &[head])
+            .await
+            .unwrap();
+
+        let after_rewrite = read_repository_snapshot(&store, &router).await.unwrap();
+
+        assert_eq!(
+            after_rewrite.journal.refs["refs/heads/main"],
+            "c".repeat(40)
+        );
+        assert_eq!(
+            after_rewrite.journal.transactions,
+            vec![second.id().unwrap()]
         );
     }
 }

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -5,7 +5,12 @@ use crab_storage::{ETag, StorageError, Store, StoreLayout};
 
 use crate::error::{MetadataError, Result};
 use crate::manifests::{
-    BulkData, Manifest, PackManifestEntry, validate_manifest_payload, validate_pack_manifest_entry,
+    BulkData, Manifest, PackManifestEntry, compact_pack_index, compact_shard_index,
+    validate_manifest_payload, validate_pack_manifest_entry,
+};
+use crate::ref_journal::{
+    RefJournalSnapshot, cleanup_compacted_transactions, list_active_transactions,
+    materialize_ref_journal, write_ref_journal_frontier,
 };
 use crate::segmented::{self, SegmentKind, ShardSegmentEntry};
 use crate::segmented_store;
@@ -23,6 +28,17 @@ pub struct ManifestHistoryEntry {
     pub manifest: Manifest,
     /// Stored JSON body size.
     pub size: u64,
+}
+
+/// Coherent repository state materialized from the compacted manifest and ref journal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositorySnapshot {
+    /// Stored compacted manifest before journal overlay.
+    pub manifest: Manifest,
+    /// Backend CAS token for the compacted manifest.
+    pub manifest_etag: String,
+    /// Current refs, packs, and shards after committed journal transactions.
+    pub journal: RefJournalSnapshot,
 }
 
 fn serialize_manifest(manifest: &Manifest) -> Result<Vec<u8>> {
@@ -200,6 +216,95 @@ pub async fn read_manifest(
         })?;
     validate_manifest_payload(&manifest)?;
     Ok((manifest, etag.e_tag.unwrap_or_default()))
+}
+
+/// Read one coherent repository view including independently committed refs.
+pub async fn read_repository_snapshot(
+    store: &Store,
+    router: &StoreLayout<Store>,
+) -> Result<RepositorySnapshot> {
+    // Markers are captured first so compaction may safely remove them after
+    // publishing a newer manifest without stranding an old-manifest reader.
+    let active_transactions = list_active_transactions(store, router).await?;
+    let (manifest, manifest_etag) = read_manifest(store, router).await?;
+    let packs = if manifest.pack_index_hash.is_empty() {
+        Vec::new()
+    } else {
+        read_bulk_pack_list(store, router, &manifest.pack_index_hash).await?
+    };
+    let shards = if manifest.shard_index_hash.is_empty() {
+        Vec::new()
+    } else {
+        read_bulk_shard_list(store, router, &manifest.shard_index_hash).await?
+    };
+    let journal = materialize_ref_journal(
+        store,
+        router,
+        &manifest,
+        &packs,
+        &shards,
+        &active_transactions,
+    )
+    .await?;
+    Ok(RepositorySnapshot {
+        manifest,
+        manifest_etag,
+        journal,
+    })
+}
+
+/// Fold committed journal transactions into one bounded manifest snapshot.
+///
+/// Immutable indexes and the matching frontier are written before the
+/// manifest CAS. A concurrent journal commit remains above the recorded
+/// frontier and is therefore visible in the next repository snapshot.
+pub async fn compact_ref_journal(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    created_at: String,
+    pusher: Option<String>,
+    session_id: String,
+) -> Result<Option<Manifest>> {
+    let snapshot = read_repository_snapshot(store, router).await?;
+    if snapshot.journal.transactions.is_empty() {
+        return Ok(None);
+    }
+    let generation = snapshot
+        .manifest
+        .generation
+        .checked_add(1)
+        .ok_or_else(|| MetadataError::Internal("manifest generation overflow".to_owned()))?;
+    let (shard_index_hash, _, shard_index) =
+        compact_shard_index(generation, &snapshot.journal.shards)?;
+    let (pack_index_hash, _, pack_index) = compact_pack_index(generation, &snapshot.journal.packs)?;
+    upload_segmented_bulk(
+        store,
+        router,
+        &BulkData {
+            shard_index,
+            pack_index,
+        },
+    )
+    .await?;
+
+    let compacted_transactions = snapshot.journal.transactions.clone();
+    let mut manifest = snapshot.manifest;
+    manifest.generation = generation;
+    manifest.created_at = created_at;
+    manifest.pusher = pusher;
+    manifest.session_id = session_id;
+    manifest.refs = snapshot.journal.refs;
+    manifest.peeled_refs = snapshot.journal.peeled_refs;
+    manifest.head = snapshot.journal.head;
+    manifest.shard_index_hash = shard_index_hash;
+    manifest.pack_index_hash = pack_index_hash;
+    // The old summary does not cover journal-only ref advances.
+    manifest.commit_graph_hash = None;
+    manifest.seal_git_validation();
+    write_ref_journal_frontier(store, router, &manifest, &snapshot.journal.visible_heads).await?;
+    write_manifest_cas(store, router, &manifest, &snapshot.manifest_etag).await?;
+    cleanup_compacted_transactions(store, router, &compacted_transactions).await;
+    Ok(Some(manifest))
 }
 
 /// Read the segmented shard-index object and parse it into shard hashes.
@@ -386,6 +491,9 @@ mod tests {
     use object_store::memory::InMemory;
 
     use crate::manifests::{compact_pack_index, compact_shard_index};
+    use crate::ref_journal::{
+        RefJournalEdit, RefJournalTransaction, commit_ref_transaction, read_ref_head,
+    };
 
     fn memory_store() -> Store {
         let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -707,5 +815,57 @@ mod tests {
             .expect_err("stale proof must fail before generation comparison");
 
         assert!(matches!(error, MetadataError::CorruptObject { .. }));
+    }
+
+    #[tokio::test]
+    async fn journal_compaction_publishes_bounded_repository_snapshot() {
+        let store = memory_store();
+        let router = test_layout(store.clone());
+        let mut base = Manifest::default_for_repo("refs/heads/main");
+        base.refs
+            .insert("refs/heads/main".to_owned(), "a".repeat(40));
+        base.seal_git_validation();
+        create_manifest(&store, &router, &base).await.unwrap();
+        let head = read_ref_head(&store, &router, "refs/heads/main")
+            .await
+            .unwrap();
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([("refs/heads/main".to_owned(), None)]),
+            vec![RefJournalEdit {
+                ref_name: "refs/heads/main".to_owned(),
+                old_oid: Some("a".repeat(40)),
+                new_oid: Some("b".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        commit_ref_transaction(&store, &router, &transaction, &[head])
+            .await
+            .unwrap();
+
+        let compacted = compact_ref_journal(
+            &store,
+            &router,
+            "2026-08-20T00:00:00Z".to_owned(),
+            Some("test".to_owned()),
+            "compact-1".to_owned(),
+        )
+        .await
+        .unwrap()
+        .expect("one journal transaction should compact");
+        let snapshot = read_repository_snapshot(&store, &router).await.unwrap();
+
+        assert_eq!(compacted.refs["refs/heads/main"], "b".repeat(40));
+        assert!(snapshot.journal.transactions.is_empty());
+        assert_eq!(snapshot.journal.refs["refs/heads/main"], "b".repeat(40));
+        assert!(
+            crate::ref_journal::list_active_transactions(&store, &router)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/crates/crab-metadata/src/manifests.rs
+++ b/crates/crab-metadata/src/manifests.rs
@@ -13,11 +13,11 @@ use crate::error::{MetadataError, Result};
 use crate::segmented::{self, SegmentKind, SegmentWrite, ShardSegmentEntry};
 use crate::validation::{corrupt_object, validate_content_hash, validate_sha1};
 
-/// The unified manifest pointer for mutable repository state.
+/// A compacted repository snapshot.
 ///
-/// Stored at `{repo}/manifest`. The CAS target for every push. Contains refs
-/// inline and content hashes pointing to immutable segmented indexes for large
-/// shard and pack lists.
+/// Stored at `{repo}/manifest`. Contains refs inline and content hashes
+/// pointing to immutable segmented indexes. Committed journal transactions
+/// newer than this snapshot are materialized on reads until compaction.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Manifest {
     /// Format version. Always 2 for segmented metadata.

--- a/crates/crab-metadata/src/ref_journal.rs
+++ b/crates/crab-metadata/src/ref_journal.rs
@@ -534,7 +534,7 @@ pub async fn materialize_ref_journal(
     })
 }
 
-async fn read_ref_journal_frontier(
+pub(crate) async fn read_ref_journal_frontier(
     store: &Store,
     router: &StoreLayout<Store>,
     manifest: &Manifest,
@@ -1147,5 +1147,32 @@ mod tests {
 
         assert!(after.transactions.is_empty());
         assert_eq!(after.refs["refs/heads/main"], "a".repeat(40));
+    }
+
+    #[tokio::test]
+    async fn old_manifest_reader_survives_active_marker_cleanup() {
+        let (store, layout) = fixture();
+        let base = Manifest::default_for_repo("refs/heads/main");
+        let (transaction, heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/main", 'a')]).await;
+        let transaction_id = transaction.id().unwrap();
+        commit_ref_transaction(&store, &layout, &transaction, &heads)
+            .await
+            .unwrap();
+
+        // Repository reads capture the active set before the manifest. A
+        // compactor may remove its marker after publishing a newer manifest,
+        // but this old-manifest reader must retain the captured transaction.
+        let captured_active = list_active_transactions(&store, &layout).await.unwrap();
+        store
+            .delete(&layout.ref_journal_active_path(&transaction_id))
+            .await
+            .unwrap();
+
+        let snapshot = materialize_ref_journal(&store, &layout, &base, &[], &[], &captured_active)
+            .await
+            .unwrap();
+
+        assert_eq!(snapshot.refs["refs/heads/main"], "a".repeat(40));
     }
 }

--- a/crates/crab-metadata/src/ref_journal.rs
+++ b/crates/crab-metadata/src/ref_journal.rs
@@ -1,0 +1,1151 @@
+//! Atomic multi-ref publication without a repository-wide mutable pointer.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use bytes::Bytes;
+use crab_storage::{ETag, StorageError, Store, StoreLayout};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::error::{MetadataError, Result};
+use crate::manifests::{Manifest, PackManifestEntry, validate_pack_manifest_entry};
+use crate::validation::{corrupt_object, validate_content_hash, validate_sha1};
+
+const REF_JOURNAL_VERSION: u32 = 1;
+const MAX_REF_HEADS: usize = 1_000_000;
+const MAX_ACTIVE_TRANSACTIONS: usize = 1_000_000;
+
+/// One expected-old ref edit committed by a journal transaction.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RefJournalEdit {
+    pub ref_name: String,
+    pub old_oid: Option<String>,
+    pub new_oid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peeled_oid: Option<String>,
+}
+
+/// Immutable data published atomically by one push.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RefJournalTransaction {
+    pub version: u32,
+    /// Visible parent transaction for every edited ref.
+    pub parents: BTreeMap<String, Option<String>>,
+    /// Ref edits sorted by canonical ref name.
+    pub edits: Vec<RefJournalEdit>,
+    /// HEAD replacement only when this transaction retargets HEAD.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head: Option<String>,
+    /// New immutable Git packs made reachable by these edits.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub packs: Vec<PackManifestEntry>,
+    /// New immutable shard hashes made reachable by these edits.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shards: Vec<String>,
+}
+
+impl RefJournalTransaction {
+    /// Builds and validates one canonical transaction body.
+    pub fn new(
+        parents: BTreeMap<String, Option<String>>,
+        mut edits: Vec<RefJournalEdit>,
+        head: Option<String>,
+        mut packs: Vec<PackManifestEntry>,
+        mut shards: Vec<String>,
+    ) -> Result<Self> {
+        edits.sort_unstable_by(|left, right| left.ref_name.cmp(&right.ref_name));
+        packs.sort_unstable_by(|left, right| left.pack_id.cmp(&right.pack_id));
+        shards.sort_unstable();
+        let transaction = Self {
+            version: REF_JOURNAL_VERSION,
+            parents,
+            edits,
+            head,
+            packs,
+            shards,
+        };
+        validate_transaction(&transaction)?;
+        Ok(transaction)
+    }
+
+    /// Returns the Blake3 identity of the canonical JSON body.
+    pub fn id(&self) -> Result<String> {
+        Ok(blake3::hash(&serialize(self)?).to_hex().to_string())
+    }
+}
+
+/// Mutable pointer for one ref. Prepared state is invisible until its marker exists.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RefJournalHead {
+    pub version: u32,
+    pub ref_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub committed_transaction: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prepared_transaction: Option<String>,
+}
+
+impl RefJournalHead {
+    fn empty(ref_name: &str) -> Self {
+        Self {
+            version: REF_JOURNAL_VERSION,
+            ref_name: ref_name.to_owned(),
+            committed_transaction: None,
+            prepared_transaction: None,
+        }
+    }
+}
+
+/// Head body, CAS token, and currently visible transaction observed together.
+#[derive(Debug, Clone)]
+pub struct RefJournalHeadSnapshot {
+    pub head: RefJournalHead,
+    pub etag: Option<ETag>,
+    pub visible_transaction: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct RefJournalActiveMarker {
+    version: u32,
+    transaction_id: String,
+}
+
+/// Result of an atomic journal commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefJournalCommitResult {
+    pub transaction_id: String,
+    pub edited_refs: usize,
+}
+
+/// Journal positions already folded into one immutable manifest state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RefJournalFrontier {
+    pub version: u32,
+    pub manifest_git_validation_digest: String,
+    pub heads: BTreeMap<String, String>,
+}
+
+/// Fully materialized repository state after applying committed ref transactions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefJournalSnapshot {
+    pub refs: BTreeMap<String, String>,
+    pub peeled_refs: BTreeMap<String, String>,
+    pub head: String,
+    pub packs: Vec<PackManifestEntry>,
+    pub shards: Vec<String>,
+    /// Canonically ordered transaction identities included in this view.
+    pub transactions: Vec<String>,
+    /// Visible per-ref journal positions used to publish a compaction frontier.
+    pub visible_heads: BTreeMap<String, String>,
+    /// Digest binding the base manifest and ordered transaction set.
+    pub state_digest: String,
+}
+
+/// Hash a canonical ref name for its mutable head key.
+#[must_use]
+pub fn ref_name_hash(ref_name: &str) -> String {
+    blake3::hash(ref_name.as_bytes()).to_hex().to_string()
+}
+
+/// Read one ref head and resolve prepared state through its immutable marker.
+pub async fn read_ref_head(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    ref_name: &str,
+) -> Result<RefJournalHeadSnapshot> {
+    validate_ref_name(ref_name, "ref journal head")?;
+    let path = router.ref_journal_head_path(&ref_name_hash(ref_name));
+    match store.get_with_etag(&path).await {
+        Ok((body, etag)) => {
+            let head: RefJournalHead =
+                serde_json::from_slice(&body).map_err(|error| MetadataError::CorruptObject {
+                    path: path.to_string(),
+                    reason: format!("invalid ref journal head JSON: {error}"),
+                })?;
+            validate_head(&head, ref_name, path.as_ref())?;
+            let visible_transaction = visible_transaction(store, router, &head).await?;
+            Ok(RefJournalHeadSnapshot {
+                head,
+                etag: Some(etag),
+                visible_transaction,
+            })
+        }
+        Err(StorageError::NotFound { .. }) => Ok(RefJournalHeadSnapshot {
+            head: RefJournalHead::empty(ref_name),
+            etag: None,
+            visible_transaction: None,
+        }),
+        Err(source) => Err(source.into()),
+    }
+}
+
+/// Commit one transaction after callers hold every edited ref lock.
+///
+/// Each head first points at invisible prepared state. The immutable commit
+/// marker makes every edit visible together; later head promotion is cleanup.
+pub async fn commit_ref_transaction(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    transaction: &RefJournalTransaction,
+    expected_heads: &[RefJournalHeadSnapshot],
+) -> Result<RefJournalCommitResult> {
+    validate_transaction(transaction)?;
+    validate_expected_heads(transaction, expected_heads)?;
+    let transaction_id = transaction.id()?;
+    let transaction_path = router.ref_journal_transaction_path(&transaction_id);
+    store
+        .put_exact(&transaction_path, Bytes::from(serialize(transaction)?))
+        .await?;
+
+    let mut prepared = Vec::with_capacity(expected_heads.len());
+    for expected in expected_heads {
+        match prepare_head(store, router, expected, &transaction_id).await {
+            Ok(snapshot) => prepared.push((expected, snapshot)),
+            Err(error) => {
+                rollback_prepared_heads(store, router, &prepared).await;
+                return Err(error);
+            }
+        }
+    }
+
+    let marker = RefJournalActiveMarker {
+        version: REF_JOURNAL_VERSION,
+        transaction_id: transaction_id.clone(),
+    };
+    store
+        .put_exact(
+            &router.ref_journal_active_path(&transaction_id),
+            Bytes::from(serialize(&marker)?),
+        )
+        .await?;
+
+    for (_, prepared_head) in prepared {
+        if let Err(error) = promote_head(store, router, prepared_head, &transaction_id).await {
+            // The marker is the atomic visibility boundary. Promotion is only
+            // bounded read cleanup and must not turn a committed push into an error.
+            warn!(
+                ref_name = %error.0,
+                error = %error.1,
+                "committed ref journal head promotion needs repair"
+            );
+        }
+    }
+
+    Ok(RefJournalCommitResult {
+        transaction_id,
+        edited_refs: expected_heads.len(),
+    })
+}
+
+/// Read and verify an immutable transaction by identity.
+pub async fn read_transaction(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    transaction_id: &str,
+) -> Result<RefJournalTransaction> {
+    validate_content_hash(
+        transaction_id,
+        "ref journal transaction id",
+        "ref journal transaction",
+    )?;
+    let path = router.ref_journal_transaction_path(transaction_id);
+    let (body, _) = store.get_with_etag(&path).await?;
+    if blake3::hash(&body).to_hex().as_str() != transaction_id {
+        return Err(corrupt_object(
+            path.as_ref(),
+            "ref journal transaction body does not match its identity",
+        ));
+    }
+    let transaction: RefJournalTransaction =
+        serde_json::from_slice(&body).map_err(|error| MetadataError::CorruptObject {
+            path: path.to_string(),
+            reason: format!("invalid ref journal transaction JSON: {error}"),
+        })?;
+    validate_transaction(&transaction)?;
+    Ok(transaction)
+}
+
+/// List every ref head with a hard repository cardinality bound.
+pub async fn list_ref_heads(
+    store: &Store,
+    router: &StoreLayout<Store>,
+) -> Result<Vec<RefJournalHeadSnapshot>> {
+    let prefix = router.ref_journal_heads_prefix();
+    let objects = store
+        .list_prefix_bounded(&prefix, MAX_REF_HEADS)
+        .await?
+        .ok_or_else(|| MetadataError::Internal("ref journal head limit exceeded".to_owned()))?;
+    let mut heads = Vec::with_capacity(objects.len());
+    for object in objects {
+        let (body, etag) = store.get_with_etag(&object.location).await?;
+        let head: RefJournalHead =
+            serde_json::from_slice(&body).map_err(|error| MetadataError::CorruptObject {
+                path: object.location.to_string(),
+                reason: format!("invalid ref journal head JSON: {error}"),
+            })?;
+        validate_head(&head, &head.ref_name, object.location.as_ref())?;
+        let expected_path = router.ref_journal_head_path(&ref_name_hash(&head.ref_name));
+        if expected_path != object.location {
+            return Err(corrupt_object(
+                object.location.as_ref(),
+                "ref journal head key does not match its ref name",
+            ));
+        }
+        let visible_transaction = visible_transaction(store, router, &head).await?;
+        heads.push(RefJournalHeadSnapshot {
+            head,
+            etag: Some(etag),
+            visible_transaction,
+        });
+    }
+    heads.sort_unstable_by(|left, right| left.head.ref_name.cmp(&right.head.ref_name));
+    Ok(heads)
+}
+
+/// List transaction identities visible at one repository read's linearization point.
+pub async fn list_active_transactions(
+    store: &Store,
+    router: &StoreLayout<Store>,
+) -> Result<BTreeSet<String>> {
+    let prefix = router.ref_journal_active_prefix();
+    let objects = store
+        .list_prefix_bounded(&prefix, MAX_ACTIVE_TRANSACTIONS)
+        .await?
+        .ok_or_else(|| {
+            MetadataError::Internal("active ref transaction limit exceeded".to_owned())
+        })?;
+    let prefix = format!("{prefix}/");
+    objects
+        .into_iter()
+        .map(|object| {
+            let transaction_id = object
+                .location
+                .as_ref()
+                .strip_prefix(&prefix)
+                .and_then(|name| name.strip_suffix(".json"))
+                .ok_or_else(|| {
+                    corrupt_object(
+                        object.location.as_ref(),
+                        "active ref transaction key has an invalid shape",
+                    )
+                })?;
+            validate_content_hash(
+                transaction_id,
+                "active ref transaction id",
+                object.location.as_ref(),
+            )?;
+            Ok(transaction_id.to_owned())
+        })
+        .collect()
+}
+
+/// Remove compacted visibility markers once no failed head promotion needs them.
+pub async fn cleanup_compacted_transactions(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    transaction_ids: &[String],
+) {
+    for transaction_id in transaction_ids {
+        let transaction = match read_transaction(store, router, transaction_id).await {
+            Ok(transaction) => transaction,
+            Err(error) => {
+                warn!(%transaction_id, %error, "retaining compacted ref transaction marker");
+                continue;
+            }
+        };
+        let mut promotion_pending = false;
+        for edit in &transaction.edits {
+            match read_ref_head(store, router, &edit.ref_name).await {
+                Ok(head) => {
+                    promotion_pending |=
+                        head.head.prepared_transaction.as_deref() == Some(transaction_id);
+                }
+                Err(error) => {
+                    warn!(%transaction_id, ref_name = %edit.ref_name, %error, "retaining compacted ref transaction marker");
+                    promotion_pending = true;
+                    break;
+                }
+            }
+        }
+        if promotion_pending {
+            continue;
+        }
+        let path = router.ref_journal_active_path(transaction_id);
+        if let Err(error) = store.delete(&path).await
+            && !matches!(error, StorageError::NotFound { .. })
+        {
+            warn!(%transaction_id, %error, "failed to clean compacted ref transaction marker");
+        }
+    }
+}
+
+/// Publish the immutable frontier before its matching compacted manifest CAS.
+pub async fn write_ref_journal_frontier(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    manifest: &Manifest,
+    heads: &BTreeMap<String, String>,
+) -> Result<()> {
+    let frontier = RefJournalFrontier {
+        version: REF_JOURNAL_VERSION,
+        manifest_git_validation_digest: manifest.git_validation_digest.clone(),
+        heads: heads.clone(),
+    };
+    validate_frontier(&frontier, manifest)?;
+    store
+        .put_exact(
+            &router.ref_journal_frontier_path(&manifest.git_validation_digest),
+            Bytes::from(serialize(&frontier)?),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Materialize one coherent repository view from the compacted manifest plus
+/// the active transactions captured before reading that manifest.
+pub async fn materialize_ref_journal(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    base: &Manifest,
+    base_packs: &[PackManifestEntry],
+    base_shards: &[String],
+    active_transactions: &BTreeSet<String>,
+) -> Result<RefJournalSnapshot> {
+    let frontier = read_ref_journal_frontier(store, router, base).await?;
+    let compacted = frontier
+        .as_ref()
+        .map(|value| value.heads.values().cloned().collect::<BTreeSet<_>>())
+        .unwrap_or_default();
+    let mut visible_heads = frontier
+        .as_ref()
+        .map(|value| value.heads.clone())
+        .unwrap_or_default();
+    let mut pending = active_transactions
+        .iter()
+        .filter(|transaction| !compacted.contains(*transaction))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut transactions = BTreeMap::new();
+    while let Some(transaction_id) = pending.pop_first() {
+        if transactions.contains_key(&transaction_id) {
+            continue;
+        }
+        if transactions.len() == MAX_REF_HEADS {
+            return Err(MetadataError::Internal(
+                "ref journal transaction limit exceeded".to_owned(),
+            ));
+        }
+        let transaction = read_transaction(store, router, &transaction_id).await?;
+        for parent in transaction.parents.values().flatten() {
+            if !transactions.contains_key(parent) && !compacted.contains(parent) {
+                pending.insert(parent.clone());
+            }
+        }
+        transactions.insert(transaction_id, transaction);
+    }
+
+    let order = transaction_order(&transactions)?;
+    let mut refs = base.refs.clone();
+    let mut peeled_refs = base.peeled_refs.clone();
+    let mut head = base.head.clone();
+    let mut packs = base_packs
+        .iter()
+        .cloned()
+        .map(|pack| (pack.pack_id.clone(), pack))
+        .collect::<BTreeMap<_, _>>();
+    let mut shards = base_shards.iter().cloned().collect::<BTreeSet<_>>();
+
+    for transaction_id in &order {
+        let transaction = transactions.get(transaction_id).ok_or_else(|| {
+            MetadataError::Internal("ordered ref journal transaction disappeared".to_owned())
+        })?;
+        for edit in &transaction.edits {
+            if refs.get(&edit.ref_name) != edit.old_oid.as_ref() {
+                return Err(corrupt_object(
+                    router.ref_journal_transaction_path(transaction_id).as_ref(),
+                    "ref journal edit old OID does not match its parent state",
+                ));
+            }
+            match &edit.new_oid {
+                Some(oid) => {
+                    refs.insert(edit.ref_name.clone(), oid.clone());
+                    match &edit.peeled_oid {
+                        Some(peeled) => {
+                            peeled_refs.insert(edit.ref_name.clone(), peeled.clone());
+                        }
+                        None => {
+                            peeled_refs.remove(&edit.ref_name);
+                        }
+                    }
+                }
+                None => {
+                    refs.remove(&edit.ref_name);
+                    peeled_refs.remove(&edit.ref_name);
+                }
+            }
+            visible_heads.insert(edit.ref_name.clone(), transaction_id.clone());
+        }
+        if let Some(next_head) = &transaction.head {
+            head.clone_from(next_head);
+        }
+        for pack in &transaction.packs {
+            match packs.get(&pack.pack_id) {
+                Some(existing) if existing != pack => {
+                    return Err(corrupt_object(
+                        router.ref_journal_transaction_path(transaction_id).as_ref(),
+                        "ref journal pack identity has conflicting metadata",
+                    ));
+                }
+                Some(_) => {}
+                None => {
+                    packs.insert(pack.pack_id.clone(), pack.clone());
+                }
+            }
+        }
+        shards.extend(transaction.shards.iter().cloned());
+    }
+    if !refs.is_empty() && !refs.contains_key(&head) {
+        return Err(corrupt_object(
+            router.ref_journal_heads_prefix().as_ref(),
+            "materialized ref journal HEAD does not resolve",
+        ));
+    }
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"crab ref journal state v1\0");
+    hasher.update(base.git_validation_digest.as_bytes());
+    for transaction_id in &order {
+        hasher.update(transaction_id.as_bytes());
+    }
+    Ok(RefJournalSnapshot {
+        refs,
+        peeled_refs,
+        head,
+        packs: packs.into_values().collect(),
+        shards: shards.into_iter().collect(),
+        transactions: order,
+        visible_heads,
+        state_digest: hasher.finalize().to_hex().to_string(),
+    })
+}
+
+async fn read_ref_journal_frontier(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    manifest: &Manifest,
+) -> Result<Option<RefJournalFrontier>> {
+    let path = router.ref_journal_frontier_path(&manifest.git_validation_digest);
+    let body = match store.get_with_etag(&path).await {
+        Ok((body, _)) => body,
+        Err(StorageError::NotFound { .. }) => return Ok(None),
+        Err(source) => return Err(source.into()),
+    };
+    let frontier: RefJournalFrontier =
+        serde_json::from_slice(&body).map_err(|error| MetadataError::CorruptObject {
+            path: path.to_string(),
+            reason: format!("invalid ref journal frontier JSON: {error}"),
+        })?;
+    validate_frontier(&frontier, manifest)?;
+    Ok(Some(frontier))
+}
+
+fn transaction_order(
+    transactions: &BTreeMap<String, RefJournalTransaction>,
+) -> Result<Vec<String>> {
+    let mut remaining = transactions.keys().cloned().collect::<BTreeSet<_>>();
+    let mut order = Vec::with_capacity(remaining.len());
+    while !remaining.is_empty() {
+        let ready = remaining
+            .iter()
+            .filter(|transaction_id| {
+                transactions
+                    .get(*transaction_id)
+                    .into_iter()
+                    .flat_map(|transaction| transaction.parents.values().flatten())
+                    .all(|parent| !remaining.contains(parent))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if ready.is_empty() {
+            return Err(corrupt_object(
+                "ref journal transactions",
+                "ref journal transaction parent graph contains a cycle",
+            ));
+        }
+        for transaction_id in ready {
+            remaining.remove(&transaction_id);
+            order.push(transaction_id);
+        }
+    }
+    Ok(order)
+}
+
+async fn prepare_head(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    expected: &RefJournalHeadSnapshot,
+    transaction_id: &str,
+) -> Result<RefJournalHeadSnapshot> {
+    let mut next = expected.head.clone();
+    next.committed_transaction = expected.visible_transaction.clone();
+    next.prepared_transaction = Some(transaction_id.to_owned());
+    let path = router.ref_journal_head_path(&ref_name_hash(&next.ref_name));
+    let body = Bytes::from(serialize(&next)?);
+    let etag = match &expected.etag {
+        Some(etag) => store.update(&path, body, etag.clone()).await?,
+        None => store.create_strict_with_etag(&path, body).await?,
+    };
+    Ok(RefJournalHeadSnapshot {
+        head: next,
+        etag: Some(etag),
+        visible_transaction: expected.visible_transaction.clone(),
+    })
+}
+
+async fn promote_head(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    mut prepared: RefJournalHeadSnapshot,
+    transaction_id: &str,
+) -> std::result::Result<(), (String, StorageError)> {
+    prepared.head.committed_transaction = Some(transaction_id.to_owned());
+    prepared.head.prepared_transaction = None;
+    let path = router.ref_journal_head_path(&ref_name_hash(&prepared.head.ref_name));
+    let body = serialize(&prepared.head)
+        .map(Bytes::from)
+        .map_err(|error| {
+            (
+                prepared.head.ref_name.clone(),
+                StorageError::Internal(error.to_string()),
+            )
+        })?;
+    let etag = prepared.etag.ok_or_else(|| {
+        (
+            prepared.head.ref_name.clone(),
+            StorageError::Internal("prepared ref head lost its CAS token".to_owned()),
+        )
+    })?;
+    store
+        .update(&path, body, etag)
+        .await
+        .map(|_| ())
+        .map_err(|error| (prepared.head.ref_name, error))
+}
+
+async fn rollback_prepared_heads(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    prepared: &[(&RefJournalHeadSnapshot, RefJournalHeadSnapshot)],
+) {
+    for (original, written) in prepared.iter().rev() {
+        let path = router.ref_journal_head_path(&ref_name_hash(&original.head.ref_name));
+        let result = match (&original.etag, &written.etag) {
+            (Some(_), Some(written_etag)) => match serialize(&original.head) {
+                Ok(body) => store
+                    .update(&path, Bytes::from(body), written_etag.clone())
+                    .await
+                    .map(|_| ())
+                    .map_err(MetadataError::from),
+                Err(error) => Err(error),
+            },
+            (None, Some(_)) => store.delete(&path).await.map_err(MetadataError::from),
+            _ => Ok(()),
+        };
+        if let Err(error) = result {
+            warn!(ref_name = %original.head.ref_name, %error, "failed to roll back uncommitted ref journal head");
+        }
+    }
+}
+
+async fn visible_transaction(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    head: &RefJournalHead,
+) -> Result<Option<String>> {
+    let Some(prepared) = head.prepared_transaction.as_deref() else {
+        return Ok(head.committed_transaction.clone());
+    };
+    if active_marker_exists(store, router, prepared).await? {
+        Ok(Some(prepared.to_owned()))
+    } else {
+        Ok(head.committed_transaction.clone())
+    }
+}
+
+async fn active_marker_exists(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    transaction_id: &str,
+) -> Result<bool> {
+    match store
+        .head(&router.ref_journal_active_path(transaction_id))
+        .await
+    {
+        Ok(_) => Ok(true),
+        Err(StorageError::NotFound { .. }) => Ok(false),
+        Err(source) => Err(source.into()),
+    }
+}
+
+fn validate_expected_heads(
+    transaction: &RefJournalTransaction,
+    expected_heads: &[RefJournalHeadSnapshot],
+) -> Result<()> {
+    if expected_heads.len() != transaction.edits.len() {
+        return Err(MetadataError::Internal(
+            "ref journal transaction and head counts differ".to_owned(),
+        ));
+    }
+    for (edit, expected) in transaction.edits.iter().zip(expected_heads) {
+        if edit.ref_name != expected.head.ref_name
+            || transaction.parents.get(&edit.ref_name) != Some(&expected.visible_transaction)
+        {
+            return Err(MetadataError::Internal(format!(
+                "ref journal head for {} changed before commit",
+                edit.ref_name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_transaction(transaction: &RefJournalTransaction) -> Result<()> {
+    if transaction.version != REF_JOURNAL_VERSION || transaction.edits.is_empty() {
+        return Err(corrupt_object(
+            "ref journal transaction",
+            "transaction version or edit set is invalid",
+        ));
+    }
+    let mut names = BTreeSet::new();
+    let mut previous = None;
+    for edit in &transaction.edits {
+        validate_ref_name(&edit.ref_name, "ref journal transaction")?;
+        if !names.insert(edit.ref_name.as_str())
+            || previous.is_some_and(|name| name >= edit.ref_name.as_str())
+        {
+            return Err(corrupt_object(
+                "ref journal transaction",
+                "transaction edits must be unique and sorted",
+            ));
+        }
+        previous = Some(edit.ref_name.as_str());
+        if edit.old_oid.is_none() && edit.new_oid.is_none() {
+            return Err(corrupt_object(
+                "ref journal transaction",
+                "ref edit cannot keep both old and new OIDs absent",
+            ));
+        }
+        if let Some(oid) = &edit.old_oid {
+            validate_sha1(oid, "ref journal old oid", "ref journal transaction")?;
+        }
+        if let Some(oid) = &edit.new_oid {
+            validate_sha1(oid, "ref journal new oid", "ref journal transaction")?;
+        }
+        if let Some(oid) = &edit.peeled_oid {
+            validate_sha1(oid, "ref journal peeled oid", "ref journal transaction")?;
+        }
+        match transaction.parents.get(&edit.ref_name) {
+            Some(Some(parent)) => validate_content_hash(
+                parent,
+                "ref journal parent transaction",
+                "ref journal transaction",
+            )?,
+            Some(None) => {}
+            None => {
+                return Err(corrupt_object(
+                    "ref journal transaction",
+                    "transaction is missing an edited ref parent",
+                ));
+            }
+        }
+    }
+    if transaction.parents.len() != transaction.edits.len() {
+        return Err(corrupt_object(
+            "ref journal transaction",
+            "transaction contains an unedited ref parent",
+        ));
+    }
+    if let Some(head) = &transaction.head {
+        validate_ref_name(head, "ref journal HEAD")?;
+    }
+    for pack in &transaction.packs {
+        validate_pack_manifest_entry(pack)?;
+    }
+    if transaction
+        .packs
+        .windows(2)
+        .any(|pair| pair[0].pack_id >= pair[1].pack_id)
+    {
+        return Err(corrupt_object(
+            "ref journal transaction",
+            "transaction packs must be unique and sorted",
+        ));
+    }
+    for shard in &transaction.shards {
+        validate_content_hash(shard, "ref journal shard hash", "ref journal transaction")?;
+    }
+    if transaction.shards.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(corrupt_object(
+            "ref journal transaction",
+            "transaction shards must be unique and sorted",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_head(head: &RefJournalHead, ref_name: &str, path: &str) -> Result<()> {
+    if head.version != REF_JOURNAL_VERSION || head.ref_name != ref_name {
+        return Err(corrupt_object(path, "ref journal head identity is invalid"));
+    }
+    validate_ref_name(&head.ref_name, path)?;
+    for transaction in [
+        head.committed_transaction.as_deref(),
+        head.prepared_transaction.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        validate_content_hash(transaction, "ref journal head transaction", path)?;
+    }
+    Ok(())
+}
+
+fn validate_frontier(frontier: &RefJournalFrontier, manifest: &Manifest) -> Result<()> {
+    if frontier.version != REF_JOURNAL_VERSION
+        || frontier.manifest_git_validation_digest != manifest.git_validation_digest
+    {
+        return Err(corrupt_object(
+            "ref journal frontier",
+            "frontier does not match its compacted manifest",
+        ));
+    }
+    for (ref_name, transaction) in &frontier.heads {
+        validate_ref_name(ref_name, "ref journal frontier")?;
+        validate_content_hash(
+            transaction,
+            "ref journal frontier transaction",
+            "ref journal frontier",
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_ref_name(ref_name: &str, path: &str) -> Result<()> {
+    if !ref_name.starts_with("refs/")
+        || ref_name.len() > 1_024
+        || ref_name.bytes().any(|byte| byte.is_ascii_control())
+    {
+        return Err(corrupt_object(path, "ref journal ref name is invalid"));
+    }
+    Ok(())
+}
+
+fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    serde_json::to_vec(value)
+        .map_err(|error| MetadataError::Internal(format!("ref journal serialize: {error}")))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use std::sync::Arc;
+
+    use object_store::memory::InMemory;
+
+    use super::*;
+
+    fn fixture() -> (Store, StoreLayout<Store>) {
+        let store = Store::new(Arc::new(InMemory::new()));
+        let layout = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        (store, layout)
+    }
+
+    fn edit(ref_name: &str, byte: char) -> RefJournalEdit {
+        RefJournalEdit {
+            ref_name: ref_name.to_owned(),
+            old_oid: None,
+            new_oid: Some(byte.to_string().repeat(40)),
+            peeled_oid: None,
+        }
+    }
+
+    async fn transaction_for(
+        store: &Store,
+        layout: &StoreLayout<Store>,
+        edits: Vec<RefJournalEdit>,
+    ) -> (RefJournalTransaction, Vec<RefJournalHeadSnapshot>) {
+        let mut heads = Vec::new();
+        let mut parents = BTreeMap::new();
+        for edit in &edits {
+            let head = read_ref_head(store, layout, &edit.ref_name).await.unwrap();
+            parents.insert(edit.ref_name.clone(), head.visible_transaction.clone());
+            heads.push(head);
+        }
+        (
+            RefJournalTransaction::new(parents, edits, None, Vec::new(), Vec::new()).unwrap(),
+            heads,
+        )
+    }
+
+    async fn materialize(
+        store: &Store,
+        layout: &StoreLayout<Store>,
+        base: &Manifest,
+    ) -> RefJournalSnapshot {
+        let active = list_active_transactions(store, layout).await.unwrap();
+        materialize_ref_journal(store, layout, base, &[], &[], &active)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn unrelated_refs_commit_through_distinct_mutable_heads() {
+        let (store, layout) = fixture();
+        let (left, left_heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/left", 'a')]).await;
+        let (right, right_heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/right", 'b')]).await;
+
+        let (left_result, right_result) = tokio::join!(
+            commit_ref_transaction(&store, &layout, &left, &left_heads),
+            commit_ref_transaction(&store, &layout, &right, &right_heads),
+        );
+
+        assert!(left_result.is_ok());
+        assert!(right_result.is_ok());
+        assert_ne!(
+            layout.ref_journal_head_path(&ref_name_hash("refs/heads/left")),
+            layout.ref_journal_head_path(&ref_name_hash("refs/heads/right"))
+        );
+        assert!(store.head(&layout.manifest_path()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn same_ref_rejects_a_stale_head_snapshot() {
+        let (store, layout) = fixture();
+        let (first, stale_heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/main", 'a')]).await;
+        let (second, _) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/main", 'b')]).await;
+
+        commit_ref_transaction(&store, &layout, &first, &stale_heads)
+            .await
+            .unwrap();
+
+        assert!(
+            commit_ref_transaction(&store, &layout, &second, &stale_heads)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_ref_transaction_becomes_visible_at_one_marker() {
+        let (store, layout) = fixture();
+        let edits = vec![edit("refs/heads/left", 'a'), edit("refs/heads/right", 'b')];
+        let (transaction, heads) = transaction_for(&store, &layout, edits).await;
+        let transaction_id = transaction.id().unwrap();
+        store
+            .put_exact(
+                &layout.ref_journal_transaction_path(&transaction_id),
+                Bytes::from(serialize(&transaction).unwrap()),
+            )
+            .await
+            .unwrap();
+        for head in &heads {
+            prepare_head(&store, &layout, head, &transaction_id)
+                .await
+                .unwrap();
+        }
+
+        assert!(
+            list_ref_heads(&store, &layout)
+                .await
+                .unwrap()
+                .iter()
+                .all(|head| head.visible_transaction.is_none())
+        );
+
+        let marker = RefJournalActiveMarker {
+            version: REF_JOURNAL_VERSION,
+            transaction_id: transaction_id.clone(),
+        };
+        store
+            .put_exact(
+                &layout.ref_journal_active_path(&transaction_id),
+                Bytes::from(serialize(&marker).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            list_ref_heads(&store, &layout)
+                .await
+                .unwrap()
+                .iter()
+                .all(|head| head.visible_transaction.as_deref() == Some(&transaction_id))
+        );
+    }
+
+    #[tokio::test]
+    async fn abandoned_prepared_state_is_reclaimed_by_the_next_commit() {
+        let (store, layout) = fixture();
+        let (abandoned, heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/main", 'a')]).await;
+        let abandoned_id = abandoned.id().unwrap();
+        prepare_head(&store, &layout, &heads[0], &abandoned_id)
+            .await
+            .unwrap();
+        let observed = read_ref_head(&store, &layout, "refs/heads/main")
+            .await
+            .unwrap();
+        assert!(observed.visible_transaction.is_none());
+
+        let mut parents = BTreeMap::new();
+        parents.insert("refs/heads/main".to_owned(), None);
+        let next = RefJournalTransaction::new(
+            parents,
+            vec![edit("refs/heads/main", 'b')],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        commit_ref_transaction(&store, &layout, &next, &[observed])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_ref_head(&store, &layout, "refs/heads/main")
+                .await
+                .unwrap()
+                .visible_transaction,
+            Some(next.id().unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn materialization_merges_unrelated_transactions_without_a_manifest_write() {
+        let (store, layout) = fixture();
+        let mut base = Manifest::default_for_repo("refs/heads/main");
+        base.refs
+            .insert("refs/heads/main".to_owned(), "c".repeat(40));
+        base.seal_git_validation();
+        let (left, left_heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/left", 'a')]).await;
+        let (right, right_heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/right", 'b')]).await;
+        commit_ref_transaction(&store, &layout, &left, &left_heads)
+            .await
+            .unwrap();
+        commit_ref_transaction(&store, &layout, &right, &right_heads)
+            .await
+            .unwrap();
+
+        let snapshot = materialize(&store, &layout, &base).await;
+
+        assert_eq!(snapshot.refs["refs/heads/left"], "a".repeat(40));
+        assert_eq!(snapshot.refs["refs/heads/right"], "b".repeat(40));
+        assert_eq!(snapshot.transactions.len(), 2);
+        assert!(store.head(&layout.manifest_path()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn materialization_does_not_read_dormant_ref_heads() {
+        let (store, layout) = fixture();
+        let mut base = Manifest::default_for_repo("refs/heads/main");
+        base.refs
+            .insert("refs/heads/main".to_owned(), "c".repeat(40));
+        base.seal_git_validation();
+        store
+            .put_exact(
+                &layout.ref_journal_head_path(&ref_name_hash("refs/heads/dormant")),
+                Bytes::from_static(b"not-json"),
+            )
+            .await
+            .unwrap();
+
+        let snapshot = materialize(&store, &layout, &base).await;
+
+        assert_eq!(snapshot.refs, base.refs);
+    }
+
+    #[tokio::test]
+    async fn materialization_applies_same_ref_parent_chain_in_order() {
+        let (store, layout) = fixture();
+        let base = Manifest::default_for_repo("refs/heads/main");
+        let (first, first_heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/main", 'a')]).await;
+        commit_ref_transaction(&store, &layout, &first, &first_heads)
+            .await
+            .unwrap();
+        let current = read_ref_head(&store, &layout, "refs/heads/main")
+            .await
+            .unwrap();
+        let mut parents = BTreeMap::new();
+        parents.insert(
+            "refs/heads/main".to_owned(),
+            current.visible_transaction.clone(),
+        );
+        let second = RefJournalTransaction::new(
+            parents,
+            vec![RefJournalEdit {
+                ref_name: "refs/heads/main".to_owned(),
+                old_oid: Some("a".repeat(40)),
+                new_oid: Some("b".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        commit_ref_transaction(&store, &layout, &second, &[current])
+            .await
+            .unwrap();
+
+        let snapshot = materialize(&store, &layout, &base).await;
+
+        assert_eq!(snapshot.refs["refs/heads/main"], "b".repeat(40));
+        assert_eq!(
+            snapshot.transactions,
+            vec![first.id().unwrap(), second.id().unwrap()]
+        );
+    }
+
+    #[tokio::test]
+    async fn compaction_frontier_stops_replaying_folded_transactions() {
+        let (store, layout) = fixture();
+        let base = Manifest::default_for_repo("refs/heads/main");
+        let (transaction, heads) =
+            transaction_for(&store, &layout, vec![edit("refs/heads/main", 'a')]).await;
+        let transaction_id = transaction.id().unwrap();
+        commit_ref_transaction(&store, &layout, &transaction, &heads)
+            .await
+            .unwrap();
+        let snapshot = materialize(&store, &layout, &base).await;
+        let mut compacted = base;
+        compacted.generation = 1;
+        compacted.refs = snapshot.refs;
+        compacted.peeled_refs = snapshot.peeled_refs;
+        compacted.head = snapshot.head;
+        compacted.seal_git_validation();
+        write_ref_journal_frontier(&store, &layout, &compacted, &snapshot.visible_heads)
+            .await
+            .unwrap();
+        store
+            .delete(&layout.ref_journal_transaction_path(&transaction_id))
+            .await
+            .unwrap();
+
+        let after = materialize(&store, &layout, &compacted).await;
+
+        assert!(after.transactions.is_empty());
+        assert_eq!(after.refs["refs/heads/main"], "a".repeat(40));
+    }
+}

--- a/crates/crab-read/src/selection.rs
+++ b/crates/crab-read/src/selection.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 
+use crab_metadata::ref_journal::list_active_transactions;
 use crab_metadata::{error::MetadataError, manifest_store, manifests::Manifest};
 use crab_storage::{StorageError, Store, StoreLayout};
 use crab_types::replication::ReplicaConfig;
@@ -251,6 +252,9 @@ pub async fn check_read_replica_readiness(
     options: ReadinessCheckOptions,
 ) -> Result<ReadReplicaReadiness> {
     let mut stats = ReadinessProbeStats::default();
+    // Capture journal visibility before the manifest, matching repository
+    // snapshot ordering without loading the primary's pack and shard indexes.
+    let primary_active = list_active_transactions(primary_store, primary_router).await?;
     let (primary_manifest, _) =
         manifest_store::read_manifest(primary_store, primary_router).await?;
     let primary_generation = primary_manifest.generation;
@@ -267,6 +271,15 @@ pub async fn check_read_replica_readiness(
             ));
         }
     };
+
+    if !primary_active.is_empty() {
+        return Ok(ReadReplicaReadiness::not_ready(
+            primary_generation,
+            Some(replica_manifest.generation),
+            "primary has uncompacted ref transactions",
+            stats,
+        ));
+    }
 
     if replica_manifest.generation < primary_generation {
         return Ok(ReadReplicaReadiness::not_ready(
@@ -647,12 +660,16 @@ impl<Store, Router> ReadStoreSelection<Store, Router> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     use bytes::Bytes;
     use crab_metadata::{
         manifest_store::create_manifest,
         manifests::{Manifest, PackManifestEntry, compact_pack_index},
+        ref_journal::{
+            RefJournalEdit, RefJournalTransaction, commit_ref_transaction, read_ref_head,
+        },
         segmented_store,
     };
     use object_store::memory::InMemory;
@@ -930,6 +947,54 @@ mod tests {
         );
         assert_eq!(readiness.stats.object_read_count, 1);
         assert_eq!(readiness.stats.object_probe_count, 1);
+    }
+
+    #[tokio::test]
+    async fn readiness_check_rejects_replica_while_primary_journal_is_uncompacted() {
+        let (primary_store, primary_router) = memory_store_with_layout("org/repo");
+        let (replica_store, replica_router) = memory_store_with_layout("org/repo");
+        let manifest = test_manifest(9);
+        write_test_manifest(&primary_store, &primary_router, &manifest).await;
+        write_test_manifest(&replica_store, &replica_router, &manifest).await;
+
+        let ref_name = "refs/heads/main";
+        let head = read_ref_head(&primary_store, &primary_router, ref_name)
+            .await
+            .expect("read ref head");
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([(ref_name.to_owned(), head.visible_transaction.clone())]),
+            vec![RefJournalEdit {
+                ref_name: ref_name.to_owned(),
+                old_oid: None,
+                new_oid: Some("c".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("build transaction");
+        commit_ref_transaction(&primary_store, &primary_router, &transaction, &[head])
+            .await
+            .expect("commit transaction");
+
+        let readiness = check_read_replica_readiness(
+            &primary_store,
+            &primary_router,
+            &replica_store,
+            &replica_router,
+            ReadinessCheckOptions::deep(),
+        )
+        .await
+        .expect("readiness check");
+
+        assert!(!readiness.ready);
+        assert_eq!(readiness.primary_generation, 9);
+        assert_eq!(readiness.replica_generation, Some(9));
+        assert_eq!(
+            readiness.reason.as_deref(),
+            Some("primary has uncompacted ref transactions")
+        );
     }
 
     #[test]

--- a/crates/crab-remote-git/src/repository.rs
+++ b/crates/crab-remote-git/src/repository.rs
@@ -6,6 +6,7 @@ use crab_metadata::git_object_locator::{
     GitLocatorCoverage, GitObjectLocatorSession, GitPackInventoryEntry,
 };
 use crab_metadata::manifest_store::{read_bulk_pack_list, read_manifest};
+use crab_metadata::ref_journal::{list_active_transactions, materialize_ref_journal};
 use crab_storage::{Store, StoreLayout};
 use crab_xet::hash::MerkleHash;
 use gix_hash::ObjectId;
@@ -286,6 +287,9 @@ impl RemoteGitRepository {
         for attempt in 0..2 {
             check_cancelled(cancellation)?;
             check_cancelled(&runtime_cancellation)?;
+            let active_transactions = list_active_transactions(&store, &layout)
+                .await
+                .map_err(Error::Metadata)?;
             let (manifest, manifest_etag) = load_manifest(
                 &store,
                 &layout,
@@ -295,6 +299,34 @@ impl RemoteGitRepository {
                 &runtime_cancellation,
             )
             .await?;
+            let base_packs = if manifest.pack_index_hash.is_empty() {
+                Vec::new()
+            } else {
+                tokio::select! {
+                    biased;
+                    () = cancellation.cancelled() => return Err(Error::Cancelled),
+                    () = runtime_cancellation.cancelled() => return Err(Error::Cancelled),
+                    result = read_bulk_pack_list(&store, &layout, &manifest.pack_index_hash) => {
+                        result.map_err(|source| Error::Inventory { source })?
+                    }
+                }
+            };
+            let journal = materialize_ref_journal(
+                &store,
+                &layout,
+                &manifest,
+                &base_packs,
+                &[],
+                &active_transactions,
+            )
+            .await
+            .map_err(Error::Metadata)?;
+            if !journal.transactions.is_empty() {
+                return Err(Error::RepositoryIndexing {
+                    observed: Some(manifest.generation),
+                    required: manifest.generation.saturating_add(1),
+                });
+            }
             check_cancelled(cancellation)?;
             check_cancelled(&runtime_cancellation)?;
             let refs = parse_refs(&manifest)?;
@@ -322,17 +354,9 @@ impl RemoteGitRepository {
             let inventory = match runtime.cached_inventory(&identity, pack_index_hash).await {
                 Some(inventory) => inventory.as_ref().clone(),
                 None => {
-                    let packs = tokio::select! {
-                        biased;
-                        () = cancellation.cancelled() => return Err(Error::Cancelled),
-                        () = runtime_cancellation.cancelled() => return Err(Error::Cancelled),
-                        result = read_bulk_pack_list(&store, &layout, &manifest.pack_index_hash) => {
-                            result.map_err(|source| Error::Inventory { source })?
-                        }
-                    };
                     check_cancelled(cancellation)?;
                     check_cancelled(&runtime_cancellation)?;
-                    let inventory = parse_inventory(packs)?;
+                    let inventory = parse_inventory(journal.packs.clone())?;
                     runtime
                         .insert_inventory(
                             identity.clone(),
@@ -1386,9 +1410,10 @@ mod tests {
             "2222222222222222222222222222222222222222".to_owned(),
         );
         next.seal_git_validation();
-        let (_, etag) = read_manifest(&fixture.store, &fixture.layout)
-            .await
-            .expect("read current manifest");
+        let (_, etag) =
+            crab_metadata::manifest_store::read_manifest(&fixture.store, &fixture.layout)
+                .await
+                .expect("read current manifest");
         write_manifest_cas(&fixture.store, &fixture.layout, &next, &etag)
             .await
             .expect("publish changed manifest");
@@ -1519,9 +1544,10 @@ mod tests {
             "2222222222222222222222222222222222222222".to_owned(),
         );
         next.seal_git_validation();
-        let (_, etag) = read_manifest(&fixture.store, &fixture.layout)
-            .await
-            .expect("read manifest");
+        let (_, etag) =
+            crab_metadata::manifest_store::read_manifest(&fixture.store, &fixture.layout)
+                .await
+                .expect("read manifest");
         write_manifest_cas(&fixture.store, &fixture.layout, &next, &etag)
             .await
             .expect("publish manifest");

--- a/crates/crab-storage/src/layout.rs
+++ b/crates/crab-storage/src/layout.rs
@@ -111,9 +111,7 @@ impl<S> StoreLayout<S> {
         self.global_path("shards", &hash.to_string())
     }
 
-    /// Path to the unified manifest pointer: `{repo}/manifest`.
-    ///
-    /// This is the single CAS target for every push.
+    /// Path to the compacted repository snapshot: `{repo}/manifest`.
     #[must_use]
     pub fn manifest_path(&self) -> ObjectPath {
         self.repo_path("manifest")
@@ -129,6 +127,44 @@ impl<S> StoreLayout<S> {
     #[must_use]
     pub fn manifest_history_path(&self, generation: u64, digest: &str) -> ObjectPath {
         self.repo_path(&format!("manifests/history/{generation:020}-{digest}.json"))
+    }
+
+    /// Prefix containing independently mutable ref-journal heads.
+    #[must_use]
+    pub fn ref_journal_heads_prefix(&self) -> ObjectPath {
+        self.repo_path("refs/journal/heads")
+    }
+
+    /// Path to one independently mutable ref-journal head.
+    #[must_use]
+    pub fn ref_journal_head_path(&self, ref_name_hash: &str) -> ObjectPath {
+        self.repo_path(&format!("refs/journal/heads/{ref_name_hash}.json"))
+    }
+
+    /// Path to one immutable ref-journal transaction body.
+    #[must_use]
+    pub fn ref_journal_transaction_path(&self, transaction_id: &str) -> ObjectPath {
+        self.repo_path(&format!("refs/journal/transactions/{transaction_id}.json"))
+    }
+
+    /// Prefix containing committed transactions not yet cleaned by compaction.
+    #[must_use]
+    pub fn ref_journal_active_prefix(&self) -> ObjectPath {
+        self.repo_path("refs/journal/active")
+    }
+
+    /// Path to one atomic ref-journal visibility marker.
+    #[must_use]
+    pub fn ref_journal_active_path(&self, transaction_id: &str) -> ObjectPath {
+        self.repo_path(&format!("refs/journal/active/{transaction_id}.json"))
+    }
+
+    /// Path to the immutable compaction frontier for one manifest Git state.
+    #[must_use]
+    pub fn ref_journal_frontier_path(&self, git_validation_digest: &str) -> ObjectPath {
+        self.repo_path(&format!(
+            "refs/journal/frontiers/{git_validation_digest}.json"
+        ))
     }
 
     /// Path to a bulk manifest object: `{repo}/manifests/{prefix}-{hash}`.


### PR DESCRIPTION
## Summary

- replace repository-wide manifest CAS publication with immutable expected-old ref transactions and independently CASed per-ref heads
- make one immutable active marker the atomic visibility boundary for multi-ref pushes, then compact committed transactions into bounded manifest snapshots
- capture active markers before reading the manifest so readers remain race-safe during marker cleanup without per-head GET amplification
- release per-ref locks immediately after journal publication and make derived compaction best-effort: writers no longer queue behind the repository-global compaction lock
- carry journal frontiers across every ordinary manifest CAS so repack, recovery, restripe, GC, replication, and active-active projections cannot replay compacted ancestors
- make remote reads, protected-push discovery, auth views, fsck, file-index fallback, shard sync, repack warnings, and replica routing journal-aware
- preserve uncompacted journal packs, shards, and metadata across repo and bucket GC
- return structured push conflicts (`CRAB-E0088` sourced by `CRAB-E0017`) instead of misclassifying expected same-ref losers as `CRAB-E0099 internal`

## Concurrent-write semantics

- different refs: independent ref heads; publication does not wait for manifest compaction
- same ref without integration retry: one lock-serialized winner; divergent writers receive explicit non-fast-forward rejection
- same ref with `--rebase-on-non-fast-forward`: successful updates serialize and integrate in ref order, so wall time scales with the number of commits that must be rebased and published
- multi-ref push: all prepared heads become visible together through one immutable marker
- compaction/index failure after publication is repairable and cannot turn a committed push into a reported failure

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p crab -p crab-read -p crab-auth-server --locked`
- `cargo test -p crab-metadata --features file-index-reader --locked` — 166 passed
- `cargo test -p crab-read --locked` — 51 passed
- `cargo test -p crab-remote-git --locked` — 74 unit + 44 integration passed
- `cargo test -p crab-auth-server --locked` — 70 passed
- `cargo test -p crab --lib git::push::tests:: --locked` — 233 passed, 1 ignored
- `cargo test -p crab --lib cmd::push::tests:: --locked` — 39 passed
- focused regression proof for distinct mutable heads, stale same-ref rejection, multi-ref marker visibility, marker-cleanup races, frontier carry, uncompacted shard/file lookup, shard-sync generation caching, fsck inventory, replica readiness, GC reachability, and fail-fast compaction
- `make install` with dedicated external Cargo target

## Final Kubernetes repository qualification

Fresh remote: `crab://crab/verify-cli/k8s-ref-journal-20260820-1015` using the Kubernetes repository and final release binary SHA-256 `2edc9e383052282e06e50a2149c5de062ecb65ca04a71a40bb904ad39f734cdc`.

| Scenario | Wall | Result |
|---|---:|---|
| 100 simultaneous unrelated branches | 36.211s | 100/100 succeeded; all remote OIDs exact; zero CAS/internal/unpack errors |
| 10 simultaneous divergent writers to one ref | 3.404s | exactly one winner and nine non-fast-forward rejections; winner OID exact |
| Fetch all 100 new branches into the qualification clone | 2.13s | 100/100 refs fetched; all OIDs exact |

All nine expected same-ref losers emitted `CRAB-E0088` with `CRAB-E0017` as the source; none emitted `CRAB-E0099`.

The original 100-branch baseline took 213.295s and encountered 99 whole-manifest conflicts. An intermediate optimized path took 62.706s with 69 manifest CAS conflicts, and the first journal implementation took 50.517s because every writer still queued for derived compaction. The final 36.211s run removes both shared-manifest publication conflicts and the compaction-lock queue from unrelated writers.

Supplementary 2/5/10-writer fanout runs completed in 0.575s/1.188s/1.829s. Same-ref rebase-and-integrate runs completed in 7.117s/22.749s/48.750s with every writer and marker integrated; this intentional linear cost is confined to writers targeting the same ref.

A fresh lazy clone succeeded in 51.87s (31,301 files) and initially contained all 23 qualification refs with zero missing or mismatched OIDs. After the final 100-writer wave, an incremental fetch brought in all 100 additional branches in 2.13s. The remote then contained 139 packs and correctly emitted the repack warning; pack consolidation is a separate clone/transfer optimization axis.

## Known baseline failures

The broad Crab library run reached 3,558 passing tests before unrelated failures. Two static replication inventory tests are demonstrably stale on `origin/main`: main already contains the unclassified `recover-history`/`doctor::run_cost_report` call sites while its inventory still expects removed call sites. Repository policy forbids editing inventories only to silence checks. Missing snapshot baselines and environment-dependent `/var` symlink/HTTP tests also fail independently of this patch.

The all-target Rust 1.97 `-D warnings` run reaches the touched crates but is blocked by pre-existing lints in unchanged metadata and remote-git test scaffolding. Those files were not modified to silence unrelated checks.

GitHub Actions currently fails all jobs during startup in 1–3 seconds and publishes no logs. The repository check inspector reports every failing job as `log_unavailable`; local and live evidence above is therefore the authoritative verification for this revision.
