### PR TITLE
feat: complete garbage collection lifecycle

### DIFF
--- a/crab-web/content/docs/cli/reference/crab-gc.mdx
+++ b/crab-web/content/docs/cli/reference/crab-gc.mdx
@@ -30,6 +30,17 @@ Destructive repository GC takes a renewable repository-maintenance lease. A
 destructive bucket GC takes that lease for every registered repository. Neither
 can run concurrently with history pruning or history restoration.
 
+Bucket GC reads current and retained historical shard roots for registered
+repositories in parallel, downloads referenced shards with bounded concurrency,
+and lists the complete global shard and xorb namespaces concurrently. It also
+tombstones generation-pinned `file_index_db` rows that are outside each
+repository's retained shard closure.
+
+If any repository-scope object deletion or post-delete reconciliation fails,
+Crab exits non-zero with `CRAB-E0322`. Its structured error details report the
+number of successful deletions, failed deletions, and whether reconciliation
+failed. Rerunning GC is safe because successful deletions are idempotent.
+
 For conceptual background, see [Garbage Collection](/docs/cli/storage/garbage-collection).
 
 ## Options
@@ -37,8 +48,13 @@ For conceptual background, see [Garbage Collection](/docs/cli/storage/garbage-co
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--dry-run` | `false` | Show what would be deleted without removing |
-| `--grace-period` | `24h` | Don't delete objects newer than this |
+| `--scope` | `repo` | Collect repository objects, or use `bucket` for global deduplicated objects |
+| `--bucket` | — | Physical bucket name required by bucket scope and registry maintenance |
+| `--grace-period` | `1h` | Don't delete objects newer than this |
+| `--force` | `false` | Bypass age checks without bypassing registry or coordinator safety proof |
+| `--yes` | `false` | Skip repository force-mode confirmation |
 | `--json` | `false` | Emit structured JSON output |
+| `--jsonl` | `false` | Emit streaming structured output |
 
 ## Examples
 

--- a/crab-web/content/docs/cli/storage/garbage-collection.mdx
+++ b/crab-web/content/docs/cli/storage/garbage-collection.mdx
@@ -107,6 +107,13 @@ Crab's GC is designed to be safe by default:
 4. **Confirmation required** — `--force` prompts for confirmation unless `--yes` is also passed.
 5. **Atomic ref reads** — The reachability scan uses a consistent snapshot of refs.
 6. **Maintenance serialization** — Destructive repo GC takes one repository lease; destructive bucket GC takes a lease for every registered repository. Neither can race history pruning or restoration.
+7. **Explicit partial failure** — Failed repository deletions or metadata reconciliation return `CRAB-E0322` with structured counters and a non-zero exit status.
+
+Bucket scope scans every registered repository's current and retained history
+with bounded concurrency. It lists global shard and xorb namespaces
+concurrently, downloads referenced shards in parallel, and tombstones stale
+generation-pinned file-index rows using each repository's own retained shard
+closure.
 
 ## When to Run GC
 

--- a/crab/schemas/gc.json
+++ b/crab/schemas/gc.json
@@ -1,8 +1,64 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "GcSummary",
   "description": "Terminal result payload for `--json` / `--jsonl` structured output.",
-  "type": "object",
+  "properties": {
+    "bytes_reclaimed": {
+      "description": "Total bytes reclaimed.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "cancelled": {
+      "description": "Whether the run was cancelled mid-sweep.",
+      "type": "boolean"
+    },
+    "delete_failures": {
+      "default": 0,
+      "description": "Number of object deletions that failed.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "dry_run": {
+      "description": "Whether this was a dry-run (no mutations).",
+      "type": "boolean"
+    },
+    "file_index_entries_deleted": {
+      "default": 0,
+      "description": "Number of stale per-repository file-index rows tombstoned.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "packs_deleted": {
+      "description": "Number of pack objects deleted (or would-be-deleted in dry-run).",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "partial_enumeration": {
+      "default": false,
+      "description": "Whether enumeration was partial (some LIST requests failed). When `true`, GC may not have considered all objects for collection; re-running GC after transient S3 issues clear is recommended. See finding S1-P5-1.",
+      "type": "boolean"
+    },
+    "reconciliation_failed": {
+      "default": false,
+      "description": "Whether post-delete metadata reconciliation failed.",
+      "type": "boolean"
+    },
+    "shards_deleted": {
+      "description": "Number of shard objects deleted.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "xorbs_deleted": {
+      "description": "Number of xorb objects deleted.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    }
+  },
   "required": [
     "bytes_reclaimed",
     "cancelled",
@@ -11,43 +67,6 @@
     "shards_deleted",
     "xorbs_deleted"
   ],
-  "properties": {
-    "bytes_reclaimed": {
-      "description": "Total bytes reclaimed.",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
-    "cancelled": {
-      "description": "Whether the run was cancelled mid-sweep.",
-      "type": "boolean"
-    },
-    "dry_run": {
-      "description": "Whether this was a dry-run (no mutations).",
-      "type": "boolean"
-    },
-    "packs_deleted": {
-      "description": "Number of pack objects deleted (or would-be-deleted in dry-run).",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
-    "partial_enumeration": {
-      "description": "Whether enumeration was partial (some LIST requests failed). When `true`, GC may not have considered all objects for collection; re-running GC after transient S3 issues clear is recommended. See finding S1-P5-1.",
-      "default": false,
-      "type": "boolean"
-    },
-    "shards_deleted": {
-      "description": "Number of shard objects deleted.",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
-    "xorbs_deleted": {
-      "description": "Number of xorb objects deleted.",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    }
-  }
+  "title": "GcSummary",
+  "type": "object"
 }

--- a/crab/src/cmd/gc/bucket.rs
+++ b/crab/src/cmd/gc/bucket.rs
@@ -12,15 +12,14 @@
 //! 5. Dry-run reports; otherwise delete candidates.
 //!
 //! The legacy `.crab/file-index/` enumeration is gone — per-file
-//! objects don't exist anymore. Dead-entry tombstones in the per-repo
-//! `file_index_db` are a future enhancement; for now the
-//! content-addressed idempotency of SlateDB keys keeps any orphan
-//! entries harmless until the GC sweep grows a tombstone pass.
+//! objects don't exist anymore. Each repository's `file_index_db` is
+//! swept against the file hashes reachable from its retained shards.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use futures_util::TryStreamExt;
+use futures_util::{StreamExt, TryStreamExt};
 use object_store::ObjectStoreExt;
 use object_store::path::Path as ObjectPath;
 use tokio_util::sync::CancellationToken;
@@ -45,6 +44,10 @@ pub struct BucketGcArgs {
     pub grace_period: Duration,
     /// Bypass object age checks, but never registry or coordinator safety proof.
     pub force: bool,
+    /// Maximum concurrent LIST, history, and metadata-read operations.
+    pub list_concurrency: usize,
+    /// Maximum concurrent object DELETE requests.
+    pub delete_concurrency: usize,
 }
 
 /// Structured outcome of a bucket-scope GC run.
@@ -84,10 +87,13 @@ impl BucketGcOutcome {
             packs_deleted: 0,
             xorbs_deleted: self.xorbs_deleted,
             shards_deleted: self.shards_deleted,
+            file_index_entries_deleted: self.file_index_deleted,
             bytes_reclaimed: self.bytes_reclaimed,
             dry_run: self.dry_run,
             cancelled: false,
             partial_enumeration: false,
+            delete_failures: 0,
+            reconciliation_failed: false,
         }
     }
 }
@@ -97,6 +103,7 @@ const MIN_GRACE_PERIOD: Duration = Duration::from_secs(3600);
 
 /// Global prefix for content-addressed objects.
 const GLOBAL_PREFIX: &str = ".crab";
+const FILE_INDEX_GC_BATCH_SIZE: usize = 4_096;
 
 /// Run bucket-scope garbage collection.
 ///
@@ -163,8 +170,15 @@ async fn run_bucket_gc_under_maintenance(
     let now = SystemTime::now();
     let cutoff = now - effective_grace;
 
-    let mut referenced_shards = registry.all_referenced_shards();
-    referenced_shards.extend(historical_referenced_shards(store, registry).await?);
+    let (repo_shards, shard_objects, xorb_objects) = tokio::try_join!(
+        repository_referenced_shards(store, registry, args.list_concurrency),
+        list_global_objects(store, "shards"),
+        list_global_objects(store, "xorbs"),
+    )?;
+    let referenced_shards = repo_shards
+        .values()
+        .flat_map(|shards| shards.iter().cloned())
+        .collect::<HashSet<_>>();
     info!(
         repos = registry.repos.len(),
         referenced_shards = referenced_shards.len(),
@@ -172,7 +186,6 @@ async fn run_bucket_gc_under_maintenance(
     );
 
     // Step 2: List shards, find unreferenced candidates.
-    let shard_objects = list_global_objects(store, "shards").await?;
     check_cancelled(cancel)?;
     let listed_shards = shard_objects
         .iter()
@@ -210,20 +223,22 @@ async fn run_bucket_gc_under_maintenance(
 
     // Step 3: Download each referenced shard once, in parallel, and
     // extract both xorb hashes (for step 4) and file hashes (for step 5)
-    // in a single pass. See findings CR5-F3 and CR5-F4.
+    // in a single pass so the shard objects are not downloaded twice.
     let ShardHashes {
         xorb_hashes: referenced_xorbs,
-        file_hashes: referenced_file_hashes,
-    } = extract_hashes_from_shards(store, &referenced_shard_objects).await?;
+        file_hashes_by_shard,
+    } = extract_hashes_from_shards(store, &referenced_shard_objects, args.list_concurrency).await?;
+    let referenced_file_hashes = file_hashes_by_shard
+        .values()
+        .map(HashSet::len)
+        .sum::<usize>();
     check_cancelled(cancel)?;
     info!(
         referenced_xorbs = referenced_xorbs.len(),
-        referenced_file_hashes = referenced_file_hashes.len(),
-        "computed referenced xorbs + file-index entries from shards"
+        referenced_file_hashes, "computed referenced xorbs + file-index entries from shards"
     );
 
     // Step 4: List xorbs, find unreferenced candidates.
-    let xorb_objects = list_global_objects(store, "xorbs").await?;
     check_cancelled(cancel)?;
     let xorb_partition =
         partition_xorbs_for_gc(xorb_objects, &referenced_xorbs, coordinator_protected_keys);
@@ -235,15 +250,14 @@ async fn run_bucket_gc_under_maintenance(
         protected_xorbs, "unreferenced xorbs eligible for deletion"
     );
 
-    // Legacy per-file `.crab/file-index/{hash}` enumeration is gone —
-    // file_index lives in the per-repo `file_index_db` SlateDB now.
-    // Dead-entry tombstoning through a MetaDb `Transaction` is a
-    // future enhancement; today, orphaned entries are harmless
-    // (content-addressed keys) and get compacted away by SlateDB's
-    // background compaction. `referenced_file_hashes` is still read
-    // above so we can plug the tombstone pass in without touching the
-    // shard-download path.
-    let _ = &referenced_file_hashes;
+    outcome.file_index_deleted = gc_file_indexes(
+        store,
+        &repo_shards,
+        &file_hashes_by_shard,
+        args.dry_run,
+        args.list_concurrency,
+    )
+    .await?;
 
     // Step 6: Delete or report.
     check_cancelled(cancel)?;
@@ -252,40 +266,66 @@ async fn run_bucket_gc_under_maintenance(
         "shards",
         &shard_candidates,
         args.dry_run,
+        args.delete_concurrency,
         &mut outcome,
     )
     .await?;
-    delete_or_report(store, "xorbs", &xorb_candidates, args.dry_run, &mut outcome).await?;
+    delete_or_report(
+        store,
+        "xorbs",
+        &xorb_candidates,
+        args.dry_run,
+        args.delete_concurrency,
+        &mut outcome,
+    )
+    .await?;
 
     outcome.log();
     Ok(outcome)
 }
 
-async fn historical_referenced_shards(
+async fn repository_referenced_shards(
     store: &Store,
     registry: &RefRegistry,
-) -> Result<HashSet<String>> {
-    let storage = store.as_storage();
-    let mut shards = HashSet::new();
-    let mut repositories = registry.repos.keys().collect::<Vec<_>>();
-    repositories.sort_unstable();
-    for repo_prefix in repositories {
-        let router = crab_storage::StoreLayout::new(storage.clone(), repo_prefix.clone());
-        for entry in crab_metadata::manifest_store::list_manifest_history(storage, &router).await? {
-            if entry.manifest.shard_index_hash.is_empty() {
-                continue;
-            }
-            shards.extend(
-                crab_metadata::manifest_store::read_bulk_shard_list(
-                    storage,
-                    &router,
-                    &entry.manifest.shard_index_hash,
-                )
-                .await?,
-            );
+    concurrency: usize,
+) -> Result<HashMap<String, HashSet<String>>> {
+    let storage = store.clone().into_storage();
+    let parallelism = concurrency.max(1);
+    futures_util::stream::iter(registry.repos.iter().map(|(repo_prefix, current)| {
+        let storage = storage.clone();
+        let repo_prefix = repo_prefix.clone();
+        let mut shards = current.iter().cloned().collect::<HashSet<_>>();
+        async move {
+            let router = crab_storage::StoreLayout::new(storage.clone(), repo_prefix.clone());
+            let history =
+                crab_metadata::manifest_store::list_manifest_history(&storage, &router).await?;
+            let historical = futures_util::stream::iter(history.into_iter().filter_map(|entry| {
+                (!entry.manifest.shard_index_hash.is_empty())
+                    .then_some(entry.manifest.shard_index_hash)
+            }))
+            .map(|shard_index_hash| {
+                let storage = storage.clone();
+                let router = router.clone();
+                async move {
+                    crab_metadata::manifest_store::read_bulk_shard_list(
+                        &storage,
+                        &router,
+                        &shard_index_hash,
+                    )
+                    .await
+                }
+            })
+            .buffer_unordered(parallelism)
+            .try_collect::<Vec<_>>()
+            .await?;
+            shards.extend(historical.into_iter().flatten());
+            Ok::<_, crab_metadata::error::MetadataError>((repo_prefix, shards))
         }
-    }
-    Ok(shards)
+    }))
+    .buffer_unordered(parallelism)
+    .map(|result| result.map_err(CrabError::from))
+    .try_collect()
+    .await
 }
 
 fn ensure_registry_complete_for_destructive_gc(registry: &RefRegistry) -> Result<()> {
@@ -428,8 +468,12 @@ fn partition_xorbs_for_gc(
 /// List all objects under `.crab/{kind}/`.
 async fn list_global_objects(store: &Store, kind: &str) -> Result<Vec<ListedObject>> {
     let prefix = ObjectPath::from(format!("{GLOBAL_PREFIX}/{kind}/"));
-    let stream = store.inner().list(Some(&prefix));
-    let objects: Vec<_> = stream.try_collect().await.map_err(CrabError::Storage)?;
+    let objects = store
+        .inner()
+        .list(Some(&prefix))
+        .try_collect::<Vec<_>>()
+        .await
+        .map_err(CrabError::Storage)?;
 
     Ok(objects
         .into_iter()
@@ -464,23 +508,19 @@ fn filter_by_grace(
 /// Hashes extracted from a batch of shards.
 struct ShardHashes {
     xorb_hashes: HashSet<String>,
-    file_hashes: HashSet<String>,
+    file_hashes_by_shard: HashMap<String, HashSet<MerkleHash>>,
 }
 
 /// Download each referenced shard once and extract both xorb hashes and
 /// file hashes in a single pass. Runs downloads in parallel with a
 /// bounded concurrency budget. Previously GC downloaded each shard
-/// twice (once per extraction pass) and serially. See findings
-/// CR5-F3 and CR5-F4.
+/// twice (once per extraction pass) and serially.
 async fn extract_hashes_from_shards(
     store: &Store,
     shard_objects: &[ListedObject],
+    concurrency: usize,
 ) -> Result<ShardHashes> {
-    use futures_util::stream::{self, StreamExt};
-
-    const SHARD_DOWNLOAD_CONCURRENCY: usize = 16;
-
-    let per_shard = stream::iter(shard_objects.iter())
+    let per_shard = futures_util::stream::iter(shard_objects.iter())
         .map(|obj| async move {
             let hash_hex = extract_hash_from_key(&obj.location);
             let path = ObjectPath::from(obj.location.as_str());
@@ -536,7 +576,7 @@ async fn extract_hashes_from_shards(
             }
 
             // Second pass: file info (sequential but no re-download).
-            let mut files: HashSet<String> = HashSet::new();
+            let mut files = HashSet::new();
             let mut cursor = std::io::Cursor::new(v1_bytes);
             let file_infos = shard_info
                 .read_all_file_info_sections(&mut cursor)
@@ -545,26 +585,82 @@ async fn extract_hashes_from_shards(
                     reason: format!("failed to read referenced shard file info: {error}"),
                 })?;
             for file_info in &file_infos {
-                files.insert(file_info.metadata.file_hash.hex());
+                files.insert(file_info.metadata.file_hash);
             }
 
-            Ok((xorbs, files))
+            Ok((hash_hex, xorbs, files))
         })
-        .buffer_unordered(SHARD_DOWNLOAD_CONCURRENCY)
+        .buffer_unordered(concurrency.max(1))
         .try_collect::<Vec<_>>()
         .await?;
 
     let mut xorb_hashes = HashSet::new();
-    let mut file_hashes = HashSet::new();
-    for (x, f) in per_shard {
+    let mut file_hashes_by_shard = HashMap::new();
+    for (shard_hash, x, f) in per_shard {
         xorb_hashes.extend(x);
-        file_hashes.extend(f);
+        file_hashes_by_shard.insert(shard_hash, f);
     }
 
     Ok(ShardHashes {
         xorb_hashes,
-        file_hashes,
+        file_hashes_by_shard,
     })
+}
+
+async fn gc_file_indexes(
+    store: &Store,
+    repo_shards: &HashMap<String, HashSet<String>>,
+    file_hashes_by_shard: &HashMap<String, HashSet<MerkleHash>>,
+    dry_run: bool,
+    concurrency: usize,
+) -> Result<u64> {
+    futures_util::stream::iter(repo_shards.iter())
+        .map(|(repo_prefix, shards)| async move {
+            let db_prefix = ObjectPath::from(format!(
+                "{}/file_index_db/",
+                repo_prefix.trim_end_matches('/')
+            ));
+            let mut objects = store.inner().list(Some(&db_prefix));
+            match objects.next().await {
+                None => return Ok(0),
+                Some(Err(error)) => return Err(CrabError::Storage(error)),
+                Some(Ok(_)) => {}
+            }
+
+            let referenced = shards
+                .iter()
+                .filter_map(|shard| file_hashes_by_shard.get(shard))
+                .flat_map(|files| files.iter().copied())
+                .collect::<HashSet<_>>();
+            let config =
+                crate::metadata::MetaDbConfig::for_repo(repo_prefix).with_read_only(dry_run);
+            let metadb = crate::metadata::MetaDb::new(
+                Arc::clone(store.inner()),
+                repo_prefix.clone(),
+                config,
+            );
+            let guard = crate::metadata::MetaDbGuard::new(metadb);
+            let operation = async {
+                guard
+                    .file_index()
+                    .await?
+                    .gc_unreferenced_committed(&referenced, dry_run, FILE_INDEX_GC_BATCH_SIZE)
+                    .await
+            }
+            .await;
+            let close = guard.close().await;
+            match (operation, close) {
+                (Ok(removed), Ok(())) => Ok(removed),
+                (Err(error), _) | (Ok(_), Err(error)) => Err(error),
+            }
+        })
+        .buffer_unordered(concurrency.max(1))
+        .try_fold(0u64, |total, removed| async move {
+            total
+                .checked_add(removed)
+                .ok_or_else(|| CrabError::Internal("file-index GC count overflow".to_owned()))
+        })
+        .await
 }
 
 /// Delete or report candidates depending on dry-run mode.
@@ -573,28 +669,31 @@ async fn delete_or_report(
     kind: &str,
     candidates: &[ListedObject],
     dry_run: bool,
+    concurrency: usize,
     outcome: &mut BucketGcOutcome,
 ) -> Result<()> {
-    for obj in candidates {
-        let hash = extract_hash_from_key(&obj.location);
-        if dry_run {
-            info!(kind = %kind, hash = %hash, size = obj.size, "would delete (dry-run)");
-        } else {
+    let deleted = futures_util::stream::iter(candidates.iter())
+        .map(|obj| async move {
+            let hash = extract_hash_from_key(&obj.location);
+            if dry_run {
+                info!(kind = %kind, hash = %hash, size = obj.size, "would delete (dry-run)");
+                return Ok::<_, CrabError>(obj);
+            }
             let path = ObjectPath::from(obj.location.as_str());
             match store.delete(&path).await {
-                Ok(()) => {
-                    debug!(kind = %kind, hash = %hash, "deleted");
-                }
+                Ok(()) => debug!(kind = %kind, hash = %hash, "deleted"),
                 Err(CrabError::NotFound { .. }) => {
-                    // Already gone — idempotent.
                     debug!(kind = %kind, hash = %hash, "already deleted");
                 }
-                Err(e) => {
-                    return Err(e);
-                }
+                Err(error) => return Err(error),
             }
-        }
+            Ok(obj)
+        })
+        .buffer_unordered(concurrency.max(1))
+        .try_collect::<Vec<_>>()
+        .await?;
 
+    for obj in deleted {
         match kind {
             "shards" => outcome.shards_deleted += 1,
             "xorbs" => outcome.xorbs_deleted += 1,
@@ -890,11 +989,14 @@ mod tests {
         let mut registry = RefRegistry::default();
         registry.register("org/models", Vec::new());
 
-        let historical = historical_referenced_shards(&store, &registry)
+        let historical = repository_referenced_shards(&store, &registry, 4)
             .await
             .unwrap();
 
-        assert_eq!(historical, [historical_shard].into_iter().collect());
+        assert_eq!(
+            historical["org/models"],
+            [historical_shard].into_iter().collect()
+        );
     }
 
     #[tokio::test]
@@ -911,6 +1013,8 @@ mod tests {
             dry_run: true,
             grace_period: Duration::from_secs(3600),
             force: false,
+            list_concurrency: 16,
+            delete_concurrency: 64,
         };
 
         let protected = HashSet::new();
@@ -955,6 +1059,8 @@ mod tests {
                 dry_run: false,
                 grace_period: Duration::from_secs(3600),
                 force: false,
+                list_concurrency: 16,
+                delete_concurrency: 64,
             },
             &store,
             &HashSet::new(),
@@ -991,6 +1097,8 @@ mod tests {
                 dry_run: false,
                 grace_period: Duration::from_secs(3600),
                 force: true,
+                list_concurrency: 16,
+                delete_concurrency: 64,
             },
             &store,
             &HashSet::new(),
@@ -1014,6 +1122,77 @@ mod tests {
         assert!(!summary.dry_run);
         assert!(!summary.cancelled);
         assert!(!summary.partial_enumeration);
+    }
+
+    #[tokio::test]
+    async fn bucket_gc_tombstones_file_rows_outside_each_repo_closure() {
+        use crab_metadata::value_codec::CommittedFileRecord;
+
+        let store = memory_store();
+        let repo = "org/models";
+        let retained = MerkleHash::from([1, 2, 3, 4]);
+        let stale = MerkleHash::from([5, 6, 7, 8]);
+        let shard = MerkleHash::from([9, 10, 11, 12]);
+        let config = crate::metadata::MetaDbConfig::for_repo(repo);
+        let guard = crate::metadata::MetaDbGuard::new(crate::metadata::MetaDb::new(
+            Arc::clone(store.inner()),
+            repo.to_owned(),
+            config.clone(),
+        ));
+        let file_index = guard.file_index().await.unwrap();
+        let mut transaction = guard.new_transaction().unwrap();
+        file_index.save_committed_batch(
+            &mut transaction,
+            &[
+                (
+                    retained,
+                    CommittedFileRecord {
+                        recipe_hash: [1; 32],
+                        shard_hash: shard,
+                        committed_generation: 1,
+                        shard_index_hash: shard,
+                    },
+                ),
+                (
+                    stale,
+                    CommittedFileRecord {
+                        recipe_hash: [2; 32],
+                        shard_hash: shard,
+                        committed_generation: 1,
+                        shard_index_hash: shard,
+                    },
+                ),
+            ],
+        );
+        guard.commit(transaction).await.unwrap();
+        guard.close().await.unwrap();
+
+        let removed = gc_file_indexes(
+            &store,
+            &HashMap::from([(repo.to_owned(), HashSet::from(["live-shard".to_owned()]))]),
+            &HashMap::from([("live-shard".to_owned(), HashSet::from([retained]))]),
+            false,
+            4,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(removed, 1);
+        let guard = crate::metadata::MetaDbGuard::new(crate::metadata::MetaDb::new(
+            Arc::clone(store.inner()),
+            repo.to_owned(),
+            config.with_read_only(true),
+        ));
+        let values = guard
+            .file_index()
+            .await
+            .unwrap()
+            .get_committed_batch(&[retained, stale])
+            .await
+            .unwrap();
+        assert!(values[0].is_some());
+        assert!(values[1].is_none());
+        guard.close().await.unwrap();
     }
 
     #[tokio::test]
@@ -1043,6 +1222,8 @@ mod tests {
                 dry_run: false,
                 grace_period: Duration::from_secs(3600),
                 force: false,
+                list_concurrency: 16,
+                delete_concurrency: 64,
             },
             &store,
             &HashSet::new(),
@@ -1058,6 +1239,8 @@ mod tests {
                 dry_run: true,
                 grace_period: Duration::from_secs(3600),
                 force: false,
+                list_concurrency: 16,
+                delete_concurrency: 64,
             },
             &store,
             &HashSet::new(),
@@ -1101,6 +1284,8 @@ mod tests {
                 dry_run: false,
                 grace_period: Duration::from_secs(3600),
                 force: false,
+                list_concurrency: 16,
+                delete_concurrency: 64,
             },
             &store,
             &HashSet::new(),
@@ -1133,6 +1318,8 @@ mod tests {
                 dry_run: false,
                 grace_period: Duration::from_secs(3600),
                 force: false,
+                list_concurrency: 16,
+                delete_concurrency: 64,
             },
             &store,
             &HashSet::new(),
@@ -1167,6 +1354,8 @@ mod tests {
             dry_run: false,
             grace_period: Duration::from_secs(3600),
             force: false,
+            list_concurrency: 16,
+            delete_concurrency: 64,
         };
         let protected = HashSet::new();
         let protected_repos = HashSet::new();
@@ -1207,6 +1396,8 @@ mod tests {
             dry_run: false,
             grace_period: Duration::from_secs(3600),
             force: false,
+            list_concurrency: 16,
+            delete_concurrency: 64,
         };
         let protected = HashSet::new();
         let protected_repos = ["org/models".to_owned()].into_iter().collect();
@@ -1239,6 +1430,8 @@ mod tests {
             dry_run: false,
             grace_period: Duration::from_secs(3600),
             force: true,
+            list_concurrency: 16,
+            delete_concurrency: 64,
         };
 
         let err = run_bucket_gc(
@@ -1366,6 +1559,8 @@ mod tests {
             dry_run: true,
             grace_period: Duration::from_secs(3600),
             force: true,
+            list_concurrency: 16,
+            delete_concurrency: 64,
         };
         let protected = HashSet::new();
         let protected_repos = HashSet::new();

--- a/crab/src/cmd/gc/mod.rs
+++ b/crab/src/cmd/gc/mod.rs
@@ -135,6 +135,10 @@ pub struct GcOutcome {
     /// `true` when one or more LIST requests failed — enumeration was
     /// partial and GC may not have considered all objects. See S1-P5-1.
     pub partial_enumeration: bool,
+    /// Number of object DELETE requests that failed.
+    pub delete_failures: u64,
+    /// Whether post-delete metadata reconciliation failed.
+    pub reconciliation_failed: bool,
 }
 
 impl GcOutcome {
@@ -150,13 +154,16 @@ impl GcOutcome {
                 list_wall_secs = format!("{:.2}", self.list_wall_seconds),
                 "gc dry-run complete (no objects deleted)"
             );
-        } else if self.cancelled {
+        } else if self.cancelled || self.delete_failures > 0 || self.reconciliation_failed {
             warn!(
                 packs = self.packs_deleted,
                 xorbs = self.xorbs_deleted,
                 shards = self.shards_deleted,
                 bytes = self.bytes_reclaimed,
-                "gc cancelled — partial results"
+                delete_failures = self.delete_failures,
+                reconciliation_failed = self.reconciliation_failed,
+                cancelled = self.cancelled,
+                "gc incomplete — partial results"
             );
         } else {
             info!(
@@ -178,10 +185,13 @@ impl GcOutcome {
             packs_deleted: self.packs_deleted,
             xorbs_deleted: self.xorbs_deleted,
             shards_deleted: self.shards_deleted,
+            file_index_entries_deleted: 0,
             bytes_reclaimed: self.bytes_reclaimed,
             dry_run: self.dry_run,
             cancelled: self.cancelled,
             partial_enumeration: self.partial_enumeration,
+            delete_failures: self.delete_failures,
+            reconciliation_failed: self.reconciliation_failed,
         }
     }
 }
@@ -207,6 +217,9 @@ pub struct GcSummary {
     pub xorbs_deleted: u64,
     /// Number of shard objects deleted.
     pub shards_deleted: u64,
+    /// Number of stale per-repository file-index rows tombstoned.
+    #[serde(default)]
+    pub file_index_entries_deleted: u64,
     /// Total bytes reclaimed.
     pub bytes_reclaimed: u64,
     /// Whether this was a dry-run (no mutations).
@@ -219,6 +232,12 @@ pub struct GcSummary {
     /// recommended. See finding S1-P5-1.
     #[serde(default)]
     pub partial_enumeration: bool,
+    /// Number of object deletions that failed.
+    #[serde(default)]
+    pub delete_failures: u64,
+    /// Whether post-delete metadata reconciliation failed.
+    #[serde(default)]
+    pub reconciliation_failed: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -632,7 +651,7 @@ pub async fn run_gc(
 
     // Phase 5: Parallel deletes bounded by delete_concurrency.
     check_cancelled(cancel)?;
-    let deleted_keys = execute_deletes(
+    let delete_outcome = execute_deletes(
         &to_delete,
         cancel,
         delete_concurrency,
@@ -650,16 +669,26 @@ pub async fn run_gc(
 
     // Phase 6: Manifest CAS to remove deleted entries.
     check_cancelled(cancel)?;
-    if let Err(e) = deleter.reconcile_manifest(&deleted_keys).await {
-        warn!(error = %e, "manifest reconciliation failed");
-    }
+    outcome.delete_failures = delete_outcome.failure_count;
+    let reconciliation_error = deleter
+        .reconcile_manifest(&delete_outcome.deleted_keys)
+        .await
+        .err();
+    outcome.reconciliation_failed = reconciliation_error.is_some();
 
     // Phase 7: Log structured outcome.
     outcome.log();
+    if let Some(source) = delete_outcome.first_error.or(reconciliation_error) {
+        return Err(CrabError::GcPartialFailure {
+            objects_deleted: delete_outcome.deleted_keys.len() as u64,
+            delete_failures: outcome.delete_failures,
+            reconciliation_failed: outcome.reconciliation_failed,
+            source: Box::new(source),
+        });
+    }
     Ok(outcome)
 }
 
-/// Execute deletes with bounded concurrency, checking cancellation between
 /// Execute deletes with bounded concurrency, checking cancellation between
 /// batches. Returns the list of successfully deleted keys.
 ///
@@ -667,8 +696,14 @@ pub async fn run_gc(
 /// then we wait for all deletes in the chunk to complete before moving to
 /// the next one. This gives up to `concurrency`-way parallelism while
 /// keeping results and cancellation coordinated batch-by-batch. The
-/// previous implementation processed each chunk serially despite the
-/// `concurrency` parameter. See finding CR5-F1.
+/// This keeps the concurrency setting effective while preserving coordinated
+/// cancellation and result accounting between batches.
+struct DeleteOutcome {
+    deleted_keys: Vec<String>,
+    failure_count: u64,
+    first_error: Option<CrabError>,
+}
+
 async fn execute_deletes(
     objects: &[ObjectMeta],
     cancel: &CancellationToken,
@@ -676,8 +711,10 @@ async fn execute_deletes(
     deleter: &dyn ObjectDeleter,
     outcome: &mut GcOutcome,
     jsonl_stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>,
-) -> Vec<String> {
+) -> DeleteOutcome {
     let mut deleted_keys = Vec::new();
+    let mut failure_count = 0u64;
+    let mut first_error = None;
     let start = Instant::now();
     let semaphore = Arc::new(Semaphore::new(concurrency.max(1)));
 
@@ -723,12 +760,20 @@ async fn execute_deletes(
                 }
                 Err(e) => {
                     warn!(key = %key, error = %e, "delete failed, skipping");
+                    failure_count += 1;
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
                 }
             }
         }
     }
 
-    deleted_keys
+    DeleteOutcome {
+        deleted_keys,
+        failure_count,
+        first_error,
+    }
 }
 
 /// Production-ready parallel delete using `Arc<dyn ObjectDeleter>`.
@@ -1316,6 +1361,41 @@ pub async fn cleanup_orphaned_bulk_objects(
 mod tests {
     use super::*;
 
+    struct FailingDeleter {
+        fail_delete_for: Option<String>,
+        fail_reconcile: bool,
+    }
+
+    impl ObjectDeleter for FailingDeleter {
+        fn delete(
+            &self,
+            key: &str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + '_>> {
+            let should_fail = self.fail_delete_for.as_deref() == Some(key);
+            Box::pin(async move {
+                if should_fail {
+                    return Err(CrabError::Internal("injected delete failure".to_owned()));
+                }
+                Ok(())
+            })
+        }
+
+        fn reconcile_manifest(
+            &self,
+            _deleted_keys: &[String],
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + '_>> {
+            let should_fail = self.fail_reconcile;
+            Box::pin(async move {
+                if should_fail {
+                    return Err(CrabError::Internal(
+                        "injected reconciliation failure".to_owned(),
+                    ));
+                }
+                Ok(())
+            })
+        }
+    }
+
     fn make_obj(key: &str, size: u64, age: Duration) -> ObjectMeta {
         ObjectMeta {
             key: key.to_string(),
@@ -1625,6 +1705,86 @@ mod tests {
         assert_eq!(outcome.xorbs_deleted, 1);
         assert_eq!(outcome.packs_deleted, 1);
         assert_eq!(outcome.bytes_reclaimed, 500);
+    }
+
+    #[tokio::test]
+    async fn gc_returns_error_when_any_delete_fails() {
+        let objects = vec![
+            make_obj("xorbs/ab/good", 100, Duration::from_secs(48 * 3600)),
+            make_obj("xorbs/ab/bad", 200, Duration::from_secs(48 * 3600)),
+        ];
+        let deleter = FailingDeleter {
+            fail_delete_for: Some("xorbs/ab/bad".to_owned()),
+            fail_reconcile: false,
+        };
+
+        let result = run_gc(
+            &GcArgs::default(),
+            objects,
+            &HashSet::<String>::new(),
+            &HashSet::<String>::new(),
+            &ShardListSnapshot {
+                generation: 0,
+                shard_keys: HashSet::new(),
+            },
+            &CancellationToken::new(),
+            2,
+            Duration::from_secs(3600),
+            ListOutcome::default(),
+            &deleter,
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(CrabError::GcPartialFailure {
+                objects_deleted: 1,
+                delete_failures: 1,
+                reconciliation_failed: false,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn gc_returns_error_when_reconciliation_fails() {
+        let deleter = FailingDeleter {
+            fail_delete_for: None,
+            fail_reconcile: true,
+        };
+
+        let result = run_gc(
+            &GcArgs::default(),
+            vec![make_obj(
+                "packs/ab/good",
+                100,
+                Duration::from_secs(48 * 3600),
+            )],
+            &HashSet::<String>::new(),
+            &HashSet::<String>::new(),
+            &ShardListSnapshot {
+                generation: 0,
+                shard_keys: HashSet::new(),
+            },
+            &CancellationToken::new(),
+            1,
+            Duration::from_secs(3600),
+            ListOutcome::default(),
+            &deleter,
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(CrabError::GcPartialFailure {
+                objects_deleted: 1,
+                delete_failures: 0,
+                reconciliation_failed: true,
+                ..
+            })
+        ));
     }
 
     // --- Manifest-aware GC reachability (Task 8.4) ---

--- a/crab/src/core/error.rs
+++ b/crab/src/core/error.rs
@@ -794,6 +794,17 @@ pub enum CrabError {
     ObjectLockedRetention { path: String, until: String },
 
     #[error(
+        "garbage collection completed partially [CRAB-E0322]: deleted {objects_deleted} object(s), {delete_failures} deletion(s) failed, reconciliation_failed={reconciliation_failed}: {source}"
+    )]
+    GcPartialFailure {
+        objects_deleted: u64,
+        delete_failures: u64,
+        reconciliation_failed: bool,
+        #[source]
+        source: Box<CrabError>,
+    },
+
+    #[error(
         "xorb optimization profile '{name}' out of range [CRAB-E0330]: target_xorb_bytes={bytes} (allowed 4 MiB..2 GiB)"
     )]
     RestripeProfileOutOfRange { name: String, bytes: u64 },
@@ -2182,6 +2193,7 @@ impl CrabError {
             | Self::RestoreTierUnsupported { .. }
             | Self::GcEarlyDeleteBlocked { .. }
             | Self::ObjectLockedRetention { .. }
+            | Self::GcPartialFailure { .. }
             | Self::RestripeProfileOutOfRange { .. }
             | Self::CostPricingMissing { .. }
             | Self::CostInventoryReportStale { .. }
@@ -2331,6 +2343,7 @@ impl CrabError {
             Self::RestoreTierUnsupported { .. } => "CRAB-E0312",
             Self::GcEarlyDeleteBlocked { .. } => "CRAB-E0320",
             Self::ObjectLockedRetention { .. } => "CRAB-E0321",
+            Self::GcPartialFailure { .. } => "CRAB-E0322",
             Self::RestripeProfileOutOfRange { .. } => "CRAB-E0330",
             Self::RestripeCorruptSource { .. } => "CRAB-E0331",
             Self::RestripeAlreadyInProgress { .. } => "CRAB-E0332",
@@ -2535,6 +2548,7 @@ impl CrabError {
             | Self::ArchiveRestoreRequired { .. }
             | Self::GcEarlyDeleteBlocked { .. }
             | Self::ObjectLockedRetention { .. }
+            | Self::GcPartialFailure { .. }
             | Self::CostInventoryReportStale { .. }
             | Self::PrefetchProfileNotFound { .. }
             | Self::UnadoptChunksMissing { .. }
@@ -2733,6 +2747,7 @@ impl CrabError {
             | Self::RestoreTierUnsupported { .. }
             | Self::GcEarlyDeleteBlocked { .. }
             | Self::ObjectLockedRetention { .. }
+            | Self::GcPartialFailure { .. }
             | Self::RestripeProfileOutOfRange { .. }
             | Self::RestripeCorruptSource { .. }
             | Self::RestripeAlreadyInProgress { .. }
@@ -3397,6 +3412,20 @@ impl CrabError {
                 serde_json::json!({
                     "path": path,
                     "until": until,
+                })
+            }
+            Self::GcPartialFailure {
+                objects_deleted,
+                delete_failures,
+                reconciliation_failed,
+                source,
+            } => {
+                serde_json::json!({
+                    "objects_deleted": objects_deleted,
+                    "delete_failures": delete_failures,
+                    "reconciliation_failed": reconciliation_failed,
+                    "source_code": source.code(),
+                    "source": source.to_string(),
                 })
             }
             Self::RestripeProfileOutOfRange { name, bytes } => {
@@ -4627,6 +4656,12 @@ mod tests {
             CrabError::ObjectLockedRetention {
                 path: ".crab/xorbs/abc123".into(),
                 until: "2026-12-31T00:00:00Z".into(),
+            },
+            CrabError::GcPartialFailure {
+                objects_deleted: 3,
+                delete_failures: 1,
+                reconciliation_failed: false,
+                source: Box::new(CrabError::Internal("delete failed".into())),
             },
             CrabError::RestripeProfileOutOfRange {
                 name: "custom".into(),

--- a/crab/src/core/error_catalog.rs
+++ b/crab/src/core/error_catalog.rs
@@ -1365,6 +1365,16 @@ pub fn lookup(code: &str) -> Option<ErrorExplanation> {
   Add at least one value to the empty variable list in the `matrix:` block.\n\
   If the variable is intentionally unused, remove it from the matrix.",
         }),
+        "CRAB-E0322" => Some(ErrorExplanation {
+            code: "CRAB-E0322",
+            summary: "Garbage collection completed only part of its cleanup",
+            causes: "\
+  - One or more object-store DELETE requests failed\n\
+  - Post-delete metadata reconciliation failed",
+            remediation: "\
+  Review the structured failure counts and source error, resolve the storage\n\
+  failure, then rerun `crab gc`. Successful deletions are idempotent.",
+        }),
         _ => None,
     }
 }
@@ -1496,6 +1506,7 @@ pub fn error_code(err: &CrabError) -> &'static str {
         CrabError::RestoreTierUnsupported { .. } => "CRAB-E0312",
         CrabError::GcEarlyDeleteBlocked { .. } => "CRAB-E0320",
         CrabError::ObjectLockedRetention { .. } => "CRAB-E0321",
+        CrabError::GcPartialFailure { .. } => "CRAB-E0322",
         CrabError::RestripeProfileOutOfRange { .. } => "CRAB-E0330",
         CrabError::RestripeCorruptSource { .. } => "CRAB-E0331",
         CrabError::RestripeAlreadyInProgress { .. } => "CRAB-E0332",

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -3684,6 +3684,8 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                         dry_run,
                         grace_period: parsed_grace,
                         force,
+                        list_concurrency: config.gc_list_concurrency,
+                        delete_concurrency: config.gc_delete_concurrency,
                     };
                     let outcome = crab::cmd::gc::bucket::run_bucket_gc(
                         &args,
@@ -3698,9 +3700,10 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                         OutputMode::Text => {
                             let verb = if dry_run { "would delete" } else { "deleted" };
                             eprintln!(
-                                "crab gc: bucket GC complete; {verb} {} xorb(s), {} shard(s), reclaimed {} byte(s).",
+                                "crab gc: bucket GC complete; {verb} {} xorb(s), {} shard(s), tombstoned {} file-index row(s), reclaimed {} byte(s).",
                                 summary.xorbs_deleted,
                                 summary.shards_deleted,
+                                summary.file_index_entries_deleted,
                                 summary.bytes_reclaimed,
                             );
                         }

--- a/crab/src/metadata/metadb/stores/file_index.rs
+++ b/crab/src/metadata/metadb/stores/file_index.rs
@@ -11,6 +11,7 @@
 //! unversioned rows are read only by tests and removed after a complete
 //! manifest-scoped rebuild.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -19,8 +20,8 @@ use crate::core::error::{CrabError, Result};
 use crate::metadata::metadb::db::Db;
 use crate::metadata::metadb::transaction::{DbTarget, Transaction};
 use crab_metadata::key_codec::{
-    PREFIX_CONTENT, decode_committed_file_key, decode_content_key, encode_committed_content_prefix,
-    encode_committed_file_key, encode_content_key,
+    PREFIX_COMMITTED, PREFIX_CONTENT, decode_committed_file_key, decode_content_key,
+    encode_committed_content_prefix, encode_committed_file_key, encode_content_key,
 };
 use crab_metadata::value_codec::{
     CommittedFileRecord, decode_committed_file_record, encode_committed_file_record,
@@ -225,6 +226,51 @@ impl FileIndexStore {
             txn.delete(DbTarget::FileIndex, key.clone());
         }
     }
+
+    /// Remove generation-pinned rows whose file hash is outside the retained
+    /// shard closure. The caller must hold the repository maintenance lease.
+    pub(crate) async fn gc_unreferenced_committed(
+        &self,
+        referenced: &HashSet<MerkleHash>,
+        dry_run: bool,
+        batch_size: usize,
+    ) -> Result<u64> {
+        let mut rows = self.db.scan_prefix(&[PREFIX_COMMITTED]).await?;
+        let mut batch = slatedb::WriteBatch::new();
+        let mut pending = 0usize;
+        let mut removed = 0u64;
+
+        while let Some(row) = rows.next().await.map_err(|source| {
+            CrabError::from(crate::core::error::MetaDbError::Read {
+                db: DB_LABEL.to_owned(),
+                prefix: String::from("<committed-file-gc>"),
+                source,
+            })
+        })? {
+            let (file_hash, _) = decode_committed_file_key(&row.key)
+                .map_err(|error| super::map_value_codec_error(error, DB_LABEL, &row.key))?;
+            if referenced.contains(&file_hash) {
+                continue;
+            }
+
+            removed += 1;
+            if dry_run {
+                continue;
+            }
+            batch.delete(row.key.as_ref());
+            pending += 1;
+            if pending >= batch_size.max(1) {
+                self.db.write(batch).await?;
+                batch = slatedb::WriteBatch::new();
+                pending = 0;
+            }
+        }
+
+        if pending > 0 {
+            self.db.write(batch).await?;
+        }
+        Ok(removed)
+    }
 }
 
 /// Decode a raw SlateDB value as a 32-byte shard hash.
@@ -418,6 +464,57 @@ mod tests {
             "delete must remove the entry"
         );
 
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn file_index_gc_tombstones_only_unreferenced_committed_rows() {
+        let db = open_store().await;
+        let store = FileIndexStore::new(Arc::clone(&db));
+        let retained = hash_from_seed(10);
+        let stale = hash_from_seed(20);
+        let entries = [
+            (
+                retained,
+                CommittedFileRecord {
+                    recipe_hash: [1; 32],
+                    shard_hash: hash_from_seed(100),
+                    committed_generation: 1,
+                    shard_index_hash: hash_from_seed(200),
+                },
+            ),
+            (
+                stale,
+                CommittedFileRecord {
+                    recipe_hash: [2; 32],
+                    shard_hash: hash_from_seed(101),
+                    committed_generation: 1,
+                    shard_index_hash: hash_from_seed(201),
+                },
+            ),
+            (
+                stale,
+                CommittedFileRecord {
+                    recipe_hash: [3; 32],
+                    shard_hash: hash_from_seed(102),
+                    committed_generation: 2,
+                    shard_index_hash: hash_from_seed(202),
+                },
+            ),
+        ];
+        let mut txn = Transaction::new();
+        store.save_committed_batch(&mut txn, &entries);
+        let (batch, _) = crate::metadata::metadb::transaction::into_per_db_batches(txn);
+        db.write(batch).await.expect("seed committed rows");
+
+        let removed = store
+            .gc_unreferenced_committed(&HashSet::from([retained]), false, 1)
+            .await
+            .expect("sweep stale rows");
+
+        assert_eq!(removed, 2);
+        assert!(store.get_committed_batch(&[retained]).await.unwrap()[0].is_some());
+        assert!(store.get_committed_batch(&[stale]).await.unwrap()[0].is_none());
         db.close().await.expect("close");
     }
 

--- a/crab/src/storage/retry.rs
+++ b/crab/src/storage/retry.rs
@@ -71,6 +71,7 @@ pub fn retry_class(err: &CrabError) -> RetryClass {
         // deep inside the push pipeline still gets the backoff it
         // needs, while a hard auth failure surfaces fatally.
         CrabError::PushPartialOutcome { source, .. } => retry_class(source),
+        CrabError::GcPartialFailure { source, .. } => retry_class(source),
         CrabError::ManagedRepository { diagnostic } => {
             if matches!(
                 diagnostic,

--- a/crab/tests/schema_validate.rs
+++ b/crab/tests/schema_validate.rs
@@ -472,10 +472,13 @@ fn validate_gc() {
             packs_deleted: 2,
             xorbs_deleted: 5,
             shards_deleted: 1,
+            file_index_entries_deleted: 3,
             bytes_reclaimed: 50000,
             dry_run: false,
             cancelled: false,
             partial_enumeration: false,
+            delete_failures: 0,
+            reconciliation_failed: false,
         },
     );
 }


### PR DESCRIPTION
## Summary

- make repository GC return structured CRAB-E0322 partial-failure errors when deletes or reconciliation fail, while retaining exact successful-delete counts
- parallelize bucket reachability, global object listing, shard reads, repository file-index sweeps, and deletes with configured concurrency bounds
- tombstone committed file-index rows outside each repository retained current-and-history shard closure under maintenance leases
- extend GC JSON output/schema and operator docs with file-index and partial-failure fields

This is the GC follow-up to merged PR #22.

## Destructive isolated RustFS qualification

- installed the release CLI through make install
- pushed two real Crab repositories into one disposable bucket
- repo dry-run found one injected pack orphan; destructive repo GC deleted exactly that candidate with zero failures
- fresh repo clone matched the source commit and hydrated file hash; fsck passed
- repaired the bucket ref registry from two manifests and two shard roots
- bucket dry-run found one injected xorb and one injected shard; destructive bucket GC removed both while retained xorb and shard HEAD checks passed
- fresh clones of both repositories matched source commits and hydrated file hashes; both fsck runs passed
- repeated destructive bucket GC deleted zero xorbs, shards, or file-index rows
- deleted the unique bucket, stopped RustFS, and moved the isolated local fixture to Trash

## Verification

- cargo check -p crab --locked
- 77 cmd::gc tests passed
- file-index tombstone owner test passed
- GC schema validation and schema drift tests passed
- cargo fmt --all -- --check
- git diff --check
- npm run check:links: 190 pages and 1,960 fragments
- make install with the external per-worktree Cargo target

Strict broad Clippy is blocked by the pre-existing manual_is_multiple_of warning in crates/crab-remote-git/src/snapshot.rs:1226; no unrelated source was changed.