### PR TITLE
perf: harden repack, GC, and history maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,6 +2258,7 @@ dependencies = [
 name = "crab-metadata"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "blake3",
  "bytes",
  "crab-storage",

--- a/crab-web/content/docs/cli/reference/crab-gc.mdx
+++ b/crab-web/content/docs/cli/reference/crab-gc.mdx
@@ -15,9 +15,14 @@ crab gc [OPTIONS]
 
 ## Description
 
-`crab gc` identifies and removes xorbs that are no longer referenced by any
-ref in the repository. It respects a grace period to avoid deleting objects
+`crab gc` identifies and removes repository objects that are not referenced by
+the current repository state, ref journal, workflow artifact catalog, or any
+immutable recovery root. It respects a grace period to avoid deleting objects
 that may be in use by concurrent operations.
+
+Historical roots used by `crab recover history` are retained without a time or
+count limit. Objects referenced by those roots are therefore not GC candidates,
+even when they are absent from current branches and tags.
 
 For conceptual background, see [Garbage Collection](/docs/cli/storage/garbage-collection).
 

--- a/crab-web/content/docs/cli/reference/crab-gc.mdx
+++ b/crab-web/content/docs/cli/reference/crab-gc.mdx
@@ -21,8 +21,14 @@ immutable recovery root. It respects a grace period to avoid deleting objects
 that may be in use by concurrent operations.
 
 Historical roots used by `crab recover history` are retained without a time or
-count limit. Objects referenced by those roots are therefore not GC candidates,
-even when they are absent from current branches and tags.
+count limit by default. Objects referenced by those roots are therefore not GC
+candidates, even when they are absent from current branches and tags. Use
+`crab recover history prune --keep-last N` to preview an explicit retention
+boundary, apply it with `--apply`, and then rerun GC.
+
+Destructive repository GC takes a renewable repository-maintenance lease. A
+destructive bucket GC takes that lease for every registered repository. Neither
+can run concurrently with history pruning or history restoration.
 
 For conceptual background, see [Garbage Collection](/docs/cli/storage/garbage-collection).
 

--- a/crab-web/content/docs/cli/reference/crab-recover.mdx
+++ b/crab-web/content/docs/cli/reference/crab-recover.mdx
@@ -22,7 +22,7 @@ crab recover <SUBCOMMAND> [OPTIONS]
 | `plan` | Build a repair plan from an expected release inventory and available sources |
 | `show` | Inspect a saved plan |
 | `apply` | Materialize verified files and optionally repair durable objects or a remote |
-| `history` | List, verify, and restore immutable historical repository roots |
+| `history` | List, retain, verify, and restore immutable historical repository roots |
 
 ## Plan and apply
 
@@ -48,6 +48,8 @@ restore one explicitly:
 
 ```bash
 crab recover history list
+crab recover history prune --keep-last 20
+crab recover history prune --keep-last 20 --apply
 crab recover history verify 41
 crab recover history restore 41
 crab recover history restore 41 --apply
@@ -55,3 +57,9 @@ crab recover history restore 41 --apply
 
 Verification is required before restoration. If a generation has multiple
 valid roots, provide `--digest` to select one.
+
+History is retained indefinitely unless explicitly pruned. `history prune`
+previews by default; `--apply` removes roots older than the newest
+`--keep-last N` distinct generations while preserving every alternate root in
+those retained generations. Run repository GC afterward to preview and reclaim
+objects no longer reachable from current state or retained roots.

--- a/crab-web/content/docs/cli/reference/crab-repack.mdx
+++ b/crab-web/content/docs/cli/reference/crab-repack.mdx
@@ -17,7 +17,9 @@ crab repack [OPTIONS]
 
 `crab repack` consolidates remote Git pack files. Over time, many pushes can
 leave many small packs in the remote. Repacking merges those packs and
-atomically updates the pack list; old packs are reclaimed later by `crab gc`.
+atomically updates the active pack list. Immutable recovery history continues
+to retain old packs, so repack optimizes active reads but does not currently
+reclaim their storage bytes.
 
 For conceptual background, see [Repacking Objects](/docs/cli/storage/repacking-objects).
 

--- a/crab-web/content/docs/cli/reference/crab-repack.mdx
+++ b/crab-web/content/docs/cli/reference/crab-repack.mdx
@@ -18,8 +18,9 @@ crab repack [OPTIONS]
 `crab repack` consolidates remote Git pack files. Over time, many pushes can
 leave many small packs in the remote. Repacking merges those packs and
 atomically updates the active pack list. Immutable recovery history continues
-to retain old packs, so repack optimizes active reads but does not currently
-reclaim their storage bytes.
+to retain old packs by default, so repack first optimizes active reads. To
+reclaim superseded storage, explicitly prune older recovery generations and
+then run repository GC.
 
 For conceptual background, see [Repacking Objects](/docs/cli/storage/repacking-objects).
 

--- a/crab-web/content/docs/cli/storage/garbage-collection.mdx
+++ b/crab-web/content/docs/cli/storage/garbage-collection.mdx
@@ -13,7 +13,19 @@ storage space and reducing cloud costs.
 Crab retains immutable manifest history for `crab recover history`. A deleted
 branch, force-push, or repack does not make its old objects collectible while a
 historical root still references them. Crab currently retains those roots
-without a time or count limit.
+without a time or count limit by default. To trade older recovery points for
+storage reclamation, preview and apply an explicit generation boundary:
+
+```bash
+crab recover history prune --keep-last 20
+crab recover history prune --keep-last 20 --apply
+crab gc --scope repo --dry-run
+crab gc --scope repo
+```
+
+Retention counts distinct generations and preserves every alternate root in a
+kept generation. Pruning removes only root manifests. GC separately proves
+which dependent objects became unreachable and still applies its grace period.
 
 ## What Becomes Garbage?
 
@@ -94,6 +106,7 @@ Crab's GC is designed to be safe by default:
 3. **Minimum grace** — Even with `--force`, the minimum grace period is 1 hour.
 4. **Confirmation required** — `--force` prompts for confirmation unless `--yes` is also passed.
 5. **Atomic ref reads** — The reachability scan uses a consistent snapshot of refs.
+6. **Maintenance serialization** — Destructive repo GC takes one repository lease; destructive bucket GC takes a lease for every registered repository. Neither can race history pruning or restoration.
 
 ## When to Run GC
 

--- a/crab-web/content/docs/cli/storage/garbage-collection.mdx
+++ b/crab-web/content/docs/cli/storage/garbage-collection.mdx
@@ -5,7 +5,15 @@ description: "How Crab identifies and removes unreachable objects from cloud sto
 
 # Garbage Collection
 
-Over time, your cloud bucket accumulates objects that are no longer referenced by any branch or tag — leftover chunks from deleted files, abandoned experiments, or force-pushed branches. Garbage collection identifies these unreachable objects and removes them, reclaiming storage space and reducing cloud costs.
+Over time, your cloud bucket accumulates objects that are no longer referenced
+by current repository state, recovery roots, or workflow artifacts. Garbage
+collection identifies these unreachable objects and removes them, reclaiming
+storage space and reducing cloud costs.
+
+Crab retains immutable manifest history for `crab recover history`. A deleted
+branch, force-push, or repack does not make its old objects collectible while a
+historical root still references them. Crab currently retains those roots
+without a time or count limit.
 
 ## What Becomes Garbage?
 
@@ -81,7 +89,7 @@ This reduces the grace period to 1 hour (the minimum). Use only when you're cert
 
 Crab's GC is designed to be safe by default:
 
-1. **Never deletes referenced objects** — Only objects unreachable from any ref are candidates.
+1. **Never deletes referenced objects** — Current state, journal transactions, workflow artifacts, and every immutable recovery root are protected.
 2. **Grace period** — Recently created objects are protected even if currently unreachable.
 3. **Minimum grace** — Even with `--force`, the minimum grace period is 1 hour.
 4. **Confirmation required** — `--force` prompts for confirmation unless `--yes` is also passed.

--- a/crab-web/content/docs/cli/storage/repacking-objects.mdx
+++ b/crab-web/content/docs/cli/storage/repacking-objects.mdx
@@ -24,8 +24,10 @@ flowchart LR
 6. Atomically updates the manifest using compare-and-swap (CAS).
 7. Rebinds the existing Git visibility proof to the replacement pack inventory.
 
-Old pack files remain unreachable after the manifest update and are reclaimed
-by a later repo-scoped `crab gc` run.
+Old pack files leave the active manifest after the update, but immutable
+recovery history continues to reference them. Repack therefore reduces the
+pack count used by clone and fetch; it does not currently reclaim the old pack
+bytes through repo-scoped `crab gc`.
 
 ### Atomicity and Safety
 

--- a/crab-web/content/docs/cli/storage/repacking-objects.mdx
+++ b/crab-web/content/docs/cli/storage/repacking-objects.mdx
@@ -19,14 +19,22 @@ flowchart LR
 1. Reads the pack list manifest from the remote store.
 2. Downloads all existing pack files.
 3. Merges contents into a single new pack with a fresh index.
-4. Merges pack metadata (ref tips) from sidecar files and inline entries.
-5. Uploads the merged pack to the remote.
-6. Atomically updates the pack list manifest using compare-and-swap (CAS).
-7. Cleans up old pack files after the manifest update succeeds.
+4. Validates the replacement pack against every manifest ref.
+5. Uploads the merged pack, index, and reverse index to the remote.
+6. Atomically updates the manifest using compare-and-swap (CAS).
+7. Rebinds the existing Git visibility proof to the replacement pack inventory.
+
+Old pack files remain unreachable after the manifest update and are reclaimed
+by a later repo-scoped `crab gc` run.
 
 ### Atomicity and Safety
 
-The manifest update uses CAS to prevent concurrent repacks from corrupting state. If another process modifies the manifest between read and write, the repack retries automatically. This means repacking is safe to run alongside normal push operations.
+The manifest update uses CAS to prevent concurrent maintenance or push activity
+from corrupting state. If the manifest changes between read and write, repack
+fails without replacing the newer manifest; rerun the command against the new
+generation. The existing visibility proof is reused because repack changes the
+physical pack layout, not refs or reachable objects. Repack does not create a
+missing proof; `crab fsck` reports that pre-existing condition.
 
 ## Usage
 

--- a/crab-web/content/docs/cli/storage/repacking-objects.mdx
+++ b/crab-web/content/docs/cli/storage/repacking-objects.mdx
@@ -26,8 +26,9 @@ flowchart LR
 
 Old pack files leave the active manifest after the update, but immutable
 recovery history continues to reference them. Repack therefore reduces the
-pack count used by clone and fetch; it does not currently reclaim the old pack
-bytes through repo-scoped `crab gc`.
+pack count used by clone and fetch. To reclaim old pack bytes, preview and apply
+an explicit history-retention boundary with `crab recover history prune
+--keep-last N`, then run repo-scoped `crab gc`.
 
 ### Atomicity and Safety
 

--- a/crab/docs/guides/repository-recovery.md
+++ b/crab/docs/guides/repository-recovery.md
@@ -9,11 +9,26 @@ Every successful manifest replacement now preserves the displaced committed
 manifest as an immutable object under
 `<repository>/manifests/history/<generation>-<blake3>.json`. The current
 `<repository>/manifest` remains the only visible repository state. History is
-kept indefinitely, and repository, bucket, and managed-service GC retain every
-pack, pack index, reverse index, metadata segment, shard, and xorb reachable
-from every validated historical root. This favors recoverability over storage
-reclamation; operators should account for old pack and large-file data that
-remains reachable through history.
+kept indefinitely by default, and repository, bucket, and managed-service GC
+retain every pack, pack index, reverse index, metadata segment, shard, and xorb
+reachable from every validated historical root.
+
+Operators can preview an explicit retention boundary and then apply it:
+
+```bash
+crab recover history prune --keep-last 20
+crab recover history prune --keep-last 20 --apply
+crab gc --scope repo --dry-run
+crab gc --scope repo
+```
+
+`--keep-last` counts distinct generations and retains every root in each kept
+generation. Prune never removes the current manifest or dependent data; a
+later GC run re-evaluates reachability and grace periods before reclaiming
+objects that were unique to removed roots. Prune apply, restore apply, and
+destructive repository GC share a renewable maintenance lease, so recovery
+cannot race object deletion. Destructive bucket GC acquires the same lease for
+every registered repository before deleting shared objects.
 
 Writers create history only when they replace a manifest. Repositories pushed
 only by older Crab versions therefore have no retroactive history for those
@@ -25,6 +40,8 @@ then apply it explicitly:
 
 ```bash
 crab recover history list
+crab recover history prune --keep-last 20
+crab recover history prune --keep-last 20 --apply
 crab recover history verify 41
 crab recover history verify 41 --digest <64-character-blake3>
 crab recover history restore 41

--- a/crab/schemas/recover.history.prune.json
+++ b/crab/schemas/recover.history.prune.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "HistoryEntryPayload": {
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "string"
+        },
+        "generation": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "manifest_bytes": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "refs": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "session_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "created_at",
+        "digest",
+        "generation",
+        "manifest_bytes",
+        "refs",
+        "session_id"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "applied": {
+      "type": "boolean"
+    },
+    "keep_last": {
+      "format": "uint64",
+      "minimum": 1.0,
+      "type": "integer"
+    },
+    "manifest_bytes_pruned": {
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "pruned": {
+      "items": {
+        "$ref": "#/definitions/HistoryEntryPayload"
+      },
+      "type": "array"
+    },
+    "roots_before": {
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "roots_kept": {
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "roots_pruned": {
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "applied",
+    "keep_last",
+    "manifest_bytes_pruned",
+    "pruned",
+    "roots_before",
+    "roots_kept",
+    "roots_pruned"
+  ],
+  "title": "HistoryPrunePayload",
+  "type": "object"
+}

--- a/crab/src/cmd/gc/bucket.rs
+++ b/crab/src/cmd/gc/bucket.rs
@@ -23,10 +23,11 @@ use std::time::{Duration, SystemTime};
 use futures_util::TryStreamExt;
 use object_store::ObjectStoreExt;
 use object_store::path::Path as ObjectPath;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::coordination::cas::cas_update_default;
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::storage::StoreLayout;
 use crate::storage::store::Store;
 use crab_metadata::ref_registry::RefRegistry;
@@ -107,7 +108,52 @@ pub async fn run_bucket_gc(
     store: &Store,
     coordinator_protected_keys: &HashSet<String>,
     coordinator_protected_repos: &HashSet<String>,
+    cancel: &CancellationToken,
 ) -> Result<BucketGcOutcome> {
+    let registry = load_ref_registry(store, args.force).await?;
+    if args.dry_run {
+        return run_bucket_gc_under_maintenance(
+            args,
+            store,
+            coordinator_protected_keys,
+            &registry,
+            cancel,
+        )
+        .await;
+    }
+    ensure_registry_complete_for_destructive_gc(&registry)?;
+    ensure_active_active_bucket_gc_proof(&registry, coordinator_protected_repos)?;
+
+    let operation_cancel = cancel.child_token();
+    let leases = crate::maintenance::RepositoryMaintenanceLeases::acquire(
+        store,
+        registry.repos.keys().cloned(),
+        &operation_cancel,
+    )
+    .await?;
+    let operation = run_bucket_gc_under_maintenance(
+        args,
+        store,
+        coordinator_protected_keys,
+        &registry,
+        &operation_cancel,
+    )
+    .await;
+    let release = leases.release().await;
+    match (operation, release) {
+        (Ok(outcome), Ok(())) => Ok(outcome),
+        (Err(error), _) | (Ok(_), Err(error)) => Err(error),
+    }
+}
+
+async fn run_bucket_gc_under_maintenance(
+    args: &BucketGcArgs,
+    store: &Store,
+    coordinator_protected_keys: &HashSet<String>,
+    registry: &RefRegistry,
+    cancel: &CancellationToken,
+) -> Result<BucketGcOutcome> {
+    check_cancelled(cancel)?;
     let mut outcome = BucketGcOutcome {
         dry_run: args.dry_run,
         ..BucketGcOutcome::default()
@@ -117,14 +163,8 @@ pub async fn run_bucket_gc(
     let now = SystemTime::now();
     let cutoff = now - effective_grace;
 
-    // Step 1: Load ref-registry.
-    let registry = load_ref_registry(store, args.force).await?;
-    if !args.dry_run {
-        ensure_registry_complete_for_destructive_gc(&registry)?;
-        ensure_active_active_bucket_gc_proof(&registry, coordinator_protected_repos)?;
-    }
     let mut referenced_shards = registry.all_referenced_shards();
-    referenced_shards.extend(historical_referenced_shards(store, &registry).await?);
+    referenced_shards.extend(historical_referenced_shards(store, registry).await?);
     info!(
         repos = registry.repos.len(),
         referenced_shards = referenced_shards.len(),
@@ -133,6 +173,7 @@ pub async fn run_bucket_gc(
 
     // Step 2: List shards, find unreferenced candidates.
     let shard_objects = list_global_objects(store, "shards").await?;
+    check_cancelled(cancel)?;
     let listed_shards = shard_objects
         .iter()
         .map(|object| extract_hash_from_key(&object.location))
@@ -174,6 +215,7 @@ pub async fn run_bucket_gc(
         xorb_hashes: referenced_xorbs,
         file_hashes: referenced_file_hashes,
     } = extract_hashes_from_shards(store, &referenced_shard_objects).await?;
+    check_cancelled(cancel)?;
     info!(
         referenced_xorbs = referenced_xorbs.len(),
         referenced_file_hashes = referenced_file_hashes.len(),
@@ -182,6 +224,7 @@ pub async fn run_bucket_gc(
 
     // Step 4: List xorbs, find unreferenced candidates.
     let xorb_objects = list_global_objects(store, "xorbs").await?;
+    check_cancelled(cancel)?;
     let xorb_partition =
         partition_xorbs_for_gc(xorb_objects, &referenced_xorbs, coordinator_protected_keys);
     let protected_xorbs = xorb_partition.protected_count;
@@ -203,6 +246,7 @@ pub async fn run_bucket_gc(
     let _ = &referenced_file_hashes;
 
     // Step 6: Delete or report.
+    check_cancelled(cancel)?;
     delete_or_report(
         store,
         "shards",
@@ -871,9 +915,15 @@ mod tests {
 
         let protected = HashSet::new();
         let protected_repos = HashSet::new();
-        let outcome = run_bucket_gc(&args, &store, &protected, &protected_repos)
-            .await
-            .unwrap();
+        let outcome = run_bucket_gc(
+            &args,
+            &store,
+            &protected,
+            &protected_repos,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
         assert!(outcome.dry_run);
         assert_eq!(outcome.shards_deleted, 0);
         assert_eq!(outcome.xorbs_deleted, 0);
@@ -909,6 +959,7 @@ mod tests {
             &store,
             &HashSet::new(),
             &HashSet::new(),
+            &CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -944,6 +995,7 @@ mod tests {
             &store,
             &HashSet::new(),
             &HashSet::new(),
+            &CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -962,6 +1014,61 @@ mod tests {
         assert!(!summary.dry_run);
         assert!(!summary.cancelled);
         assert!(!summary.partial_enumeration);
+    }
+
+    #[tokio::test]
+    async fn maintenance_lease_blocks_destructive_bucket_gc_but_not_preview() {
+        let store = memory_store();
+        let mut registry = RefRegistry::default();
+        registry.register("org/models", Vec::new());
+        registry.mark_coverage_complete();
+        store
+            .put(
+                &ObjectPath::from(format!("{GLOBAL_PREFIX}/ref-registry")),
+                Bytes::from(serde_json::to_vec(&registry).unwrap()),
+            )
+            .await
+            .unwrap();
+        let held = crab_coordination::PushLock::acquire_internal_default(
+            store.inner(),
+            "org/models",
+            crab_coordination::REPOSITORY_MAINTENANCE_RESOURCE,
+        )
+        .await
+        .unwrap();
+
+        let destructive = run_bucket_gc(
+            &BucketGcArgs {
+                bucket: "test-bucket".to_owned(),
+                dry_run: false,
+                grace_period: Duration::from_secs(3600),
+                force: false,
+            },
+            &store,
+            &HashSet::new(),
+            &HashSet::new(),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(matches!(destructive, Err(CrabError::PushLockHeld { .. })));
+
+        let preview = run_bucket_gc(
+            &BucketGcArgs {
+                bucket: "test-bucket".to_owned(),
+                dry_run: true,
+                grace_period: Duration::from_secs(3600),
+                force: false,
+            },
+            &store,
+            &HashSet::new(),
+            &HashSet::new(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert!(preview.dry_run);
+
+        held.release().await.unwrap();
     }
 
     #[tokio::test]
@@ -998,6 +1105,7 @@ mod tests {
             &store,
             &HashSet::new(),
             &HashSet::new(),
+            &CancellationToken::new(),
         )
         .await
         .unwrap_err();
@@ -1029,6 +1137,7 @@ mod tests {
             &store,
             &HashSet::new(),
             &HashSet::new(),
+            &CancellationToken::new(),
         )
         .await
         .unwrap_err();
@@ -1062,9 +1171,15 @@ mod tests {
         let protected = HashSet::new();
         let protected_repos = HashSet::new();
 
-        let err = run_bucket_gc(&args, &store, &protected, &protected_repos)
-            .await
-            .unwrap_err();
+        let err = run_bucket_gc(
+            &args,
+            &store,
+            &protected,
+            &protected_repos,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
 
         assert!(matches!(err, CrabError::Configuration { .. }));
         assert!(err.to_string().contains("org/models"));
@@ -1096,9 +1211,15 @@ mod tests {
         let protected = HashSet::new();
         let protected_repos = ["org/models".to_owned()].into_iter().collect();
 
-        let outcome = run_bucket_gc(&args, &store, &protected, &protected_repos)
-            .await
-            .unwrap();
+        let outcome = run_bucket_gc(
+            &args,
+            &store,
+            &protected,
+            &protected_repos,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(outcome.shards_deleted, 0);
         assert_eq!(outcome.xorbs_deleted, 0);
@@ -1120,9 +1241,15 @@ mod tests {
             force: true,
         };
 
-        let err = run_bucket_gc(&args, &store, &HashSet::new(), &HashSet::new())
-            .await
-            .unwrap_err();
+        let err = run_bucket_gc(
+            &args,
+            &store,
+            &HashSet::new(),
+            &HashSet::new(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
 
         assert!(matches!(err, CrabError::Configuration { .. }));
         assert!(err.to_string().contains("ref-registry"));
@@ -1242,9 +1369,15 @@ mod tests {
         };
         let protected = HashSet::new();
         let protected_repos = HashSet::new();
-        let outcome = run_bucket_gc(&args, &store, &protected, &protected_repos)
-            .await
-            .unwrap();
+        let outcome = run_bucket_gc(
+            &args,
+            &store,
+            &protected,
+            &protected_repos,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
         assert!(outcome.dry_run);
         assert_eq!(
             outcome.shards_deleted, 0,

--- a/crab/src/cmd/gc/mod.rs
+++ b/crab/src/cmd/gc/mod.rs
@@ -1025,6 +1025,52 @@ pub async fn run_repo_remote_gc(
     grace_period: Duration,
     jsonl_stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>,
 ) -> Result<GcOutcome> {
+    if args.dry_run {
+        return run_repo_remote_gc_under_maintenance(
+            args,
+            store,
+            router,
+            coordinator_protected_keys,
+            cancel,
+            grace_period,
+            jsonl_stream,
+        )
+        .await;
+    }
+
+    let operation_cancel = cancel.child_token();
+    let lease = crate::maintenance::RepositoryMaintenanceLease::acquire(
+        store,
+        router.repo_prefix(),
+        &operation_cancel,
+    )
+    .await?;
+    let operation = run_repo_remote_gc_under_maintenance(
+        args,
+        store,
+        router,
+        coordinator_protected_keys,
+        &operation_cancel,
+        grace_period,
+        jsonl_stream,
+    )
+    .await;
+    let release = lease.release().await;
+    match (operation, release) {
+        (Ok(outcome), Ok(())) => Ok(outcome),
+        (Err(error), _) | (Ok(_), Err(error)) => Err(error),
+    }
+}
+
+async fn run_repo_remote_gc_under_maintenance(
+    args: &GcArgs,
+    store: &Store,
+    router: &StoreLayout,
+    coordinator_protected_keys: &HashSet<String>,
+    cancel: &CancellationToken,
+    grace_period: Duration,
+    jsonl_stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>,
+) -> Result<GcOutcome> {
     let reachability_started = Instant::now();
     let reachability =
         reachable_repo_objects_from_manifest_with_concurrency(store, router, args.list_concurrency)
@@ -2075,6 +2121,64 @@ mod tests {
             store.head(&ObjectPath::from(free_key)).await,
             Err(CrabError::NotFound { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn maintenance_lease_blocks_destructive_repo_gc_but_not_preview() {
+        use crate::metadata::manifest::{Manifest, create_manifest};
+        use crate::storage::StoreLayout;
+        use crate::storage::store::Store;
+        use crab_coordination::PushLock;
+        use object_store::memory::InMemory;
+        use std::sync::Arc;
+
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(inner);
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        create_manifest(
+            &store,
+            &router,
+            &Manifest::default_for_repo("refs/heads/main"),
+        )
+        .await
+        .unwrap();
+        let lock = PushLock::acquire_internal_default(
+            store.inner(),
+            router.repo_prefix(),
+            crab_coordination::REPOSITORY_MAINTENANCE_RESOURCE,
+        )
+        .await
+        .unwrap();
+
+        let error = run_repo_remote_gc(
+            &GcArgs::default(),
+            &store,
+            &router,
+            &HashSet::new(),
+            &CancellationToken::new(),
+            Duration::from_secs(3600),
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(error, CrabError::PushLockHeld { .. }));
+
+        let preview = run_repo_remote_gc(
+            &GcArgs {
+                dry_run: true,
+                ..GcArgs::default()
+            },
+            &store,
+            &router,
+            &HashSet::new(),
+            &CancellationToken::new(),
+            Duration::from_secs(3600),
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(preview.dry_run);
+        lock.release().await.unwrap();
     }
 
     // --- GC compaction (Task 8.5) ---

--- a/crab/src/cmd/gc/mod.rs
+++ b/crab/src/cmd/gc/mod.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime};
 
-use futures_util::TryStreamExt;
+use futures_util::{StreamExt, TryStreamExt};
 use object_store::path::Path as ObjectPath;
 use serde::Serialize;
 use tokio::sync::Semaphore;
@@ -43,7 +43,8 @@ const REPO_GC_PREFIXES: &[&str] = &[
     "workflow/artifacts/",
     "refs/crab/artifacts/",
 ];
-const DEFAULT_DELETE_CONCURRENCY: usize = 16;
+const DEFAULT_DELETE_CONCURRENCY: usize = 64;
+const DEFAULT_LIST_CONCURRENCY: usize = 32;
 
 // ---------------------------------------------------------------------------
 // GC arguments
@@ -67,6 +68,10 @@ pub struct GcArgs {
     /// Confirm destructive operations that bypass safety guards
     /// (`--force-early-delete`).
     pub yes_really: bool,
+    /// Maximum concurrent object-store DELETE requests.
+    pub delete_concurrency: usize,
+    /// Maximum concurrent object-store LIST and history-closure reads.
+    pub list_concurrency: usize,
 }
 
 impl Default for GcArgs {
@@ -78,6 +83,8 @@ impl Default for GcArgs {
             mode: OutputMode::Text,
             force_early_delete: false,
             yes_really: false,
+            delete_concurrency: DEFAULT_DELETE_CONCURRENCY,
+            list_concurrency: DEFAULT_LIST_CONCURRENCY,
         }
     }
 }
@@ -469,31 +476,46 @@ pub async fn list_repo_gc_candidates(
     store: &Store,
     router: &StoreLayout,
 ) -> Result<(Vec<ObjectMeta>, ListOutcome)> {
-    let started = Instant::now();
-    let mut candidates = Vec::new();
+    list_repo_gc_candidates_with_concurrency(store, router, DEFAULT_LIST_CONCURRENCY).await
+}
 
-    for prefix in REPO_GC_PREFIXES {
-        let object_prefix = router.repo_path(prefix);
-        let objects: Vec<_> = store
-            .inner()
-            .list(Some(&object_prefix))
-            .try_collect()
-            .await
-            .map_err(CrabError::Storage)?;
-        candidates.extend(objects.into_iter().map(|meta| ObjectMeta {
+async fn list_repo_gc_candidates_with_concurrency(
+    store: &Store,
+    router: &StoreLayout,
+    concurrency: usize,
+) -> Result<(Vec<ObjectMeta>, ListOutcome)> {
+    let started = Instant::now();
+    let parallelism = concurrency.max(1).min(REPO_GC_PREFIXES.len());
+    let batches =
+        futures_util::stream::iter(REPO_GC_PREFIXES.iter().copied().map(|prefix| async move {
+            let object_prefix = router.repo_path(prefix);
+            store
+                .inner()
+                .list(Some(&object_prefix))
+                .try_collect()
+                .await
+                .map_err(CrabError::Storage)
+        }))
+        .buffer_unordered(parallelism)
+        .try_collect::<Vec<Vec<object_store::ObjectMeta>>>()
+        .await?;
+    let candidates = batches
+        .into_iter()
+        .flatten()
+        .map(|meta| ObjectMeta {
             key: meta.location.to_string(),
             size: meta.size,
             last_modified: meta.last_modified.into(),
             storage_class: None,
             transitioned_at: None,
-        }));
-    }
+        })
+        .collect();
 
     Ok((
         candidates,
         ListOutcome {
             requests: REPO_GC_PREFIXES.len() as u64,
-            parallelism: 1,
+            parallelism,
             wall_seconds: started.elapsed().as_secs_f64(),
             failed_prefixes: Vec::new(),
         },
@@ -890,11 +912,32 @@ pub async fn reachable_repo_objects_from_manifest(
     store: &Store,
     router: &StoreLayout,
 ) -> Result<(crate::metadata::manifest::Manifest, HashSet<String>)> {
-    let (manifest, mut reachable) = reachable_bulk_objects_from_manifest(store, router).await?;
+    let snapshot = reachable_repo_objects_from_manifest_with_concurrency(
+        store,
+        router,
+        DEFAULT_LIST_CONCURRENCY,
+    )
+    .await?;
+    Ok((snapshot.manifest, snapshot.reachable_keys))
+}
+
+struct RepoGcReachability {
+    manifest: crate::metadata::manifest::Manifest,
+    reachable_keys: HashSet<String>,
+    shard_snapshot: ShardListSnapshot,
+}
+
+async fn reachable_repo_objects_from_manifest_with_concurrency(
+    store: &Store,
+    router: &StoreLayout,
+    concurrency: usize,
+) -> Result<RepoGcReachability> {
+    let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
+    let manifest = snapshot.manifest;
+    let mut reachable = HashSet::new();
+    extend_reachable_bulk_objects(store, router, &manifest, &mut reachable).await?;
     reachable.insert(router.manifest_path().as_ref().to_string());
 
-    extend_reachable_pack_objects(store, router, &manifest, &mut reachable).await?;
-    let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
     for pack in &snapshot.journal.packs {
         insert_pack_objects(router, &pack.pack_id, &mut reachable);
     }
@@ -907,16 +950,41 @@ pub async fn reachable_repo_objects_from_manifest(
 
     let storage_router =
         crab_storage::StoreLayout::new(store.as_storage().clone(), router.repo_prefix().to_owned());
-    let history =
-        crab_metadata::manifest_store::list_manifest_history(store.as_storage(), &storage_router)
-            .await?;
-    for entry in history {
-        reachable.insert(entry.path);
-        extend_reachable_bulk_objects(store, router, &entry.manifest, &mut reachable).await?;
-        extend_reachable_pack_objects(store, router, &entry.manifest, &mut reachable).await?;
+    let history = crab_metadata::manifest_store::list_manifest_history_with_concurrency(
+        store.as_storage(),
+        &storage_router,
+        concurrency,
+    )
+    .await?;
+    let historical_reachable =
+        futures_util::stream::iter(history.into_iter().map(|entry| async move {
+            let mut keys = HashSet::new();
+            keys.insert(entry.path);
+            extend_reachable_bulk_objects(store, router, &entry.manifest, &mut keys).await?;
+            extend_reachable_pack_objects(store, router, &entry.manifest, &mut keys).await?;
+            Ok::<_, CrabError>(keys)
+        }))
+        .buffer_unordered(concurrency.max(1))
+        .try_collect::<Vec<_>>()
+        .await?;
+    for keys in historical_reachable {
+        reachable.extend(keys);
     }
 
-    Ok((manifest, reachable))
+    let shard_snapshot = ShardListSnapshot {
+        generation: manifest.generation,
+        shard_keys: snapshot
+            .journal
+            .shards
+            .iter()
+            .map(|hash| format!("shards/{}/{hash}", &hash[..2.min(hash.len())]))
+            .collect(),
+    };
+    Ok(RepoGcReachability {
+        manifest,
+        reachable_keys: reachable,
+        shard_snapshot,
+    })
 }
 
 async fn extend_reachable_pack_objects(
@@ -957,16 +1025,24 @@ pub async fn run_repo_remote_gc(
     grace_period: Duration,
     jsonl_stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>,
 ) -> Result<GcOutcome> {
-    let (manifest, mut reachable_keys) =
-        reachable_repo_objects_from_manifest(store, router).await?;
+    let reachability_started = Instant::now();
+    let reachability =
+        reachable_repo_objects_from_manifest_with_concurrency(store, router, args.list_concurrency)
+            .await?;
+    let mut reachable_keys = reachability.reachable_keys;
     let workflow_store = crab_workflow::WorkflowStore::from_storage(store.clone().into());
     reachable_keys.extend(
         crab_workflow::reachable_remote_artifact_objects(&workflow_store, router.repo_prefix())
             .await?
             .into_iter(),
     );
-    let shard_snapshot = shard_snapshot_from_repository(store, router, &manifest).await?;
-    let (listed_objects, list_outcome) = list_repo_gc_candidates(store, router).await?;
+    debug!(
+        reachable_objects = reachable_keys.len(),
+        wall_seconds = reachability_started.elapsed().as_secs_f64(),
+        "repo GC reachability scan complete"
+    );
+    let (listed_objects, list_outcome) =
+        list_repo_gc_candidates_with_concurrency(store, router, args.list_concurrency).await?;
     let deleter = StoreObjectDeleter::new(store.clone());
 
     run_gc(
@@ -974,33 +1050,15 @@ pub async fn run_repo_remote_gc(
         listed_objects,
         &reachable_keys,
         coordinator_protected_keys,
-        &shard_snapshot,
+        &reachability.shard_snapshot,
         cancel,
-        DEFAULT_DELETE_CONCURRENCY,
+        args.delete_concurrency,
         grace_period,
         list_outcome,
         &deleter,
         jsonl_stream,
     )
     .await
-}
-
-async fn shard_snapshot_from_repository(
-    store: &Store,
-    router: &StoreLayout,
-    manifest: &crate::metadata::manifest::Manifest,
-) -> Result<ShardListSnapshot> {
-    let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
-    let shard_keys = snapshot
-        .journal
-        .shards
-        .iter()
-        .map(|hash| format!("shards/{}/{hash}", &hash[..2.min(hash.len())]))
-        .collect();
-    Ok(ShardListSnapshot {
-        generation: manifest.generation,
-        shard_keys,
-    })
 }
 
 /// Build a shard-list snapshot from the manifest for GC T0 safety.
@@ -1626,6 +1684,7 @@ mod tests {
         let keys: HashSet<_> = candidates.into_iter().map(|object| object.key).collect();
 
         assert_eq!(outcome.requests, 5);
+        assert_eq!(outcome.parallelism, 5);
         assert!(keys.contains("org/repo/packs/pack-old.pack"));
         assert!(keys.contains("org/repo/metadata/pack/indexes/old.json"));
         assert!(keys.contains("org/repo/manifests/pack-list-old"));
@@ -1633,6 +1692,28 @@ mod tests {
         assert!(!keys.contains("org/repo/locks/refs/heads/main/lock"));
         assert!(!keys.contains("org/repo/locks/internal/repack/lock"));
         assert!(!keys.contains(".crab/xorbs/abc"));
+    }
+
+    #[tokio::test]
+    async fn repo_gc_candidate_listing_honors_concurrency_limit() {
+        use crate::storage::StoreLayout;
+        use crate::storage::store::Store;
+        use object_store::memory::InMemory;
+        use std::sync::Arc;
+
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(inner);
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+
+        let (_, serial) = list_repo_gc_candidates_with_concurrency(&store, &router, 1)
+            .await
+            .unwrap();
+        let (_, bounded) = list_repo_gc_candidates_with_concurrency(&store, &router, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(serial.parallelism, 1);
+        assert_eq!(bounded.parallelism, 2);
     }
 
     #[tokio::test]

--- a/crab/src/cmd/history_recovery.rs
+++ b/crab/src/cmd/history_recovery.rs
@@ -34,16 +34,20 @@ use crate::storage::StoreLayout;
 use crate::storage::store::Store;
 
 pub const HISTORY_LIST_SCHEMA: &str = "recover.history.list";
+pub const HISTORY_PRUNE_SCHEMA: &str = "recover.history.prune";
 pub const HISTORY_VERIFY_SCHEMA: &str = "recover.history.verify";
 pub const HISTORY_RESTORE_SCHEMA: &str = "recover.history.restore";
 pub const HISTORY_SCHEMA_VERSION: &str = "1.0";
 
 const RECOVERY_LOCK_TTL: Duration = Duration::from_mins(5);
+const HISTORY_PRUNE_DELETE_CONCURRENCY: usize = 64;
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum HistoryCmd {
     /// List immutable historical repository roots.
     List(HistoryListArgs),
+    /// Preview or apply retention of the newest historical generations.
+    Prune(HistoryPruneArgs),
     /// Verify one historical root and its complete dependency closure.
     Verify(HistoryVerifyArgs),
     /// Preview or apply restoration of one verified historical root.
@@ -55,6 +59,29 @@ pub struct HistoryListArgs {
     /// Structured JSON output.
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct HistoryPruneArgs {
+    /// Number of newest distinct generations to retain.
+    #[arg(long, value_name = "N", value_parser = parse_positive_usize)]
+    pub keep_last: usize,
+    /// Delete the planned historical roots. Without this flag, show a preview.
+    #[arg(long)]
+    pub apply: bool,
+    /// Structured JSON output.
+    #[arg(long)]
+    pub json: bool,
+}
+
+fn parse_positive_usize(value: &str) -> std::result::Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|error| format!("invalid positive integer: {error}"))?;
+    if parsed == 0 {
+        return Err("value must be at least 1".to_owned());
+    }
+    Ok(parsed)
 }
 
 #[derive(Debug, Clone, Args)]
@@ -94,6 +121,7 @@ impl HistoryCmd {
     pub fn schema_name(&self) -> &'static str {
         match self {
             Self::List(_) => HISTORY_LIST_SCHEMA,
+            Self::Prune(_) => HISTORY_PRUNE_SCHEMA,
             Self::Verify(_) => HISTORY_VERIFY_SCHEMA,
             Self::Restore(_) => HISTORY_RESTORE_SCHEMA,
         }
@@ -104,9 +132,15 @@ impl HistoryCmd {
         matches!(self, Self::Restore(args) if args.apply)
     }
 
+    #[must_use]
+    pub fn applies_prune(&self) -> bool {
+        matches!(self, Self::Prune(args) if args.apply)
+    }
+
     fn json(&self) -> bool {
         match self {
             Self::List(args) => args.json,
+            Self::Prune(args) => args.json,
             Self::Verify(args) => args.json,
             Self::Restore(args) => args.json,
         }
@@ -127,6 +161,18 @@ pub struct HistoryEntryPayload {
 pub struct HistoryListPayload {
     pub current_generation: u64,
     pub entries: Vec<HistoryEntryPayload>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct HistoryPrunePayload {
+    pub applied: bool,
+    #[schemars(range(min = 1))]
+    pub keep_last: u64,
+    pub roots_before: u64,
+    pub roots_kept: u64,
+    pub roots_pruned: u64,
+    pub manifest_bytes_pruned: u64,
+    pub pruned: Vec<HistoryEntryPayload>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
@@ -184,6 +230,16 @@ pub async fn run(
     let router = StoreLayout::new(store.clone(), prefix.to_owned());
     match command {
         HistoryCmd::List(_) => run_list(store, &router, command.output_mode()).await,
+        HistoryCmd::Prune(args) => {
+            let payload = prune_history(store, &router, args, cancel).await?;
+            if payload.applied
+                && let Err(error) = record_prune_audit(prefix, &payload)
+            {
+                warn!(%error, "failed to append historical prune audit event");
+            }
+            emit_prune(&payload, command.output_mode());
+            Ok(())
+        }
         HistoryCmd::Verify(args) => {
             let verified = verify_history(
                 store,
@@ -207,6 +263,27 @@ pub async fn run(
             Ok(())
         }
     }
+}
+
+fn record_prune_audit(prefix: &str, payload: &HistoryPrunePayload) -> Result<()> {
+    let event = AuditEvent::new(NewAuditEvent {
+        operation: "recover.history.prune".to_owned(),
+        outcome: AuditOutcome::Success,
+        actor: None,
+        repository: Some(prefix.to_owned()),
+        details: serde_json::json!({
+            "keep_last": payload.keep_last,
+            "roots_before": payload.roots_before,
+            "roots_kept": payload.roots_kept,
+            "roots_pruned": payload.roots_pruned,
+            "manifest_bytes_pruned": payload.manifest_bytes_pruned,
+            "pruned": payload.pruned.iter().map(|entry| serde_json::json!({
+                "generation": entry.generation,
+                "digest": entry.digest,
+            })).collect::<Vec<_>>(),
+        }),
+    });
+    append_event(&default_log_path(), &event)
 }
 
 fn record_restore_audit(prefix: &str, payload: &HistoryRestorePayload) -> Result<()> {
@@ -236,14 +313,7 @@ async fn run_list(store: &Store, router: &StoreLayout, mode: OutputMode) -> Resu
     let entries = list_manifest_history(store, router)
         .await?
         .into_iter()
-        .map(|entry| HistoryEntryPayload {
-            generation: entry.generation,
-            digest: entry.digest,
-            created_at: entry.manifest.created_at,
-            session_id: entry.manifest.session_id,
-            refs: entry.manifest.refs.len() as u64,
-            manifest_bytes: entry.size,
-        })
+        .map(|entry| history_entry_payload(&entry))
         .collect::<Vec<_>>();
     let payload = HistoryListPayload {
         current_generation: current.generation,
@@ -274,7 +344,119 @@ async fn run_list(store: &Store, router: &StoreLayout, mode: OutputMode) -> Resu
     Ok(())
 }
 
+fn history_entry_payload(entry: &ManifestHistoryEntry) -> HistoryEntryPayload {
+    HistoryEntryPayload {
+        generation: entry.generation,
+        digest: entry.digest.clone(),
+        created_at: entry.manifest.created_at.clone(),
+        session_id: entry.manifest.session_id.clone(),
+        refs: entry.manifest.refs.len() as u64,
+        manifest_bytes: entry.size,
+    }
+}
+
+fn plan_history_prune(
+    entries: &[ManifestHistoryEntry],
+    keep_last: usize,
+) -> Vec<&ManifestHistoryEntry> {
+    let generations = entries
+        .iter()
+        .map(|entry| entry.generation)
+        .collect::<BTreeSet<_>>();
+    let Some(oldest_retained) = generations.iter().rev().nth(keep_last.saturating_sub(1)) else {
+        return Vec::new();
+    };
+    entries
+        .iter()
+        .filter(|entry| entry.generation < *oldest_retained)
+        .collect()
+}
+
+fn prune_payload(
+    entries: &[ManifestHistoryEntry],
+    keep_last: usize,
+    applied: bool,
+) -> HistoryPrunePayload {
+    let pruned = plan_history_prune(entries, keep_last);
+    HistoryPrunePayload {
+        applied,
+        keep_last: keep_last as u64,
+        roots_before: entries.len() as u64,
+        roots_kept: entries.len().saturating_sub(pruned.len()) as u64,
+        roots_pruned: pruned.len() as u64,
+        manifest_bytes_pruned: pruned.iter().map(|entry| entry.size).sum(),
+        pruned: pruned.into_iter().map(history_entry_payload).collect(),
+    }
+}
+
+async fn prune_history(
+    store: &Store,
+    router: &StoreLayout,
+    args: &HistoryPruneArgs,
+    cancel: &CancellationToken,
+) -> Result<HistoryPrunePayload> {
+    if !args.apply {
+        let entries = list_manifest_history(store, router).await?;
+        return Ok(prune_payload(&entries, args.keep_last, false));
+    }
+
+    let operation_cancel = cancel.child_token();
+    let lease = crate::maintenance::RepositoryMaintenanceLease::acquire(
+        store,
+        router.repo_prefix(),
+        &operation_cancel,
+    )
+    .await?;
+    let operation = async {
+        let entries = list_manifest_history(store, router).await?;
+        let paths = plan_history_prune(&entries, args.keep_last)
+            .into_iter()
+            .map(|entry| object_store::path::Path::from(entry.path.clone()))
+            .collect::<Vec<_>>();
+        for paths in paths.chunks(HISTORY_PRUNE_DELETE_CONCURRENCY) {
+            check_cancelled(&operation_cancel)?;
+            for result in
+                futures_util::future::join_all(paths.iter().map(|path| store.delete(path))).await
+            {
+                result?;
+            }
+        }
+        Ok(prune_payload(&entries, args.keep_last, true))
+    }
+    .await;
+    let release = lease.release().await;
+    match (operation, release) {
+        (Ok(payload), Ok(())) => Ok(payload),
+        (Err(error), _) | (Ok(_), Err(error)) => Err(error),
+    }
+}
+
 async fn restore_history(
+    store: &Store,
+    router: &StoreLayout,
+    args: &HistoryRestoreArgs,
+    cancel: &CancellationToken,
+) -> Result<HistoryRestorePayload> {
+    if !args.apply {
+        return restore_history_under_maintenance(store, router, args, cancel).await;
+    }
+
+    let operation_cancel = cancel.child_token();
+    let lease = crate::maintenance::RepositoryMaintenanceLease::acquire(
+        store,
+        router.repo_prefix(),
+        &operation_cancel,
+    )
+    .await?;
+    let operation = restore_history_under_maintenance(store, router, args, &operation_cancel).await;
+    let release = lease.release().await;
+    match (operation, release) {
+        (Ok(payload), Ok(())) => Ok(payload),
+        (Err(error), _) | (Ok(_), Err(error)) => Err(error),
+    }
+}
+
+async fn restore_history_under_maintenance(
     store: &Store,
     router: &StoreLayout,
     args: &HistoryRestoreArgs,
@@ -1016,6 +1198,28 @@ fn emit_verification(payload: &HistoryVerificationPayload, mode: OutputMode) {
     }
 }
 
+fn emit_prune(payload: &HistoryPrunePayload, mode: OutputMode) {
+    match mode {
+        OutputMode::Json | OutputMode::Jsonl => {
+            emit_json(HISTORY_PRUNE_SCHEMA, HISTORY_SCHEMA_VERSION, payload);
+        }
+        OutputMode::Text => {
+            let action = if payload.applied { "pruned" } else { "preview" };
+            println!(
+                "history prune {action}: before={} kept={} pruned={} manifest_bytes={} keep_last={}",
+                payload.roots_before,
+                payload.roots_kept,
+                payload.roots_pruned,
+                payload.manifest_bytes_pruned,
+                payload.keep_last,
+            );
+            for entry in &payload.pruned {
+                println!("{} {}", entry.generation, entry.digest);
+            }
+        }
+    }
+}
+
 fn emit_restore(payload: &HistoryRestorePayload, mode: OutputMode) {
     match mode {
         OutputMode::Json | OutputMode::Jsonl => {
@@ -1055,7 +1259,10 @@ mod tests {
     use object_store::memory::InMemory;
 
     use super::*;
-    use crate::metadata::manifest::{create_manifest, read_manifest, write_manifest_cas};
+    use crate::metadata::manifest::{
+        BulkData, PackManifestEntry, compact_pack_index, create_manifest, read_manifest,
+        upload_segmented_bulk, write_manifest_cas,
+    };
 
     fn memory_store() -> Store {
         let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
@@ -1166,6 +1373,207 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(selected.entry.digest, digest);
+    }
+
+    #[tokio::test]
+    async fn history_prune_keeps_every_root_in_newest_generations_and_is_idempotent() {
+        let store = memory_store();
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        for generation in 1..=4 {
+            let mut manifest = Manifest::default_for_repo("refs/heads/main");
+            manifest.generation = generation;
+            manifest.session_id = format!("generation-{generation}");
+            manifest.seal_git_validation();
+            put_history(&store, &router, &manifest).await;
+            if generation == 3 {
+                manifest.session_id = "generation-3-alternate".to_owned();
+                manifest.seal_git_validation();
+                put_history(&store, &router, &manifest).await;
+            }
+        }
+        let args = HistoryPruneArgs {
+            keep_last: 2,
+            apply: false,
+            json: false,
+        };
+
+        let preview = prune_history(&store, &router, &args, &CancellationToken::new())
+            .await
+            .unwrap();
+        assert!(!preview.applied);
+        assert_eq!(preview.roots_before, 5);
+        assert_eq!(preview.roots_pruned, 2);
+        assert_eq!(preview.roots_kept, 3);
+        assert_eq!(
+            preview
+                .pruned
+                .iter()
+                .map(|entry| entry.generation)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(
+            list_manifest_history(&store, &router).await.unwrap().len(),
+            5
+        );
+
+        let applied = prune_history(
+            &store,
+            &router,
+            &HistoryPruneArgs {
+                apply: true,
+                ..args.clone()
+            },
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert!(applied.applied);
+        assert_eq!(applied.roots_pruned, 2);
+        assert_eq!(
+            list_manifest_history(&store, &router)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|entry| entry.generation)
+                .collect::<Vec<_>>(),
+            vec![3, 3, 4]
+        );
+
+        let repeated = prune_history(
+            &store,
+            &router,
+            &HistoryPruneArgs {
+                apply: true,
+                ..args
+            },
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(repeated.roots_pruned, 0);
+    }
+
+    #[tokio::test]
+    async fn pruning_old_root_makes_its_unique_pack_collectible() {
+        let store = memory_store();
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        let old_pack_id = "c".repeat(64);
+        let (old_pack_hash, _, pack_write) = compact_pack_index(
+            1,
+            &[PackManifestEntry {
+                pack_id: old_pack_id.clone(),
+                size: 1024,
+                content_hash: old_pack_id.clone(),
+                ref_tips: Vec::new(),
+                object_count: 1,
+            }],
+        )
+        .unwrap();
+        upload_segmented_bulk(
+            &store,
+            &router,
+            &BulkData {
+                shard_index: crab_metadata::segmented::SegmentWrite::default(),
+                pack_index: pack_write,
+            },
+        )
+        .await
+        .unwrap();
+        let mut old = Manifest::default_for_repo("refs/heads/main");
+        old.generation = 1;
+        old.pack_index_hash = old_pack_hash;
+        old.seal_git_validation();
+        create_manifest(&store, &router, &old).await.unwrap();
+
+        let (_, etag) = read_manifest(&store, &router).await.unwrap();
+        let mut middle = old.clone();
+        middle.generation = 2;
+        middle.pack_index_hash.clear();
+        middle.session_id = "middle".to_owned();
+        middle.seal_git_validation();
+        write_manifest_cas(&store, &router, &middle, &etag)
+            .await
+            .unwrap();
+        let (_, etag) = read_manifest(&store, &router).await.unwrap();
+        let mut current = middle;
+        current.generation = 3;
+        current.session_id = "current".to_owned();
+        current.seal_git_validation();
+        write_manifest_cas(&store, &router, &current, &etag)
+            .await
+            .unwrap();
+
+        let pack_key = format!("org/repo/packs/pack-{old_pack_id}.pack");
+        let (_, before) = crate::cmd::gc::reachable_repo_objects_from_manifest(&store, &router)
+            .await
+            .unwrap();
+        assert!(before.contains(&pack_key));
+
+        prune_history(
+            &store,
+            &router,
+            &HistoryPruneArgs {
+                keep_last: 1,
+                apply: true,
+                json: false,
+            },
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let (_, after) = crate::cmd::gc::reachable_repo_objects_from_manifest(&store, &router)
+            .await
+            .unwrap();
+        assert!(!after.contains(&pack_key));
+    }
+
+    #[tokio::test]
+    async fn maintenance_lease_blocks_history_prune_and_restore_apply() {
+        let (store, router, _) = repository_with_history().await;
+        let lock = PushLock::acquire_internal(
+            store.inner(),
+            router.repo_prefix(),
+            crab_coordination::REPOSITORY_MAINTENANCE_RESOURCE,
+            RECOVERY_LOCK_TTL,
+        )
+        .await
+        .unwrap();
+
+        let prune_error = prune_history(
+            &store,
+            &router,
+            &HistoryPruneArgs {
+                keep_last: 1,
+                apply: true,
+                json: false,
+            },
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(prune_error, CrabError::PushLockHeld { .. }));
+
+        let restore_error = restore_history(
+            &store,
+            &router,
+            &HistoryRestoreArgs {
+                generation: 0,
+                digest: None,
+                apply: true,
+                json: false,
+            },
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(restore_error, CrabError::PushLockHeld { .. }));
+        assert_eq!(
+            read_manifest(&store, &router).await.unwrap().0.generation,
+            1
+        );
+        lock.release().await.unwrap();
     }
 
     #[tokio::test]

--- a/crab/src/cmd/recover.rs
+++ b/crab/src/cmd/recover.rs
@@ -282,6 +282,7 @@ impl RecoverCmd {
             Self::Show(_) => "recover.show",
             Self::History { command } => match command {
                 crate::cmd::history_recovery::HistoryCmd::List(_) => "recover.history.list",
+                crate::cmd::history_recovery::HistoryCmd::Prune(_) => "recover.history.prune",
                 crate::cmd::history_recovery::HistoryCmd::Verify(_) => "recover.history.verify",
                 crate::cmd::history_recovery::HistoryCmd::Restore(_) => "recover.history.restore",
             },
@@ -299,6 +300,10 @@ impl RecoverCmd {
                 | crate::cmd::history_recovery::HistoryCmd::Verify(_) => {
                     PlanApplyOperation::Inspect
                 }
+                crate::cmd::history_recovery::HistoryCmd::Prune(args) if args.apply => {
+                    PlanApplyOperation::Apply
+                }
+                crate::cmd::history_recovery::HistoryCmd::Prune(_) => PlanApplyOperation::Preview,
                 crate::cmd::history_recovery::HistoryCmd::Restore(args) if args.apply => {
                     PlanApplyOperation::Apply
                 }
@@ -309,7 +314,15 @@ impl RecoverCmd {
 
     #[cfg(test)]
     fn idempotent_apply(&self) -> bool {
-        matches!(self, Self::Apply(_))
+        matches!(
+            self,
+            Self::Apply(_)
+                | Self::History {
+                    command: crate::cmd::history_recovery::HistoryCmd::Prune(
+                        crate::cmd::history_recovery::HistoryPruneArgs { apply: true, .. }
+                    )
+                }
+        )
     }
 
     fn json(&self) -> bool {

--- a/crab/src/cmd/repack.rs
+++ b/crab/src/cmd/repack.rs
@@ -17,7 +17,6 @@ use crate::coordination::heartbeat::LockHeartbeat;
 use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::git::push::{
     CommittedManifestAnchor, CommittedPackIndex, publish_committed_pack_locators,
-    publish_git_visibility_index_from_git_dir,
 };
 use crate::metadata::manifest::{
     BulkData, Manifest, PackManifestEntry, compact_pack_index, read_bulk_pack_list, read_manifest,
@@ -169,6 +168,7 @@ async fn run_repack_locked(
     if config.dry_run {
         return Ok(outcome(packs_before, 1, bytes_before, bytes_before, start));
     }
+    let visibility = read_current_visibility(store, router, &manifest).await?;
 
     let temp = tempfile::tempdir()?;
     let git_dir = temp.path().join("source.git");
@@ -223,13 +223,29 @@ async fn run_repack_locked(
 
     let committed = repack_manifest(manifest, new_generation, pack_index_hash);
     write_manifest_cas(store, router, &committed, &manifest_etag).await?;
-    if let Err(error) =
-        publish_git_visibility_index_from_git_dir(&git_dir, &committed, store, router).await
-    {
-        warn!(
-            error = %error,
+    if let Some(visibility) = visibility {
+        let visibility = rebind_visibility(visibility, &committed);
+        let storage_router = crab_storage::StoreLayout::new(
+            store.as_storage().clone(),
+            router.repo_prefix().to_owned(),
+        );
+        if let Err(error) = crab_metadata::git_visibility::upload_if_absent(
+            store.as_storage(),
+            &storage_router,
+            &visibility,
+        )
+        .await
+        {
+            warn!(
+                error = %error,
+                generation = committed.generation,
+                "repack committed; Git visibility proof requires repair"
+            );
+        }
+    } else {
+        debug!(
             generation = committed.generation,
-            "repack committed; Git visibility proof requires repair"
+            "repack preserved repository without a Git visibility proof"
         );
     }
     let anchor = CommittedManifestAnchor {
@@ -295,6 +311,71 @@ fn repack_manifest(mut manifest: Manifest, generation: u64, pack_index_hash: Str
     // before this helper commits its single-pack inventory.
     manifest.seal_git_validation();
     manifest
+}
+
+async fn read_current_visibility(
+    store: &Store,
+    router: &StoreLayout,
+    manifest: &Manifest,
+) -> Result<Option<crab_metadata::git_visibility::GitVisibilityIndex>> {
+    if manifest.refs.is_empty() || manifest.pack_index_hash.is_empty() {
+        return Ok(None);
+    }
+    let storage_router =
+        crab_storage::StoreLayout::new(store.as_storage().clone(), router.repo_prefix().to_owned());
+    match crab_metadata::git_visibility::read(
+        store.as_storage(),
+        &storage_router,
+        manifest.generation,
+        &manifest.pack_index_hash,
+    )
+    .await
+    {
+        Ok(index) => {
+            if visibility_matches_manifest(&index, manifest) {
+                Ok(Some(index))
+            } else {
+                Err(CrabError::CorruptObject {
+                    path: storage_router
+                        .git_visibility_path(manifest.generation, &manifest.pack_index_hash)
+                        .as_ref()
+                        .to_owned(),
+                    reason: "Git visibility proof does not match manifest refs".to_owned(),
+                })
+            }
+        }
+        Err(crab_metadata::error::MetadataError::Storage {
+            source: crab_storage::StorageError::NotFound { .. },
+        }) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn visibility_matches_manifest(
+    visibility: &crab_metadata::git_visibility::GitVisibilityIndex,
+    manifest: &Manifest,
+) -> bool {
+    visibility.refs.len() == manifest.refs.len()
+        && manifest.refs.iter().all(|(name, tip)| {
+            visibility.refs.get(name).is_some_and(|objects| {
+                objects.binary_search(tip).is_ok()
+                    && manifest
+                        .peeled_refs
+                        .get(name)
+                        .is_none_or(|peeled| objects.binary_search(peeled).is_ok())
+            })
+        })
+}
+
+fn rebind_visibility(
+    mut visibility: crab_metadata::git_visibility::GitVisibilityIndex,
+    manifest: &Manifest,
+) -> crab_metadata::git_visibility::GitVisibilityIndex {
+    visibility.generation = manifest.generation;
+    visibility
+        .pack_index_hash
+        .clone_from(&manifest.pack_index_hash);
+    visibility
 }
 
 fn manifest_hash_or_default(value: &str) -> Result<MerkleHash> {
@@ -660,6 +741,43 @@ mod tests {
         assert_eq!(updated.ref_registry_hash, manifest.ref_registry_hash);
     }
 
+    #[test]
+    fn rebind_visibility_changes_only_generation_anchor() {
+        let mut refs = std::collections::BTreeMap::new();
+        refs.insert("refs/heads/main".to_owned(), vec!["a".repeat(40)]);
+        let visibility =
+            crab_metadata::git_visibility::GitVisibilityIndex::new(3, "b".repeat(64), refs.clone());
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 4;
+        manifest.pack_index_hash = "c".repeat(64);
+
+        let rebound = rebind_visibility(visibility, &manifest);
+
+        assert_eq!(rebound.generation, 4);
+        assert_eq!(rebound.pack_index_hash, "c".repeat(64));
+        assert_eq!(rebound.refs, refs);
+    }
+
+    #[tokio::test]
+    async fn missing_visibility_remains_optional() -> Result<()> {
+        let backend: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(backend);
+        let router = StoreLayout::new(store.clone(), "org/repack-test".to_owned());
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 1;
+        manifest.pack_index_hash = "a".repeat(64);
+        manifest
+            .refs
+            .insert("refs/heads/main".to_owned(), "b".repeat(40));
+
+        assert!(
+            read_current_visibility(&store, &router, &manifest)
+                .await?
+                .is_none()
+        );
+        Ok(())
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn repack_commits_one_verified_pack_and_locator_generation() -> Result<()> {
         let backend: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -712,6 +830,13 @@ mod tests {
         manifest.pack_index_hash = pack_index_hash;
         manifest.seal_git_validation();
         crate::metadata::manifest::create_manifest(&store, &router, &manifest).await?;
+        crate::git::push::publish_git_visibility_index_from_git_dir(
+            &repository.join(".git"),
+            &manifest,
+            &store,
+            &router,
+        )
+        .await?;
 
         let outcome = run_repack(
             &store,
@@ -754,6 +879,23 @@ mod tests {
             })
         );
         session.close().await?;
+        let storage_router = crab_storage::StoreLayout::new(
+            store.as_storage().clone(),
+            router.repo_prefix().to_owned(),
+        );
+        let visibility = crab_metadata::git_visibility::read(
+            store.as_storage(),
+            &storage_router,
+            committed.generation,
+            &committed.pack_index_hash,
+        )
+        .await?;
+        assert_eq!(visibility.refs.len(), 1);
+        assert!(
+            visibility.refs["refs/heads/main"]
+                .binary_search(&tip)
+                .is_ok()
+        );
         Ok(())
     }
 

--- a/crab/src/lib.rs
+++ b/crab/src/lib.rs
@@ -39,6 +39,7 @@ pub mod git;
 pub mod hydrate;
 pub mod import;
 pub mod lfs;
+pub(crate) mod maintenance;
 pub mod metadata;
 pub mod read;
 pub mod release;

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -3174,10 +3174,10 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
             let _span = tracing::info_span!("recover").entered();
             if let crab::cmd::recover::RecoverCmd::History { command } = &sub {
                 let config = Config::resolve_local()?;
-                if command.applies_restore() {
+                if command.applies_restore() || command.applies_prune() {
                     crab::replication::ensure_active_active_maintenance_admitted(
                         &config,
-                        "historical manifest recovery",
+                        "historical manifest maintenance",
                     )?;
                 }
                 let remote_url =
@@ -3190,10 +3190,16 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                                 .to_owned(),
                         })?;
                 let parsed = crab::git::url::CrabUrl::parse(remote_url)?;
-                let store =
-                    create_cli_store(&parsed.bucket, &config, "recover-history", &cancel).await?;
-                crab::cmd::history_recovery::run(command, &store, &parsed.repo_path, &cancel)
+                let selection = crab::replication::StoreResolver::new(&config, parsed, &cancel)
+                    .write_store("recover-history")
                     .await?;
+                crab::cmd::history_recovery::run(
+                    command,
+                    &selection.store,
+                    selection.router.repo_prefix(),
+                    &cancel,
+                )
+                .await?;
             } else {
                 crab::cmd::recover::run(&sub, &cancel).await?;
             }
@@ -3684,6 +3690,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                         &store,
                         &protection.protected_keys,
                         &protection.protected_repos,
+                        &cancel,
                     )
                     .await?;
                     let summary = outcome.to_summary();
@@ -6478,7 +6485,7 @@ mod tests {
     }
 
     #[test]
-    fn recover_history_parses_list_verify_and_explicit_restore() {
+    fn recover_history_parses_list_prune_verify_and_explicit_restore() {
         parse_cli_on_large_stack(|| {
             let list =
                 Cli::try_parse_from(["crab", "recover", "history", "list", "--json"]).unwrap();
@@ -6488,6 +6495,28 @@ mod tests {
                     command: crab::cmd::history_recovery::HistoryCmd::List(_)
                 }))
             ));
+
+            let prune = Cli::try_parse_from([
+                "crab",
+                "recover",
+                "history",
+                "prune",
+                "--keep-last",
+                "10",
+                "--apply",
+                "--json",
+            ])
+            .unwrap();
+            assert!(matches!(
+                prune.cmd,
+                Some(Cmd::Recover(crab::cmd::recover::RecoverCmd::History {
+                    command: crab::cmd::history_recovery::HistoryCmd::Prune(args)
+                })) if args.keep_last == 10 && args.apply && args.json
+            ));
+            assert!(
+                Cli::try_parse_from(["crab", "recover", "history", "prune", "--keep-last", "0",])
+                    .is_err()
+            );
 
             let verify = Cli::try_parse_from([
                 "crab",

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -3715,6 +3715,8 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                         mode,
                         force_early_delete: false,
                         yes_really: false,
+                        delete_concurrency: config.gc_delete_concurrency,
+                        list_concurrency: config.gc_list_concurrency,
                     };
                     tracing::info!(
                         dry_run = args.dry_run,

--- a/crab/src/maintenance.rs
+++ b/crab/src/maintenance.rs
@@ -1,0 +1,135 @@
+//! Repository-wide serialization for destructive maintenance operations.
+
+use std::time::Duration;
+
+use crab_coordination::PushLock;
+use tokio_util::sync::CancellationToken;
+
+use crate::coordination::heartbeat::LockHeartbeat;
+use crate::core::error::{CrabError, Result, check_cancelled};
+use crate::storage::store::Store;
+
+const MAINTENANCE_LOCK_TTL: Duration = Duration::from_mins(5);
+
+/// Renewable lease shared by destructive repository maintenance commands.
+pub(crate) struct RepositoryMaintenanceLease {
+    lock: PushLock,
+    heartbeat: LockHeartbeat,
+}
+
+impl RepositoryMaintenanceLease {
+    /// Acquire the repository maintenance lease and start renewing it.
+    pub async fn acquire(store: &Store, prefix: &str, cancel: &CancellationToken) -> Result<Self> {
+        check_cancelled(cancel)?;
+        let lock = PushLock::acquire_internal(
+            store.inner(),
+            prefix,
+            crab_coordination::REPOSITORY_MAINTENANCE_RESOURCE,
+            MAINTENANCE_LOCK_TTL,
+        )
+        .await
+        .map_err(CrabError::from)?;
+        let heartbeat = LockHeartbeat::spawn(
+            store.clone(),
+            lock.path().to_owned(),
+            lock.holder().to_owned(),
+            lock.ttl(),
+            lock.ttl() / 3,
+            cancel.clone(),
+        );
+        Ok(Self { lock, heartbeat })
+    }
+
+    /// Stop renewal and release the holder-checked lease.
+    pub async fn release(self) -> Result<()> {
+        self.heartbeat.stop().await;
+        self.lock.release().await.map_err(CrabError::from)
+    }
+}
+
+/// Ordered set of repository maintenance leases for bucket-wide GC.
+pub(crate) struct RepositoryMaintenanceLeases {
+    leases: Vec<RepositoryMaintenanceLease>,
+}
+
+impl RepositoryMaintenanceLeases {
+    /// Acquire each repository lease in sorted order, releasing partial work on failure.
+    pub(crate) async fn acquire(
+        store: &Store,
+        prefixes: impl IntoIterator<Item = String>,
+        cancel: &CancellationToken,
+    ) -> Result<Self> {
+        let mut prefixes = prefixes.into_iter().collect::<Vec<_>>();
+        prefixes.sort_unstable();
+        prefixes.dedup();
+        let mut leases = Vec::with_capacity(prefixes.len());
+        for prefix in prefixes {
+            let lease = match RepositoryMaintenanceLease::acquire(store, &prefix, cancel).await {
+                Ok(lease) => lease,
+                Err(error) => {
+                    let _ = Self { leases }.release().await;
+                    return Err(error);
+                }
+            };
+            leases.push(lease);
+        }
+        Ok(Self { leases })
+    }
+
+    /// Release all leases in reverse acquisition order.
+    pub(crate) async fn release(mut self) -> Result<()> {
+        let mut first_error = None;
+        while let Some(lease) = self.leases.pop() {
+            if let Err(error) = lease.release().await
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use std::sync::Arc;
+
+    use object_store::memory::InMemory;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn multi_repo_acquisition_releases_partial_leases_on_contention() {
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(inner);
+        let held = PushLock::acquire_internal_default(
+            store.inner(),
+            "org/b",
+            crab_coordination::REPOSITORY_MAINTENANCE_RESOURCE,
+        )
+        .await
+        .unwrap();
+
+        let result = RepositoryMaintenanceLeases::acquire(
+            &store,
+            ["org/b".to_owned(), "org/a".to_owned()],
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(matches!(result, Err(CrabError::PushLockHeld { .. })));
+
+        let released_partial = PushLock::acquire_internal_default(
+            store.inner(),
+            "org/a",
+            crab_coordination::REPOSITORY_MAINTENANCE_RESOURCE,
+        )
+        .await
+        .unwrap();
+        released_partial.release().await.unwrap();
+        held.release().await.unwrap();
+    }
+}

--- a/crab/tests/generate_schemas.rs
+++ b/crab/tests/generate_schemas.rs
@@ -44,7 +44,7 @@ use crab::cmd::fetch::FetchSummary;
 use crab::cmd::fsck::FsckSummary;
 use crab::cmd::gc::GcSummary;
 use crab::cmd::history_recovery::{
-    HistoryListPayload, HistoryRestorePayload, HistoryVerificationPayload,
+    HistoryListPayload, HistoryPrunePayload, HistoryRestorePayload, HistoryVerificationPayload,
 };
 use crab::cmd::hydrate::HydrateSummaryPayload;
 use crab::cmd::ls_files::{LsFileEntry, LsFilesPayload};
@@ -178,6 +178,7 @@ fn regenerate_schemas() {
     write_schema("release.verify", &schema_for!(ReleaseVerifyPayload));
     write_schema("recover.apply", &schema_for!(RecoverApplyPayload));
     write_schema("recover.history.list", &schema_for!(HistoryListPayload));
+    write_schema("recover.history.prune", &schema_for!(HistoryPrunePayload));
     write_schema(
         "recover.history.restore",
         &schema_for!(HistoryRestorePayload),

--- a/crab/tests/schema_drift.rs
+++ b/crab/tests/schema_drift.rs
@@ -39,7 +39,7 @@ use crab::cmd::fetch::FetchSummary;
 use crab::cmd::fsck::FsckSummary;
 use crab::cmd::gc::GcSummary;
 use crab::cmd::history_recovery::{
-    HistoryListPayload, HistoryRestorePayload, HistoryVerificationPayload,
+    HistoryListPayload, HistoryPrunePayload, HistoryRestorePayload, HistoryVerificationPayload,
 };
 use crab::cmd::hydrate::HydrateSummaryPayload;
 use crab::cmd::ls_files::{LsFileEntry, LsFilesPayload};
@@ -156,6 +156,10 @@ fn schemas_up_to_date() {
         ("release.verify", schema_value::<ReleaseVerifyPayload>()),
         ("recover.apply", schema_value::<RecoverApplyPayload>()),
         ("recover.history.list", schema_value::<HistoryListPayload>()),
+        (
+            "recover.history.prune",
+            schema_value::<HistoryPrunePayload>(),
+        ),
         (
             "recover.history.restore",
             schema_value::<HistoryRestorePayload>(),

--- a/crates/crab-coordination/src/push_lock.rs
+++ b/crates/crab-coordination/src/push_lock.rs
@@ -25,6 +25,8 @@ pub const REPACK_RESOURCE: &str = "repack";
 pub const BATCH_RESOURCE: &str = "batch";
 /// Internal resource serializing history recovery without existing refs.
 pub const HISTORY_RECOVERY_RESOURCE: &str = "history-recovery";
+/// Internal resource serializing destructive repository maintenance.
+pub const REPOSITORY_MAINTENANCE_RESOURCE: &str = "repository-maintenance";
 
 /// JSON payload stored in a push-lock object.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -762,6 +764,10 @@ mod tests {
         assert_eq!(
             internal_lock_path("org/repo", GIT_MANIFEST_RESOURCE).unwrap(),
             "org/repo/locks/internal/git-manifest/lock"
+        );
+        assert_eq!(
+            internal_lock_path("org/repo", REPOSITORY_MAINTENANCE_RESOURCE).unwrap(),
+            "org/repo/locks/internal/repository-maintenance/lock"
         );
         assert_eq!(push_locks_prefix("org/repo").unwrap(), "org/repo/locks");
     }

--- a/crates/crab-git/src/walk.rs
+++ b/crates/crab-git/src/walk.rs
@@ -430,18 +430,18 @@ fn walk_tree(
     let mut visitor = ObjectCollector::new(result, maximum);
     let mut state = gix_traverse::tree::breadthfirst::State::default();
 
-    gix_traverse::tree::breadthfirst(tree_iter, &mut state, odb, &mut visitor).map_err(
-        |source| WalkError::Git {
-            operation: format!("tree walk error at {tree_id}"),
-            source: Box::new(source),
-        },
-    )?;
+    let traversal = gix_traverse::tree::breadthfirst(tree_iter, &mut state, odb, &mut visitor);
 
     if visitor.overflowed
         && let Some(maximum) = maximum
     {
         return Err(limit_error(visitor.result, maximum));
     }
+
+    traversal.map_err(|source| WalkError::Git {
+        operation: format!("tree walk error at {tree_id}"),
+        source: Box::new(source),
+    })?;
 
     // Now read each newly discovered blob to check for pointers.
     for blob_oid in &visitor.pending_blobs {
@@ -714,6 +714,20 @@ mod tests {
             WalkError::LimitExceeded {
                 actual: 2,
                 maximum: 1
+            }
+        ));
+
+        let tree_bounded = walk_reachable_bounded(
+            &git_dir_path,
+            &[("refs/heads/main".to_owned(), head_sha.clone())],
+            2,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            tree_bounded,
+            WalkError::LimitExceeded {
+                actual: 3,
+                maximum: 2
             }
         ));
 

--- a/crates/crab-metadata/Cargo.toml
+++ b/crates/crab-metadata/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 file-index-reader = ["storage", "dep:futures-util", "dep:object_store", "dep:slatedb", "dep:tokio"]
 local-index = ["dep:rusqlite"]
 remote-index = ["dep:futures-util", "dep:object_store", "dep:slatedb"]
-storage = ["dep:crab-storage", "dep:object_store"]
+storage = ["dep:crab-storage", "dep:futures-util", "dep:object_store"]
 
 [dependencies]
 blake3 = { workspace = true }
@@ -33,5 +33,6 @@ tokio = { workspace = true, features = ["sync"], optional = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -2,6 +2,7 @@
 
 use bytes::Bytes;
 use crab_storage::{ETag, StorageError, Store, StoreLayout};
+use futures_util::{StreamExt, TryStreamExt};
 
 use crate::error::{MetadataError, Result};
 use crate::manifests::{
@@ -14,6 +15,8 @@ use crate::ref_journal::{
 };
 use crate::segmented::{self, SegmentKind, ShardSegmentEntry};
 use crate::segmented_store;
+
+const DEFAULT_HISTORY_READ_CONCURRENCY: usize = 32;
 
 /// One validated immutable historical manifest root.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -138,11 +141,24 @@ pub async fn list_manifest_history(
     store: &Store,
     router: &StoreLayout<Store>,
 ) -> Result<Vec<ManifestHistoryEntry>> {
+    list_manifest_history_with_concurrency(store, router, DEFAULT_HISTORY_READ_CONCURRENCY).await
+}
+
+/// List and validate immutable historical roots with bounded read concurrency.
+pub async fn list_manifest_history_with_concurrency(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    concurrency: usize,
+) -> Result<Vec<ManifestHistoryEntry>> {
     let prefix = router.manifest_history_prefix();
-    let mut entries = Vec::new();
-    for object in store.list_prefix(&prefix).await? {
-        entries.push(read_history_entry(store, router, &object.location).await?);
-    }
+    let objects = store.list_prefix(&prefix).await?;
+    let mut entries =
+        futures_util::stream::iter(objects.into_iter().map(|object| async move {
+            read_history_entry(store, router, &object.location).await
+        }))
+        .buffer_unordered(concurrency.max(1))
+        .try_collect::<Vec<_>>()
+        .await?;
     entries.sort_unstable_by(|left, right| {
         left.generation
             .cmp(&right.generation)
@@ -504,10 +520,17 @@ pub async fn materialize_active_active_manifest_projection(
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+    use std::fmt;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
-    use object_store::ObjectStore;
+    use futures_util::stream::BoxStream;
     use object_store::memory::InMemory;
+    use object_store::{
+        CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+        PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    };
 
     use crate::manifests::{compact_pack_index, compact_shard_index};
     use crate::ref_journal::{
@@ -517,6 +540,101 @@ mod tests {
     fn memory_store() -> Store {
         let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         Store::new(inner)
+    }
+
+    struct DelayedGetStore {
+        inner: Arc<InMemory>,
+        active_gets: AtomicUsize,
+        max_active_gets: AtomicUsize,
+    }
+
+    impl DelayedGetStore {
+        fn new(inner: Arc<InMemory>) -> Self {
+            Self {
+                inner,
+                active_gets: AtomicUsize::new(0),
+                max_active_gets: AtomicUsize::new(0),
+            }
+        }
+
+        fn max_active_gets(&self) -> usize {
+            self.max_active_gets.load(Ordering::Acquire)
+        }
+    }
+
+    impl fmt::Debug for DelayedGetStore {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("DelayedGetStore")
+        }
+    }
+
+    impl fmt::Display for DelayedGetStore {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("DelayedGetStore")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for DelayedGetStore {
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: PutPayload,
+            options: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, options).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            let active = self.active_gets.fetch_add(1, Ordering::AcqRel) + 1;
+            self.max_active_gets.fetch_max(active, Ordering::AcqRel);
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let result = self.inner.get_opts(location, options).await;
+            self.active_gets.fetch_sub(1, Ordering::AcqRel);
+            result
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, object_store::Result<object_store::path::Path>>,
+        ) -> BoxStream<'static, object_store::Result<object_store::path::Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
     }
 
     fn test_layout(store: Store) -> StoreLayout<Store> {
@@ -734,6 +852,39 @@ mod tests {
             list_manifest_history(&store, &router).await.unwrap().len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn manifest_history_validates_entries_concurrently_and_sorts_results() {
+        let inner = Arc::new(InMemory::new());
+        let seed_store = Store::new(inner.clone() as Arc<dyn ObjectStore>);
+        let seed_router = test_layout(seed_store.clone());
+        for generation in (0..64).rev() {
+            let mut manifest = Manifest::default_for_repo("refs/heads/main");
+            manifest.generation = generation;
+            manifest.session_id = format!("session-{generation}");
+            manifest.seal_git_validation();
+            archive_manifest(&seed_store, &seed_router, &manifest)
+                .await
+                .unwrap();
+        }
+
+        let delayed = Arc::new(DelayedGetStore::new(inner));
+        let store = Store::new(delayed.clone() as Arc<dyn ObjectStore>);
+        let router = test_layout(store.clone());
+        let entries = list_manifest_history_with_concurrency(&store, &router, 4)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.generation)
+                .collect::<Vec<_>>(),
+            (0..64).collect::<Vec<_>>()
+        );
+        assert!(delayed.max_active_gets() > 1);
+        assert!(delayed.max_active_gets() <= 4);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- rebind an existing generation-scoped Git visibility proof after repack instead of recomputing unchanged ref closures
- report traversal budget overflow as `LimitExceeded` instead of a false tree-walk corruption error
- compute repo GC reachability from one coherent snapshot and parallelize history validation, historical closures, and candidate-prefix LISTs
- honor configured GC list and delete concurrency in repo scope
- add `crab recover history prune --keep-last N` with preview-by-default, explicit apply, JSON schema, audit output, distinct-generation retention, bounded parallel deletion, and idempotent reruns
- serialize history prune/restore and destructive repo or bucket GC with renewable repository-maintenance leases; bucket GC acquires ordered leases for every registered repository and releases partial acquisition on contention
- route history maintenance through the canonical primary write-store resolver
- document the explicit history-prune then GC path for reclaiming superseded repack storage

## Kubernetes qualification

Remote: `crab://crab/verify-cli/k8s-ref-journal-20260820-1015`

### Repack

- before: 140 -> 1 packs in 601.26s, followed by `CRAB-E0099` while rebuilding visibility
- patched: 2 -> 1 packs in 268.93s with no warning
- complete ref hash unchanged: `b15c0498913024631de1f5a4f0eac64f88cd685ccf43ce754ae4c3ccb82f7e17`
- post-repack fetch resolved `qualification/repack-fixed-20260820` to exact commit `5f3aeb2ec2b276ac1e1cc111abe17ddbae136645`
- fresh post-repack lazy clone: 49.94s; exact HEAD; strict full Git fsck clean

### Garbage collection and retention

- baseline repo dry-run: 1.20-1.45s, 1.32s average
- optimized repo dry-run: 0.64-0.95s after warm-up, about 45% lower average wall time
- exact result unchanged: 79,238 reclaimable bytes, no partial enumeration
- maintenance qualification on 129 K8s history roots: `--keep-last 20` previewed 109 removals in 0.13s and did not mutate history
- K8s repo GC dry-run: 1.16s with `partial_enumeration=false`

## Disposable object-store E2E

Run: `maintenance-history-20260820-222155`

- created and pushed three real Git generations through RustFS
- prune preview proposed two roots and left the remote key set unchanged
- prune apply removed exactly two immutable history keys and retained the newest distinct generation
- repeated apply removed zero roots
- repo GC dry-run completed without partial enumeration
- fresh clone matched the latest source bytes and `crab fsck --json` was healthy
- deregistered the fixture and removed only its unique remote prefix; local evidence retained under `/Volumes/Workspace/CrabCLI/maintenance-history/maintenance-history-20260820-222155`

## Verification

- `make install` with the external per-worktree Cargo target
- history recovery tests: 8 passed
- repo GC tests: 27 passed
- bucket GC tests: 22 passed
- maintenance lease rollback test: passed
- coordination lock-path contract test: passed
- CLI parsing and store-classification tests: passed
- schema generation and drift tests: passed
- `cargo check -p crab --locked`
- `cargo fmt --all -- --check`
- `npm run check:links` (190 pages, 1,960 fragments)

A broad `make test` run reached 3,568 passing tests. Remaining failures are existing unrelated snapshot fixtures, environment-sensitive workflow tests, and a stale direct-store inventory on `main`; no baseline or snapshot files were changed. Strict broad Clippy is also blocked by existing warnings beginning in `crates/crab-remote-git/src/snapshot.rs`.

Destructive GC and history prune apply were not run against the shared K8s qualification remote. Destructive retention was proven only against the isolated RustFS fixture.