### PR TITLE
feat(storage)!: shard global content for parallel GC

### DIFF
--- a/crab-web/content/docs/cli/cache-service/architecture.mdx
+++ b/crab-web/content/docs/cli/cache-service/architecture.mdx
@@ -29,8 +29,8 @@ Before uploading new chunks, Crab can also ask the cache service which chunks ar
 
 | Object key pattern | Cached |
 |--------------------|--------|
-| `.crab/xorbs/{hash}` | Yes |
-| `.crab/shards/{hash}` | Yes |
+| `.crab/xorbs/{first-two-hex}/{hash}` | Yes |
+| `.crab/shards/{first-two-hex}/{hash}` | Yes |
 | `{repo}/packs/pack-{id}.pack` | Yes |
 | `{repo}/packs/pack-{id}.idx` | Yes |
 | `{repo}/file_index_db/compacted/*.sst` | Yes |

--- a/crab-web/content/docs/cli/reference/crab-configure.mdx
+++ b/crab-web/content/docs/cli/reference/crab-configure.mdx
@@ -55,6 +55,16 @@ Provider-prefixed URLs let Crab infer the provider, so `--provider` is optional
 in those examples. Use it with a canonical `crab://` URL when the provider is
 not S3.
 
+Choose the local bucket-GC listing policy during setup when desired:
+
+```bash
+crab configure s3://team-data/models --gc-list-profile adaptive
+```
+
+The default `adaptive` profile minimizes LIST streams for smaller namespaces
+and switches larger namespaces to hash-partition parallelism. `cost` always
+prefers fewer LIST streams; `latency` immediately prefers partition scans.
+
 ## Tracking options
 
 Pass explicit patterns instead of relying only on the repository scan:

--- a/crab-web/content/docs/cli/reference/crab-gc.mdx
+++ b/crab-web/content/docs/cli/reference/crab-gc.mdx
@@ -32,7 +32,11 @@ can run concurrently with history pruning or history restoration.
 
 Bucket GC reads current and retained historical shard roots for registered
 repositories in parallel, downloads referenced shards with bounded concurrency,
-and lists the complete global shard and xorb namespaces concurrently. It also
+and adaptively lists the complete global shard and xorb namespaces. Small
+namespaces use one recursive stream per kind; larger namespaces switch to
+concurrent populated hash partitions after a bounded provider-aware probe. The
+crossover waits until recursive pagination reaches the cost of the complete
+256-way fan-out, bounding restart overhead to about 2x at the threshold. It also
 tombstones generation-pinned `file_index_db` rows that are outside each
 repository's retained shard closure.
 
