### PR TITLE
fix: keep Git locator readers storage read-only

### DIFF
--- a/crates/crab-metadata/src/git_object_locator/reader.rs
+++ b/crates/crab-metadata/src/git_object_locator/reader.rs
@@ -53,8 +53,12 @@ pub struct GitObjectLocatorSession {
 
 impl GitObjectLocatorSession {
     /// Open the compact locator, treating an absent database as an empty index.
+    ///
+    /// A published locator checkpoint is opened explicitly so a read-only
+    /// session does not create or refresh durable reader state. A legacy
+    /// database with no checkpoint uses SlateDB's compatibility path.
     pub async fn open(store: Arc<dyn ObjectStore>, repo_prefix: &str) -> Result<Self> {
-        Self::open_with_options(store, repo_prefix, locator_reader_options()).await
+        Self::open_with_published_checkpoint(store, repo_prefix, locator_reader_options()).await
     }
 
     /// Open a locator whose SlateDB checkpoint cannot refresh before `minimum`.
@@ -80,11 +84,20 @@ impl GitObjectLocatorSession {
             checkpoint_lifetime,
             ..locator_reader_options()
         };
+        Self::open_with_published_checkpoint(store, repo_prefix, options).await
+    }
+
+    async fn open_with_published_checkpoint(
+        store: Arc<dyn ObjectStore>,
+        repo_prefix: &str,
+        options: DbReaderOptions,
+    ) -> Result<Self> {
         let path = git_object_locator_path(repo_prefix);
         let checkpoint = reader_checkpoint_id(Arc::clone(&store), &path).await?;
         Self::open_with_checkpoint(store, repo_prefix, options, checkpoint).await
     }
 
+    #[cfg(test)]
     async fn open_with_options(
         store: Arc<dyn ObjectStore>,
         repo_prefix: &str,
@@ -691,6 +704,30 @@ mod tests {
         .await
         .expect("open operation reader");
         session.close().await.expect("close operation reader");
+
+        let after = store
+            .list(Some(&prefix))
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("list after reader");
+        assert_eq!(before, after);
+    }
+
+    #[tokio::test]
+    async fn published_locator_open_is_storage_read_only() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        publish(Arc::clone(&store), pack(1), [32; 20], None).await;
+        let prefix = ObjectPath::from("org/repo/git_locator_db");
+        let before = store
+            .list(Some(&prefix))
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("list before reader");
+
+        let session = GitObjectLocatorSession::open(Arc::clone(&store), "org/repo")
+            .await
+            .expect("open reader");
+        session.close().await.expect("close reader");
 
         let after = store
             .list(Some(&prefix))

--- a/crates/crab-remote-git/src/repository.rs
+++ b/crates/crab-remote-git/src/repository.rs
@@ -1077,11 +1077,10 @@ mod tests {
                 }
             }
             let mut result = self.inner.get_opts(location, options).await?;
-            if location.as_ref() == self.manifest_path {
-                if self.short_manifest.load(Ordering::SeqCst) {
-                    result.meta.size = result.meta.size.saturating_add(1);
-                    result.range.end = result.range.end.saturating_add(1);
-                }
+            if location.as_ref() == self.manifest_path && self.short_manifest.load(Ordering::SeqCst)
+            {
+                result.meta.size = result.meta.size.saturating_add(1);
+                result.range.end = result.range.end.saturating_add(1);
             }
             Ok(result)
         }

--- a/crates/crab-remote-git/src/snapshot.rs
+++ b/crates/crab-remote-git/src/snapshot.rs
@@ -1223,7 +1223,7 @@ async fn lcs_matches(
             let (mut row, mut column) = (rows - 1, columns - 1);
             let mut backtrace_steps = 0usize;
             while row > 0 && column > 0 {
-                if backtrace_steps % CPU_CANCELLATION_INTERVAL == 0 {
+                if backtrace_steps.is_multiple_of(CPU_CANCELLATION_INTERVAL) {
                     check_cpu_cancellation(&cancellation)?;
                 }
                 if parent[parent_lines[equal_prefix + row - 1].clone()]
@@ -1746,9 +1746,9 @@ mod tests {
         let error = lcs_matches(
             &runtime,
             bytes::Bytes::from_static(b"parent\n"),
-            vec![0..7],
+            std::iter::once(0..7).collect(),
             bytes::Bytes::from_static(b"current\n"),
-            vec![0..8],
+            std::iter::once(0..8).collect(),
             0,
             0,
             cancellation,

--- a/crates/crab-remote-git/tests/remote_repository.rs
+++ b/crates/crab-remote-git/tests/remote_repository.rs
@@ -2286,7 +2286,7 @@ async fn repository_semantics_match_native_git_ground_truth() {
         (line.starts_with(b"+") && !line.starts_with(b"+++"))
             || (line.starts_with(b"-") && !line.starts_with(b"---"))
     })
-    .flat_map(|line| line.iter().copied().chain([b'\n']))
+    .flat_map(|line| line.iter().copied().chain(*b"\n"))
     .collect::<Vec<_>>();
     let native_blame_output = git(
         &[


### PR DESCRIPTION
## Summary

- make the general `GitObjectLocatorSession::open` path reuse the writer-published immutable SlateDB checkpoint
- prevent diagnostics and other read-only locator consumers from creating or refreshing durable reader manifests
- add a regression that compares the exact locator object set before and after a published locator session
- clear the Rust 1.97 Clippy findings discovered while qualifying `crab-remote-git`

## Why this is the best fix

The mutation originated at the locator session owner boundary: SlateDB creates a managed checkpoint whenever `DbReader` is opened without an explicit checkpoint. Reusing the same published-checkpoint selection already used by operation-scoped readers fixes every general caller (doctor, fsck, push basis checks, repack, and auth workflows) without caller-specific workarounds or a second read path.

## Verification

- `cargo test -p crab-metadata --release --locked --features remote-index,storage` — 187 passed
- `cargo test -p crab-remote-git --release --locked` — 118 passed
- strict Clippy passed for the changed metadata library and all `crab-remote-git` targets
- release checks passed for `crab` and `crab-auth-server`
- formatting and diff checks passed

RustFS qualification used the real Litestream repository (674 commits):

- direct refs/tree/blob/history/path-history/diff/blame/archive qualification passed
- Git protocol v2 clone and `git fsck --strict` passed
- main, side branch, annotated tag, and all 4,410 reachable objects matched exactly
- the `git_locator_db` keyset remained byte-identical after qualification, doctor, fsck, and clone
- the isolated RustFS prefix was deleted and verified empty

## Current base-branch observations

These are outside this patch and are called out so the evidence boundary is explicit:

- current `origin/main` required `crab metadb rebuild` after the test push before remote-reader admission because the newly landed ref-journal push path left Git acceleration indexes unavailable
- after that rebuild, `crab doctor --metadb` created two manifests under `file_index_db`; the locator database remained unchanged
- metadata all-target strict Clippy still reaches two pre-existing test-only warnings in `crates/crab-metadata/src/manifests.rs` and `crates/crab-metadata/src/ref_registry.rs`; the metadata library and full remote crate are clean