@@ -50,6 +54,7 @@ For conceptual background, see [Garbage Collection](/docs/cli/storage/garbage-co
 | `--dry-run` | `false` | Show what would be deleted without removing |
 | `--scope` | `repo` | Collect repository objects, or use `bucket` for global deduplicated objects |
 | `--bucket` | — | Physical bucket name required by bucket scope and registry maintenance |
+| `--list-profile` | configured value | Override bucket listing with `adaptive`, `cost`, or `latency` |
 | `--grace-period` | `1h` | Don't delete objects newer than this |
 | `--force` | `false` | Bypass age checks without bypassing registry or coordinator safety proof |
 | `--yes` | `false` | Skip repository force-mode confirmation |

--- a/crab-web/content/docs/cli/reference/crab-init.mdx
+++ b/crab-web/content/docs/cli/reference/crab-init.mdx
@@ -39,6 +39,7 @@ For conceptual background, see [Creating a Repository](/docs/cli/getting-started
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--storage-provider <PROVIDER>` | `auto` | Storage backend: `s3`, `gcs`, `azure`, or `auto` |
+| `--gc-list-profile <PROFILE>` | `adaptive` | Local bucket-GC policy: `adaptive`, `cost`, or `latency` |
 | `--mirror <REMOTE>` | — | Configure mirror mode using an existing Git remote |
 | `--json` | `false` | Emit structured JSON output |
 | `--jsonl` | `false` | Emit streaming JSONL output |
@@ -81,6 +82,17 @@ crab init crab://bucket/repo
 crab setup --no-auto-track
 # Install the filter driver without scanning for patterns
 ```
+
+### Choose bucket-GC cost or latency policy
+
+```bash
+crab init --gc-list-profile adaptive crab://bucket/repo
+```
+
+`adaptive` keeps small listings on one low-cost stream and switches large
+namespaces to concurrent hash partitions. `cost` always minimizes LIST
+streams; `latency` immediately uses partition parallelism. The setting is
+local operational policy and does not change shared object keys.
 
 ### Re-apply a committed project configuration
 

--- a/crab/docs/architecture/cache-service-implementation.md
+++ b/crab/docs/architecture/cache-service-implementation.md
@@ -81,7 +81,7 @@ The response partitions the request by input index:
 ```
 
 `xorb_hash` uses the canonical `MerkleHash::hex()` form used by
-`.crab/xorbs/{hash}` object paths. `chunk_index` is the chunk's ordinal
+`.crab/xorbs/{first-two-hex}/{hash}` object paths. `chunk_index` is the chunk's ordinal
 position inside the xorb metadata, not a byte offset. The service only returns
 a chunk in `known` after the referenced xorb is present in the local cache, the
 cached xorb parses with the expected aggregate xorb hash, and the referenced

--- a/crab/docs/architecture/caching-architecture.md
+++ b/crab/docs/architecture/caching-architecture.md
@@ -224,7 +224,7 @@ enforces `dedup.scope`. `all` accepts any repo, `bucket-prefix:<prefix>` accepts
 that prefix and nested repos, and `repos:<repo1>,<repo2>` accepts the listed
 repo prefixes. Known responses include `xorb_hash`, `chunk_index`, `length`,
 and `cache_verified: true`; `xorb_hash` is the canonical hash used in
-`.crab/xorbs/{hash}` paths, and `chunk_index` is the chunk's ordinal position
+`.crab/xorbs/{first-two-hex}/{hash}` paths, and `chunk_index` is the chunk's ordinal position
 in xorb metadata, not a byte offset. The service returns indexed chunks as
 unknown unless the referenced xorb is locally cached and verifies against the
 requested chunk. The CLI treats `cache_verified: true` as cache-local proof,

--- a/crab/docs/architecture/coordination-consistency.md
+++ b/crab/docs/architecture/coordination-consistency.md
@@ -33,7 +33,7 @@ Push locks serialize concurrent pushes with overlapping destination refs. They
 are short-TTL leases stored in the configured object store:
 
 The key grammar and shipped-client transition are normative in
-[Object Storage Layout V1](object-storage-layout.md#lock-namespaces).
+[Object Storage Layout V2](object-storage-layout.md#lock-namespaces).
 
 ```
 Path:    {repo_prefix}/locks/{full_ref}/lock

--- a/crab/docs/architecture/metadata-subsystem.md
+++ b/crab/docs/architecture/metadata-subsystem.md
@@ -42,7 +42,7 @@ has two `Db` handles per session.
 
 ## Storage Layout
 
-See [Object Storage Layout V1](object-storage-layout.md) for the normative
+See [Object Storage Layout V2](object-storage-layout.md) for the normative
 scope, key grammar, ownership, and cross-language interpretation. The tree
 below focuses on the two metadata databases.
 
@@ -298,7 +298,7 @@ would force the remote open eagerly.
 
 ## Shard Enumeration
 
-`.crab/shards/{hash}` objects remain immutable reconstruction
+`.crab/shards/{first-two-hex}/{hash}` objects remain immutable reconstruction
 recipes exactly as before. What changed is that the shards themselves
 are the authoritative source of truth for "what shards exist" — there
 is no shard-registry SlateDB.

--- a/crab/docs/architecture/object-storage-layout.md
+++ b/crab/docs/architecture/object-storage-layout.md
@@ -1,4 +1,4 @@
-# Object Storage Layout V1
+# Object Storage Layout V2
 
 This document is the normative, provider-neutral contract for Crab object
 keys. It covers the core bucket-global and repository-local namespaces used by
@@ -32,8 +32,8 @@ global_prefix = org/models/acl-views/v1/<scope>/<version>/.crab
 ```
 
 The bucket or container name is not part of either prefix. Given bucket
-`team-data` and key `.crab/xorbs/abc`, provider adapters address the same key
-as `s3://team-data/.crab/xorbs/abc`, `gs://team-data/.crab/xorbs/abc`, or the
+`team-data` and key `.crab/xorbs/ab/{hash}`, provider adapters address the same key
+as `s3://team-data/.crab/xorbs/ab/{hash}`, `gs://team-data/.crab/xorbs/ab/{hash}`, or the
 equivalent Azure container object.
 
 ## Key grammar
@@ -70,12 +70,14 @@ Paths are relative to `global_prefix`.
 
 | Relative key | Owner and responsibility | Mutability |
 | --- | --- | --- |
-| `xorbs/{blake3}` | `crab-xet`: encoded chunk aggregates shared in the scope | Immutable, idempotent create |
-| `shards/{blake3}` | `crab-xet`: reconstruction metadata shared in the scope | Immutable, idempotent create |
+| `xorbs/{first-two-hex}/{blake3}` | `crab-xet`: encoded chunk aggregates shared in the scope | Immutable, idempotent create |
+| `shards/{first-two-hex}/{blake3}` | `crab-xet`: reconstruction metadata shared in the scope | Immutable, idempotent create |
 | `chunk_index_db/` | `crab-metadata`: scope-wide chunk-to-xorb SlateDB | Opaque; SlateDB owns children |
 | `ref-registry` | `crab-metadata`: repository reachability and GC roots | Mutable JSON, CAS |
 
-Xorbs and shards have no hash fan-out and no filename extension. Code outside
+Xorbs and shards use the first two lowercase hash characters as one fan-out
+segment and have no filename extension. This gives GC 256 independent,
+discoverable partitions without provider-specific range semantics. Code outside
 the metadata owner MUST NOT construct SlateDB child keys under
 `chunk_index_db/`.
 
@@ -84,13 +86,21 @@ For direct repositories, the physical tree is:
 ```text
 s3://{bucket}/
 ├── .crab/
-│   ├── xorbs/{blake3}
-│   ├── shards/{blake3}
+│   ├── xorbs/{first-two-hex}/{blake3}
+│   ├── shards/{first-two-hex}/{blake3}
 │   ├── chunk_index_db/...
 │   └── ref-registry
 ├── {repo-a}/...
 └── {repo-b}/...
 ```
+
+### V2 hard cutover
+
+V2 readers and writers accept only the fan-out xorb and shard keys above.
+Flat V1 keys such as `.crab/xorbs/{hash}` and `.crab/shards/{hash}` are not
+read, rewritten, or collected. Operators must stop V1 writers and re-upload
+repositories with a V2 client; there is no dual-read or in-place migration
+path.
 
 ## Repository-local core
 
@@ -185,14 +195,14 @@ Implementations in every language must produce these exact UTF-8 strings:
 | Input | Result |
 | --- | --- |
 | `repo_prefix=org/models`, manifest | `org/models/manifest` |
-| `global_prefix=.crab`, xorb hash `a` × 64 | `.crab/xorbs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` |
-| `global_prefix=.crab`, shard hash `b` × 64 | `.crab/shards/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb` |
+| `global_prefix=.crab`, xorb hash `a` × 64 | `.crab/xorbs/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` |
+| `global_prefix=.crab`, shard hash `b` × 64 | `.crab/shards/bb/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb` |
 | `repo_prefix=org/models`, ref `refs/heads/main` | `org/models/locks/refs/heads/main/lock` |
 | `repo_prefix=org/models`, internal `git-object-locator` | `org/models/locks/internal/git-object-locator/lock` |
 | `repo_prefix=org/models`, pack ID `b` × 64 | `org/models/packs/pack-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.pack` |
 | LFS SHA-256 beginning `a1b2` | `org/models/lfs/objects/a1/b2/{full-sha256}` |
 | scoped `repo_prefix=org/models/acl-views/v1/scope/7-deadbeef`, manifest | `org/models/acl-views/v1/scope/7-deadbeef/manifest` |
-| scoped `global_prefix=org/models/acl-views/v1/scope/7-deadbeef/.crab`, xorb hash `a` × 64 | `org/models/acl-views/v1/scope/7-deadbeef/.crab/xorbs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` |
+| scoped `global_prefix=org/models/acl-views/v1/scope/7-deadbeef/.crab`, xorb hash `a` × 64 | `org/models/acl-views/v1/scope/7-deadbeef/.crab/xorbs/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` |
 
 For any other scoped placement, replace only the applicable root. Relative
 keys do not change.

--- a/crab/docs/architecture/object-storage-layout.md
+++ b/crab/docs/architecture/object-storage-layout.md
@@ -77,9 +77,13 @@ Paths are relative to `global_prefix`.
 
 Xorbs and shards use the first two lowercase hash characters as one fan-out
 segment and have no filename extension. This gives GC 256 independent,
-discoverable partitions without provider-specific range semantics. Code outside
-the metadata owner MUST NOT construct SlateDB child keys under
-`chunk_index_db/`.
+discoverable partitions without provider-specific range semantics. Bucket GC
+MAY recursively scan the kind prefix as one low-cost stream or scan populated
+hash partitions concurrently. The adaptive policy starts with the recursive
+stream and switches to partition scans only after a provider-aware bounded
+probe shows that serial pagination is more expensive. Listing policy never
+changes object keys. Code outside the metadata owner MUST NOT construct
+SlateDB child keys under `chunk_index_db/`.
 
 For direct repositories, the physical tree is:
 

--- a/crab/docs/architecture/storage-layer.md
+++ b/crab/docs/architecture/storage-layer.md
@@ -31,7 +31,7 @@ The `Store` is created once per CLI invocation from the parsed
 ## Remote Bucket Layout
 
 The normative object-key contract, including cross-language construction
-rules, is [Object Storage Layout V1](object-storage-layout.md). This page
+rules, is [Object Storage Layout V2](object-storage-layout.md). This page
 describes storage mechanics and does not redefine that contract.
 
 ```

--- a/crab/docs/design/cache.md
+++ b/crab/docs/design/cache.md
@@ -249,8 +249,8 @@ For mutable paths (`/refs/`, `/manifests/`, `/HEAD`): direct to origin S3.
 
 `path_to_cache_key()` maps immutable S3 paths to `CacheKey` variants:
 
-- `.crab/shards/{hash}` → `CacheKey::Shard(hash)`
-- `.crab/xorbs/{hash}` → `CacheKey::Xorb(hash)`
+- `.crab/shards/{first-two-hex}/{hash}` → `CacheKey::Shard(hash)`
+- `.crab/xorbs/{first-two-hex}/{hash}` → `CacheKey::Xorb(hash)`
 - Repo packs and MetaDB objects may use the remote cache service, but they do
   not map to the global `LocalCache`.
 

--- a/crab/docs/design/overview.md
+++ b/crab/docs/design/overview.md
@@ -374,7 +374,7 @@ to missing data).
 - Push locks (short-TTL leases in S3) serialize concurrent pushes with
   overlapping destination refs. A full ref maps to `locks/{full_ref}/lock`, so
   `refs/heads/main` maps to `locks/refs/heads/main/lock`. See
-  [Object Storage Layout V1](../architecture/object-storage-layout.md#lock-namespaces)
+  [Object Storage Layout V2](../architecture/object-storage-layout.md#lock-namespaces)
   for the normative key and hard-cutover rules.
 - Manifest updates (pack-list, shard-list) use compare-and-swap (CAS) loops:
   read current value + ETag → mutate → conditional PUT with `If-Match`. On

--- a/crab/docs/design/push.md
+++ b/crab/docs/design/push.md
@@ -697,7 +697,7 @@ Reconstruction Terms:
 ```
 For each shard (from step 8)
     ↓ parallel, bounded by upload_concurrency
-{prefix}/.crab/shards/{shard_hash}
+{prefix}/.crab/shards/{first-two-hex}/{shard_hash}
     ↓
 MetaDB transaction:
     file_index_db: file_hash → shard_hash
@@ -923,7 +923,7 @@ non-current-branch pushes are not rewritten.
  │                                     ▼                             │
  │                               ┌──────────┐   ┌──────────────────┐ │
  │                               │ Step 8   │──►│ Step 9           │ │
- │                               │ Build    │   │ Upload shards    │─┼──► .crab/shards/{hash}
+ │                               │ Build    │   │ Upload shards    │─┼──► .crab/shards/{first-two-hex}/{hash}
  │                               │ shard    │   │ + MetaDB commit  │─┼──► file_index_db/
  │                               └──────────┘   └──────────────────┘ │
  │                                                                   │
@@ -1037,7 +1037,7 @@ Step 12 ◄── specs[] (from remote helper batch)
                     │     split at 100 MiB soft cap        │
                     │                                      │
                     │  9. Upload shards + MetaDB:          │
-                    │     PUT .crab/shards/{hash}          │──► .crab/shards/
+                    │ PUT .crab/shards/{first-two-hex}/{hash} │──► .crab/shards/
                     │     commit file_index_db             │──► file_index_db/
                     │     commit chunk_index_db            │──► .crab/chunk_index_db/
                     │     (bounded parallel shard upload)  │
@@ -1097,7 +1097,7 @@ Step 12 ◄── specs[] (from remote helper batch)
 ### Push Lock Protocol
 
 Push locks prevent concurrent pushers from racing on overlapping destination
-refs. [Object Storage Layout V1](../architecture/object-storage-layout.md#lock-namespaces)
+refs. [Object Storage Layout V2](../architecture/object-storage-layout.md#lock-namespaces)
 defines the normative key and hard-cutover protocol. Each lock is a short-TTL
 lease stored as a JSON object in the configured object store:
 

--- a/crab/docs/guides/gc.md
+++ b/crab/docs/guides/gc.md
@@ -25,12 +25,23 @@ Garbage collection operates on the remote store, not the local cache. Use
 | `--dry-run` | `false` | List unreachable objects without deleting anything |
 | `--force` | `false` | Bypass the grace period — delete all unreachable objects immediately |
 | `--yes` | `false` | Skip interactive confirmation when `--force` is used |
+| `--list-profile <profile>` | configured value | Override bucket listing with `adaptive`, `cost`, or `latency` |
 
 Bucket administrators can rebuild the shared GC root registry with
 `crab gc --repair-registry --bucket <bucket>`. The repair enumerates repository
 manifests, validates each current shard index, CAS-replaces the discovered
 entries, and only then marks bucket coverage complete. Destructive bucket GC
 fails closed while the registry schema or coverage marker is incomplete.
+
+Bucket-global xorb and shard listing defaults to `adaptive`. Small namespaces
+complete through one recursive stream per kind. Large namespaces cross a
+bounded provider-aware probe threshold and restart as concurrent scans of only
+the populated two-hex hash partitions. The crossover waits until recursive
+pagination costs as many calls as the complete 256-way fan-out, bounding the
+restart overhead to about 2x at the threshold. Use `cost` to minimize LIST
+calls or `latency` to prefer parallel wall time. The logged `list_requests`
+value counts logical streams; provider pagination and retries can issue
+additional API requests.
 
 ## How It Works
 

--- a/crab/docs/guides/init.md
+++ b/crab/docs/guides/init.md
@@ -32,6 +32,7 @@ the matching `.gitattributes` rules.
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--storage-provider <provider>` | `auto` | Storage backend: `s3`, `gcs`, `azure`, or `auto` |
+| `--gc-list-profile <profile>` | `adaptive` | Local bucket-GC policy: `adaptive`, `cost`, or `latency` |
 | `--mirror <remote>` | — | Configure mirror mode with an existing Git remote |
 | `--log-level` | — | Set log verbosity |
 
@@ -68,6 +69,20 @@ crab init --storage-provider s3    crab://my-s3-bucket/my-repo
 crab init --storage-provider gcs   crab://my-gcs-bucket/my-repo
 crab init --storage-provider azure crab://my-container/my-repo
 ```
+
+Bucket administrators can also choose the local GC listing policy during
+initial setup:
+
+```bash
+crab init --gc-list-profile adaptive crab://my-bucket/my-repo
+```
+
+`adaptive` uses one low-cost recursive stream for smaller namespaces and
+switches to parallel hash partitions after a bounded provider-aware probe.
+`cost` always minimizes LIST streams. `latency` immediately scans populated
+partitions concurrently. This preference is stored only in
+`.crab/config.toml`; it does not alter the bucket-global object layout and can
+safely differ between operators.
 
 For Azure, the URL host is the Blob container; the storage account comes from
 Azure credentials, user config, or environment variables.

--- a/crab/docs/internal/public-web-archive/architecture/metadata-subsystem.mdx
+++ b/crab/docs/internal/public-web-archive/architecture/metadata-subsystem.mdx
@@ -288,7 +288,7 @@ would force the remote open eagerly.
 
 ## Shard Enumeration
 
-`.crab/shards/{hash}` objects remain immutable reconstruction
+`.crab/shards/{first-two-hex}/{hash}` objects remain immutable reconstruction
 recipes exactly as before. What changed is that the shards themselves
 are the authoritative source of truth for "what shards exist" — there
 is no shard-registry SlateDB.

--- a/crab/docs/internal/public-web-archive/cache-service/architecture.mdx
+++ b/crab/docs/internal/public-web-archive/cache-service/architecture.mdx
@@ -72,7 +72,7 @@ flowchart TB
 A `crab clone`, `crab fetch`, or `crab hydrate` issues GETs for immutable objects. The path traversal is:
 
 1. **Local disk cache** (`~/.cache/crab`) — if present, return immediately.
-2. **Cache service** — `GET /v1/.crab/xorbs/{hash}` or another immutable object-store key.
+2. **Cache service** — `GET /v1/.crab/xorbs/{first-two-hex}/{hash}` or another immutable object-store key.
 3. **Origin object store** — only on cache miss or service unavailability.
 
 ```mermaid
@@ -127,8 +127,8 @@ If the cache service is unreachable, `CachingStore` logs a warning and falls bac
 A `crab push` does **not** route uploads through the cache service — that would add a hop to the upload critical path. Instead, the push pipeline warms the cache as a side effect of the upload it would have done anyway:
 
 1. **Step 4 — dedup query.** Before staging any chunks, push asks the cache `POST /v1/dedup/query` with up to 100,000 chunk hashes. The cache responds with `known` chunks (already deduped, with their xorb location) and `unknown` chunks. Known chunks are skipped entirely — no upload, no storage cost.
-2. **Shard warming.** After newly generated shards are uploaded to origin, they are `PUT` into the cache at `.crab/shards/{hash}`. This triggers `ChunkIndex::ingest_shard`, which adds the shard's chunk locations to the dedup index. Future pushes from any teammate can see those chunks as `known`.
-3. **Xorb warming.** After the xorb upload to origin succeeds, every uploaded xorb is `PUT` into the cache at `.crab/xorbs/{hash}` via `warm_remote_only`. Now a clone or hydrate can read the xorb from the cache instead of taking the cold origin path.
+2. **Shard warming.** After newly generated shards are uploaded to origin, they are `PUT` into the cache at `.crab/shards/{first-two-hex}/{hash}`. This triggers `ChunkIndex::ingest_shard`, which adds the shard's chunk locations to the dedup index. Future pushes from any teammate can see those chunks as `known`.
+3. **Xorb warming.** After the xorb upload to origin succeeds, every uploaded xorb is `PUT` into the cache at `.crab/xorbs/{first-two-hex}/{hash}` via `warm_remote_only`. Now a clone or hydrate can read the xorb from the cache instead of taking the cold origin path.
 
 Warming is best-effort: a failure in any of these steps logs a warning and proceeds. A push never blocks on the cache service.
 

--- a/crab/src/cmd/add_push_plan.rs
+++ b/crab/src/cmd/add_push_plan.rs
@@ -297,7 +297,8 @@ mod tests {
             uncompressed_size: xorb_ref.uncompressed_size,
             origin: OriginReceipt::new(
                 "canonical-origin".to_owned(),
-                format!(".crab/xorbs/{}", xorb_ref.xorb_hash.hex()),
+                crab_storage::canonical_global_content_path("xorbs", &xorb_ref.xorb_hash.hex())
+                    .to_string(),
                 xorb_ref.xorb_hash.into(),
                 [9; 32],
                 1024,

--- a/crab/src/cmd/compact.rs
+++ b/crab/src/cmd/compact.rs
@@ -2,7 +2,7 @@
 //!
 //! Downloads all shards referenced by a repo's shard-list, merges them
 //! using xet-core's `merge_shards()`, uploads the compacted shards to
-//! `.crab/shards/{new_hash}`, and CAS-updates the shard-list and
+//! `.crab/shards/{first-two-hex}/{new_hash}`, and CAS-updates the shard-list and
 //! ref-registry. Source shards are left for GC.
 //!
 //! When shards contain xorb-info entries from other repos (cross-repo
@@ -22,6 +22,7 @@ use crate::core::error::{CrabError, Result};
 use crate::storage::store::Store;
 use crab_metadata::manifests::ShardList;
 use crab_metadata::ref_registry::RefRegistry;
+use crab_storage::canonical_global_content_path;
 use crab_xet::hash::{MerkleHash, compute_data_hash};
 use crab_xet::shard::{
     MDBMinimalShard, MDBShardFile, merge_shards, new_shard_file_cache, shard_set_union,
@@ -190,11 +191,11 @@ pub async fn run_compact(args: &CompactArgs, store: &Store) -> Result<CompactOut
     .await
     .map_err(|e| CrabError::Internal(format!("filter_unreferenced_xorbs join error: {e}")))??;
 
-    // Step 4: Upload merged shards to `.crab/shards/{new_hash}`.
+    // Step 4: Upload merged shards to the canonical global shard namespace.
     let mut new_hashes: Vec<String> = Vec::with_capacity(filtered.len());
     for shard_file in &filtered {
         let hash_hex = shard_file.shard_hash.hex();
-        let shard_path = ObjectPath::from(format!("{GLOBAL_PREFIX}/shards/{hash_hex}"));
+        let shard_path = canonical_global_content_path("shards", &hash_hex);
 
         let mut buf = Vec::new();
         shard_file
@@ -205,7 +206,7 @@ pub async fn run_compact(args: &CompactArgs, store: &Store) -> Result<CompactOut
         let computed = compute_data_hash(&buf);
         if computed != shard_file.shard_hash {
             return Err(CrabError::CorruptObject {
-                path: format!("{GLOBAL_PREFIX}/shards/{hash_hex}"),
+                path: shard_path.to_string(),
                 reason: format!(
                     "hash mismatch: expected {}, computed {}",
                     hash_hex,
@@ -291,7 +292,7 @@ async fn download_shards(
 ) -> Result<()> {
     let shard_file_cache = new_shard_file_cache();
     for hash_hex in shard_hashes {
-        let shard_path = ObjectPath::from(format!("{GLOBAL_PREFIX}/shards/{hash_hex}"));
+        let shard_path = canonical_global_content_path("shards", hash_hex);
 
         let data = match store.get_with_etag(&shard_path).await {
             Ok((body, _)) => body,

--- a/crab/src/cmd/configure.rs
+++ b/crab/src/cmd/configure.rs
@@ -7,7 +7,7 @@ use console::Term;
 use tokio_util::sync::CancellationToken;
 
 use crate::cmd::setup::SetupArgs;
-use crate::core::config::StorageProvider;
+use crate::core::config::{GcListProfile, StorageProvider};
 use crate::core::error::{CrabError, Result};
 use crate::core::output::OutputMode;
 use crate::core::project_config::ProjectConfig;
@@ -17,6 +17,7 @@ use crate::core::style::CliStyle;
 pub struct ConfigureArgs {
     pub remote: Option<String>,
     pub storage_provider: Option<StorageProvider>,
+    pub gc_list_profile: Option<GcListProfile>,
     pub track: Vec<String>,
     pub no_auto_track: bool,
     pub dry_run: bool,
@@ -25,6 +26,7 @@ pub struct ConfigureArgs {
 struct ConfigurePlan {
     remote: String,
     storage_provider: Option<StorageProvider>,
+    gc_list_profile: Option<GcListProfile>,
 }
 
 /// Configure cloud storage, Git integration, and large-file tracking.
@@ -55,6 +57,13 @@ pub async fn run_configure_at(
             "  Large files  {}",
             tracking_summary(&args.track, args.no_auto_track)
         );
+        eprintln!(
+            "  GC listing   {}",
+            plan.gc_list_profile.map_or(
+                "adaptive (preserves an existing choice)",
+                GcListProfile::as_str
+            )
+        );
         eprintln!("\nRun again without --dry-run to apply this plan.");
         return Ok(());
     }
@@ -62,14 +71,27 @@ pub async fn run_configure_at(
     eprintln!("{}", style.bold("Configure Crab"));
     eprintln!("  Remote   {}", plan.remote);
     eprintln!(
-        "  Provider {}\n",
+        "  Provider {}",
         plan.storage_provider
             .as_ref()
             .map_or("infer from remote", StorageProvider::label)
     );
+    eprintln!(
+        "  GC listing {}\n",
+        plan.gc_list_profile.map_or(
+            "adaptive (preserves an existing choice)",
+            GcListProfile::as_str
+        )
+    );
 
-    crate::cmd::init::run_init_for_configure(&plan.remote, root, cancel, plan.storage_provider)
-        .await?;
+    crate::cmd::init::run_init_for_configure(
+        &plan.remote,
+        root,
+        cancel,
+        plan.storage_provider,
+        plan.gc_list_profile,
+    )
+    .await?;
 
     crate::cmd::setup::run_setup_at(
         root,
@@ -91,7 +113,11 @@ pub async fn run_configure_at(
 
 fn resolve_plan(root: &Path, args: &ConfigureArgs) -> Result<ConfigurePlan> {
     if let Some(remote) = args.remote.as_ref() {
-        return configure_plan(remote.clone(), args.storage_provider.clone());
+        return configure_plan(
+            remote.clone(),
+            args.storage_provider.clone(),
+            args.gc_list_profile,
+        );
     }
 
     if let Some(config) = ProjectConfig::discover(root) {
@@ -101,7 +127,7 @@ fn resolve_plan(root: &Path, args: &ConfigureArgs) -> Result<ConfigurePlan> {
                 .as_ref()
                 .and_then(|auth| auth.storage_provider.clone())
         });
-        return configure_plan(config.remote.url, storage_provider);
+        return configure_plan(config.remote.url, storage_provider, args.gc_list_profile);
     }
 
     if !std::io::stdin().is_terminal() {
@@ -121,12 +147,14 @@ fn resolve_plan(root: &Path, args: &ConfigureArgs) -> Result<ConfigurePlan> {
     Ok(ConfigurePlan {
         remote,
         storage_provider: Some(provider),
+        gc_list_profile: args.gc_list_profile,
     })
 }
 
 fn configure_plan(
     remote: String,
     storage_provider: Option<StorageProvider>,
+    gc_list_profile: Option<GcListProfile>,
 ) -> Result<ConfigurePlan> {
     if !crate::cmd::init::is_valid_init_url(&remote) {
         return Err(CrabError::Configuration {
@@ -137,6 +165,7 @@ fn configure_plan(
     Ok(ConfigurePlan {
         remote,
         storage_provider,
+        gc_list_profile,
     })
 }
 
@@ -270,7 +299,7 @@ mod tests {
 
     #[test]
     fn explicit_plan_rejects_invalid_remote() {
-        let result = configure_plan("team/models".to_owned(), Some(StorageProvider::S3));
+        let result = configure_plan("team/models".to_owned(), Some(StorageProvider::S3), None);
         assert!(matches!(result, Err(CrabError::Configuration { .. })));
     }
 
@@ -280,6 +309,7 @@ mod tests {
         let args = ConfigureArgs {
             remote: Some("s3://team-data/models".to_owned()),
             storage_provider: Some(StorageProvider::S3),
+            gc_list_profile: None,
             track: vec!["*.safetensors".to_owned()],
             no_auto_track: false,
             dry_run: true,

--- a/crab/src/cmd/doctor.rs
+++ b/crab/src/cmd/doctor.rs
@@ -1712,7 +1712,7 @@ async fn check_cache_service(root: &Path, active_probe: bool) -> Vec<CheckResult
     }
 
     let probe_url = format!(
-        "{base_url}/v1/.crab/xorbs/0000000000000000000000000000000000000000000000000000000000000000"
+        "{base_url}/v1/.crab/xorbs/00/0000000000000000000000000000000000000000000000000000000000000000"
     );
     let req = apply_cache_service_auth(client.get(&probe_url), &config.cache.service_auth);
     results.push(match req.send().await {

--- a/crab/src/cmd/gc/bucket.rs
+++ b/crab/src/cmd/gc/bucket.rs
@@ -27,11 +27,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::coordination::cas::cas_update_default;
+use crate::core::config::GcListProfile;
 use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::storage::store::Store;
 use crab_metadata::ref_registry::RefRegistry;
 use crab_storage::{
-    StoreLayout, canonical_global_content_path, content_hash_from_path,
+    StorageProviderKind, StoreLayout, canonical_global_content_path, content_hash_from_path,
     global_content_partition_prefix, global_content_prefix,
 };
 use crab_xet::hash::MerkleHash;
@@ -50,6 +51,8 @@ pub struct BucketGcArgs {
     pub force: bool,
     /// Maximum concurrent LIST, history, and metadata-read operations.
     pub list_concurrency: usize,
+    /// Cost/latency policy for bucket-global object enumeration.
+    pub list_profile: GcListProfile,
     /// Maximum concurrent object DELETE requests.
     pub delete_concurrency: usize,
 }
@@ -186,14 +189,18 @@ async fn run_bucket_gc_under_maintenance(
         list_global_objects(
             store,
             "shards",
+            args.list_profile,
             args.list_concurrency,
             Arc::clone(&global_list_permits),
+            cancel,
         ),
         list_global_objects(
             store,
             "xorbs",
+            args.list_profile,
             args.list_concurrency,
             Arc::clone(&global_list_permits),
+            cancel,
         ),
     )?;
     outcome.list_requests = shard_listing.requests + xorb_listing.requests;
@@ -201,6 +208,13 @@ async fn run_bucket_gc_under_maintenance(
         .list_concurrency
         .max(1)
         .min(shard_listing.parallelism + xorb_listing.parallelism);
+    debug!(
+        profile = args.list_profile.as_str(),
+        shard_partitioned = shard_listing.partitioned,
+        xorb_partitioned = xorb_listing.partitioned,
+        logical_list_streams = outcome.list_requests,
+        "selected bucket-global listing strategy"
+    );
     let shard_objects = shard_listing.objects;
     let xorb_objects = xorb_listing.objects;
     let referenced_shards = repo_shards
@@ -495,27 +509,149 @@ fn partition_xorbs_for_gc(
 
 struct GlobalListOutcome {
     objects: Vec<ListedObject>,
+    /// Logical list streams. Provider pagination and retries are internal to
+    /// `object_store` and are not counted here.
     requests: u64,
     parallelism: usize,
+    partitioned: bool,
+}
+
+// object_store leaves max-keys unset, so each provider applies these service
+// page capacities. Probe by object count because object_store hides pages.
+const S3_GCS_LIST_PAGE_OBJECTS: usize = 1_000;
+const AZURE_LIST_PAGE_OBJECTS: usize = 5_000;
+const GLOBAL_HASH_PARTITIONS: usize = 256;
+
+fn adaptive_probe_limit(store: &Store) -> usize {
+    let page_objects = match store.bucket_identity().cloud {
+        StorageProviderKind::Azure => AZURE_LIST_PAGE_OBJECTS,
+        StorageProviderKind::S3 | StorageProviderKind::Gcs => S3_GCS_LIST_PAGE_OBJECTS,
+        StorageProviderKind::Local => return usize::MAX,
+    };
+    // Switch only once recursive pagination costs as many calls as the full
+    // fan-out. Replaying the bounded probe then caps crossover cost near 2x.
+    page_objects.saturating_mul(GLOBAL_HASH_PARTITIONS)
+}
+
+/// List a global namespace using the selected cost/latency policy.
+async fn list_global_objects(
+    store: &Store,
+    kind: &str,
+    profile: GcListProfile,
+    concurrency: usize,
+    permits: Arc<Semaphore>,
+    cancel: &CancellationToken,
+) -> Result<GlobalListOutcome> {
+    let prefix = global_content_prefix(GLOBAL_PREFIX, kind);
+    match profile {
+        GcListProfile::Cost => {
+            list_global_prefix(store, kind, &prefix, None, permits, cancel).await
+        }
+        GcListProfile::Latency => {
+            list_global_partitions(store, kind, concurrency, permits, cancel).await
+        }
+        GcListProfile::Adaptive if concurrency <= 1 => {
+            list_global_prefix(store, kind, &prefix, None, permits, cancel).await
+        }
+        GcListProfile::Adaptive => {
+            let probe_limit = adaptive_probe_limit(store);
+            let probe = list_global_prefix(
+                store,
+                kind,
+                &prefix,
+                Some(probe_limit),
+                Arc::clone(&permits),
+                cancel,
+            )
+            .await?;
+            if probe.objects.len() <= probe_limit {
+                return Ok(probe);
+            }
+
+            let probe_requests = probe.requests;
+            drop(probe);
+            let mut partitioned =
+                list_global_partitions(store, kind, concurrency, permits, cancel).await?;
+            partitioned.requests += probe_requests;
+            Ok(partitioned)
+        }
+    }
+}
+
+async fn list_global_prefix(
+    store: &Store,
+    kind: &str,
+    prefix: &ObjectPath,
+    max_objects: Option<usize>,
+    permits: Arc<Semaphore>,
+    cancel: &CancellationToken,
+) -> Result<GlobalListOutcome> {
+    let _permit = tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        permit = permits.acquire() => {
+            permit.map_err(|_| CrabError::Internal("global LIST semaphore closed".to_owned()))?
+        }
+    };
+    let mut stream = store.inner().list(Some(prefix));
+    let mut objects = Vec::new();
+    loop {
+        let next = tokio::select! {
+            biased;
+            () = cancel.cancelled() => return Err(CrabError::Cancelled),
+            next = stream.try_next() => next.map_err(CrabError::Storage)?,
+        };
+        let Some(meta) = next else {
+            break;
+        };
+        let location = meta.location.to_string();
+        if content_hash_from_path(&location, kind).is_none() {
+            return Err(CrabError::CorruptObject {
+                path: location,
+                reason: format!("global {kind} object does not match its hash partition"),
+            });
+        }
+        objects.push(ListedObject {
+            location,
+            size: meta.size,
+            last_modified: meta.last_modified.into(),
+        });
+        if max_objects.is_some_and(|limit| objects.len() > limit) {
+            break;
+        }
+    }
+
+    Ok(GlobalListOutcome {
+        objects,
+        requests: 1,
+        parallelism: 1,
+        partitioned: false,
+    })
 }
 
 /// Discover populated hash partitions, then scan them with bounded concurrency.
-async fn list_global_objects(
+async fn list_global_partitions(
     store: &Store,
     kind: &str,
     concurrency: usize,
     permits: Arc<Semaphore>,
+    cancel: &CancellationToken,
 ) -> Result<GlobalListOutcome> {
     let prefix = global_content_prefix(GLOBAL_PREFIX, kind);
-    let discovery_permit = permits
-        .acquire()
-        .await
-        .map_err(|_| CrabError::Internal("global LIST semaphore closed".to_owned()))?;
-    let discovery = store
-        .inner()
-        .list_with_delimiter(Some(&prefix))
-        .await
-        .map_err(CrabError::Storage)?;
+    let discovery_permit = tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        permit = permits.acquire() => {
+            permit.map_err(|_| CrabError::Internal("global LIST semaphore closed".to_owned()))?
+        }
+    };
+    let discovery = tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        result = store.inner().list_with_delimiter(Some(&prefix)) => {
+            result.map_err(CrabError::Storage)?
+        }
+    };
     drop(discovery_permit);
     if let Some(object) = discovery.objects.first() {
         return Err(CrabError::CorruptObject {
@@ -552,48 +688,27 @@ async fn list_global_objects(
     partitions.dedup();
 
     let parallelism = concurrency.max(1).min(partitions.len().max(1));
-    let batches = futures_util::stream::iter(partitions.iter().map(|partition| {
-        let partition_prefix = global_content_partition_prefix(GLOBAL_PREFIX, kind, partition);
-        let permits = Arc::clone(&permits);
-        async move {
-            let _permit = permits
-                .acquire()
-                .await
-                .map_err(|_| CrabError::Internal("global LIST semaphore closed".to_owned()))?;
-            store
-                .inner()
-                .list(Some(&partition_prefix))
-                .try_collect::<Vec<_>>()
-                .await
-                .map_err(CrabError::Storage)
-        }
-    }))
-    .buffer_unordered(concurrency.max(1))
-    .try_collect::<Vec<_>>()
-    .await?;
+    let batches =
+        futures_util::stream::iter(partitions.iter().map(|partition| {
+            let partition_prefix = global_content_partition_prefix(GLOBAL_PREFIX, kind, partition);
+            let permits = Arc::clone(&permits);
+            async move {
+                list_global_prefix(store, kind, &partition_prefix, None, permits, cancel).await
+            }
+        }))
+        .buffer_unordered(concurrency.max(1))
+        .try_collect::<Vec<_>>()
+        .await?;
     let objects = batches
         .into_iter()
-        .flatten()
-        .map(|meta| ListedObject {
-            location: meta.location.to_string(),
-            size: meta.size,
-            last_modified: meta.last_modified.into(),
-        })
+        .flat_map(|batch| batch.objects)
         .collect::<Vec<_>>();
-    if let Some(object) = objects
-        .iter()
-        .find(|object| content_hash_from_path(&object.location, kind).is_none())
-    {
-        return Err(CrabError::CorruptObject {
-            path: object.location.clone(),
-            reason: format!("global {kind} object does not match its hash partition"),
-        });
-    }
 
     Ok(GlobalListOutcome {
         objects,
         requests: 1 + partitions.len() as u64,
         parallelism,
+        partitioned: true,
     })
 }
 
@@ -921,7 +1036,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn global_listing_scans_only_populated_hash_partitions() {
+    async fn adaptive_global_listing_keeps_small_namespace_on_one_stream() {
         let store = memory_store();
         let hashes = [
             "aa".repeat(32),
@@ -938,22 +1053,165 @@ mod tests {
                 .unwrap();
         }
 
-        let mut outcome = list_global_objects(&store, "xorbs", 8, Arc::new(Semaphore::new(8)))
-            .await
-            .unwrap();
+        let mut outcome = list_global_objects(
+            &store,
+            "xorbs",
+            GcListProfile::Adaptive,
+            8,
+            Arc::new(Semaphore::new(8)),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
         outcome
             .objects
             .sort_by(|left, right| left.location.cmp(&right.location));
 
         assert_eq!(outcome.objects.len(), 3);
-        assert_eq!(outcome.requests, 3);
-        assert_eq!(outcome.parallelism, 2);
+        assert_eq!(outcome.requests, 1);
+        assert_eq!(outcome.parallelism, 1);
         assert!(
             outcome
                 .objects
                 .iter()
                 .all(|object| { content_hash_from_path(&object.location, "xorbs").is_some() })
         );
+    }
+
+    #[tokio::test]
+    async fn latency_global_listing_scans_only_populated_hash_partitions() {
+        let store = memory_store();
+        for hash in ["aa".repeat(32), "ff".repeat(32)] {
+            store
+                .put(
+                    &crab_storage::canonical_global_content_path("xorbs", &hash),
+                    Bytes::from(hash),
+                )
+                .await
+                .unwrap();
+        }
+
+        let outcome = list_global_objects(
+            &store,
+            "xorbs",
+            GcListProfile::Latency,
+            8,
+            Arc::new(Semaphore::new(8)),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.requests, 3);
+        assert_eq!(outcome.parallelism, 2);
+    }
+
+    #[tokio::test]
+    async fn adaptive_global_listing_partitions_large_namespace_after_bounded_probe() {
+        let store = memory_store().with_bucket_identity(crab_storage::BucketIdentity::new(
+            StorageProviderKind::S3,
+            "bucket",
+            "bucket",
+        ));
+        for index in 0..=256_000_u64 {
+            let hash = format!("{:02x}{index:062x}", index % 256);
+            store
+                .put(
+                    &crab_storage::canonical_global_content_path("xorbs", &hash),
+                    Bytes::new(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let outcome = list_global_objects(
+            &store,
+            "xorbs",
+            GcListProfile::Adaptive,
+            16,
+            Arc::new(Semaphore::new(16)),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.objects.len(), 256_001);
+        assert_eq!(outcome.requests, 258);
+    }
+
+    #[tokio::test]
+    async fn adaptive_global_listing_keeps_local_and_serial_stores_recursive() {
+        let local = memory_store();
+        let s3 = memory_store().with_bucket_identity(crab_storage::BucketIdentity::new(
+            StorageProviderKind::S3,
+            "bucket",
+            "bucket",
+        ));
+        for index in 0..=2_000_u64 {
+            let hash = format!("{index:064x}");
+            let path = crab_storage::canonical_global_content_path("xorbs", &hash);
+            local.put(&path, Bytes::new()).await.unwrap();
+            s3.put(&path, Bytes::new()).await.unwrap();
+        }
+
+        let local_outcome = list_global_objects(
+            &local,
+            "xorbs",
+            GcListProfile::Adaptive,
+            8,
+            Arc::new(Semaphore::new(8)),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        let serial_outcome = list_global_objects(
+            &s3,
+            "xorbs",
+            GcListProfile::Adaptive,
+            1,
+            Arc::new(Semaphore::new(1)),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(local_outcome.requests, 1);
+        assert_eq!(serial_outcome.requests, 1);
+    }
+
+    #[test]
+    fn adaptive_probe_uses_provider_page_capacity() {
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let s3 = Store::new(Arc::clone(&inner)).with_bucket_identity(
+            crab_storage::BucketIdentity::new(StorageProviderKind::S3, "bucket", "bucket"),
+        );
+        let azure = Store::new(Arc::clone(&inner)).with_bucket_identity(
+            crab_storage::BucketIdentity::new(StorageProviderKind::Azure, "account", "container"),
+        );
+        let local = Store::new(inner);
+
+        assert_eq!(adaptive_probe_limit(&s3), 256_000);
+        assert_eq!(adaptive_probe_limit(&azure), 1_280_000);
+        assert_eq!(adaptive_probe_limit(&local), usize::MAX);
+    }
+
+    #[tokio::test]
+    async fn global_listing_honors_cancellation_during_enumeration() {
+        let store = memory_store();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let result = list_global_objects(
+            &store,
+            "xorbs",
+            GcListProfile::Cost,
+            8,
+            Arc::new(Semaphore::new(8)),
+            &cancel,
+        )
+        .await;
+
+        assert!(matches!(result, Err(CrabError::Cancelled)));
     }
 
     #[tokio::test]
@@ -968,7 +1226,15 @@ mod tests {
             .await
             .unwrap();
 
-        let result = list_global_objects(&store, "xorbs", 8, Arc::new(Semaphore::new(8))).await;
+        let result = list_global_objects(
+            &store,
+            "xorbs",
+            GcListProfile::Adaptive,
+            8,
+            Arc::new(Semaphore::new(8)),
+            &CancellationToken::new(),
+        )
+        .await;
 
         assert!(matches!(result, Err(CrabError::CorruptObject { .. })));
     }
@@ -1185,6 +1451,7 @@ mod tests {
             grace_period: Duration::from_secs(3600),
             force: false,
             list_concurrency: 16,
+            list_profile: GcListProfile::Adaptive,
             delete_concurrency: 64,
         };
 
@@ -1231,6 +1498,7 @@ mod tests {
                 grace_period: Duration::from_secs(3600),
                 force: false,
                 list_concurrency: 16,
+                list_profile: GcListProfile::Adaptive,
                 delete_concurrency: 64,
             },
             &store,
@@ -1269,6 +1537,7 @@ mod tests {
                 grace_period: Duration::from_secs(3600),
                 force: true,
                 list_concurrency: 16,
+                list_profile: GcListProfile::Adaptive,
                 delete_concurrency: 64,
             },
             &store,
@@ -1394,6 +1663,7 @@ mod tests {
                 grace_period: Duration::from_secs(3600),
                 force: false,
                 list_concurrency: 16,
+                list_profile: GcListProfile::Adaptive,
                 delete_concurrency: 64,
             },
             &store,
@@ -1411,6 +1681,7 @@ mod tests {
                 grace_period: Duration::from_secs(3600),
                 force: false,
                 list_concurrency: 16,
+                list_profile: GcListProfile::Adaptive,
                 delete_concurrency: 64,
             },
             &store,
@@ -1456,6 +1727,7 @@ mod tests {
                 grace_period: Duration::from_secs(3600),
                 force: false,
                 list_concurrency: 16,
+                list_profile: GcListProfile::Adaptive,
                 delete_concurrency: 64,
             },
             &store,
@@ -1490,6 +1762,7 @@ mod tests {
                 grace_period: Duration::from_secs(3600),
                 force: false,
                 list_concurrency: 16,
+                list_profile: GcListProfile::Adaptive,
                 delete_concurrency: 64,
             },
             &store,
@@ -1526,6 +1799,7 @@ mod tests {
             grace_period: Duration::from_secs(3600),
             force: false,
             list_concurrency: 16,
+            list_profile: GcListProfile::Adaptive,
             delete_concurrency: 64,
         };
         let protected = HashSet::new();
@@ -1568,6 +1842,7 @@ mod tests {
             grace_period: Duration::from_secs(3600),
             force: false,
             list_concurrency: 16,
+            list_profile: GcListProfile::Adaptive,
             delete_concurrency: 64,
         };
         let protected = HashSet::new();
@@ -1602,6 +1877,7 @@ mod tests {
             grace_period: Duration::from_secs(3600),
             force: true,
             list_concurrency: 16,
+            list_profile: GcListProfile::Adaptive,
             delete_concurrency: 64,
         };
 
@@ -1731,6 +2007,7 @@ mod tests {
             grace_period: Duration::from_secs(3600),
             force: true,
             list_concurrency: 16,
+            list_profile: GcListProfile::Adaptive,
             delete_concurrency: 64,
         };
         let protected = HashSet::new();

--- a/crab/src/cmd/gc/bucket.rs
+++ b/crab/src/cmd/gc/bucket.rs
@@ -22,14 +22,18 @@ use std::time::{Duration, SystemTime};
 use futures_util::{StreamExt, TryStreamExt};
 use object_store::ObjectStoreExt;
 use object_store::path::Path as ObjectPath;
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::coordination::cas::cas_update_default;
 use crate::core::error::{CrabError, Result, check_cancelled};
-use crate::storage::StoreLayout;
 use crate::storage::store::Store;
 use crab_metadata::ref_registry::RefRegistry;
+use crab_storage::{
+    StoreLayout, canonical_global_content_path, content_hash_from_path,
+    global_content_partition_prefix, global_content_prefix,
+};
 use crab_xet::hash::MerkleHash;
 use crab_xet::shard::ShardReader;
 
@@ -57,6 +61,8 @@ pub struct BucketGcOutcome {
     pub xorbs_deleted: u64,
     pub file_index_deleted: u64,
     pub bytes_reclaimed: u64,
+    pub list_requests: u64,
+    pub list_parallelism: usize,
     pub dry_run: bool,
 }
 
@@ -68,6 +74,8 @@ impl BucketGcOutcome {
                 xorbs = self.xorbs_deleted,
                 file_index = self.file_index_deleted,
                 bytes = self.bytes_reclaimed,
+                list_requests = self.list_requests,
+                list_parallelism = self.list_parallelism,
                 "bucket gc dry-run complete (no objects deleted)"
             );
         } else {
@@ -76,6 +84,8 @@ impl BucketGcOutcome {
                 xorbs = self.xorbs_deleted,
                 file_index = self.file_index_deleted,
                 bytes = self.bytes_reclaimed,
+                list_requests = self.list_requests,
+                list_parallelism = self.list_parallelism,
                 "bucket gc complete"
             );
         }
@@ -170,11 +180,29 @@ async fn run_bucket_gc_under_maintenance(
     let now = SystemTime::now();
     let cutoff = now - effective_grace;
 
-    let (repo_shards, shard_objects, xorb_objects) = tokio::try_join!(
+    let global_list_permits = Arc::new(Semaphore::new(args.list_concurrency.max(1)));
+    let (repo_shards, shard_listing, xorb_listing) = tokio::try_join!(
         repository_referenced_shards(store, registry, args.list_concurrency),
-        list_global_objects(store, "shards"),
-        list_global_objects(store, "xorbs"),
+        list_global_objects(
+            store,
+            "shards",
+            args.list_concurrency,
+            Arc::clone(&global_list_permits),
+        ),
+        list_global_objects(
+            store,
+            "xorbs",
+            args.list_concurrency,
+            Arc::clone(&global_list_permits),
+        ),
     )?;
+    outcome.list_requests = shard_listing.requests + xorb_listing.requests;
+    outcome.list_parallelism = args
+        .list_concurrency
+        .max(1)
+        .min(shard_listing.parallelism + xorb_listing.parallelism);
+    let shard_objects = shard_listing.objects;
+    let xorb_objects = xorb_listing.objects;
     let referenced_shards = repo_shards
         .values()
         .flat_map(|shards| shards.iter().cloned())
@@ -198,7 +226,7 @@ async fn run_bucket_gc_under_maintenance(
     missing_referenced_shards.sort();
     if let Some(missing) = missing_referenced_shards.first() {
         return Err(CrabError::CorruptObject {
-            path: format!("{GLOBAL_PREFIX}/shards/{missing}"),
+            path: canonical_global_content_path("shards", &missing).to_string(),
             reason: format!(
                 "ref-registry references {} missing shard object(s)",
                 missing_referenced_shards.len()
@@ -465,27 +493,111 @@ fn partition_xorbs_for_gc(
     }
 }
 
-/// List all objects under `.crab/{kind}/`.
-async fn list_global_objects(store: &Store, kind: &str) -> Result<Vec<ListedObject>> {
-    let prefix = ObjectPath::from(format!("{GLOBAL_PREFIX}/{kind}/"));
-    let objects = store
+struct GlobalListOutcome {
+    objects: Vec<ListedObject>,
+    requests: u64,
+    parallelism: usize,
+}
+
+/// Discover populated hash partitions, then scan them with bounded concurrency.
+async fn list_global_objects(
+    store: &Store,
+    kind: &str,
+    concurrency: usize,
+    permits: Arc<Semaphore>,
+) -> Result<GlobalListOutcome> {
+    let prefix = global_content_prefix(GLOBAL_PREFIX, kind);
+    let discovery_permit = permits
+        .acquire()
+        .await
+        .map_err(|_| CrabError::Internal("global LIST semaphore closed".to_owned()))?;
+    let discovery = store
         .inner()
-        .list(Some(&prefix))
-        .try_collect::<Vec<_>>()
+        .list_with_delimiter(Some(&prefix))
         .await
         .map_err(CrabError::Storage)?;
+    drop(discovery_permit);
+    if let Some(object) = discovery.objects.first() {
+        return Err(CrabError::CorruptObject {
+            path: object.location.to_string(),
+            reason: format!("global {kind} object is outside the required two-hex hash partition"),
+        });
+    }
 
-    Ok(objects
+    let mut partitions = discovery
+        .common_prefixes
         .into_iter()
+        .map(|partition| {
+            let value = partition
+                .as_ref()
+                .strip_prefix(prefix.as_ref())
+                .and_then(|suffix| suffix.strip_prefix('/'))
+                .unwrap_or_default();
+            if value.len() != 2
+                || !value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+            {
+                return Err(CrabError::CorruptObject {
+                    path: partition.to_string(),
+                    reason: format!(
+                        "global {kind} partition must be exactly two lowercase hex characters"
+                    ),
+                });
+            }
+            Ok(value.to_owned())
+        })
+        .collect::<Result<Vec<_>>>()?;
+    partitions.sort_unstable();
+    partitions.dedup();
+
+    let parallelism = concurrency.max(1).min(partitions.len().max(1));
+    let batches = futures_util::stream::iter(partitions.iter().map(|partition| {
+        let partition_prefix = global_content_partition_prefix(GLOBAL_PREFIX, kind, partition);
+        let permits = Arc::clone(&permits);
+        async move {
+            let _permit = permits
+                .acquire()
+                .await
+                .map_err(|_| CrabError::Internal("global LIST semaphore closed".to_owned()))?;
+            store
+                .inner()
+                .list(Some(&partition_prefix))
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(CrabError::Storage)
+        }
+    }))
+    .buffer_unordered(concurrency.max(1))
+    .try_collect::<Vec<_>>()
+    .await?;
+    let objects = batches
+        .into_iter()
+        .flatten()
         .map(|meta| ListedObject {
             location: meta.location.to_string(),
             size: meta.size,
             last_modified: meta.last_modified.into(),
         })
-        .collect())
+        .collect::<Vec<_>>();
+    if let Some(object) = objects
+        .iter()
+        .find(|object| content_hash_from_path(&object.location, kind).is_none())
+    {
+        return Err(CrabError::CorruptObject {
+            path: object.location.clone(),
+            reason: format!("global {kind} object does not match its hash partition"),
+        });
+    }
+
+    Ok(GlobalListOutcome {
+        objects,
+        requests: 1 + partitions.len() as u64,
+        parallelism,
+    })
 }
 
-/// Extract the hash portion from a key like `.crab/shards/{hash}`.
+/// Extract the hash portion from a canonical global content key.
 fn extract_hash_from_key(key: &str) -> String {
     key.rsplit('/').next().unwrap_or("").to_string()
 }
@@ -797,9 +909,68 @@ mod tests {
 
     #[test]
     fn extract_hash_from_key_works() {
-        assert_eq!(extract_hash_from_key(".crab/shards/abc123"), "abc123");
-        assert_eq!(extract_hash_from_key(".crab/xorbs/def456"), "def456");
+        assert_eq!(
+            extract_hash_from_key(&format!(".crab/shards/ab/{}", "ab".repeat(32))),
+            "ab".repeat(32)
+        );
+        assert_eq!(
+            extract_hash_from_key(&format!(".crab/xorbs/de/{}", "de".repeat(32))),
+            "de".repeat(32)
+        );
         assert_eq!(extract_hash_from_key(""), "");
+    }
+
+    #[tokio::test]
+    async fn global_listing_scans_only_populated_hash_partitions() {
+        let store = memory_store();
+        let hashes = [
+            "aa".repeat(32),
+            "ff".repeat(32),
+            format!("aa{}", "1".repeat(62)),
+        ];
+        for hash in &hashes {
+            store
+                .put(
+                    &crab_storage::canonical_global_content_path("xorbs", hash),
+                    Bytes::from(hash.clone()),
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut outcome = list_global_objects(&store, "xorbs", 8, Arc::new(Semaphore::new(8)))
+            .await
+            .unwrap();
+        outcome
+            .objects
+            .sort_by(|left, right| left.location.cmp(&right.location));
+
+        assert_eq!(outcome.objects.len(), 3);
+        assert_eq!(outcome.requests, 3);
+        assert_eq!(outcome.parallelism, 2);
+        assert!(
+            outcome
+                .objects
+                .iter()
+                .all(|object| { content_hash_from_path(&object.location, "xorbs").is_some() })
+        );
+    }
+
+    #[tokio::test]
+    async fn global_listing_rejects_flat_legacy_objects() {
+        let store = memory_store();
+        let hash = "ab".repeat(32);
+        store
+            .put(
+                &ObjectPath::from(format!(".crab/xorbs/{hash}")),
+                Bytes::from_static(b"legacy"),
+            )
+            .await
+            .unwrap();
+
+        let result = list_global_objects(&store, "xorbs", 8, Arc::new(Semaphore::new(8))).await;
+
+        assert!(matches!(result, Err(CrabError::CorruptObject { .. })));
     }
 
     #[test]
@@ -1047,7 +1218,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let xorb_path = ObjectPath::from(format!("{GLOBAL_PREFIX}/xorbs/{}", "a".repeat(64)));
+        let xorb_path = canonical_global_content_path("xorbs", &"a".repeat(64));
         store
             .put(&xorb_path, Bytes::from_static(b"recent orphan"))
             .await
@@ -1087,7 +1258,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let xorb_path = ObjectPath::from(format!("{GLOBAL_PREFIX}/xorbs/{}", "b".repeat(64)));
+        let xorb_path = canonical_global_content_path("xorbs", &"b".repeat(64));
         let xorb = Bytes::from_static(b"recent orphan");
         store.put(&xorb_path, xorb.clone()).await.unwrap();
 
@@ -1261,7 +1432,7 @@ mod tests {
         let shard_hash = crab_xet::hash::compute_data_hash(&corrupt_shard).hex();
         store
             .put(
-                &ObjectPath::from(format!("{GLOBAL_PREFIX}/shards/{shard_hash}")),
+                &canonical_global_content_path("shards", &shard_hash),
                 corrupt_shard,
             )
             .await

--- a/crab/src/cmd/init.rs
+++ b/crab/src/cmd/init.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
-use crate::core::config::StorageProvider;
+use crate::core::config::{GcListProfile, StorageProvider};
 use crate::core::credential_discovery::{CredentialSource, discover_credentials};
 use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::{OutputMode, emit_json};
@@ -51,6 +51,8 @@ pub struct InitPayload {
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gc_list_profile: Option<String>,
     pub credential_status: CredentialStatus,
 }
 
@@ -101,7 +103,7 @@ pub async fn run_init_with_options(
     cancel: &CancellationToken,
     mode: OutputMode,
 ) -> Result<()> {
-    run_init_with_storage_provider(url, root, cancel, mode, None).await
+    run_init_with_storage_provider(url, root, cancel, mode, None, None).await
 }
 
 /// Options-driven init implementation with an explicit storage backend.
@@ -111,8 +113,18 @@ pub async fn run_init_with_storage_provider(
     cancel: &CancellationToken,
     mode: OutputMode,
     storage_provider: Option<StorageProvider>,
+    gc_list_profile: Option<GcListProfile>,
 ) -> Result<()> {
-    run_init_inner(url, root, cancel, mode, storage_provider, true).await
+    run_init_inner(
+        url,
+        root,
+        cancel,
+        mode,
+        storage_provider,
+        gc_list_profile,
+        true,
+    )
+    .await
 }
 
 /// Initialize a repository as the first phase of guided configuration.
@@ -121,8 +133,18 @@ pub(crate) async fn run_init_for_configure(
     root: &Path,
     cancel: &CancellationToken,
     storage_provider: Option<StorageProvider>,
+    gc_list_profile: Option<GcListProfile>,
 ) -> Result<()> {
-    run_init_inner(url, root, cancel, OutputMode::Text, storage_provider, false).await
+    run_init_inner(
+        url,
+        root,
+        cancel,
+        OutputMode::Text,
+        storage_provider,
+        gc_list_profile,
+        false,
+    )
+    .await
 }
 
 async fn run_init_inner(
@@ -131,6 +153,7 @@ async fn run_init_inner(
     cancel: &CancellationToken,
     mode: OutputMode,
     storage_provider: Option<StorageProvider>,
+    gc_list_profile: Option<GcListProfile>,
     show_next_steps: bool,
 ) -> Result<()> {
     check_cancelled(cancel)?;
@@ -193,6 +216,11 @@ async fn run_init_inner(
         remote.inferred_storage_provider,
         url,
     )?;
+    let config_path = crab_dir.join("config.toml");
+    let gc_list_profile = match gc_list_profile {
+        Some(profile) => Some(profile),
+        None => existing_gc_list_profile(&config_path)?,
+    };
 
     tokio::fs::create_dir_all(&crab_dir).await?;
     ensure_crab_dir_excluded(root)?;
@@ -205,8 +233,11 @@ async fn run_init_inner(
 
     // Write .crab/config.toml with the [remote] section so the config
     // resolver can find the URL.
-    let config_path = crab_dir.join("config.toml");
-    let config_content = render_local_config(&remote_url, selected_storage_provider.as_ref());
+    let config_content = render_local_config(
+        &remote_url,
+        selected_storage_provider.as_ref(),
+        gc_list_profile,
+    );
     tokio::fs::write(&config_path, config_content.as_bytes()).await?;
     tracing::info!(path = %config_path.display(), "wrote config.toml");
 
@@ -280,6 +311,11 @@ async fn run_init_inner(
     {
         eprintln!("Storage provider → {}", provider.label());
     }
+    if let Some(profile) = gc_list_profile
+        && !mode.is_machine()
+    {
+        eprintln!("Bucket GC list profile → {}", profile.as_str());
+    }
 
     // Run credential discovery and report the result.
     let credential_url = credential_discovery_url(&parsed, selected_storage_provider.as_ref());
@@ -317,6 +353,7 @@ async fn run_init_inner(
             storage_provider: selected_storage_provider
                 .as_ref()
                 .map(|provider| provider.toml_value().to_owned()),
+            gc_list_profile: gc_list_profile.map(|profile| profile.as_str().to_owned()),
             credential_status,
         };
         emit_json(INIT_SCHEMA, INIT_VERSION, payload);
@@ -357,7 +394,11 @@ async fn run_init_inner(
     Ok(())
 }
 
-fn render_local_config(url: &str, storage_provider: Option<&StorageProvider>) -> String {
+fn render_local_config(
+    url: &str,
+    storage_provider: Option<&StorageProvider>,
+    gc_list_profile: Option<GcListProfile>,
+) -> String {
     let mut config = format!("# Crab configuration\n\n[remote]\nurl = \"{url}\"\n");
     if let Some(provider) = storage_provider {
         use std::fmt::Write as _;
@@ -367,7 +408,32 @@ fn render_local_config(url: &str, storage_provider: Option<&StorageProvider>) ->
             provider.toml_value()
         );
     }
+    if let Some(profile) = gc_list_profile {
+        use std::fmt::Write as _;
+        let _ = write!(config, "\n[gc]\nlist_profile = \"{}\"\n", profile.as_str());
+    }
     config
+}
+
+fn existing_gc_list_profile(path: &Path) -> Result<Option<GcListProfile>> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(CrabError::Io(error)),
+    };
+    let value =
+        toml::from_str::<toml::Value>(&content).map_err(|error| CrabError::Configuration {
+            key: "gc.list_profile".to_owned(),
+            origin: format!("failed to parse {}: {error}", path.display()),
+        })?;
+    let Some(profile) = value.get("gc").and_then(|gc| gc.get("list_profile")) else {
+        return Ok(None);
+    };
+    let profile = profile.as_str().ok_or_else(|| CrabError::Configuration {
+        key: "gc.list_profile".to_owned(),
+        origin: format!("{} must contain a string value", path.display()),
+    })?;
+    GcListProfile::parse(profile).map(Some)
 }
 
 fn project_auth_config_with_storage_provider(
@@ -1214,6 +1280,7 @@ mod tests {
             &cancel,
             OutputMode::Text,
             Some(StorageProvider::Gcs),
+            None,
         )
         .await
         .expect("init should succeed");
@@ -1322,6 +1389,60 @@ storage_provider = "azure"
     }
 
     #[tokio::test]
+    async fn init_persists_and_preserves_gc_list_profile_locally() {
+        let dir = temp_git_repo();
+        let cancel = CancellationToken::new();
+
+        run_init_with_storage_provider(
+            "crab://my-bucket/my-repo",
+            dir.path(),
+            &cancel,
+            OutputMode::Text,
+            None,
+            Some(GcListProfile::Cost),
+        )
+        .await
+        .expect("init should persist GC profile");
+        run_init_with_storage_provider(
+            "crab://my-bucket/my-repo",
+            dir.path(),
+            &cancel,
+            OutputMode::Text,
+            None,
+            None,
+        )
+        .await
+        .expect("re-init should preserve GC profile");
+
+        let local_config = std::fs::read_to_string(dir.path().join(".crab/config.toml")).unwrap();
+
+        assert!(local_config.contains("list_profile = \"cost\""));
+    }
+
+    #[tokio::test]
+    async fn init_rejects_invalid_existing_gc_list_profile_without_overwriting_it() {
+        let dir = temp_git_repo();
+        let local_dir = dir.path().join(".crab");
+        std::fs::create_dir_all(&local_dir).unwrap();
+        let config_path = local_dir.join("config.toml");
+        let invalid = "[gc]\nlist_profile = \"fast\"\n";
+        std::fs::write(&config_path, invalid).unwrap();
+
+        let result = run_init_with_storage_provider(
+            "crab://my-bucket/my-repo",
+            dir.path(),
+            &CancellationToken::new(),
+            OutputMode::Text,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(matches!(result, Err(CrabError::Configuration { .. })));
+        assert_eq!(std::fs::read_to_string(config_path).unwrap(), invalid);
+    }
+
+    #[tokio::test]
     async fn init_excludes_local_crab_dir_from_add_all() {
         let dir = temp_git_repo();
         let cancel = CancellationToken::new();
@@ -1392,6 +1513,7 @@ storage_provider = "azure"
             &cancel,
             OutputMode::Text,
             Some(StorageProvider::S3),
+            None,
         )
         .await;
         assert!(

--- a/crab/src/cmd/metadb.rs
+++ b/crab/src/cmd/metadb.rs
@@ -2730,10 +2730,12 @@ mod tests {
         // Seed two distinct shards at their content-addressed keys.
         let (shard_a_bytes, shard_a_hash, xorb_a_bytes, xorb_a_hash) = build_test_shard(7);
         let (shard_b_bytes, shard_b_hash, xorb_b_bytes, xorb_b_hash) = build_test_shard(77);
-        let shard_a_path = ObjectPath::from(format!(".crab/shards/{}", shard_a_hash.hex()));
-        let shard_b_path = ObjectPath::from(format!(".crab/shards/{}", shard_b_hash.hex()));
-        let xorb_a_path = ObjectPath::from(format!(".crab/xorbs/{}", xorb_a_hash.hex()));
-        let xorb_b_path = ObjectPath::from(format!(".crab/xorbs/{}", xorb_b_hash.hex()));
+        let shard_a_path =
+            crab_storage::canonical_global_content_path("shards", &shard_a_hash.hex());
+        let shard_b_path =
+            crab_storage::canonical_global_content_path("shards", &shard_b_hash.hex());
+        let xorb_a_path = crab_storage::canonical_global_content_path("xorbs", &xorb_a_hash.hex());
+        let xorb_b_path = crab_storage::canonical_global_content_path("xorbs", &xorb_b_hash.hex());
         store
             .put(&shard_a_path, shard_a_bytes.clone().into())
             .await
@@ -2873,8 +2875,8 @@ mod tests {
     async fn rebuild_is_idempotent_across_reruns() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let (shard_bytes, shard_hash, xorb_bytes, xorb_hash) = build_test_shard(5);
-        let shard_path = ObjectPath::from(format!(".crab/shards/{}", shard_hash.hex()));
-        let xorb_path = ObjectPath::from(format!(".crab/xorbs/{}", xorb_hash.hex()));
+        let shard_path = crab_storage::canonical_global_content_path("shards", &shard_hash.hex());
+        let xorb_path = crab_storage::canonical_global_content_path("xorbs", &xorb_hash.hex());
         store
             .put(&shard_path, shard_bytes.clone().into())
             .await

--- a/crab/src/cmd/restripe.rs
+++ b/crab/src/cmd/restripe.rs
@@ -20,7 +20,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use object_store::path::Path as ObjectPath;
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -38,6 +37,7 @@ use crate::storage::StoreLayout;
 use crate::storage::head_class::head_with_class;
 use crate::storage::store::Store;
 use crate::tier::audit_shim::{self, AuditOp};
+use crab_storage::{GLOBAL_PREFIX, content_hash_from_path, global_content_prefix};
 
 const OPTIMIZE_XORBS_AUTH_OPERATION: &str = "optimize-xorbs";
 const OPTIMIZE_XORBS_OPERATION: &str = "optimize xorbs";
@@ -325,7 +325,7 @@ async fn enumerate_sources(
         return Err(CrabError::Cancelled);
     }
 
-    let prefix = ObjectPath::from(".crab/xorbs/");
+    let prefix = global_content_prefix(GLOBAL_PREFIX, "xorbs");
     let objects = store.list_prefix(&prefix).await?;
     let mut sources = Vec::with_capacity(objects.len());
 
@@ -335,18 +335,11 @@ async fn enumerate_sources(
         }
 
         let key = object.location.to_string();
-        let hash = key
-            .strip_prefix(".crab/xorbs/")
-            .ok_or_else(|| CrabError::Configuration {
+        let hash =
+            content_hash_from_path(&key, "xorbs").ok_or_else(|| CrabError::Configuration {
                 key: format!("remote xorb key {key}"),
-                origin: "xorb listing returned an object outside .crab/xorbs/".to_string(),
+                origin: "expected a canonical two-hex-fan-out xorb key".to_string(),
             })?;
-        if hash.is_empty() || hash.contains('/') {
-            return Err(CrabError::Configuration {
-                key: format!("remote xorb key {key}"),
-                origin: "expected one content hash directly below .crab/xorbs/".to_string(),
-            });
-        }
 
         let head = head_with_class(store, &object.location).await?;
         sources.push(SourceXorbMeta {

--- a/crab/src/core/config.rs
+++ b/crab/src/core/config.rs
@@ -26,6 +26,8 @@ use serde::{Deserialize, Serialize};
 
 use crab_types::{replication::ReplicationConfig, storage::StorageProviderKind};
 
+use super::error::{CrabError, Result};
+
 pub use crab_auth::AuthProviderKind as AuthProvider;
 
 // ---------------------------------------------------------------------------
@@ -380,22 +382,64 @@ pub struct RestripeConfig {
 /// Default: class-aware GC is opt-in for the first release.
 const DEFAULT_GC_CLASS_AWARE: bool = false;
 
+/// Cost/latency policy for bucket-global object enumeration.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GcListProfile {
+    /// Use one recursive stream for small namespaces, then switch to hash
+    /// partitions once serial pagination becomes more expensive.
+    #[default]
+    Adaptive,
+    /// Minimize provider LIST calls by using one recursive stream per kind.
+    Cost,
+    /// Minimize wall time by scanning populated hash partitions concurrently.
+    Latency,
+}
+
+impl GcListProfile {
+    /// Parse one user-facing GC list profile.
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "adaptive" => Ok(Self::Adaptive),
+            "cost" => Ok(Self::Cost),
+            "latency" => Ok(Self::Latency),
+            other => Err(CrabError::Configuration {
+                key: "gc.list_profile".to_owned(),
+                origin: format!("unsupported value {other:?}; expected adaptive, cost, or latency"),
+            }),
+        }
+    }
+
+    /// Return the stable configuration spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Adaptive => "adaptive",
+            Self::Cost => "cost",
+            Self::Latency => "latency",
+        }
+    }
+}
+
 /// GC configuration from the `[gc]` TOML section.
 ///
 /// The existing GC settings (`gc_grace_period`, `gc_delete_concurrency`,
-/// `gc_list_concurrency`) remain as flat fields on [`Config`] for backward
-/// compatibility. This struct carries the new class-aware flag.
+/// `gc_list_concurrency`) remain as flat fields on [`Config`]. This struct
+/// carries bucket-global GC policy.
 #[derive(Debug, Clone)]
 pub struct GcConfig {
     /// When true, GC checks storage class and refuses early-delete for
     /// objects within their minimum retention window.
     pub class_aware: bool,
+    /// Bucket-global listing policy.
+    pub list_profile: GcListProfile,
 }
 
 impl Default for GcConfig {
     fn default() -> Self {
         Self {
             class_aware: DEFAULT_GC_CLASS_AWARE,
+            list_profile: GcListProfile::Adaptive,
         }
     }
 }
@@ -1500,6 +1544,7 @@ pub struct RestripeOverlay {
 #[serde(deny_unknown_fields)]
 pub struct GcOverlay {
     pub class_aware: Option<bool>,
+    pub list_profile: Option<GcListProfile>,
 }
 
 /// Partial repack configuration overlay.
@@ -2552,6 +2597,9 @@ impl Config {
     fn apply_gc_overlay(&mut self, overlay: GcOverlay) {
         if let Some(v) = overlay.class_aware {
             self.gc.class_aware = v;
+        }
+        if let Some(v) = overlay.list_profile {
+            self.gc.list_profile = v;
         }
     }
 
@@ -4304,6 +4352,7 @@ target_xorb_bytes = 16777216
     fn config_default_embeds_gc_defaults() {
         let cfg = Config::default();
         assert!(!cfg.gc.class_aware);
+        assert_eq!(cfg.gc.list_profile, GcListProfile::Adaptive);
     }
 
     #[test]
@@ -4315,6 +4364,18 @@ target_xorb_bytes = 16777216
         let cfg = Config::resolve_local_from(Some(p), PathBuf::from("/nonexistent"))
             .expect("should parse gc section");
         assert!(cfg.gc.class_aware);
+    }
+
+    #[test]
+    fn overlay_gc_section_parses_list_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("config.toml");
+        std::fs::write(&p, "[gc]\nlist_profile = \"cost\"\n").unwrap();
+
+        let cfg = Config::resolve_local_from(Some(p), PathBuf::from("/nonexistent"))
+            .expect("should parse gc list profile");
+
+        assert_eq!(cfg.gc.list_profile, GcListProfile::Cost);
     }
 
     // --- Hydrate auto_restore ---

--- a/crab/src/cost/inventory/mod.rs
+++ b/crab/src/cost/inventory/mod.rs
@@ -29,7 +29,7 @@ use crate::tier::classes::StorageClass;
 /// A single object in the inventory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InventoryItem {
-    /// Full object key (e.g. `.crab/xorbs/abcd1234...`).
+    /// Full object key (e.g. `.crab/xorbs/ab/abcd1234...`).
     pub key: String,
     /// Object size in bytes.
     pub size: u64,

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -58,6 +58,9 @@ use crab_metadata::pack_metadata::PackMetadata;
 use crab_staging::StagingAreaReadOnly;
 use crab_staging::push_plan::{self, FilePushPlan, PlannedXorb};
 use crab_staging::recipe::{ChunkingPolicyId, FileRecipe};
+#[cfg(test)]
+use crab_storage::canonical_global_content_path;
+use crab_storage::global_content_partition_prefix;
 use crab_storage::head_batch::{HeadBatchConfig, HeadBatchStore, head_batch};
 use crab_xet::hash::{MerkleHash, compute_data_hash, xorb_hash};
 use crab_xet::shard::PushShardSession;
@@ -9986,7 +9989,8 @@ impl PushPipeline {
 
     /// Step 9: Upload shards.
     ///
-    /// Uploads each shard produced by step 8 to `.crab/shards/{shard_hash}`
+    /// Uploads each shard produced by step 8 to
+    /// `.crab/shards/{first-two-hex}/{shard_hash}`.
     /// (via `StoreLayout`) or `{prefix}/shards/{shard_hash}` as fallback.
     ///
     /// The legacy `file-index/{hash}` PUT loop has been removed; file-index
@@ -10026,7 +10030,7 @@ impl PushPipeline {
         let use_color = self.progress.as_ref().is_some_and(|p| p.use_color());
         let is_tty = crate::git::progress::is_tty();
 
-        // Upload each shard — routed to `.crab/shards/{hash}` when
+        // Upload each shard — routed to `.crab/shards/{first-two-hex}/{hash}` when
         // the router is available, falling back to `{prefix}/shards/{hash}`.
         let shard_payloads: Vec<(MerkleHash, ObjectPath, Bytes)> = {
             let shard_results = self.shard_results.lock().await;
@@ -14120,7 +14124,8 @@ impl HeadBatchStore for StoreHeadBatch {
     }
 
     async fn list_prefix(&self, prefix: &str) -> crab_storage::error::Result<Vec<String>> {
-        let list_prefix = self.router.global_path("xorbs", prefix);
+        let list_prefix =
+            global_content_partition_prefix(self.router.global_prefix(), "xorbs", prefix);
         let objects = self
             .store
             .list_prefix(&list_prefix)
@@ -14617,7 +14622,8 @@ mod tests {
                         uncompressed_size: xorb_ref.uncompressed_size,
                         origin: crab_metadata::receipts::OriginReceipt::new(
                             "canonical-origin".to_owned(),
-                            format!(".crab/xorbs/{}", xorb_ref.xorb_hash.hex()),
+                            canonical_global_content_path("xorbs", &xorb_ref.xorb_hash.hex())
+                                .to_string(),
                             xorb_ref.xorb_hash.into(),
                             [9; 32],
                             1,
@@ -17747,6 +17753,33 @@ mod tests {
     // --- Step 6: head_check_resume metrics ---
 
     #[tokio::test]
+    async fn head_batch_adapter_lists_one_canonical_hash_partition() {
+        let store = Store::new(Arc::new(object_store::memory::InMemory::new()));
+        let router = StoreLayout::new(store.clone(), "head-check-partition".to_owned());
+        let included = format!("aa{}", "1".repeat(62));
+        let excluded = format!("ab{}", "2".repeat(62));
+        store
+            .put(
+                &router.xorb_path(&included),
+                Bytes::from_static(b"included"),
+            )
+            .await
+            .unwrap();
+        store
+            .put(
+                &router.xorb_path(&excluded),
+                Bytes::from_static(b"excluded"),
+            )
+            .await
+            .unwrap();
+        let adapter = StoreHeadBatch { store, router };
+
+        let hashes = adapter.list_prefix("aa").await.unwrap();
+
+        assert_eq!(hashes, vec![included]);
+    }
+
+    #[tokio::test]
     async fn head_check_resume_populates_metrics_counters() {
         let _guard = GitDirGuard::new();
         let metrics = Arc::new(Metrics::new());
@@ -20832,7 +20865,7 @@ mod tests {
     #[tokio::test]
     async fn committed_origin_receipt_requires_current_object_identity() {
         let xorb_hash = MerkleHash::from([0xC01117, 0x5151, 0xA11, 0xD]);
-        let path = Path::from(format!(".crab/xorbs/{}", xorb_hash.hex()));
+        let path = canonical_global_content_path("xorbs", &xorb_hash.hex());
         let index = RemoteXorbIndex {
             hash: xorb_hash,
             payload_digest: [7; 32],
@@ -23163,7 +23196,7 @@ mod tests {
         use crate::storage::retry::RetryPolicy;
 
         let fail_hash = MerkleHash::from([1_u64, 1, 1, 1]);
-        let fail_path = Path::from(format!(".crab/xorbs/{}", fail_hash.hex()));
+        let fail_path = canonical_global_content_path("xorbs", &fail_hash.hex());
         let completed_puts = Arc::new(AtomicUsize::new(0));
         let delay = std::time::Duration::from_millis(75);
         let inner: Arc<dyn object_store::ObjectStore> = Arc::new(DelayedFailurePutStore::new(
@@ -23354,7 +23387,7 @@ mod tests {
         let fail_hash = MerkleHash::from([1_u64, 1, 1, 1]);
         let ok_hash_a = MerkleHash::from([2_u64, 2, 2, 2]);
         let ok_hash_b = MerkleHash::from([3_u64, 3, 3, 3]);
-        let fail_path = Path::from(format!(".crab/xorbs/{}", fail_hash.hex()));
+        let fail_path = canonical_global_content_path("xorbs", &fail_hash.hex());
         let completed_puts = Arc::new(AtomicUsize::new(0));
         let delay = std::time::Duration::from_millis(75);
         let inner: Arc<dyn object_store::ObjectStore> = Arc::new(DelayedFailurePutStore::new(
@@ -24613,7 +24646,11 @@ mod tests {
                 .expect("cache request capture");
         assert_eq!(
             request_line,
-            format!("PUT /v1/.crab/xorbs/{} HTTP/1.1", hash.hex())
+            format!(
+                "PUT /v1/.crab/xorbs/{}/{} HTTP/1.1",
+                &hash.hex()[..2],
+                hash.hex()
+            )
         );
         assert_eq!(body, bytes.as_ref());
         server.await.expect("cache server task");
@@ -26385,12 +26422,12 @@ mod tests {
         assert!(
             plan.request
                 .uploaded_objects
-                .contains(&format!(".crab/xorbs/{}", xorb_hash.hex()))
+                .contains(&canonical_global_content_path("xorbs", &xorb_hash.hex()).to_string())
         );
         assert!(
             plan.request
                 .uploaded_objects
-                .contains(&format!(".crab/shards/{}", shard_hash.hex()))
+                .contains(&canonical_global_content_path("shards", &shard_hash.hex()).to_string())
         );
         assert!(
             plan.request

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -3687,7 +3687,10 @@ mod tests {
         assert!(!manifest.shard_index_hash.is_empty());
         assert!(
             !store
-                .list_prefix(&router.global_path("xorbs", ""))
+                .list_prefix(&crab_storage::global_content_prefix(
+                    router.global_prefix(),
+                    "xorbs",
+                ))
                 .await
                 .expect("list xorbs")
                 .is_empty(),
@@ -3695,7 +3698,10 @@ mod tests {
         );
         assert!(
             !store
-                .list_prefix(&router.global_path("shards", ""))
+                .list_prefix(&crab_storage::global_content_prefix(
+                    router.global_prefix(),
+                    "shards",
+                ))
                 .await
                 .expect("list shards")
                 .is_empty(),

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -84,6 +84,9 @@ enum Cmd {
         /// Cloud storage provider.
         #[arg(long, value_name = "PROVIDER", value_parser = ["s3", "gcs", "azure"])]
         provider: Option<String>,
+        /// Bucket-GC listing policy configured locally for this operator.
+        #[arg(long, value_name = "PROFILE", value_parser = ["adaptive", "cost", "latency"])]
+        gc_list_profile: Option<String>,
         /// Track an explicit large-file pattern (can repeat).
         #[arg(long = "track", value_name = "PATTERN")]
         track: Vec<String>,
@@ -102,6 +105,9 @@ enum Cmd {
         /// Storage backend used by the Crab remote.
         #[arg(long, value_name = "PROVIDER", value_parser = ["s3", "gcs", "azure", "auto"])]
         storage_provider: Option<String>,
+        /// Bucket-GC listing policy configured locally for this operator.
+        #[arg(long, value_name = "PROFILE", value_parser = ["adaptive", "cost", "latency"])]
+        gc_list_profile: Option<String>,
         /// Enable mirror mode: sync large files to Crab transparently on push.
         /// Value is the name of the existing git remote (typically "origin").
         #[arg(long)]
@@ -362,6 +368,9 @@ enum Cmd {
         /// S3 bucket name (required for --scope=bucket).
         #[arg(long)]
         bucket: Option<String>,
+        /// Override the bucket-GC listing policy.
+        #[arg(long, value_name = "PROFILE", value_parser = ["adaptive", "cost", "latency"])]
+        list_profile: Option<String>,
         /// Minimum age before unreferenced objects are deleted (e.g. `1h`, `24h`).
         #[arg(long, default_value = "1h")]
         grace_period: String,
@@ -3014,6 +3023,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
         Some(Cmd::Configure {
             remote,
             provider,
+            gc_list_profile,
             track,
             no_auto_track,
             dry_run,
@@ -3022,10 +3032,15 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                 .as_deref()
                 .map(crab::cmd::init::parse_storage_provider_arg)
                 .transpose()?;
+            let gc_list_profile = gc_list_profile
+                .as_deref()
+                .map(crab::core::config::GcListProfile::parse)
+                .transpose()?;
             crab::cmd::configure::run_configure(
                 crab::cmd::configure::ConfigureArgs {
                     remote,
                     storage_provider,
+                    gc_list_profile,
                     track,
                     no_auto_track,
                     dry_run,
@@ -3258,6 +3273,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
         Some(Cmd::Init {
             url,
             storage_provider,
+            gc_list_profile,
             mirror,
             json,
             jsonl,
@@ -3267,6 +3283,10 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
             let storage_provider = storage_provider
                 .as_deref()
                 .map(crab::cmd::init::parse_storage_provider_arg)
+                .transpose()?;
+            let gc_list_profile = gc_list_profile
+                .as_deref()
+                .map(crab::core::config::GcListProfile::parse)
                 .transpose()?;
             let resolved_url = match url {
                 Some(u) => u,
@@ -3285,6 +3305,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                                 &cancel,
                                 mode,
                                 storage_provider.clone(),
+                                gc_list_profile,
                             )
                             .await?;
                             // Sync .gitattributes with [track] patterns from .crab.toml
@@ -3351,6 +3372,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                 &cancel,
                 mode,
                 storage_provider,
+                gc_list_profile,
             )
             .await?;
 
@@ -3599,6 +3621,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
             yes,
             scope,
             bucket,
+            list_profile,
             grace_period,
             deregister,
             repair_registry,
@@ -3653,7 +3676,12 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                             key: "--bucket is required for --scope=bucket".into(),
                             origin: "cli".into(),
                         })?;
-                    let config = Config::resolve_local().unwrap_or_default();
+                    let config = Config::resolve_local()?;
+                    let list_profile = list_profile
+                        .as_deref()
+                        .map(crab::core::config::GcListProfile::parse)
+                        .transpose()?
+                        .unwrap_or(config.gc.list_profile);
                     let store = create_cli_store(bucket_name, &config, "gc", &cancel).await?;
                     let registry = crab::cmd::gc::bucket::load_ref_registry(&store, force).await?;
                     let current_repo_prefix = if config
@@ -3685,6 +3713,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                         grace_period: parsed_grace,
                         force,
                         list_concurrency: config.gc_list_concurrency,
+                        list_profile,
                         delete_concurrency: config.gc_delete_concurrency,
                     };
                     let outcome = crab::cmd::gc::bucket::run_bucket_gc(

--- a/crab/src/metadata/metadb/mod.rs
+++ b/crab/src/metadata/metadb/mod.rs
@@ -1039,7 +1039,8 @@ mod tests {
             uncompressed_size: xorb_ref.uncompressed_size,
             origin: crab_metadata::receipts::OriginReceipt::new(
                 "canonical-origin".to_owned(),
-                format!(".crab/xorbs/{}", xorb_ref.xorb_hash.hex()),
+                crab_storage::canonical_global_content_path("xorbs", &xorb_ref.xorb_hash.hex())
+                    .to_string(),
                 xorb_ref.xorb_hash.into(),
                 [9; 32],
                 1,

--- a/crab/src/metadata/metadb/stores/chunk_index.rs
+++ b/crab/src/metadata/metadb/stores/chunk_index.rs
@@ -651,7 +651,8 @@ mod tests {
             uncompressed_size: xorb_ref.uncompressed_size,
             origin: crab_metadata::receipts::OriginReceipt::new(
                 "canonical-origin".to_owned(),
-                format!(".crab/xorbs/{}", xorb_ref.xorb_hash.hex()),
+                crab_storage::canonical_global_content_path("xorbs", &xorb_ref.xorb_hash.hex())
+                    .to_string(),
                 xorb_ref.xorb_hash.into(),
                 [9; 32],
                 1024,

--- a/crab/src/restripe/executor.rs
+++ b/crab/src/restripe/executor.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::Bytes;
-use object_store::path::Path as ObjectPath;
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -38,6 +37,7 @@ use crate::restripe::profile::Profile;
 use crate::storage::head_class::head_with_class;
 use crate::storage::store::Store;
 use crate::tier::restore::RestoreOrchestrator;
+use crab_storage::canonical_global_content_path;
 use crab_xet::xorb::builder::{FixedCompression, RunId, XorbBuilder};
 use crab_xet::xorb::format::CompressionScheme;
 use crab_xet::xorb::parser::XorbParser;
@@ -329,7 +329,7 @@ async fn process_single_xorb(
         });
     };
 
-    let xorb_path = ObjectPath::from(format!(".crab/xorbs/{src_hash}"));
+    let xorb_path = canonical_global_content_path("xorbs", src_hash);
 
     // --- Step 1: HEAD with class probe ---
     let head_meta = head_with_class(store, &xorb_path).await;
@@ -458,7 +458,7 @@ async fn process_single_xorb(
 
     for xorb_result in &dest_xorbs {
         let dest_hash = xorb_result.hash.hex();
-        let dest_path = ObjectPath::from(format!(".crab/xorbs/{dest_hash}"));
+        let dest_path = canonical_global_content_path("xorbs", &dest_hash);
         let dest_bytes = Bytes::copy_from_slice(&xorb_result.bytes);
         let written = dest_bytes.len() as u64;
 

--- a/crab/tests/e2e_add_commit_push.rs
+++ b/crab/tests/e2e_add_commit_push.rs
@@ -168,13 +168,19 @@ async fn push_main_to_memory(repo: &Path, scratch: &Path) -> (Store, StoreLayout
     assert!(!manifest.shard_index_hash.is_empty());
 
     let xorbs = store
-        .list_prefix(&router.global_path("xorbs", ""))
+        .list_prefix(&crab_storage::global_content_prefix(
+            router.global_prefix(),
+            "xorbs",
+        ))
         .await
         .expect("list xorbs");
     assert!(!xorbs.is_empty(), "push should upload at least one xorb");
 
     let shards = store
-        .list_prefix(&router.global_path("shards", ""))
+        .list_prefix(&crab_storage::global_content_prefix(
+            router.global_prefix(),
+            "shards",
+        ))
         .await
         .expect("list shards");
     assert!(!shards.is_empty(), "push should upload at least one shard");

--- a/crates/crab-auth-server/src/receive.rs
+++ b/crates/crab-auth-server/src/receive.rs
@@ -29,7 +29,10 @@ use crab_metadata::{
     value_codec::CommittedFileRecord,
 };
 use crab_staging::recipe::{ChunkingPolicyId, FileRecipe};
-use crab_storage::{StagedWrite, StorageError, StorageProviderKind, Store, StoreLayout};
+use crab_storage::{
+    StagedWrite, StorageError, StorageProviderKind, Store, StoreLayout,
+    canonical_global_content_path, content_hash_from_path,
+};
 use crab_types::time::now_rfc3339_millis;
 use crab_xet::hash::MerkleHash;
 use crab_xet::shard::MDBShardInfo;
@@ -621,7 +624,7 @@ pub fn strict_xorb_references_from_shard(
         if chunks.len() != declared_chunks {
             return Err(invalid("staged shard xorb chunk count mismatch"));
         }
-        let key = format!(".crab/xorbs/{hash}");
+        let key = canonical_global_content_path("xorbs", &hash).to_string();
         if refs.insert(key, chunks).is_some() {
             return Err(invalid("staged shard contains duplicate xorb metadata"));
         }
@@ -1678,9 +1681,7 @@ async fn build_service_pack_index(
 }
 
 fn xorb_hash_from_key(key: &str) -> Result<MerkleHash> {
-    let hash = key
-        .strip_prefix(".crab/xorbs/")
-        .or_else(|| key.rsplit_once("/.crab/xorbs/").map(|(_, hash)| hash))
+    let hash = content_hash_from_path(key, "xorbs")
         .ok_or_else(|| invalid(format!("unsupported xorb canonical key: {key}")))?;
     merkle_hash_from_hex(hash, "xorb key hash")
 }
@@ -1952,10 +1953,9 @@ fn has_unsafe_key_shape(key: &str) -> bool {
 }
 
 fn is_allowed_global_key(key: &str) -> bool {
-    [".crab/xorbs/", ".crab/shards/"].iter().any(|prefix| {
-        key.strip_prefix(prefix)
-            .is_some_and(|hash| validate_hash_component(hash, "global object hash").is_ok())
-    })
+    key.starts_with(".crab/")
+        && (content_hash_from_path(key, "xorbs").is_some()
+            || content_hash_from_path(key, "shards").is_some())
 }
 
 fn is_allowed_repo_key(relative: &str) -> bool {
@@ -2470,10 +2470,10 @@ mod tests {
     fn canonical_key_allowlist_accepts_push_immutable_objects() {
         let repo = "org/repo";
         for key in [
-            format!(".crab/xorbs/{}", hash('a')),
-            format!(".crab/shards/{}", hash('b')),
-            format!("{repo}/.crab/xorbs/{}", hash('a')),
-            format!("{repo}/.crab/shards/{}", hash('b')),
+            format!(".crab/xorbs/aa/{}", hash('a')),
+            format!(".crab/shards/bb/{}", hash('b')),
+            format!("{repo}/.crab/xorbs/aa/{}", hash('a')),
+            format!("{repo}/.crab/shards/bb/{}", hash('b')),
             format!("{repo}/packs/pack-{}.pack", hash('c')),
             format!("{repo}/packs/pack-{}.meta", hash('c')),
             format!("{repo}/metadata/pack/segments/{}.jsonl", hash('d')),
@@ -2499,6 +2499,7 @@ mod tests {
             format!("{repo}/staging/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/object"),
             format!("{repo}/.crab/ref-registry"),
             format!("{repo}/.crab/chunk_index_db/{}", hash('a')),
+            format!("evil/.crab/xorbs/aa/{}", hash('a')),
             ".crab/ref-registry".to_owned(),
             format!(".crab/chunk_index_db/{}", hash('a')),
             format!("{repo}/packs/pack-{}.idx", hash('a')),
@@ -2576,7 +2577,7 @@ mod tests {
         }))?;
         let (shard_bytes, _) = writer.finalize()?;
 
-        let key = format!(".crab/xorbs/{}", xorb.hash.hex());
+        let key = canonical_global_content_path("xorbs", &xorb.hash.hex()).to_string();
         let refs = strict_xorb_references_from_shard(&shard_bytes)?;
         let expected_chunks = refs
             .get(&key)
@@ -2643,7 +2644,7 @@ mod tests {
         })?;
         let (shard_bytes, shard_hash) = writer.finalize()?;
 
-        let xorb_key = format!(".crab/xorbs/{}", xorb.hash.hex());
+        let xorb_key = canonical_global_content_path("xorbs", &xorb.hash.hex()).to_string();
         let refs = strict_xorb_references_from_shard(&shard_bytes)?;
         let expected_chunks = refs
             .get(&xorb_key)

--- a/crates/crab-auth-server/src/receive/session.rs
+++ b/crates/crab-auth-server/src/receive/session.rs
@@ -306,7 +306,7 @@ mod tests {
 
         assert_eq!(
             context.router().xorb_path(&hash('a')).as_ref(),
-            format!("org/repo/.crab/xorbs/{}", hash('a'))
+            format!("org/repo/.crab/xorbs/aa/{}", hash('a'))
         );
     }
 

--- a/crates/crab-auth-server/src/view.rs
+++ b/crates/crab-auth-server/src/view.rs
@@ -1061,7 +1061,8 @@ mod tests {
         assert!(
             store
                 .head(&ObjectPath::from(format!(
-                    "{view_prefix}/.crab/xorbs/{}",
+                    "{view_prefix}/.crab/xorbs/{}/{}",
+                    &source_xorb_hash.hex()[..2],
                     source_xorb_hash.hex()
                 )))
                 .await

--- a/crates/crab-auth-server/src/view/objects.rs
+++ b/crates/crab-auth-server/src/view/objects.rs
@@ -313,7 +313,8 @@ mod tests {
         assert!(
             store
                 .head(&ObjectPath::from(format!(
-                    "{repo_prefix}/.crab/xorbs/{}",
+                    "{repo_prefix}/.crab/xorbs/{}/{}",
+                    &xorb_hash.hex()[..2],
                     xorb_hash.hex()
                 )))
                 .await
@@ -322,7 +323,8 @@ mod tests {
         assert!(matches!(
             store
                 .head(&ObjectPath::from(format!(
-                    ".crab/xorbs/{}",
+                    ".crab/xorbs/{}/{}",
+                    &xorb_hash.hex()[..2],
                     xorb_hash.hex()
                 )))
                 .await,

--- a/crates/crab-cache-server/src/evidence.rs
+++ b/crates/crab-cache-server/src/evidence.rs
@@ -20,10 +20,10 @@ pub use summary::{
 const EVIDENCE_MANIFEST_SCHEMA: &str = "crab-cache-service.evidence-manifest.v1";
 const DEFAULT_PSK: &str = "cache-smoke-psk";
 const DEFAULT_PSK_BLAKE3: &str = "4fb898757c4c93662343bbbb25419f8c4f9c979352d40ff896578cabf620cf6e";
-const EXPECTED_ROUTE_SCHEMA: &str = "crab-cache-service.routes.v1";
+const EXPECTED_ROUTE_SCHEMA: &str = "crab-cache-service.routes.v2";
 const EXPECTED_IMMUTABLE_ROUTE_PATTERNS: &[&str] = &[
-    ".crab/xorbs/{hash}",
-    ".crab/shards/{hash}",
+    ".crab/xorbs/{first-two-hex}/{hash}",
+    ".crab/shards/{first-two-hex}/{hash}",
     "{repo}/packs/pack-{id}.pack",
     "{repo}/packs/pack-{id}.idx",
     "{repo}/file_index_db/compacted/*.sst",

--- a/crates/crab-cache-server/src/handlers.rs
+++ b/crates/crab-cache-server/src/handlers.rs
@@ -1311,8 +1311,8 @@ fn check_mutable_read_action(
 /// Parse a wildcard path into (bucket, repo_path, object_type, hash).
 ///
 /// Expected patterns:
-/// - `.crab/xorbs/abcdef...`  → Xorb (CLI global path)
-/// - `.crab/shards/abcdef...`  → Shard (CLI global path)
+/// - `.crab/xorbs/ab/abcdef...`  → Xorb (CLI global path)
+/// - `.crab/shards/ab/abcdef...`  → Shard (CLI global path)
 /// - `org/repo/packs/sha.pack`        → Pack
 /// - `org/repo/packs/sha.idx`         → PackIndex
 /// - versioned SlateDB metadata objects → Metadata
@@ -2013,6 +2013,10 @@ mod tests {
         byte.to_string().repeat(64)
     }
 
+    fn global_path(kind: &str, hash: &str) -> String {
+        format!(".crab/{kind}/{}/{hash}", &hash[..2])
+    }
+
     fn test_dedup_state() -> TestDedupState {
         test_dedup_state_with_origin(Arc::new(InMemory::new()))
     }
@@ -2183,7 +2187,7 @@ mod tests {
             .cache_store
             .put_unverified(&key, fixture.bytes.clone())
             .unwrap();
-        let path = format!(".crab/xorbs/{}", fixture.xorb_hash_hex);
+        let path = global_path("xorbs", &fixture.xorb_hash_hex);
         let state = Arc::new(state);
 
         let response = head_object(
@@ -2215,7 +2219,7 @@ mod tests {
     async fn head_object_reports_cache_miss_from_origin_metadata() {
         let fixture = dedup_xorb_fixture();
         let origin = Arc::new(InMemory::new());
-        let path = format!(".crab/xorbs/{}", fixture.xorb_hash_hex);
+        let path = global_path("xorbs", &fixture.xorb_hash_hex);
         origin
             .put(
                 &ObjectPath::from(path.clone()),
@@ -2419,7 +2423,7 @@ mod tests {
 
         let response = read_object(
             State(Arc::clone(&state)),
-            Path(format!(".crab/xorbs/{}", fixture.xorb_hash_hex)),
+            Path(global_path("xorbs", &fixture.xorb_hash_hex)),
             headers,
             axum::Extension(test_identity()),
         )
@@ -2452,7 +2456,7 @@ mod tests {
 
         let response = read_object(
             State(Arc::clone(&state)),
-            Path(format!(".crab/xorbs/{}", fixture.xorb_hash_hex)),
+            Path(global_path("xorbs", &fixture.xorb_hash_hex)),
             headers,
             axum::Extension(test_identity()),
         )
@@ -2479,7 +2483,7 @@ mod tests {
     async fn fetch_and_cache_data_streams_origin_fill_to_cached_file() {
         let fixture = dedup_xorb_fixture();
         let origin = Arc::new(InMemory::new());
-        let object_path = format!(".crab/xorbs/{}", fixture.xorb_hash_hex);
+        let object_path = global_path("xorbs", &fixture.xorb_hash_hex);
         origin
             .put(
                 &ObjectPath::from(object_path.clone()),
@@ -2691,7 +2695,7 @@ mod tests {
 
         let response = write_object(
             State(Arc::clone(&state)),
-            Path(format!(".crab/xorbs/{}", fixture.xorb_hash_hex)),
+            Path(global_path("xorbs", &fixture.xorb_hash_hex)),
             axum::Extension(test_identity()),
             Body::from(fixture.bytes.clone()),
         )
@@ -2721,7 +2725,7 @@ mod tests {
 
         let response = write_object(
             State(Arc::clone(&state)),
-            Path(format!(".crab/xorbs/{}", fixture.xorb_hash_hex)),
+            Path(global_path("xorbs", &fixture.xorb_hash_hex)),
             axum::Extension(test_identity()),
             Body::from(Bytes::from(corrupt)),
         )
@@ -2795,7 +2799,7 @@ mod tests {
     fn parse_global_crab_shard_path() {
         let hash_hex = hex_hash('b');
         let (bucket, repo, ot, hash) =
-            parse_object_path(&format!(".crab/shards/{hash_hex}")).unwrap();
+            parse_object_path(&global_path("shards", &hash_hex)).unwrap();
         assert_eq!(bucket, "");
         assert_eq!(repo, ".crab");
         assert_eq!(ot, ObjectType::Shard);
@@ -2805,8 +2809,7 @@ mod tests {
     #[test]
     fn parse_global_crab_xorb_path() {
         let hash_hex = hex_hash('c');
-        let (bucket, repo, ot, hash) =
-            parse_object_path(&format!(".crab/xorbs/{hash_hex}")).unwrap();
+        let (bucket, repo, ot, hash) = parse_object_path(&global_path("xorbs", &hash_hex)).unwrap();
         assert_eq!(bucket, "");
         assert_eq!(repo, ".crab");
         assert_eq!(ot, ObjectType::Xorb);

--- a/crates/crab-cache-server/tests/cache_server_preflight_cli.rs
+++ b/crates/crab-cache-server/tests/cache_server_preflight_cli.rs
@@ -1398,7 +1398,7 @@ fn evidence_summarize_reports_customer_proof_without_config() {
     assert_eq!(summary["routes"]["capabilities_status"].as_i64(), Some(200));
     assert_eq!(
         summary["routes"]["route_schema"].as_str(),
-        Some("crab-cache-service.routes.v1")
+        Some("crab-cache-service.routes.v2")
     );
     assert_eq!(
         summary["routes"]["route_transport_prefix"].as_str(),
@@ -1834,7 +1834,7 @@ impl EvidenceFixture {
                     "name": "cache-service-capabilities",
                     "status": 200,
                     "schema": "crab-cache-service.capabilities.v1",
-                    "route_schema": "crab-cache-service.routes.v1",
+                    "route_schema": "crab-cache-service.routes.v2",
                     "route_transport_prefix": "/v1/",
                     "immutable_route_patterns": immutable_route_patterns(),
                     "mutable_route_patterns": mutable_route_patterns(),
@@ -2016,8 +2016,8 @@ fn copy_dir(from: &Path, to: &Path) {
 
 fn immutable_route_patterns() -> Vec<&'static str> {
     vec![
-        ".crab/xorbs/{hash}",
-        ".crab/shards/{hash}",
+        ".crab/xorbs/{first-two-hex}/{hash}",
+        ".crab/shards/{first-two-hex}/{hash}",
         "{repo}/packs/pack-{id}.pack",
         "{repo}/packs/pack-{id}.idx",
         "{repo}/file_index_db/compacted/*.sst",

--- a/crates/crab-cache-server/tests/cache_service_integration.rs
+++ b/crates/crab-cache-server/tests/cache_service_integration.rs
@@ -630,13 +630,13 @@ fn build_real_shard() -> RealShardFixture {
 }
 
 async fn put_real_shard_fixture(client: &CacheClient, fixture: &RealShardFixture) {
-    let xorb_path = format!(".crab/xorbs/{}", fixture.xorb_hash_hex);
+    let xorb_path = global_path("xorbs", &fixture.xorb_hash_hex);
     client
         .put(&xorb_path, fixture.xorb_bytes.clone())
         .await
         .unwrap();
 
-    let shard_path = format!(".crab/shards/{}", fixture.shard_hash_hex);
+    let shard_path = global_path("shards", &fixture.shard_hash_hex);
     client
         .put(&shard_path, fixture.shard_bytes.clone())
         .await
@@ -645,6 +645,10 @@ async fn put_real_shard_fixture(client: &CacheClient, fixture: &RealShardFixture
 
 fn hex_bytes(bytes: &[u8; 32]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn global_path(kind: &str, hash: &str) -> String {
+    format!(".crab/{kind}/{}/{hash}", &hash[..2])
 }
 
 fn pack_storage_hex(name: &str) -> String {
@@ -950,7 +954,7 @@ async fn test_cache_miss_fetches_and_caches() {
     let (data, hash_hex) = build_test_xorb(Bytes::from_static(b"hello cache world"));
 
     // Pre-populate the origin store with the object at the expected path.
-    let origin_path = format!(".crab/xorbs/{hash_hex}");
+    let origin_path = global_path("xorbs", &hash_hex);
     server
         .origin
         .put(
@@ -960,7 +964,7 @@ async fn test_cache_miss_fetches_and_caches() {
         .await
         .unwrap();
 
-    let cache_path = format!(".crab/xorbs/{hash_hex}");
+    let cache_path = global_path("xorbs", &hash_hex);
     let url = format!("http://{}/v1/{cache_path}", server.addr);
     let http = reqwest::Client::new();
 
@@ -1189,7 +1193,7 @@ async fn test_push_warming_populates_cache() {
     let (data, hash_hex) = build_test_xorb(Bytes::from_static(b"push-warmed content"));
 
     // PUT via cache client (push warming).
-    let path = format!(".crab/xorbs/{hash_hex}");
+    let path = global_path("xorbs", &hash_hex);
     client.put(&path, data.clone()).await.unwrap();
 
     // GET should return the cached data without needing origin.
@@ -1218,7 +1222,7 @@ async fn test_push_warming_accepts_multimegabyte_xorb() {
             .collect::<Vec<_>>(),
     );
     let (data, hash_hex) = build_test_xorb(chunk);
-    let path = format!(".crab/xorbs/{hash_hex}");
+    let path = global_path("xorbs", &hash_hex);
 
     client.put(&path, data.clone()).await.unwrap();
 
@@ -1281,7 +1285,7 @@ async fn test_dedup_query_requires_cached_xorb_proof() {
 
     let fixture = build_real_shard();
 
-    let shard_path = format!(".crab/shards/{}", fixture.shard_hash_hex);
+    let shard_path = global_path("shards", &fixture.shard_hash_hex);
     client
         .put(&shard_path, fixture.shard_bytes.clone())
         .await
@@ -1305,8 +1309,8 @@ async fn test_dedup_query_after_shard_and_xorb_ingestion() {
 
     let fixture = build_real_shard();
     put_real_shard_fixture(&client, &fixture).await;
-    let xorb_path = format!(".crab/xorbs/{}", fixture.xorb_hash_hex);
-    let shard_path = format!(".crab/shards/{}", fixture.shard_hash_hex);
+    let xorb_path = global_path("xorbs", &fixture.xorb_hash_hex);
+    let shard_path = global_path("shards", &fixture.shard_hash_hex);
 
     let cached_xorb = client.get(&xorb_path).await.unwrap();
     assert_eq!(cached_xorb, fixture.xorb_bytes);
@@ -1454,7 +1458,7 @@ async fn test_bad_shard_push_warming_rejects_and_does_not_index() {
 
     let fixture = build_real_shard();
     let wrong_hash = "0000000000000000000000000000000000000000000000000000000000000000";
-    let shard_path = format!(".crab/shards/{wrong_hash}");
+    let shard_path = global_path("shards", &wrong_hash);
 
     let err = client
         .put(&shard_path, fixture.shard_bytes.clone())
@@ -1480,7 +1484,7 @@ async fn test_bad_xorb_push_warming_rejects() {
 
     let fixture = build_real_shard();
     let wrong_hash = "0000000000000000000000000000000000000000000000000000000000000000";
-    let xorb_path = format!(".crab/xorbs/{wrong_hash}");
+    let xorb_path = global_path("xorbs", &wrong_hash);
 
     let err = client
         .put(&xorb_path, fixture.xorb_bytes.clone())
@@ -1500,7 +1504,7 @@ async fn test_corrupt_xorb_payload_push_warming_rejects() {
     let (data, hash_hex) = build_test_xorb(Bytes::from_static(b"payload must reconstruct"));
     let mut corrupt = data.to_vec();
     corrupt[0] ^= 0xFF;
-    let xorb_path = format!(".crab/xorbs/{hash_hex}");
+    let xorb_path = global_path("xorbs", &hash_hex);
 
     let err = client
         .put(&xorb_path, Bytes::from(corrupt))
@@ -1519,7 +1523,7 @@ async fn test_bad_origin_shard_read_miss_rejects_and_does_not_index() {
 
     let fixture = build_real_shard();
     let wrong_hash = "1111111111111111111111111111111111111111111111111111111111111111";
-    let shard_path = format!(".crab/shards/{wrong_hash}");
+    let shard_path = global_path("shards", &wrong_hash);
     server
         .origin
         .put(
@@ -1551,7 +1555,7 @@ async fn test_corrupt_cached_shard_hit_refetches_from_origin() {
     let (server, origin_get_count) = start_test_server_with_counting_origin().await;
 
     let fixture = build_real_shard();
-    let shard_path = format!(".crab/shards/{}", fixture.shard_hash_hex);
+    let shard_path = global_path("shards", &fixture.shard_hash_hex);
     server
         .origin
         .put(
@@ -1607,7 +1611,7 @@ async fn test_bad_origin_xorb_read_miss_rejects() {
 
     let fixture = build_real_shard();
     let wrong_hash = "1111111111111111111111111111111111111111111111111111111111111111";
-    let xorb_path = format!(".crab/xorbs/{wrong_hash}");
+    let xorb_path = global_path("xorbs", &wrong_hash);
     server
         .origin
         .put(
@@ -1635,7 +1639,7 @@ async fn test_corrupt_origin_xorb_payload_read_miss_rejects() {
     let (data, hash_hex) = build_test_xorb(Bytes::from_static(b"origin payload must reconstruct"));
     let mut corrupt = data.to_vec();
     corrupt[0] ^= 0xFF;
-    let xorb_path = format!(".crab/xorbs/{hash_hex}");
+    let xorb_path = global_path("xorbs", &hash_hex);
     server
         .origin
         .put(
@@ -1661,7 +1665,7 @@ async fn test_duplicate_shard_put_keeps_admin_stats_idempotent() {
     let client = test_client(server.addr);
 
     let fixture = build_real_shard();
-    let shard_path = format!(".crab/shards/{}", fixture.shard_hash_hex);
+    let shard_path = global_path("shards", &fixture.shard_hash_hex);
 
     client
         .put(&shard_path, fixture.shard_bytes.clone())
@@ -1843,7 +1847,7 @@ async fn test_range_get_returns_correct_slice() {
         build_test_xorb(Bytes::from_static(b"0123456789abcdefghijklmnopqrstuvwxyz"));
 
     // Pre-populate origin.
-    let origin_path = format!(".crab/xorbs/{hash_hex}");
+    let origin_path = global_path("xorbs", &hash_hex);
     server
         .origin
         .put(
@@ -1854,7 +1858,7 @@ async fn test_range_get_returns_correct_slice() {
         .unwrap();
 
     // Full GET to populate the cache.
-    let cache_path = format!(".crab/xorbs/{hash_hex}");
+    let cache_path = global_path("xorbs", &hash_hex);
     let full = client.get(&cache_path).await.unwrap();
     assert_eq!(full, data);
 
@@ -1893,7 +1897,7 @@ async fn test_cold_range_get_fetches_full_object_and_caches() {
     let (data, hash_hex) = build_test_xorb(Bytes::from_static(
         b"cold range requests should be cached by the service",
     ));
-    let path = format!(".crab/xorbs/{hash_hex}");
+    let path = global_path("xorbs", &hash_hex);
     server
         .origin
         .put(
@@ -1960,7 +1964,7 @@ async fn test_cached_unsatisfiable_range_does_not_refetch_origin() {
 
     let (data, hash_hex) =
         build_test_xorb(Bytes::from_static(b"cached range miss should stay local"));
-    let path = format!(".crab/xorbs/{hash_hex}");
+    let path = global_path("xorbs", &hash_hex);
     server
         .origin
         .put(
@@ -2027,7 +2031,7 @@ async fn test_concurrent_cold_misses_coalesce_origin_fetch() {
     let (data, hash_hex) = build_test_xorb(Bytes::from_static(
         b"concurrent cache miss should fetch origin once",
     ));
-    let path = format!(".crab/xorbs/{hash_hex}");
+    let path = global_path("xorbs", &hash_hex);
     server
         .origin
         .put(
@@ -2126,7 +2130,7 @@ async fn test_metrics_returns_prometheus_format() {
 
     // Generate some traffic so metrics have data.
     let (data, hash_hex) = build_test_xorb(Bytes::from_static(b"metrics-test-data"));
-    let path = format!(".crab/xorbs/{hash_hex}");
+    let path = global_path("xorbs", &hash_hex);
     client.put(&path, data).await.unwrap();
 
     // GET /v1/metrics (unauthenticated endpoint).
@@ -2239,7 +2243,7 @@ async fn test_eviction_triggers_on_budget_exceeded() {
     for i in 0..object_count {
         let chunk = deterministic_bytes(i as u64 + 1, object_size);
         let (data, hash_hex) = build_test_xorb(chunk);
-        let path = format!(".crab/xorbs/{hash_hex}");
+        let path = global_path("xorbs", &hash_hex);
         client.put(&path, data.clone()).await.unwrap();
         objects.push((path, data.len() as u64));
     }
@@ -2292,7 +2296,7 @@ async fn test_remaining_objects_readable_after_eviction() {
     for i in 0..object_count {
         let chunk = deterministic_bytes(i as u64 + 1, object_size);
         let (data, hash_hex) = build_test_xorb(chunk);
-        let path = format!(".crab/xorbs/{hash_hex}");
+        let path = global_path("xorbs", &hash_hex);
         client.put(&path, data.clone()).await.unwrap();
         objects.push((path, data));
     }
@@ -2445,7 +2449,11 @@ async fn test_origin_unreachable_cache_miss_returns_504() {
     // GET an object that isn't in cache — the server must fetch from origin,
     // which will fail with a connection error → 504 Gateway Timeout.
     let hash_hex = "a".repeat(64);
-    let url = format!("http://{}/v1/.crab/xorbs/{hash_hex}", server.addr);
+    let url = format!(
+        "http://{}/v1/{}",
+        server.addr,
+        global_path("xorbs", &hash_hex)
+    );
     let client = reqwest::Client::new();
     let resp = client
         .get(&url)
@@ -2470,7 +2478,7 @@ async fn test_origin_unreachable_cache_hit_serves_normally() {
 
     // Pre-warm the cache via PUT — this bypasses origin entirely.
     let (data, hash_hex) = build_test_xorb(Bytes::from_static(b"cached-despite-origin-down"));
-    let path = format!(".crab/xorbs/{hash_hex}");
+    let path = global_path("xorbs", &hash_hex);
 
     client.put(&path, data.clone()).await.unwrap();
 
@@ -2502,7 +2510,7 @@ async fn test_origin_object_identity_path_serves_non_blake3_body_hash() {
     );
 
     // Store bytes in the origin at the path keyed by the xorb aggregate ID.
-    let origin_path = format!(".crab/xorbs/{xorb_hash_hex}");
+    let origin_path = global_path("xorbs", &xorb_hash_hex);
     server
         .origin
         .put(
@@ -2513,7 +2521,11 @@ async fn test_origin_object_identity_path_serves_non_blake3_body_hash() {
         .unwrap();
 
     // GET via cache — the server validates the xorb aggregate ID, not blake3(body).
-    let url = format!("http://{}/v1/.crab/xorbs/{xorb_hash_hex}", server.addr);
+    let url = format!(
+        "http://{}/v1/{}",
+        server.addr,
+        global_path("xorbs", &xorb_hash_hex)
+    );
     let client = reqwest::Client::new();
     let resp = client
         .get(&url)

--- a/crates/crab-cache-store/src/lib.rs
+++ b/crates/crab-cache-store/src/lib.rs
@@ -1857,6 +1857,10 @@ mod tests {
         (xorb.bytes, xorb.hash.hex())
     }
 
+    fn content_path(kind: &str, hash: &str) -> Path {
+        Path::from(format!(".crab/{kind}/{}/{hash}", &hash[..2]))
+    }
+
     fn test_raw_xorb(payloads: &[Bytes]) -> (Bytes, MerkleHash) {
         let policy: Arc<dyn CompressionPolicy> =
             Arc::new(FixedCompression::new(CompressionScheme::None));
@@ -2193,7 +2197,7 @@ mod tests {
     async fn get_with_etag_uses_cache_service_and_reuses_server_cache() {
         let server = start_test_cache_server().await;
         let (body, hash_hex) = test_xorb(b"crab-side cache service read path");
-        let path = Path::from(format!(".crab/xorbs/{hash_hex}"));
+        let path = Path::from(format!(".crab/xorbs/{}/{hash_hex}", &hash_hex[..2]));
         server
             .origin
             .put(&path, PutPayload::from_bytes(body.clone()))
@@ -2231,7 +2235,7 @@ mod tests {
     async fn head_cache_service_object_reports_warm_hit_without_origin_get() {
         let server = start_test_cache_server().await;
         let (body, hash_hex) = test_xorb(b"crab-side cache service head path");
-        let path = Path::from(format!(".crab/xorbs/{hash_hex}"));
+        let path = content_path("xorbs", &hash_hex);
         server
             .origin
             .put(&path, PutPayload::from_bytes(body.clone()))
@@ -2272,7 +2276,7 @@ mod tests {
     async fn object_store_head_uses_cache_service_head_without_origin_get() {
         let server = start_test_cache_server().await;
         let (body, hash_hex) = test_xorb(b"object-store head should not fetch body");
-        let path = Path::from(format!(".crab/xorbs/{hash_hex}"));
+        let path = content_path("xorbs", &hash_hex);
         server
             .origin
             .put(&path, PutPayload::from_bytes(body.clone()))
@@ -2388,7 +2392,7 @@ mod tests {
         assert_eq!(server.origin_get_count.load(Ordering::Relaxed), 0);
 
         let (immutable_body, hash_hex) = test_xorb(b"immutable route contract body");
-        let immutable_path = Path::from(format!(".crab/xorbs/{hash_hex}"));
+        let immutable_path = content_path("xorbs", &hash_hex);
         server
             .origin
             .put(
@@ -2485,7 +2489,7 @@ mod tests {
         };
 
         let (body, hash_hex) = test_xorb(b"object-store suffix range should use head plus range");
-        let path = format!(".crab/xorbs/{hash_hex}");
+        let path = content_path("xorbs", &hash_hex).to_string();
         let object_path = Path::from(path.clone());
         let body = Arc::new(body);
         let head_count = Arc::new(AtomicUsize::new(0));
@@ -2661,7 +2665,7 @@ mod tests {
         };
 
         let (body, hash_hex) = test_xorb(b"object-store bounded range clamps past eof");
-        let path = format!(".crab/xorbs/{hash_hex}");
+        let path = content_path("xorbs", &hash_hex).to_string();
         let object_path = Path::from(path.clone());
         let body = Arc::new(body);
         let head_count = Arc::new(AtomicUsize::new(0));
@@ -2833,7 +2837,7 @@ mod tests {
         let server = start_malformed_object_server(b"bad shard body").await;
         let good_body = Bytes::from_static(b"correct shard body");
         let hash = crab_xet::hash::compute_data_hash(&good_body);
-        let path = Path::from(format!(".crab/shards/{}", hash.hex()));
+        let path = content_path("shards", &hash.hex());
         let origin = origin_store();
         origin.put(&path, good_body.clone()).await.unwrap();
         let tempdir = tempfile::tempdir().unwrap();
@@ -2863,7 +2867,7 @@ mod tests {
         let server = start_malformed_object_server(b"bad xorb body").await;
         let (good_body, hash_hex) = test_xorb(b"correct xorb body");
         let hash = MerkleHash::from_hex(&hash_hex).unwrap();
-        let path = Path::from(format!(".crab/xorbs/{hash_hex}"));
+        let path = content_path("xorbs", &hash_hex);
         let origin = origin_store();
         origin.put(&path, good_body.clone()).await.unwrap();
         let tempdir = tempfile::tempdir().unwrap();
@@ -2892,7 +2896,7 @@ mod tests {
     async fn range_get_uses_cache_service_when_server_cache_is_warm() {
         let server = start_test_cache_server().await;
         let (body, hash_hex) = test_xorb(b"0123456789abcdefghijklmnopqrstuvwxyz");
-        let path = Path::from(format!(".crab/xorbs/{hash_hex}"));
+        let path = content_path("xorbs", &hash_hex);
         server
             .origin
             .put(&path, PutPayload::from_bytes(body.clone()))
@@ -2930,7 +2934,7 @@ mod tests {
     async fn cold_range_get_uses_cache_service_instead_of_client_origin() {
         let server = start_test_cache_server().await;
         let (body, hash_hex) = test_xorb(b"cache server owns cold range origin fetches");
-        let path = Path::from(format!(".crab/xorbs/{hash_hex}"));
+        let path = content_path("xorbs", &hash_hex);
         server
             .origin
             .put(&path, PutPayload::from_bytes(body.clone()))
@@ -3051,7 +3055,7 @@ mod tests {
             Bytes::from(vec![0x44; 32 * 1024]),
         ];
         let (xorb, hash) = test_raw_xorb(&payloads);
-        let path = Path::from(format!(".crab/xorbs/{}", hash.hex()));
+        let path = content_path("xorbs", &hash.hex());
         let origin = origin_store();
         origin.put(&path, xorb).await.unwrap();
         let tempdir = tempfile::tempdir().unwrap();
@@ -3088,7 +3092,7 @@ mod tests {
             .chunk_meta(0)
             .unwrap()
             .hash;
-        let path = Path::from(format!(".crab/xorbs/{}", hash.hex()));
+        let path = content_path("xorbs", &hash.hex());
         let origin = origin_store();
         origin.put(&path, xorb).await.unwrap();
         let tempdir = tempfile::tempdir().unwrap();
@@ -3130,7 +3134,7 @@ mod tests {
             .flat_map(|payload| payload.iter().copied())
             .collect::<Vec<_>>();
         let (xorb, hash) = test_raw_xorb(&payloads);
-        let path = Path::from(format!(".crab/xorbs/{}", hash.hex()));
+        let path = content_path("xorbs", &hash.hex());
         let inner = Arc::new(InMemory::new());
         inner
             .put(&path, PutPayload::from_bytes(xorb))
@@ -3170,7 +3174,7 @@ mod tests {
         let (xorb, hash) = test_raw_xorb(&payloads);
         let mut corrupt = xorb.to_vec();
         corrupt[0] ^= 0xff;
-        let path = Path::from(format!(".crab/xorbs/{}", hash.hex()));
+        let path = content_path("xorbs", &hash.hex());
         let origin = origin_store();
         origin.put(&path, Bytes::from(corrupt)).await.unwrap();
         let tempdir = tempfile::tempdir().unwrap();
@@ -3202,7 +3206,7 @@ mod tests {
             Bytes::from(vec![0x44; 32 * 1024]),
         ];
         let (xorb, hash) = test_raw_xorb(&payloads);
-        let path = Path::from(format!(".crab/xorbs/{}", hash.hex()));
+        let path = content_path("xorbs", &hash.hex());
         let inner = Arc::new(InMemory::new());
         inner
             .put(&path, PutPayload::from_bytes(xorb))
@@ -3246,7 +3250,7 @@ mod tests {
             .flat_map(|payload| payload.iter().copied())
             .collect::<Vec<_>>();
         let (xorb, hash) = test_raw_xorb(&payloads);
-        let path = Path::from(format!(".crab/xorbs/{}", hash.hex()));
+        let path = content_path("xorbs", &hash.hex());
         let origin = origin_store();
         origin.put(&path, xorb).await.unwrap();
         let tempdir = tempfile::tempdir().unwrap();
@@ -3293,7 +3297,7 @@ mod tests {
         let origin_probe = origin.clone();
         let cs = CachingStore::new(origin, &no_cache_config()).unwrap();
         let (_good_body, hash_hex) = test_xorb(b"expected xorb body");
-        let path = Path::from(format!(".crab/xorbs/{hash_hex}"));
+        let path = Path::from(format!(".crab/xorbs/{}/{hash_hex}", &hash_hex[..2]));
 
         let err = cs
             .put(&path, Bytes::from_static(b"not a serialized xorb"))
@@ -3506,7 +3510,7 @@ mod tests {
         };
         let mut cs = CachingStore::new(origin_store(), &config).unwrap();
         cs.max_push_warming_object_bytes = Some(4);
-        let path = Path::from(format!(".crab/xorbs/{}", MerkleHash::from([1u8; 32]).hex()));
+        let path = content_path("xorbs", &MerkleHash::from([1u8; 32]).hex());
 
         cs.warm_remote_only(&path, Bytes::from_static(b"12345"))
             .await

--- a/crates/crab-cache/src/path_class.rs
+++ b/crates/crab-cache/src/path_class.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::key::CacheKey;
 
 /// Schema identifier for the cache-service route taxonomy.
-pub const CACHE_ROUTE_CONTRACT_SCHEMA: &str = "crab-cache-service.routes.v1";
+pub const CACHE_ROUTE_CONTRACT_SCHEMA: &str = "crab-cache-service.routes.v2";
 
 /// Whether a request path refers to an immutable (content-addressed) or
 /// mutable (refs, HEAD, manifests, config, locks) object.
@@ -57,8 +57,8 @@ pub fn cache_route_contract() -> CacheRouteContract {
         schema: CACHE_ROUTE_CONTRACT_SCHEMA.to_string(),
         transport_prefix: "/v1/".to_string(),
         immutable: route_patterns(&[
-            ("xorb", ".crab/xorbs/{hash}"),
-            ("shard", ".crab/shards/{hash}"),
+            ("xorb", ".crab/xorbs/{first-two-hex}/{hash}"),
+            ("shard", ".crab/shards/{first-two-hex}/{hash}"),
             ("pack", "{repo}/packs/pack-{id}.pack"),
             ("pack_index", "{repo}/packs/pack-{id}.idx"),
             ("metadata", "{repo}/file_index_db/compacted/*.sst"),
@@ -182,8 +182,17 @@ pub(crate) fn normalize_transport_path(path: &str) -> &str {
 
 fn parse_global_crab_object(path: &str) -> Option<CacheObjectPath<'_>> {
     let after_global = path.strip_prefix(".crab/")?;
-    let (type_str, hash) = after_global.split_once('/')?;
-    if !is_hash_hex(hash) {
+    let mut parts = after_global.split('/');
+    let type_str = parts.next()?;
+    let partition = parts.next()?;
+    let hash = parts.next()?;
+    if parts.next().is_some()
+        || !is_hash_hex(hash)
+        || partition != hash.get(..2)?
+        || !partition
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
         return None;
     }
     let kind = match type_str {
@@ -257,7 +266,10 @@ fn has_extension(path: &str, extension: &str) -> bool {
 }
 
 fn is_hash_hex(hash: &str) -> bool {
-    hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+    hash.len() == 64
+        && hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
 #[cfg(test)]
@@ -291,25 +303,25 @@ mod tests {
         vec![
             RouteContractCase {
                 name: "global xorb",
-                path: format!("/v1/.crab/xorbs/{xorb_hash}"),
+                path: format!("/v1/.crab/xorbs/aa/{xorb_hash}"),
                 class: PathClass::Immutable,
                 parsed: Some(ParsedRouteContract {
                     repo_path: ".crab",
                     kind: CacheObjectKind::Xorb,
                     identity: xorb_hash,
                 }),
-                docs_token: ".crab/xorbs/{hash}",
+                docs_token: ".crab/xorbs/{first-two-hex}/{hash}",
             },
             RouteContractCase {
                 name: "global shard",
-                path: format!("/v1/.crab/shards/{shard_hash}"),
+                path: format!("/v1/.crab/shards/bb/{shard_hash}"),
                 class: PathClass::Immutable,
                 parsed: Some(ParsedRouteContract {
                     repo_path: ".crab",
                     kind: CacheObjectKind::Shard,
                     identity: shard_hash,
                 }),
-                docs_token: ".crab/shards/{hash}",
+                docs_token: ".crab/shards/{first-two-hex}/{hash}",
             },
             RouteContractCase {
                 name: "git pack",
@@ -444,8 +456,8 @@ mod tests {
         assert_eq!(contract.schema, CACHE_ROUTE_CONTRACT_SCHEMA);
         assert_eq!(contract.transport_prefix, "/v1/");
         for pattern in [
-            ".crab/xorbs/{hash}",
-            ".crab/shards/{hash}",
+            ".crab/xorbs/{first-two-hex}/{hash}",
+            ".crab/shards/{first-two-hex}/{hash}",
             "{repo}/packs/pack-{id}.pack",
             "{repo}/packs/pack-{id}.idx",
             "{repo}/file_index_db/manifest/*.manifest",
@@ -492,12 +504,20 @@ mod tests {
         let xorb_hash = MerkleHash::from([9u64, 10, 11, 12]);
         let shard_hash = MerkleHash::from([1u64, 2, 3, 4]);
 
-        let xorb_key = cache_key_for_path(&format!(".crab/xorbs/{}", xorb_hash.hex()))
-            .expect("xorb path should map to local cache key");
+        let xorb_key = cache_key_for_path(&format!(
+            ".crab/xorbs/{}/{}",
+            &xorb_hash.hex()[..2],
+            xorb_hash.hex()
+        ))
+        .expect("xorb path should map to local cache key");
         assert!(matches!(xorb_key, CacheKey::Xorb(hash) if hash == xorb_hash));
 
-        let shard_key = cache_key_for_path(&format!("/v1/.crab/shards/{}", shard_hash.hex()))
-            .expect("shard path should map to local cache key");
+        let shard_key = cache_key_for_path(&format!(
+            "/v1/.crab/shards/{}/{}",
+            &shard_hash.hex()[..2],
+            shard_hash.hex()
+        ))
+        .expect("shard path should map to local cache key");
         assert!(matches!(shard_key, CacheKey::Shard(hash) if hash == shard_hash));
 
         assert!(cache_key_for_path("org/repo/packs/pack-abc.pack").is_none());
@@ -546,7 +566,7 @@ mod tests {
             None,
         );
         assert_eq!(
-            parse_mutable_repo_path(&format!(".crab/xorbs/{hash}")),
+            parse_mutable_repo_path(&format!(".crab/xorbs/{}/{hash}", &hash[..2])),
             None,
         );
     }
@@ -597,7 +617,7 @@ mod tests {
     fn canonical_crab_xorb_path_is_immutable() {
         let hash = hex_hash('a');
         assert_eq!(
-            classify_path(&format!("/v1/.crab/xorbs/{hash}")),
+            classify_path(&format!("/v1/.crab/xorbs/{}/{hash}", &hash[..2])),
             PathClass::Immutable,
         );
     }
@@ -606,7 +626,7 @@ mod tests {
     fn canonical_crab_shard_path_is_immutable() {
         let hash = hex_hash('b');
         assert_eq!(
-            classify_path(&format!("/v1/.crab/shards/{hash}")),
+            classify_path(&format!("/v1/.crab/shards/{}/{hash}", &hash[..2])),
             PathClass::Immutable,
         );
     }
@@ -616,11 +636,17 @@ mod tests {
         let xorb_hash = hex_hash('c');
         let shard_hash = hex_hash('d');
         assert_eq!(
-            classify_path(&format!("/v1/bucket/.crab/xorbs/{xorb_hash}")),
+            classify_path(&format!(
+                "/v1/bucket/.crab/xorbs/{}/{xorb_hash}",
+                &xorb_hash[..2]
+            )),
             PathClass::Mutable,
         );
         assert_eq!(
-            classify_path(&format!("/v1/bucket/.crab/shards/{shard_hash}")),
+            classify_path(&format!(
+                "/v1/bucket/.crab/shards/{}/{shard_hash}",
+                &shard_hash[..2]
+            )),
             PathClass::Mutable,
         );
     }
@@ -632,6 +658,15 @@ mod tests {
             PathClass::Mutable,
         );
         assert_eq!(classify_path("/v1/.crab/shards/abc123"), PathClass::Mutable,);
+        let hash = hex_hash('a');
+        assert_eq!(
+            classify_path(&format!("/v1/.crab/xorbs/{hash}")),
+            PathClass::Mutable,
+        );
+        assert_eq!(
+            classify_path(&format!("/v1/.crab/xorbs/ff/{hash}")),
+            PathClass::Mutable,
+        );
     }
 
     #[test]
@@ -709,11 +744,11 @@ mod tests {
         let xorb_hash = hex_hash('e');
         let shard_hash = hex_hash('f');
         assert_eq!(
-            classify_path(&format!(".crab/xorbs/{xorb_hash}")),
+            classify_path(&format!(".crab/xorbs/{}/{xorb_hash}", &xorb_hash[..2])),
             PathClass::Immutable,
         );
         assert_eq!(
-            classify_path(&format!(".crab/shards/{shard_hash}")),
+            classify_path(&format!(".crab/shards/{}/{shard_hash}", &shard_hash[..2])),
             PathClass::Immutable,
         );
     }

--- a/crates/crab-metadata/src/remote_index.rs
+++ b/crates/crab-metadata/src/remote_index.rs
@@ -499,7 +499,8 @@ mod tests {
             uncompressed_size: xorb_ref.uncompressed_size,
             origin: crate::receipts::OriginReceipt::new(
                 "canonical-origin".to_owned(),
-                format!(".crab/xorbs/{}", xorb_ref.xorb_hash.hex()),
+                crab_storage::canonical_global_content_path("xorbs", &xorb_ref.xorb_hash.hex())
+                    .to_string(),
                 xorb_ref.xorb_hash.into(),
                 [9; 32],
                 32,

--- a/crates/crab-storage/src/layout.rs
+++ b/crates/crab-storage/src/layout.rs
@@ -7,6 +7,59 @@ use object_store::path::Path as ObjectPath;
 
 /// The default bucket-level prefix for all content-addressed objects.
 pub const GLOBAL_PREFIX: &str = ".crab";
+/// Number of leading hash characters used to partition global content.
+pub const GLOBAL_CONTENT_FANOUT_WIDTH: usize = 2;
+
+/// Build the directory containing one global content kind.
+#[must_use]
+pub fn global_content_prefix(global_prefix: &str, kind: &str) -> ObjectPath {
+    ObjectPath::from(format!("{global_prefix}/{kind}"))
+}
+
+/// Build one populated hash-partition directory below a global content kind.
+#[must_use]
+pub fn global_content_partition_prefix(
+    global_prefix: &str,
+    kind: &str,
+    partition: &str,
+) -> ObjectPath {
+    ObjectPath::from(format!("{global_prefix}/{kind}/{partition}"))
+}
+
+/// Build a two-hex-fan-out path for one global content-addressed object.
+///
+/// `hash` must be a lowercase 64-character hexadecimal content hash.
+#[must_use]
+pub fn global_content_path(global_prefix: &str, kind: &str, hash: &str) -> ObjectPath {
+    let partition = hash.get(..GLOBAL_CONTENT_FANOUT_WIDTH).unwrap_or(hash);
+    global_content_partition_prefix(global_prefix, kind, partition).join(hash)
+}
+
+/// Build a global content path under Crab's canonical bucket prefix.
+///
+/// `hash` must be a lowercase 64-character hexadecimal content hash.
+#[must_use]
+pub fn canonical_global_content_path(kind: &str, hash: &str) -> ObjectPath {
+    global_content_path(GLOBAL_PREFIX, kind, hash)
+}
+
+/// Extract and validate the hash from a canonical fan-out content path.
+#[must_use]
+pub fn content_hash_from_path<'a>(path: &'a str, kind: &str) -> Option<&'a str> {
+    let mut parts = path.rsplit('/');
+    let hash = parts.next()?;
+    let partition = parts.next()?;
+    if parts.next()? != kind
+        || hash.len() != 64
+        || !hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        || partition != hash.get(..GLOBAL_CONTENT_FANOUT_WIDTH)?
+    {
+        return None;
+    }
+    Some(hash)
+}
 
 /// Provides optional scoped prefixes for path-limited repository views.
 pub trait StorageScopeProvider {
@@ -85,10 +138,10 @@ impl<S> StoreLayout<S> {
 
     /// Build the full object-store path for a content-addressed object.
     ///
-    /// Returns `.crab/{kind}/{hash}`.
+    /// Returns `.crab/{kind}/{first-two-hex}/{hash}`.
     #[must_use]
     pub fn global_path(&self, kind: &str, hash: &str) -> ObjectPath {
-        ObjectPath::from(format!("{}/{kind}/{hash}", self.global_prefix))
+        global_content_path(&self.global_prefix, kind, hash)
     }
 
     /// Build the full object-store path for a per-repo object.
@@ -99,13 +152,13 @@ impl<S> StoreLayout<S> {
         ObjectPath::from(format!("{}/{relative_path}", self.repo_prefix))
     }
 
-    /// Convenience: xorb path at `.crab/xorbs/{hash}`.
+    /// Convenience: xorb path at `.crab/xorbs/{first-two-hex}/{hash}`.
     #[must_use]
     pub fn xorb_path(&self, hash: &(impl Display + ?Sized)) -> ObjectPath {
         self.global_path("xorbs", &hash.to_string())
     }
 
-    /// Convenience: shard path at `.crab/shards/{hash}`.
+    /// Convenience: shard path at `.crab/shards/{first-two-hex}/{hash}`.
     #[must_use]
     pub fn shard_path(&self, hash: &(impl Display + ?Sized)) -> ObjectPath {
         self.global_path("shards", &hash.to_string())
@@ -314,8 +367,9 @@ mod tests {
     #[test]
     fn global_path_routes_to_crab_prefix() {
         let layout = test_layout();
-        let path = layout.global_path("xorbs", "abcd1234");
-        assert_eq!(path.as_ref(), ".crab/xorbs/abcd1234");
+        let hash = format!("ab{}", "1".repeat(62));
+        let path = layout.global_path("xorbs", &hash);
+        assert_eq!(path.as_ref(), format!(".crab/xorbs/ab/{hash}"));
     }
 
     #[test]
@@ -362,12 +416,7 @@ mod tests {
         let layout = test_layout();
         let hash = "a".repeat(64);
         let path = layout.xorb_path(&hash);
-        let path_str = path.as_ref();
-        assert!(path_str.starts_with(".crab/xorbs/"));
-        let hex_part = path_str
-            .strip_prefix(".crab/xorbs/")
-            .expect("xorb path prefix");
-        assert_eq!(hex_part.len(), 64);
+        assert_eq!(path.as_ref(), format!(".crab/xorbs/aa/{hash}"));
     }
 
     #[test]
@@ -375,7 +424,21 @@ mod tests {
         let layout = test_layout();
         let hash = "b".repeat(64);
         let path = layout.shard_path(&hash);
-        assert!(path.as_ref().starts_with(".crab/shards/"));
+        assert_eq!(path.as_ref(), format!(".crab/shards/bb/{hash}"));
+    }
+
+    #[test]
+    fn content_path_parser_requires_matching_lowercase_fanout() {
+        let hash = format!("ab{}", "3".repeat(62));
+
+        assert_eq!(
+            content_hash_from_path(&format!(".crab/xorbs/ab/{hash}"), "xorbs"),
+            Some(hash.as_str())
+        );
+        assert!(content_hash_from_path(&format!(".crab/xorbs/ac/{hash}"), "xorbs").is_none());
+        assert!(content_hash_from_path(&format!(".crab/xorbs/AB/{hash}"), "xorbs").is_none());
+        assert!(content_hash_from_path(&format!(".crab/xorbs/ab/{hash}"), "shards").is_none());
+        assert!(content_hash_from_path(&format!(".crab/xorbs/{hash}"), "xorbs").is_none());
     }
 
     #[test]
@@ -508,7 +571,7 @@ mod tests {
             layout
                 .xorb_path(&hash)
                 .as_ref()
-                .starts_with(&format!("{view_prefix}/.crab/xorbs/"))
+                .starts_with(&format!("{view_prefix}/.crab/xorbs/cc/"))
         );
         assert_eq!(
             layout.ref_registry_path().as_ref(),
@@ -532,13 +595,13 @@ mod tests {
             layout
                 .xorb_path(&hash)
                 .as_ref()
-                .starts_with(&format!("{view_prefix}/.crab/xorbs/"))
+                .starts_with(&format!("{view_prefix}/.crab/xorbs/dd/"))
         );
         assert!(
             layout
                 .shard_path(&hash)
                 .as_ref()
-                .starts_with(&format!("{view_prefix}/.crab/shards/"))
+                .starts_with(&format!("{view_prefix}/.crab/shards/dd/"))
         );
     }
 }

--- a/crates/crab-storage/src/lib.rs
+++ b/crates/crab-storage/src/lib.rs
@@ -23,7 +23,9 @@ pub use external::{
 pub use head_batch::{HeadBatchConfig, HeadBatchOutcome, HeadBatchStore, head_batch};
 pub use identity::{BucketIdentity, StorageProviderKind};
 pub use layout::{
-    ObjectType, StorageScopeProvider, StoreLayout, repo_pack_index_path, repo_pack_metadata_path,
+    GLOBAL_CONTENT_FANOUT_WIDTH, GLOBAL_PREFIX, ObjectType, StorageScopeProvider, StoreLayout,
+    canonical_global_content_path, content_hash_from_path, global_content_partition_prefix,
+    global_content_path, global_content_prefix, repo_pack_index_path, repo_pack_metadata_path,
     repo_pack_path, repo_pack_reverse_index_path,
 };
 pub use provider_options::{

--- a/crates/crab-xet/src/shard_parse.rs
+++ b/crates/crab-xet/src/shard_parse.rs
@@ -118,7 +118,7 @@ pub fn extract_chunk_entries_streaming(data: &Bytes) -> Vec<(MerkleHash, XorbRef
 ///
 /// The `shard_hash` argument is the containing shard's content hash;
 /// callers typically parse it from the last segment of the shard
-/// object key (`.crab/shards/{hex}`). Each file-info entry in the
+/// object key (`.crab/shards/{first-two-hex}/{hex}`). Each file-info entry in the
 /// shard contributes one pair.
 ///
 /// On any parse failure the helper logs a `warn!` and returns an


### PR DESCRIPTION
## Summary

- replace flat global xorb and shard keys with canonical two-hex fanout: `.crab/{xorbs,shards}/{first-two-hex}/{full-hash}`
- fail closed on flat, malformed, uppercase, or partition/hash-mismatched global objects
- add provider-aware adaptive bucket-GC listing with three local operator profiles: `adaptive`, `cost`, and `latency`
- keep small/local/serial listings on one recursive stream; fan out only after recursive pagination reaches the complete 256-partition request cost
- expose the policy at initial setup through `crab init --gc-list-profile` and `crab configure --gc-list-profile`, with `crab gc --list-profile` as a one-run override
- preserve the local profile across re-init and reject malformed policy instead of silently overwriting or ignoring it
- move push dedup prefix scans, compact, restripe, metadb, protected push, scoped views, cache routing, and maintenance consumers to the canonical layout
- bump the cache route contract to `crab-cache-service.routes.v2` and document Object Storage Layout V2

## Breaking cutover

This intentionally has no V1 compatibility reader, dual writer, fallback, or migration shim. Existing flat xorb and shard objects must be re-uploaded with the V2 client after old writers are stopped.

## Adaptive cost/latency model

`adaptive` is the default. It starts one recursive stream per global kind. Local stores and effective concurrency 1 remain recursive. Cloud namespaces switch to populated two-hex partitions only after the bounded probe reaches:

- S3/GCS: 256,000 objects (1,000 objects/page × 256 partitions)
- Azure: 1,280,000 objects (5,000 objects/page × 256 partitions)

At the crossover, a full partition scan costs approximately the same number of provider LIST calls as the recursive scan; replaying the probe bounds transition overhead near 2×. Larger namespaces amortize the probe and gain bounded parallel wall time. `cost` always uses one recursive stream per kind. `latency` immediately discovers and scans populated partitions concurrently. Xorb and shard scans share the configured LIST-concurrency semaphore and honor cancellation throughout permit acquisition and stream consumption.

The reported `list_requests` value is explicitly a logical-stream count. Provider pagination and retries remain internal to `object_store` and can issue additional physical API requests.

## Real RustFS qualification

- installed the release CLI using `make install` with an external Cargo target
- initialized and pushed a repository containing a deterministic 5 MiB file
- verified all produced xorbs and shards used matching two-hex partitions and no flat global keys existed
- cloned to a fresh worktree, hydrated all files, and compared BLAKE3 hashes byte-identically
- ran `crab fsck --json`: passed with zero errors
- ran bucket-scope GC dry-run: complete enumeration with zero failures
- deleted the disposable bucket and local fixture and stopped RustFS

Repository policy forbids destructive bucket-scope GC qualification; destructive safety remains covered by in-memory bucket GC tests.

## Adaptive setup smoke

A newly built Crab binary was run in a disposable mounted-volume Git repository:

- `crab init ... --gc-list-profile cost --json` persisted `gc.list_profile = "cost"`
- re-running `crab init --json` preserved `cost`
- `crab configure ... --gc-list-profile latency --dry-run` reported the latency plan
- `crab gc --help` exposed `--list-profile`

## Verification

- rebased `cargo check -p crab --locked`: passed
- bucket GC module: 30 passed, including a 256,001 uniformly distributed object crossover test
- config parse and init persistence/fail-closed regressions: passed
- `cargo test -p crab --locked --lib`: 3,584 passed, 16 unrelated failures, 2 ignored
- `npm run check:links`: 190 pages and 1,960 fragments passed
- `cargo fmt --all -- --check`
- `git diff --check`

The broad failures are existing workflow HTTP/checkpoint environment assumptions, missing snapshot baselines, and a replication inventory expectation. No baseline, snapshot, inventory, or workflow expectation was changed to mask them. Rust 1.97 clippy also exposes pre-existing warnings outside this PR's changed surface; CI remains authoritative under the repository toolchain.

## CI status

All GitHub Actions jobs for `c821c69b` failed before executing any step (empty step lists, no job logs, 1–3 second duration). This is runner/infrastructure failure; local rebased compile and scoped tests above are green.