### PR TITLE
fix: harden concurrent object-store pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ shard-hint <optional-metadata-hash>
 
 | Backend | Repository URL | Credential examples |
 | --- | --- | --- |
-| Amazon S3 or an S3-compatible service | `crab://bucket/repository` | AWS SDK default chain, `AWS_PROFILE`, or access-key environment variables |
+| Amazon S3 or an S3-compatible service | `crab://bucket/repository` | Web identity, ECS/EC2 role, or access-key environment variables; shared AWS profiles are not read |
 | Google Cloud Storage | `crab://bucket/repository` | Application Default Credentials or `GOOGLE_APPLICATION_CREDENTIALS` |
-| Azure Blob Storage | `crab://container/repository` | `az login`, connection string, account key, or SAS credentials |
+| Azure Blob Storage | `crab://container/repository` | Workload/managed identity, connection string, account key, or SAS credentials |
 
 The `crab://` scheme is used for Git remotes regardless of the backing
 provider. During initialization, provider-prefixed URLs such as `s3://`,

--- a/crab/docs/architecture/configuration-system.md
+++ b/crab/docs/architecture/configuration-system.md
@@ -236,5 +236,5 @@ Source: `crab/src/cmd/config.rs`
 | `CRAB_CACHE_DIR` | Custom cache directory |
 | `CRAB_LOG_DIR` | Custom log directory |
 | `AWS_REGION` | AWS region for S3 |
-| `AWS_PROFILE` | Named AWS credentials profile |
+| `AWS_PROFILE` | Diagnostic only; the current S3 provider does not consume profiles |
 | `AWS_ENDPOINT_URL` | Custom S3 endpoint |

--- a/crab/docs/architecture/system-overview.md
+++ b/crab/docs/architecture/system-overview.md
@@ -21,7 +21,7 @@ blobs.
 │          │ remote helper protocol (stdio)                         │
 │          │ clean/smudge filter protocol (stdio)                   │
 │   ┌──────▼──────────────────────────────────────────────────┐     │
-│   │                    crab binary                        │     │
+│   │                    crab binary                          │     │
 │   │                                                         │     │
 │   │  ┌───────────────┐  ┌───────────────┐  ┌─────────────┐  │     │
 │   │  │ Remote Helper │  │ Filter Driver │  │   CLI cmds  │  │     │
@@ -40,7 +40,7 @@ blobs.
 │                             │                                     │
 │   ┌─────────────────────────┴────────────────────────┐            │
 │   │  Local state                                     │            │
-│   │  .crab/staging/  ~/.cache/crab/  .git/lfs/   │            │
+│   │  .crab/staging/  ~/.cache/crab/  .git/lfs/       │            │
 │   └──────────────────────────────────────────────────┘            │
 └─────────────────────────────┼─────────────────────────────────────┘
                               │ HTTPS + cloud-native auth

--- a/crab/docs/architecture/vfs-coordinator.md
+++ b/crab/docs/architecture/vfs-coordinator.md
@@ -26,7 +26,7 @@ Source: `crates/crab-vfs/src/coordinator.rs`
 │                                                                     │
 │  ┌───────────────────────────────────────────────────────────────┐  │
 │  │  IPC Server (daemon.sock)                                     │  │
-│  │  • Accepts connections, reads newline-delimited JSON           │  │
+│  │  • Accepts connections, reads newline-delimited JSON          │  │
 │  │  • Dispatches: mount, unmount, list, status, refresh, switch  │  │
 │  │  • Returns JSON responses                                     │  │
 │  └───────────────────────────────────────────────────────────────┘  │
@@ -36,20 +36,20 @@ Source: `crates/crab-vfs/src/coordinator.rs`
 │  │                     │  │                                      │  │
 │  │  • ChunkCache       │  │  Mount A: /mnt/models (running)      │  │
 │  │    (LRU, bounded)   │  │  Mount B: /mnt/code   (running)      │  │
-│  │                     │  │  Mount C: /tmp/browse  (running)      │  │
+│  │                     │  │  Mount C: /tmp/browse  (running)     │  │
 │  │  • HydrationService │  │                                      │  │
 │  │    (worker pool)    │  │  ref_count = 3                       │  │
 │  └─────────────────────┘  └──────────────────────────────────────┘  │
 │                                                                     │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐              │
-│  │  Mount A     │  │  Mount B     │  │  Mount C     │              │
-│  │  Snapshot    │  │  Snapshot    │  │  Snapshot    │              │
-│  │  Overlay     │  │  Overlay     │  │  Overlay     │              │
-│  │  Resolver    │  │  Resolver    │  │  Resolver    │              │
-│  │  Engine      │  │  Engine      │  │  Engine      │              │
-│  │  RefreshLoop │  │  RefreshLoop │  │  RefreshLoop │              │
-│  │  FUSE Session│  │  FUSE Session│  │  FUSE Session│              │
-│  └──────────────┘  └──────────────┘  └──────────────┘              │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐               │
+│  │  Mount A     │  │  Mount B     │  │  Mount C     │               │
+│  │  Snapshot    │  │  Snapshot    │  │  Snapshot    │               │
+│  │  Overlay     │  │  Overlay     │  │  Overlay     │               │
+│  │  Resolver    │  │  Resolver    │  │  Resolver    │               │
+│  │  Engine      │  │  Engine      │  │  Engine      │               │
+│  │  RefreshLoop │  │  RefreshLoop │  │  RefreshLoop │               │
+│  │  FUSE Session│  │  FUSE Session│  │  FUSE Session│               │
+│  └──────────────┘  └──────────────┘  └──────────────┘               │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/crab/docs/design/technical-design.md
+++ b/crab/docs/design/technical-design.md
@@ -1293,12 +1293,15 @@ crab uses cloud-native authentication exclusively. No custom usernames, password
 
 |Cloud     |Mechanism                                           |
 |----------|----------------------------------------------------|
-|AWS       |IAM user, IAM role (via STS AssumeRole), IMDS on EC2|
+|AWS       |Environment credentials, web identity, ECS task credentials, IMDS on EC2|
 |GCP       |Service account, ADC                                |
 |Azure     |Entra ID, managed identity                          |
 |R2 / MinIO|S3-compatible access key pair                       |
 
-Credentials are discovered by `object_store`’s provider chain (e.g., env vars, `~/.aws/credentials`, instance metadata).
+Credentials are discovered by `object_store`'s provider chain. The current S3
+provider supports environment credentials, web identity, ECS task credentials,
+and EC2 instance metadata; it does not read shared AWS profiles or credential
+files.
 
 For human users who don’t already have cloud credentials: crab documents how to set up short-lived STS tokens via SSO providers (AWS IAM Identity Center, Google Workload Identity, etc.). Writing yet-another-auth system is explicitly non-goals.
 

--- a/crab/docs/guides/auth/enterprise-auth-static.md
+++ b/crab/docs/guides/auth/enterprise-auth-static.md
@@ -1,14 +1,13 @@
 # Static / Multi-Cloud Authentication
 
-Use environment variables or cloud SDK default credentials with S3, GCS, or
+Use provider-supported environment or workload credentials with S3, GCS, or
 Azure Blob Storage.
 
 ## Overview
 
 The `"static"` provider is the default. Crab reads credentials from
-environment variables or the cloud SDK's default credential chain — the same
-way it worked before enterprise auth was added. No login flow, no token
-management, no IdP.
+environment variables or provider-native workload credentials. No Crab login
+flow or Crab-managed token cache is involved.
 
 This guide covers how to use static credentials with each cloud backend.
 
@@ -52,16 +51,25 @@ provider = "static"
 storage_provider = "s3"
 ```
 
-Set your AWS credentials via environment variables or `~/.aws/credentials`:
+Prefer web identity or an attached ECS/EC2 role for teams and CI:
+
+```bash
+export AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/oidc-token
+export AWS_ROLE_ARN=arn:aws:iam::123456789012:role/crab-writer
+```
+
+Temporary or static environment credentials are also accepted:
 
 ```bash
 export AWS_ACCESS_KEY_ID=AKIA...
 export AWS_SECRET_ACCESS_KEY=wJalr...
+export AWS_SESSION_TOKEN=... # required for temporary STS credentials
 export AWS_REGION=us-west-2
-
-# Or use a named profile:
-export AWS_PROFILE=my-profile
 ```
+
+The current S3 provider does not read `AWS_PROFILE`, `~/.aws/config`, or
+`~/.aws/credentials`. Export the temporary credentials produced by an SSO or
+profile workflow into the Crab process.
 
 ### Option B: Google Cloud Storage
 
@@ -96,12 +104,15 @@ Set Azure credentials (any one of these):
 export AZURE_STORAGE_ACCOUNT_NAME=myaccount
 export AZURE_STORAGE_ACCOUNT_KEY=base64key...
 
+# Workload identity:
+export AZURE_STORAGE_ACCOUNT_NAME=myaccount
+export AZURE_CLIENT_ID=...
+export AZURE_TENANT_ID=...
+export AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token
+
 # SAS token:
 export AZURE_STORAGE_ACCOUNT_NAME=myaccount
 export AZURE_STORAGE_SAS_TOKEN="sv=2024-11-04&ss=b&..."
-
-# Connection string:
-export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;..."
 ```
 
 ### Option D: Auto-detect

--- a/crab/docs/guides/doctor.md
+++ b/crab/docs/guides/doctor.md
@@ -88,8 +88,10 @@ Run `crab track '*.bin'` (or your desired pattern) to start tracking files.
 Run `crab init <url>` to set the remote URL.
 
 **Credentials check failed**
-Ensure AWS credentials are configured. Check `AWS_PROFILE`, `AWS_REGION`, and
-`~/.aws/credentials`. Run `aws sts get-caller-identity` to verify.
+Ensure supported AWS credentials are available to the Crab process. Check
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, web identity,
+ECS task credentials, or EC2 instance credentials, plus `AWS_REGION`. The
+current provider does not read `AWS_PROFILE` or shared AWS configuration files.
 
 **Staging area warnings**
 A large staging area may indicate that staged data hasn't been pushed yet. Run

--- a/crab/docs/guides/env.md
+++ b/crab/docs/guides/env.md
@@ -67,7 +67,7 @@ Only set variables are shown. Checked variables:
 |----------|---------|
 | `AWS_REGION` | AWS region for S3 operations |
 | `AWS_DEFAULT_REGION` | Fallback AWS region |
-| `AWS_PROFILE` | Named AWS credentials profile |
+| `AWS_PROFILE` | Diagnostic only; the current S3 provider does not consume profiles |
 | `AWS_ENDPOINT_URL` | Custom S3 endpoint (for MinIO, LocalStack, etc.) |
 | `CRAB_LOG` | Log verbosity level |
 | `CRAB_CACHE_DIR` | Custom local cache directory |

--- a/crab/docs/guides/fsck.md
+++ b/crab/docs/guides/fsck.md
@@ -10,10 +10,8 @@ crab fsck [OPTIONS]
 
 ## Description
 
-`crab fsck` performs a comprehensive integrity check on the crab repository,
-examining both local and remote state for inconsistencies. It detects issues
-such as dangling refs, missing blobs, missing shard/xorb objects, orphan shards,
-expired push locks, abandoned multipart uploads, and pack list divergence.
+`crab fsck` cross-checks Crab manifests, pack/index presence, the shard/xorb
+data chain, and coordination state against the object store.
 
 With `--repair`, it can automatically fix certain categories of issues.
 
@@ -29,9 +27,6 @@ With `--repair`, it can automatically fix certain categories of issues.
 
 | Issue | Description | Repairable |
 |-------|-------------|------------|
-| Dangling ref | A ref points to a commit that doesn't exist | No |
-| Missing tree | A commit references a tree object that's missing | No |
-| Missing blob | A tree references a blob that doesn't exist | No |
 | Missing file index | A pointer references a file index that's not in any shard | No |
 | Missing xorb | A shard references a xorb that doesn't exist in the store | No |
 | Pack list divergence | A manifest-selected pack or canonical index is missing from storage | No |
@@ -52,8 +47,8 @@ damage, and remain protected by the normal GC grace period.
 
 | Issue | Description | Repair Action |
 |-------|-------------|---------------|
-| Expired push lock | A push lock older than the TTL, likely from a crashed process | Delete the lock |
-| Abandoned multipart upload | An S3 multipart upload that was never completed | Abort the upload |
+| Expired push lock | A push lock older than its backend-clock lease | Delete through holder-safe repair |
+| Historical visibility backfill | A historical generation lacks its derivable Git visibility proof | Rebuild the proof |
 
 ## Examples
 
@@ -66,13 +61,7 @@ crab fsck
 Example output:
 
 ```
-crab fsck
-  ✓ Git objects          all refs resolve
-  ✓ Data chain           all file indices and xorbs present
-  ✓ Pack list            consistent
-  ⚠ Push locks           1 expired lock (3 days old)
-  ✓ Multipart uploads    none abandoned
-  ✓ Shard list           consistent
+crab fsck: 1 error(s), 0 info, 0 repaired, 0 repair failure(s)
 
 1 issue found:
   ⚠ Expired push lock: refs/push-locks/abc123 (age: 3d 2h)
@@ -86,23 +75,16 @@ crab fsck --repair
 ```
 
 ```
-crab fsck --repair
-  ✓ Git objects          all refs resolve
-  ✓ Data chain           all file indices and xorbs present
-  ✓ Pack list            consistent
-  ⚠ Push locks           1 expired lock → deleted
-  ✓ Multipart uploads    none abandoned
-
-Repaired 1 issue.
+crab fsck: 1 error(s), 0 info, 1 repaired, 0 repair failure(s)
 ```
 
 ## Repair Safety
 
 - Only issues marked as "repairable" are fixed with `--repair`.
-- Repairs are conservative: expired locks are deleted, abandoned uploads are
-  aborted, and missing manifest entries are re-added.
-- No data is ever deleted by `--repair` — only metadata cleanup.
-- Critical issues (missing blobs, trees, xorbs) require manual intervention.
+- Repairs are conservative and limited to issue types the report marks as
+  repairable.
+- Missing xorbs and other content damage require recovery from history, a
+  replica, cache, or backup.
 - Missing shard and xorb warning events can be fed to
   [`crab recover`](repository-recovery.md) with `--fsck-jsonl` to build a
   verified repair plan from cache, source, or replica candidates.
@@ -119,6 +101,22 @@ Repaired 1 issue.
 - The repository must be initialized with `crab init`.
 - AWS credentials must be configured for the remote bucket.
 - `--repair` requires write permissions on the bucket.
+
+## Verification Boundaries
+
+- The Git-object check currently confirms that ref-journal records are
+  readable; it does not reconstruct the current repository and run full Git
+  reachability for missing commits, trees, or blobs. Use `crab recover history
+  verify <generation>` for strict Git fsck of a selected historical root, and
+  qualify current-head clone/fetch in production monitoring.
+- Generic `object_store` does not expose provider multipart enumeration. The
+  current multipart check therefore cannot find or abort remote incomplete
+  uploads; configure the provider's incomplete-multipart lifecycle rule.
+- Git locator and visibility acceleration damage is diagnostic. Rebuild it
+  with `crab metadb rebuild`, then rerun `crab fsck`.
+- Full backup recovery requires provider versioning/replication or another
+  failure domain. Manifest history in the same bucket is not an independent
+  backup.
 
 ## Related Commands
 

--- a/crab/docs/guides/getting-started.md
+++ b/crab/docs/guides/getting-started.md
@@ -19,9 +19,11 @@ joining an existing one.
    works automatically on clone.
 
 3. Cloud credentials configured for your backend:
-   - S3: `AWS_PROFILE` or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+   - S3: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, web identity,
+     ECS task credentials, or EC2 instance credentials
    - GCS: `gcloud auth application-default login` or `GOOGLE_APPLICATION_CREDENTIALS`
-   - Azure: `AZURE_STORAGE_CONNECTION_STRING`, account key, SAS token, or `az login`
+   - Azure: workload/managed identity, `AZURE_STORAGE_CONNECTION_STRING`,
+     account key, or SAS token
 
 ## New Repository (Owner)
 

--- a/crab/docs/guides/init.md
+++ b/crab/docs/guides/init.md
@@ -184,8 +184,10 @@ Ensure the URL follows the `crab://<bucket>/<path>` format. The bucket name
 must not contain slashes.
 
 For S3, `crab://my-bucket/my-repo` is the correct Crab remote URL. Configure
-AWS credentials separately with `AWS_PROFILE` or `AWS_ACCESS_KEY_ID` /
-`AWS_SECRET_ACCESS_KEY`.
+AWS credentials separately with `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY`, web identity, ECS task credentials, or EC2 instance
+credentials. The current provider does not read `AWS_PROFILE` or shared AWS
+configuration files.
 
 For GCS or Azure, keep the `crab://` URL and add `--storage-provider gcs` or
 `--storage-provider azure`.

--- a/crab/docs/guides/mirror-mode.md
+++ b/crab/docs/guides/mirror-mode.md
@@ -1,23 +1,24 @@
 # Mirror Mode (GitHub + Crab Coexistence)
 
-Mirror mode lets you keep GitHub (or GitLab) for code review and pull requests
-while Crab handles large-file storage transparently. Code goes to GitHub,
-large files go to your cloud bucket — your team's PR workflow stays unchanged.
+Mirror mode keeps GitHub (or GitLab) as the collaboration control plane for
+pull requests, reviews, branch protection, CI, issues, and webhooks. Crab is a
+second Git remote backed by object storage; it stores the pushed Git graph and
+the large-file data plane.
 
 ## How It Works
 
 ```
 ┌─────────────┐     git push origin     ┌──────────────┐
 │  Developer  │ ──────────────────────── │    GitHub    │
-│  Workstation│                          │  (code only) │
+│  Workstation│                          │ review + CI  │
 └──────┬──────┘                          └──────────────┘
        │
        │  pre-push hook: crab push --remote crab
        │
        ▼
 ┌──────────────┐
-│  S3 Bucket   │
-│ (large files)│
+│ Object Store │
+│ Git + data   │
 └──────────────┘
 ```
 
@@ -86,6 +87,12 @@ Ensures all large-file content is in the bucket before pointer blobs reach
 GitHub. If the crab push fails, the git push is aborted (preventing dangling
 pointers on GitHub).
 
+This ordering is not a distributed transaction. If Crab succeeds and the
+later GitHub/GitLab push is rejected, Crab can temporarily be ahead. Retrying
+after resolving the origin rejection converges the refs. Server-side merges,
+bots, and pushes made without the installed hook can advance origin without
+advancing Crab.
+
 ### `post-checkout` (runs after `git checkout`, `git switch`, `git clone`)
 
 ```bash
@@ -146,6 +153,25 @@ Mirror mode is ideal when:
 
 If you don't need GitHub/GitLab integration (e.g. Crab is your only remote),
 standard `crab init <url>` without `--mirror` is simpler.
+
+## Team Production Posture
+
+- Treat GitHub/GitLab as the canonical collaboration and policy plane. Crab
+  does not replace pull requests, branch protection, merge queues, CI,
+  repository administration, or issue tracking.
+- Treat the object store as the canonical large-data plane. Require workload
+  identity and least-privilege bucket policy; do not distribute shared static
+  keys.
+- Install and verify hooks on every developer and automation clone. Hooks are
+  client-side convenience, not enforcement; add a CI check that hydrates or
+  verifies every pointer required by the proposed merge.
+- Run `crab mirror SOURCE DESTINATION` as a scheduled, one-way disaster-
+  recovery sync when full-ref mirroring is required. It uses `git push
+  --mirror`, so destination-only refs are deleted. Never schedule both
+  directions.
+- Alert on origin/Crab ref divergence. Do not declare Crab the sole team Git
+  backbone until access policy, multi-node object-store failure tests, backup
+  restore drills, and central monitoring meet the team's RPO and RTO.
 
 ## Troubleshooting
 

--- a/crab/docs/guides/operational-playbooks.md
+++ b/crab/docs/guides/operational-playbooks.md
@@ -202,3 +202,92 @@ ls .crab/restripe/journal.db
 crab optimize xorbs --resume   # or --abort
 crab gc
 ```
+
+## Playbook 7: Operate Crab as a team data backbone
+
+**When to use:** A team is evaluating Crab and object storage as production
+Git and large-data infrastructure rather than as a developer convenience.
+
+### Define the service contract first
+
+Record these values before rollout:
+
+| Contract | Team decision |
+|----------|---------------|
+| Recovery point objective | Maximum acceptable refs and object data lost |
+| Recovery time objective | Maximum time to restore clone, fetch, and hydrate |
+| Canonical collaboration plane | Usually GitHub/GitLab; Crab has no PR, review, CI, or branch-policy service |
+| Object-store durability | Node/zone count, erasure or replication policy, and versioning/immutability |
+| Identity lifetime | Short-lived workload or user federation; no shared team access key |
+
+A single-node RustFS process is useful for compatibility tests, not a
+production durability topology. Qualify the exact multi-node RustFS or managed
+object-store topology, including one-node loss, one-disk loss, latency, request
+timeouts, and a network partition, before committing to an RPO.
+
+Use test credentials such as `crab`/`crab` only on an isolated development
+endpoint. Production RustFS credentials must be unique per workload or user,
+least-privilege, regularly rotated, and separated between normal writes,
+backup, and destructive administration.
+
+### Backup and restore
+
+Crab manifest history protects against logical ref/manifest mistakes while the
+same object store remains healthy. It is not an independent backup: history
+and current data share the bucket and account failure domain.
+
+1. Enable provider object versioning and, where required, retention/object
+   lock before onboarding repositories.
+2. Replicate or back up the complete repository prefix, including manifests,
+   ref journal, packs and indexes, metadb objects, shards, xorbs, and history.
+   Backing up only the current manifest is insufficient.
+3. Keep a copy in a separate account or failure domain with separately
+   administered delete credentials.
+4. At least monthly, restore the backup into an isolated bucket/prefix. Clone,
+   run `crab recover history list`, verify a sampled historical generation,
+   run `crab fsck`, and hydrate representative large files. Measure the result
+   against the declared RPO and RTO.
+5. Before production GC, require a recent successful restore drill and run
+   `crab gc --scope repo --dry-run`. Never use bucket-wide GC in a shared
+   bucket without the repository registry and an explicit change window.
+
+### Monitoring schedule
+
+| Frequency | Check | Alert condition |
+|-----------|-------|-----------------|
+| Every minute | Object-store node health, request error/latency, disk capacity, replication/heal backlog | Any unavailable node, sustained 5xx/timeout rate, capacity threshold, or stalled repair |
+| Every push | Push exit status and structured ref outcomes | Any `internal`, `unpack-failed`, `missing-object`, or repeated conflict beyond retry policy |
+| Hourly | `git ls-remote`/read probe from an independent runner | Advertised refs differ from the collaboration-plane policy or cannot be read |
+| Daily | `crab doctor`, `crab fsck`, and backup freshness | Unrepaired error, expired backup, lock/admission saturation, or unexpected request amplification |
+| Weekly | `crab recover history verify <generation>` on a rotating sample | Digest, Git connectivity, shard, xorb, or index verification failure |
+| Monthly | Isolated backup restore drill | RPO/RTO miss or non-byte-identical hydration |
+
+`crab stat perf` is repository-local and cumulative. Collect it after pushes if
+you use it for cost trends; it is not a central metrics exporter. Correlate its
+upload, resume-probe, and metadb-flush counters with provider billing and
+RustFS/OpenTelemetry request metrics.
+
+### Current verification limits
+
+- `crab fsck` validates manifest-selected pack/index presence and Crab's
+  shard/xorb chain, but its Git-object check does not currently reconstruct the
+  repository and run full Git connectivity. Historical
+  `crab recover history verify` does run strict Git fsck for a selected root.
+- The generic object-store API does not expose remote multipart enumeration,
+  so `crab fsck --repair` cannot currently discover or abort provider-side
+  abandoned multipart uploads. Configure a provider lifecycle rule for
+  incomplete uploads.
+- Locator or visibility acceleration damage is reported rather than rebuilt by
+  `fsck`; use `crab metadb rebuild` and verify again.
+- Cross-ref fan-out can commit every ref while post-commit Git locator or
+  visibility publication loses its shared writer lease or lacks another
+  writer's objects. Treat `Git locator coverage is stale` and `Git visibility
+  proof unavailable` from `crab doctor --metadb` as repair-required, then run
+  `crab metadb rebuild`. Do not use `fsck` success alone as proof that these
+  accelerators are current.
+- Short-lived Git helper processes do not remain alive for SlateDB's periodic
+  garbage collector. Track metadb object growth and schedule a supported
+  cleanup workflow before high-volume production use.
+- Client-side mirror hooks are bypassable and GitHub/GitLab and Crab ref
+  updates are not one transaction. Enforce pointer availability in CI and
+  alert on ref divergence.

--- a/crab/docs/guides/stat.md
+++ b/crab/docs/guides/stat.md
@@ -51,7 +51,7 @@ Performance counters track cumulative metrics across all crab operations:
 | Counter | Description |
 |---------|-------------|
 | `push_duration_ms` | Total time spent pushing |
-| `bytes_uploaded` | Total bytes uploaded to remote |
+| `bytes_uploaded` | Total xorb payload bytes uploaded; excludes Git packs, indexes, manifests, refs, locks, and metadb objects |
 | `fetch_duration_ms` | Total time spent fetching |
 | `bytes_downloaded` | Total bytes downloaded from remote |
 | `gc_duration_ms` | Total time spent in garbage collection |
@@ -67,8 +67,19 @@ Performance counters track cumulative metrics across all crab operations:
 | `xorb_fetch_requests_coalesced` | Number of coalesced xorb fetch requests |
 | `xorb_fetch_bytes_saved` | Bytes saved by request coalescing |
 | `multipart_resumed_uploads` | Number of resumed multipart uploads |
+| `head_list_requests` | LIST requests issued by batched xorb resume checks |
+| `head_point_requests` | Individual HEAD requests issued by xorb resume checks |
+| `metadb_buffered_batch_write_count` | Buffered metadb batches submitted during pushes |
+| `metadb_wal_flush_count` | Explicit metadb WAL flushes |
+| `metadb_memtable_flush_count` | Explicit metadb memory-table-to-L0 flushes |
 
-If the perf-state file doesn't exist or is corrupt, zeroed counters are shown.
+Pushes update the file cumulatively under an advisory file lock. If the
+perf-state file doesn't exist or is corrupt, zeroed counters are shown.
+
+These counters cover selected Crab operations. They do not count every object
+store `GET`, `HEAD`, `PUT`, `LIST`, retry, pack byte, or metadata byte, so do
+not use them as a billing ledger. Correlate them with provider or RustFS server
+metrics for request and transfer cost.
 
 ### crab stat push-plan
 

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -1889,9 +1889,6 @@ fn duplicate_reuse_plan_from_fingerprints(
     let mut first_path_by_fingerprint = HashMap::<CandidateFingerprint, PathBuf>::new();
     let mut representative_by_path = HashMap::<PathBuf, PathBuf>::new();
     for record in fingerprints {
-        if record.size < ADD_DUPLICATE_REUSE_MIN_BYTES {
-            continue;
-        }
         if let Some(representative) = first_path_by_fingerprint.get(&record.fingerprint) {
             representative_by_path.insert(record.path.clone(), representative.clone());
         } else {
@@ -3962,6 +3959,32 @@ mod tests {
         assert!(enabled.contains(&first));
         assert!(!enabled.contains(&second));
         assert!(enabled.contains(&unique));
+    }
+
+    #[test]
+    fn duplicate_reuse_plan_serializes_candidates_at_stream_threshold() {
+        let fingerprint = CandidateFingerprint {
+            size: 16 * 1024 * 1024,
+            head_hash: [1; 32],
+            middle_hash: [2; 32],
+            tail_hash: [3; 32],
+        };
+        let first = PathBuf::from("first.bin");
+        let second = PathBuf::from("second.bin");
+        let plan = duplicate_reuse_plan_from_fingerprints(&[
+            CandidateFingerprintRecord {
+                path: first.clone(),
+                size: fingerprint.size,
+                fingerprint: fingerprint.clone(),
+            },
+            CandidateFingerprintRecord {
+                path: second.clone(),
+                size: fingerprint.size,
+                fingerprint,
+            },
+        ]);
+
+        assert_eq!(plan.representative_for(&second), Some(first.as_path()));
     }
 
     #[tokio::test]

--- a/crab/src/cmd/doctor.rs
+++ b/crab/src/cmd/doctor.rs
@@ -799,13 +799,7 @@ async fn check_credential_discovery(root: &Path) -> CheckResult {
     let result = discover_credentials(&url, project_auth.as_ref()).await;
 
     match result.source {
-        CredentialSource::None => CheckResult::warn(
-            "credential discovery",
-            format!(
-                "No credentials found for {}. Run: aws configure / gcloud auth login / az login",
-                url.split("://").next().unwrap_or("unknown"),
-            ),
-        ),
+        CredentialSource::None => CheckResult::warn("credential discovery", result.description),
         _ if !result.valid => CheckResult::warn(
             "credential discovery",
             format!("{} (invalid)", result.description),

--- a/crab/src/cmd/fsck.rs
+++ b/crab/src/cmd/fsck.rs
@@ -1,15 +1,8 @@
 //! `crab fsck` — repository integrity checker.
 //!
-//! Detection categories:
-//! - Git-object-level: dangling refs, missing trees/blobs (via `gix-fsck::Connectivity`)
-//! - Crab-specific: missing file-index entries, missing xorbs, orphan shards,
-//!   pack-list/storage divergence, expired push locks, abandoned multipart uploads,
-//!   PersistentChunkIndex/shard-list divergence
-//! - Informational: orphan file-index entries (not errors)
-//!
-//! `--repair` performs safe reversible operations: re-add manifest entries when
-//! the object exists in storage, repair expired push locks, abort abandoned
-//! multipart uploads.
+//! Checks Crab manifests, pack/index presence, data-chain metadata, and
+//! coordination state. The production object-store checker does not yet run
+//! full Git connectivity or enumerate provider-side multipart uploads.
 
 use std::io::Stdout;
 use std::time::{Duration, SystemTime};

--- a/crab/src/cmd/fsck_store.rs
+++ b/crab/src/cmd/fsck_store.rs
@@ -675,7 +675,7 @@ impl FsckRepairer for StoreRepairer {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send + '_>> {
         let key = key.to_string();
         Box::pin(async move {
-            PushLock::repair_expired(self.store.inner(), &key, SystemTime::now())
+            PushLock::repair_expired(self.store.inner(), &key)
                 .await
                 .map_err(Into::into)
         })
@@ -1266,7 +1266,7 @@ mod tests {
     async fn checker_detects_expired_push_lock() {
         let (store, prefix) = test_store();
 
-        let payload = PushLockPayload::new("test-holder", 1000);
+        let payload = PushLockPayload::new("test-holder", 1000, 300);
         let lock_path = Path::from(push_lock_path(&prefix, "refs/heads/main").unwrap());
         store
             .put(
@@ -1309,7 +1309,7 @@ mod tests {
 
         let lock_path = push_lock_path(&prefix, "refs/heads/main").unwrap();
         let obj_path = Path::from(lock_path.as_str());
-        let payload = PushLockPayload::new("test-holder", 1);
+        let payload = PushLockPayload::new("test-holder", 1, 1);
         store
             .put(
                 &obj_path,
@@ -1317,6 +1317,7 @@ mod tests {
             )
             .await
             .unwrap();
+        tokio::time::sleep(Duration::from_millis(1100)).await;
 
         let repairer = StoreRepairer::new(store.clone(), prefix);
         let result = repairer.repair_push_lock(&lock_path).await.unwrap();

--- a/crab/src/cmd/stat.rs
+++ b/crab/src/cmd/stat.rs
@@ -3,15 +3,13 @@
 
 use std::path::Path;
 
-use serde::Serialize;
-use tracing::debug;
-
 use crate::core::error::Result;
-use crate::core::metrics::MetricsSummary;
+use crate::core::metrics::{MetricsSummary, load_metrics_summary};
 use crate::core::output::{OutputMode, emit_json};
 use crab_staging::push_plan::{PushPlanStats, PushPlanSummaryOptions, empty_push_plan_stats};
 use crab_staging::stats::StagingStats;
 use crab_staging::{StagingAreaReadOnly, StagingError};
+use serde::Serialize;
 
 /// Payload emitted by `crab stat --json`.
 #[derive(Serialize, schemars::JsonSchema)]
@@ -180,23 +178,7 @@ pub fn run_perf(perf_path: &str, mode: OutputMode) -> Result<()> {
 /// Load a [`MetricsSummary`] from a JSON file, returning a zeroed summary
 /// if the file is missing or malformed.
 fn load_perf_summary(path: &Path) -> Result<MetricsSummary> {
-    match std::fs::read_to_string(path) {
-        Ok(data) => match serde_json::from_str::<MetricsSummary>(&data) {
-            Ok(summary) => {
-                debug!(path = %path.display(), "loaded perf counters");
-                Ok(summary)
-            }
-            Err(e) => {
-                debug!(path = %path.display(), error = %e, "corrupt perf-state.json, showing zeros");
-                Ok(MetricsSummary::zeroed())
-            }
-        },
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            debug!(path = %path.display(), "no perf-state.json, showing zeros");
-            Ok(MetricsSummary::zeroed())
-        }
-        Err(e) => Err(crate::core::error::CrabError::Io(e)),
-    }
+    load_metrics_summary(path)
 }
 
 /// Payload emitted by `crab stat classes --json`.
@@ -315,6 +297,11 @@ mod tests {
             xorb_fetch_requests_coalesced: 12,
             xorb_fetch_bytes_saved: 512,
             multipart_resumed_uploads: 1,
+            head_list_requests: 2,
+            head_point_requests: 4,
+            metadb_buffered_batch_write_count: 8,
+            metadb_wal_flush_count: 1,
+            metadb_memtable_flush_count: 1,
             workflow_runs_total: 0,
             workflow_stages_total: 0,
             workflow_retry_attempts_total: 0,

--- a/crab/src/coordination/heartbeat.rs
+++ b/crab/src/coordination/heartbeat.rs
@@ -262,6 +262,7 @@ async fn try_extend(
     let new_payload = LockPayload {
         holder: holder.to_owned(),
         expires_at: unix_now() + ttl.as_secs(),
+        lease_secs: ttl.as_secs(),
     };
     let new_body = serde_json::to_vec(&new_payload).map_err(|e| {
         HeartbeatFailure::Fatal(CrabError::Internal(format!(
@@ -300,6 +301,7 @@ mod tests {
         let payload = LockPayload {
             holder: holder.to_owned(),
             expires_at: unix_now() + ttl_secs,
+            lease_secs: ttl_secs,
         };
         let body = serde_json::to_vec(&payload).unwrap();
         store
@@ -383,6 +385,7 @@ mod tests {
         let thief_payload = LockPayload {
             holder: "thief".to_owned(),
             expires_at: unix_now() + 300,
+            lease_secs: 300,
         };
         let body = serde_json::to_vec(&thief_payload).unwrap();
         store

--- a/crab/src/core/config.rs
+++ b/crab/src/core/config.rs
@@ -1916,6 +1916,12 @@ impl Config {
     }
 
     fn validate_push(&self) -> super::error::Result<()> {
+        if self.push_lock_ttl_secs <= 20 {
+            return Err(super::error::CrabError::Configuration {
+                key: "lock_ttl_secs must be > 20".into(),
+                origin: "push".into(),
+            });
+        }
         if self.push_head_check_concurrency == 0 {
             return Err(super::error::CrabError::Configuration {
                 key: "head_check_concurrency must be > 0".into(),
@@ -3344,6 +3350,22 @@ mod tests {
         // TTL = 20s → no valid range
         assert!(cfg.clamped_heartbeat_interval(20).is_none());
         assert!(cfg.clamped_heartbeat_interval(15).is_none());
+    }
+
+    #[test]
+    fn push_lock_ttl_without_safe_heartbeat_window_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[push]\nlock_ttl_secs = 20\n").unwrap();
+
+        let error = Config::resolve_local_from(Some(path), PathBuf::from("/nonexistent"))
+            .expect_err("an unsafe lock TTL must fail config resolution");
+
+        assert!(matches!(
+            error,
+            crate::core::error::CrabError::Configuration { key, .. }
+                if key == "lock_ttl_secs must be > 20"
+        ));
     }
 
     #[test]

--- a/crab/src/core/credential_discovery.rs
+++ b/crab/src/core/credential_discovery.rs
@@ -2,8 +2,8 @@
 //!
 //! Probes credentials in priority order:
 //! 1. Project config (`[auth]` section in `.crab.toml`)
-//! 2. Environment variables (AWS_PROFILE, GOOGLE_APPLICATION_CREDENTIALS, etc.)
-//! 3. Cloud SDK default configs (~/.aws/config, gcloud, az)
+//! 2. Environment variables (AWS web identity, GCP ADC, Azure workload identity)
+//! 3. Supported cloud SDK default configs (gcloud and Azure CLI)
 //! 4. Instance metadata (EC2 IMDS with 200ms timeout)
 //!
 //! The discovery chain is read-only — it never writes credentials, creates
@@ -22,7 +22,7 @@ use crate::core::project_config::ProjectAuthConfig;
 pub enum CredentialSource {
     /// Explicit `[auth]` section in `.crab.toml`.
     ProjectConfig,
-    /// Environment variables (AWS_PROFILE, AWS_ACCESS_KEY_ID, etc.).
+    /// Environment variables supported by the active object-store provider.
     Environment,
     /// Cloud SDK config files (~/.aws/config, gcloud, az).
     CloudSdk,
@@ -106,16 +106,31 @@ pub fn check_environment_vars(url: &str) -> Option<DiscoveryResult> {
 }
 
 fn check_aws_env_vars() -> Option<DiscoveryResult> {
-    // Check AWS_PROFILE first (named profile)
-    if let Ok(profile) = std::env::var("AWS_PROFILE") {
+    if let (Ok(token_file), Ok(role_arn)) = (
+        std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE"),
+        std::env::var("AWS_ROLE_ARN"),
+    ) {
+        let valid = PathBuf::from(&token_file).is_file();
         return Some(DiscoveryResult {
             source: CredentialSource::Environment,
-            description: format!("AWS_PROFILE={profile}"),
+            description: format!(
+                "AWS web identity for {role_arn}{}",
+                if valid { "" } else { " (token file not found)" }
+            ),
+            valid,
+        });
+    }
+
+    if std::env::var_os("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI").is_some()
+        || std::env::var_os("AWS_CONTAINER_CREDENTIALS_FULL_URI").is_some()
+    {
+        return Some(DiscoveryResult {
+            source: CredentialSource::Environment,
+            description: "AWS container task-role credentials".to_owned(),
             valid: true,
         });
     }
 
-    // Check explicit access key pair
     let key_id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
     let _secret = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
 
@@ -154,12 +169,34 @@ fn check_gcp_env_vars() -> Option<DiscoveryResult> {
 }
 
 fn check_azure_env_vars() -> Option<DiscoveryResult> {
-    let account = std::env::var("AZURE_STORAGE_ACCOUNT").ok()?;
-    let _key = std::env::var("AZURE_STORAGE_KEY").ok()?;
+    let account = std::env::var("AZURE_STORAGE_ACCOUNT_NAME").ok()?;
+
+    if std::env::var_os("AZURE_FEDERATED_TOKEN_FILE").is_some()
+        && std::env::var_os("AZURE_CLIENT_ID").is_some()
+        && std::env::var_os("AZURE_TENANT_ID").is_some()
+    {
+        return Some(DiscoveryResult {
+            source: CredentialSource::Environment,
+            description: format!("Azure workload identity for {account}"),
+            valid: true,
+        });
+    }
+
+    if std::env::var_os("IDENTITY_ENDPOINT").is_some() {
+        return Some(DiscoveryResult {
+            source: CredentialSource::Environment,
+            description: format!("Azure managed identity for {account}"),
+            valid: true,
+        });
+    }
+
+    let _key = std::env::var("AZURE_STORAGE_ACCOUNT_KEY")
+        .or_else(|_| std::env::var("AZURE_STORAGE_ACCESS_KEY"))
+        .ok()?;
 
     Some(DiscoveryResult {
         source: CredentialSource::Environment,
-        description: format!("AZURE_STORAGE_ACCOUNT={account}"),
+        description: format!("AZURE_STORAGE_ACCOUNT_NAME={account}"),
         valid: true,
     })
 }
@@ -192,41 +229,8 @@ fn dirs_or_env() -> Option<PathBuf> {
 }
 
 fn check_aws_sdk() -> Option<DiscoveryResult> {
-    let home = home_dir()?;
-
-    let config_path = home.join(".aws").join("config");
-    let credentials_path = home.join(".aws").join("credentials");
-
-    // Both files must exist
-    if !config_path.exists() && !credentials_path.exists() {
-        return Option::None;
-    }
-
-    // Check for a [default] section in either file
-    let has_default = has_ini_section(&config_path, "[default]")
-        || has_ini_section(&credentials_path, "[default]");
-
-    if has_default {
-        Some(DiscoveryResult {
-            source: CredentialSource::CloudSdk,
-            description: "AWS SDK: profile 'default' from ~/.aws/config".to_string(),
-            valid: true,
-        })
-    } else {
-        Some(DiscoveryResult {
-            source: CredentialSource::CloudSdk,
-            description: "AWS SDK: ~/.aws/config exists but no [default] section".to_string(),
-            valid: false,
-        })
-    }
-}
-
-/// Check if an INI-style file contains a given section header.
-fn has_ini_section(path: &PathBuf, section: &str) -> bool {
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return false;
-    };
-    content.lines().any(|line| line.trim() == section)
+    // object_store 0.14 does not read shared AWS config/profile files.
+    Option::None
 }
 
 fn check_gcp_sdk() -> Option<DiscoveryResult> {
@@ -356,13 +360,13 @@ pub async fn discover_credentials(
     let provider = detect_provider(url);
     let instructions = match provider {
         Some(CloudProvider::Aws) => {
-            "No AWS credentials found. Try: aws configure, or set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY"
+            "No supported AWS credentials found. Use web identity, an ECS/EC2 role, or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN for temporary credentials)"
         }
         Some(CloudProvider::Gcp) => {
             "No GCP credentials found. Try: gcloud auth application-default login, or set GOOGLE_APPLICATION_CREDENTIALS"
         }
         Some(CloudProvider::Azure) => {
-            "No Azure credentials found. Try: az login, or set AZURE_STORAGE_ACCOUNT + AZURE_STORAGE_KEY"
+            "No Azure credentials found. Use workload/managed identity, Azure CLI auth, or AZURE_STORAGE_ACCOUNT_NAME + AZURE_STORAGE_ACCOUNT_KEY"
         }
         None => {
             "Could not determine cloud provider from URL scheme. Supported: crab://, s3://, gs://, az://, azure://"
@@ -478,18 +482,40 @@ mod tests {
     }
 
     #[test]
-    fn env_vars_aws_profile() {
+    fn env_vars_aws_profile_is_not_reported_as_supported() {
         let _guard = EnvGuard::apply(
             &[("AWS_PROFILE", "production")],
-            &["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+            &[
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_WEB_IDENTITY_TOKEN_FILE",
+                "AWS_ROLE_ARN",
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            ],
+        );
+        assert!(check_environment_vars("crab://bucket/repo").is_none());
+    }
+
+    #[test]
+    fn env_vars_aws_web_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let token = temp.path().join("token");
+        std::fs::write(&token, "oidc-token").unwrap();
+        let _guard = EnvGuard::apply(
+            &[
+                ("AWS_WEB_IDENTITY_TOKEN_FILE", token.to_str().unwrap()),
+                ("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/crab"),
+            ],
+            &[
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            ],
         );
         let result = check_environment_vars("crab://bucket/repo").unwrap();
-        assert_eq!(result.source, CredentialSource::Environment);
-        assert!(
-            result.description.contains("production"),
-            "expected 'production' in description: {}",
-            result.description
-        );
+        assert!(result.description.contains("web identity"));
         assert!(result.valid);
     }
 
@@ -546,29 +572,36 @@ mod tests {
     #[test]
     fn env_vars_azure() {
         let _guard = EnvGuard::set(&[
-            ("AZURE_STORAGE_ACCOUNT", "myaccount"),
-            ("AZURE_STORAGE_KEY", "base64key=="),
+            ("AZURE_STORAGE_ACCOUNT_NAME", "myaccount"),
+            ("AZURE_STORAGE_ACCOUNT_KEY", "base64key=="),
         ]);
         let result = check_environment_vars("az://container/path").unwrap();
         assert_eq!(result.source, CredentialSource::Environment);
         assert!(
             result
                 .description
-                .contains("AZURE_STORAGE_ACCOUNT=myaccount")
+                .contains("AZURE_STORAGE_ACCOUNT_NAME=myaccount")
         );
         assert!(result.valid);
     }
 
     #[test]
     fn env_vars_none_when_missing() {
-        let _guard =
-            EnvGuard::clear(&["AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]);
+        let _guard = EnvGuard::clear(&[
+            "AWS_PROFILE",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_ROLE_ARN",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        ]);
         let result = check_environment_vars("crab://bucket/repo");
         assert!(result.is_none());
     }
 
     #[test]
-    fn cloud_sdk_aws_with_default_section() {
+    fn cloud_sdk_aws_profile_is_not_supported_by_storage_provider() {
         let dir = tempfile::TempDir::new().unwrap();
         let aws_dir = dir.path().join(".aws");
         std::fs::create_dir_all(&aws_dir).unwrap();
@@ -581,28 +614,7 @@ mod tests {
 
         // Override HOME to point to our temp dir
         let _guard = EnvGuard::apply(&[("HOME", dir.path().to_str().unwrap())], &["USERPROFILE"]);
-        let result = check_cloud_sdk("crab://bucket/repo").unwrap();
-        assert_eq!(result.source, CredentialSource::CloudSdk);
-        assert!(result.valid);
-        assert!(result.description.contains("default"));
-    }
-
-    #[test]
-    fn cloud_sdk_aws_no_default_section() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let aws_dir = dir.path().join(".aws");
-        std::fs::create_dir_all(&aws_dir).unwrap();
-        std::fs::write(
-            aws_dir.join("config"),
-            "[profile production]\nregion = us-west-2\n",
-        )
-        .unwrap();
-
-        let _guard = EnvGuard::apply(&[("HOME", dir.path().to_str().unwrap())], &["USERPROFILE"]);
-        let result = check_cloud_sdk("crab://bucket/repo").unwrap();
-        assert_eq!(result.source, CredentialSource::CloudSdk);
-        assert!(!result.valid);
-        assert!(result.description.contains("no [default] section"));
+        assert!(check_cloud_sdk("crab://bucket/repo").is_none());
     }
 
     #[test]
@@ -694,7 +706,19 @@ mod tests {
 
     #[tokio::test]
     async fn discover_falls_back_to_env() {
-        let _guard = EnvGuard::set(&[("AWS_PROFILE", "test-profile")]);
+        let _guard = EnvGuard::apply(
+            &[
+                ("AWS_ACCESS_KEY_ID", "temporary-key"),
+                ("AWS_SECRET_ACCESS_KEY", "temporary-secret"),
+                ("AWS_SESSION_TOKEN", "temporary-session"),
+            ],
+            &[
+                "AWS_WEB_IDENTITY_TOKEN_FILE",
+                "AWS_ROLE_ARN",
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            ],
+        );
         let result = discover_credentials("crab://bucket/repo", None).await;
         assert_eq!(result.source, CredentialSource::Environment);
         assert!(result.valid);
@@ -705,13 +729,25 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let _guard = EnvGuard::apply(
             &[("HOME", dir.path().to_str().unwrap())],
-            &["AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+            &[
+                "AWS_PROFILE",
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_WEB_IDENTITY_TOKEN_FILE",
+                "AWS_ROLE_ARN",
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            ],
         );
 
         let result = discover_credentials("crab://bucket/repo", None).await;
         assert_eq!(result.source, CredentialSource::None);
         assert!(!result.valid);
-        assert!(result.description.contains("No AWS credentials found"));
+        assert!(
+            result
+                .description
+                .contains("No supported AWS credentials found")
+        );
     }
 
     #[tokio::test]

--- a/crab/src/core/metrics.rs
+++ b/crab/src/core/metrics.rs
@@ -8,9 +8,14 @@
 //! [`Metrics::snapshot`] to read a consistent-ish point-in-time view.
 
 use std::fmt;
+use std::fs::OpenOptions;
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 
+use fs4::fs_std::FileExt as LockFileExt;
 use serde::{Deserialize, Serialize};
+
+use super::error::{CrabError, Result};
 
 /// Plain-data snapshot of all perf counters at a point in time.
 ///
@@ -136,7 +141,9 @@ pub struct MetricsSnapshot {
     // --- operation-level counters ---
     /// Total push wall-clock time in milliseconds.
     pub push_duration_ms: u64,
-    /// Total bytes uploaded during push operations.
+    /// Total xorb payload bytes uploaded during push operations.
+    ///
+    /// Excludes Git packs, indexes, manifests, refs, locks, and metadb objects.
     pub bytes_uploaded: u64,
     /// Total fetch wall-clock time in milliseconds.
     pub fetch_duration_ms: u64,
@@ -275,6 +282,12 @@ pub struct MetricsSnapshot {
     pub metadb_batch_get_count: u64,
     /// Total `Db::write` calls across both SlateDB instances.
     pub metadb_batch_write_count: u64,
+    /// Repairable metadata batches buffered before an explicit flush.
+    pub metadb_buffered_batch_write_count: u64,
+    /// Explicit WAL durability flushes issued after durable metadata writes.
+    pub metadb_wal_flush_count: u64,
+    /// Explicit memtable flushes that amortize repairable metadata batches.
+    pub metadb_memtable_flush_count: u64,
     /// Total bytes written through `Db::write` across both SlateDB
     /// instances.
     pub metadb_write_bytes: u64,
@@ -459,6 +472,9 @@ pub struct Metrics {
     metadb_get_hits: AtomicU64,
     metadb_batch_get_count: AtomicU64,
     metadb_batch_write_count: AtomicU64,
+    metadb_buffered_batch_write_count: AtomicU64,
+    metadb_wal_flush_count: AtomicU64,
+    metadb_memtable_flush_count: AtomicU64,
     metadb_write_bytes: AtomicU64,
     metadb_open_count: AtomicU64,
     metadb_close_count: AtomicU64,
@@ -1095,6 +1111,21 @@ impl Metrics {
         self.metadb_batch_write_count.fetch_add(1, Relaxed);
     }
 
+    /// Record a repairable batch buffered until an explicit flush boundary.
+    pub fn inc_metadb_buffered_batch_write_count(&self) {
+        self.metadb_buffered_batch_write_count.fetch_add(1, Relaxed);
+    }
+
+    /// Record one explicit SlateDB WAL flush.
+    pub fn inc_metadb_wal_flush_count(&self) {
+        self.metadb_wal_flush_count.fetch_add(1, Relaxed);
+    }
+
+    /// Record one explicit SlateDB memtable flush.
+    pub fn inc_metadb_memtable_flush_count(&self) {
+        self.metadb_memtable_flush_count.fetch_add(1, Relaxed);
+    }
+
     /// Record bytes written through a `Db::write` call.
     pub fn add_metadb_write_bytes(&self, n: u64) {
         self.metadb_write_bytes.fetch_add(n, Relaxed);
@@ -1281,6 +1312,9 @@ impl Metrics {
             metadb_get_hits: self.metadb_get_hits.load(Relaxed),
             metadb_batch_get_count: self.metadb_batch_get_count.load(Relaxed),
             metadb_batch_write_count: self.metadb_batch_write_count.load(Relaxed),
+            metadb_buffered_batch_write_count: self.metadb_buffered_batch_write_count.load(Relaxed),
+            metadb_wal_flush_count: self.metadb_wal_flush_count.load(Relaxed),
+            metadb_memtable_flush_count: self.metadb_memtable_flush_count.load(Relaxed),
             metadb_write_bytes: self.metadb_write_bytes.load(Relaxed),
             metadb_open_count: self.metadb_open_count.load(Relaxed),
             metadb_close_count: self.metadb_close_count.load(Relaxed),
@@ -1366,6 +1400,7 @@ impl crab_staging::StagingMetrics for Metrics {
 /// Groups counters by subsystem so callers can render or serialize
 /// without knowing the flat field layout of [`MetricsSnapshot`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct MetricsSummary {
     pub push_duration_ms: u64,
     pub bytes_uploaded: u64,
@@ -1384,6 +1419,16 @@ pub struct MetricsSummary {
     pub xorb_fetch_requests_coalesced: u64,
     pub xorb_fetch_bytes_saved: u64,
     pub multipart_resumed_uploads: u64,
+    #[serde(default)]
+    pub head_list_requests: u64,
+    #[serde(default)]
+    pub head_point_requests: u64,
+    #[serde(default)]
+    pub metadb_buffered_batch_write_count: u64,
+    #[serde(default)]
+    pub metadb_wal_flush_count: u64,
+    #[serde(default)]
+    pub metadb_memtable_flush_count: u64,
     // --- workflow counters ---
     #[serde(default)]
     pub workflow_runs_total: u64,
@@ -1420,6 +1465,11 @@ impl MetricsSnapshot {
             xorb_fetch_requests_coalesced: self.xorb_fetch_requests_coalesced,
             xorb_fetch_bytes_saved: self.xorb_fetch_bytes_saved,
             multipart_resumed_uploads: self.multipart_resumed_uploads,
+            head_list_requests: self.head_list_requests,
+            head_point_requests: self.head_point_requests,
+            metadb_buffered_batch_write_count: self.metadb_buffered_batch_write_count,
+            metadb_wal_flush_count: self.metadb_wal_flush_count,
+            metadb_memtable_flush_count: self.metadb_memtable_flush_count,
             workflow_runs_total: self.workflow_runs_total,
             workflow_stages_total: self.workflow_stages_total,
             workflow_retry_attempts_total: self.workflow_retry_attempts_total,
@@ -1451,6 +1501,11 @@ impl MetricsSummary {
             xorb_fetch_requests_coalesced: 0,
             xorb_fetch_bytes_saved: 0,
             multipart_resumed_uploads: 0,
+            head_list_requests: 0,
+            head_point_requests: 0,
+            metadb_buffered_batch_write_count: 0,
+            metadb_wal_flush_count: 0,
+            metadb_memtable_flush_count: 0,
             workflow_runs_total: 0,
             workflow_stages_total: 0,
             workflow_retry_attempts_total: 0,
@@ -1458,6 +1513,151 @@ impl MetricsSummary {
             workflow_cache_pull_bytes_total: 0,
         }
     }
+
+    /// Adds another process-local delta to this cumulative summary.
+    pub fn merge(&mut self, delta: &Self) {
+        macro_rules! add_fields {
+            ($($field:ident),+ $(,)?) => {
+                $(self.$field = self.$field.saturating_add(delta.$field);)+
+            };
+        }
+        add_fields!(
+            push_duration_ms,
+            bytes_uploaded,
+            fetch_duration_ms,
+            bytes_downloaded,
+            gc_duration_ms,
+            gc_objects_deleted,
+            chunk_index_lookups,
+            chunk_index_hits,
+            shard_bloom_queries,
+            shard_bloom_false_positives,
+            staging_bytes_written,
+            staging_bytes_read,
+            xorbs_skipped,
+            clean_fastpath_taken,
+            xorb_fetch_requests_coalesced,
+            xorb_fetch_bytes_saved,
+            multipart_resumed_uploads,
+            head_list_requests,
+            head_point_requests,
+            metadb_buffered_batch_write_count,
+            metadb_wal_flush_count,
+            metadb_memtable_flush_count,
+            workflow_runs_total,
+            workflow_stages_total,
+            workflow_retry_attempts_total,
+            workflow_cache_push_bytes_total,
+            workflow_cache_pull_bytes_total,
+        );
+    }
+
+    /// Returns the monotonic delta since an earlier process-local snapshot.
+    #[must_use]
+    pub fn delta_since(&self, earlier: &Self) -> Self {
+        let mut delta = Self::zeroed();
+        macro_rules! subtract_fields {
+            ($($field:ident),+ $(,)?) => {
+                $(delta.$field = self.$field.saturating_sub(earlier.$field);)+
+            };
+        }
+        subtract_fields!(
+            push_duration_ms,
+            bytes_uploaded,
+            fetch_duration_ms,
+            bytes_downloaded,
+            gc_duration_ms,
+            gc_objects_deleted,
+            chunk_index_lookups,
+            chunk_index_hits,
+            shard_bloom_queries,
+            shard_bloom_false_positives,
+            staging_bytes_written,
+            staging_bytes_read,
+            xorbs_skipped,
+            clean_fastpath_taken,
+            xorb_fetch_requests_coalesced,
+            xorb_fetch_bytes_saved,
+            multipart_resumed_uploads,
+            head_list_requests,
+            head_point_requests,
+            metadb_buffered_batch_write_count,
+            metadb_wal_flush_count,
+            metadb_memtable_flush_count,
+            workflow_runs_total,
+            workflow_stages_total,
+            workflow_retry_attempts_total,
+            workflow_cache_push_bytes_total,
+            workflow_cache_pull_bytes_total,
+        );
+        delta
+    }
+}
+
+impl Default for MetricsSummary {
+    fn default() -> Self {
+        Self::zeroed()
+    }
+}
+
+/// Loads persisted cumulative counters, accepting older partial schemas.
+///
+/// Missing and malformed files produce a zeroed summary so diagnostics remain
+/// usable after an interrupted local write.
+pub fn load_metrics_summary(path: &Path) -> Result<MetricsSummary> {
+    match std::fs::read_to_string(path) {
+        Ok(data) => Ok(serde_json::from_str(&data).unwrap_or_default()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(MetricsSummary::zeroed()),
+        Err(error) => Err(CrabError::Io(error)),
+    }
+}
+
+/// Atomically merges one process-local counter delta into persistent state.
+///
+/// A sibling advisory lock serializes concurrent helper processes. Unknown
+/// JSON fields are retained because adaptive tuning state shares this file.
+pub fn persist_metrics_delta(path: &Path, delta: &MetricsSummary) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    if let Some(parent) = parent {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let lock_path = path.with_extension("json.lock");
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)?;
+    lock.lock_exclusive()?;
+
+    let existing_value = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|data| serde_json::from_str::<serde_json::Value>(&data).ok())
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    let mut cumulative =
+        serde_json::from_value::<MetricsSummary>(existing_value.clone()).unwrap_or_default();
+    cumulative.merge(delta);
+
+    let mut output = match existing_value {
+        serde_json::Value::Object(fields) => fields,
+        _ => serde_json::Map::new(),
+    };
+    let serialized = serde_json::to_value(cumulative)
+        .map_err(|error| CrabError::Internal(format!("serialize perf counters: {error}")))?;
+    if let serde_json::Value::Object(fields) = serialized {
+        output.extend(fields);
+    }
+    let json = serde_json::to_vec_pretty(&output)
+        .map_err(|error| CrabError::Internal(format!("serialize perf counters: {error}")))?;
+    let temp_parent = parent.unwrap_or_else(|| Path::new("."));
+    let temp = tempfile::NamedTempFile::new_in(temp_parent)?;
+    std::fs::write(temp.path(), json)?;
+    temp.persist(path)
+        .map_err(|error| CrabError::Internal(format!("persist perf counters: {error}")))?;
+    Ok(())
 }
 
 impl fmt::Display for MetricsSummary {
@@ -1494,6 +1694,20 @@ impl fmt::Display for MetricsSummary {
         writeln!(f, "  coalesced_bytes:   {}", self.xorb_fetch_bytes_saved)?;
         writeln!(f, "Resume:")?;
         writeln!(f, "  multipart_resumed: {}", self.multipart_resumed_uploads)?;
+        writeln!(f, "Cost signals:")?;
+        writeln!(f, "  resume_list_reqs:  {}", self.head_list_requests)?;
+        writeln!(f, "  resume_head_reqs:  {}", self.head_point_requests)?;
+        writeln!(
+            f,
+            "  metadb_batches:    {}",
+            self.metadb_buffered_batch_write_count
+        )?;
+        writeln!(f, "  metadb_wal_flush:  {}", self.metadb_wal_flush_count)?;
+        writeln!(
+            f,
+            "  metadb_l0_flush:   {}",
+            self.metadb_memtable_flush_count
+        )?;
         writeln!(f, "Workflow:")?;
         writeln!(f, "  runs_total:        {}", self.workflow_runs_total)?;
         writeln!(f, "  stages_total:      {}", self.workflow_stages_total)?;
@@ -1634,6 +1848,9 @@ mod tests {
                 metadb_get_hits: 0,
                 metadb_batch_get_count: 0,
                 metadb_batch_write_count: 0,
+                metadb_buffered_batch_write_count: 0,
+                metadb_wal_flush_count: 0,
+                metadb_memtable_flush_count: 0,
                 metadb_write_bytes: 0,
                 metadb_open_count: 0,
                 metadb_close_count: 0,
@@ -2024,5 +2241,41 @@ mod tests {
         assert_eq!(snap.speculation_hydrates_total, 2);
         assert_eq!(snap.speculation_hits_total, 1);
         assert_eq!(snap.speculation_evictions_total, 3);
+    }
+
+    #[test]
+    fn persisted_deltas_accumulate_and_preserve_tuning_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("perf-state.json");
+        std::fs::write(&path, r#"{"samples":[0.25]}"#).expect("seed state");
+
+        let mut first = MetricsSummary::zeroed();
+        first.bytes_uploaded = 12;
+        first.metadb_wal_flush_count = 1;
+        persist_metrics_delta(&path, &first).expect("persist first delta");
+
+        let mut second = MetricsSummary::zeroed();
+        second.bytes_uploaded = 30;
+        second.head_point_requests = 4;
+        persist_metrics_delta(&path, &second).expect("persist second delta");
+
+        let loaded = load_metrics_summary(&path).expect("load counters");
+        assert_eq!(loaded.bytes_uploaded, 42);
+        assert_eq!(loaded.metadb_wal_flush_count, 1);
+        assert_eq!(loaded.head_point_requests, 4);
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).expect("read state")).expect("parse state");
+        assert_eq!(value["samples"], serde_json::json!([0.25]));
+    }
+
+    #[test]
+    fn partial_older_summary_defaults_missing_counters() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("perf-state.json");
+        std::fs::write(&path, r#"{"bytes_uploaded":9}"#).expect("seed state");
+
+        let loaded = load_metrics_summary(&path).expect("load counters");
+        assert_eq!(loaded.bytes_uploaded, 9);
+        assert_eq!(loaded.metadb_memtable_flush_count, 0);
     }
 }

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -1467,6 +1467,15 @@ pub(crate) struct CommittedPackIndex<'a> {
     pub(crate) git_sha1: &'a str,
 }
 
+#[derive(Debug)]
+struct LocatorPackEvidence {
+    pack_id: MerkleHash,
+    idx_path: PathBuf,
+    rev_path: PathBuf,
+    git_sha1: String,
+    _temp: Option<tempfile::TempDir>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct GitObjectSetProof {
     count: u64,
@@ -2412,12 +2421,12 @@ const PUSH_LOCK_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(250);
 /// Cap for opt-in push-lock wait polling.
 const PUSH_LOCK_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(2);
 
+// Operational cap, not a correctness constant. With the product's default
+// eight upload workers, five pushes bound one repository to 40 upload tasks.
 const PUSH_ADMISSION_SLOTS: usize = 5;
 const PUSH_ADMISSION_WAIT_TTL_MULTIPLIER: u32 = 2;
-const PUSH_ADMISSION_QUEUED_TTL: Duration = Duration::from_secs(120);
 const PUSH_ADMISSION_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(100);
 const PUSH_ADMISSION_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(5);
-const PUSH_ADMISSION_WAIT_PER_WAVE: Duration = Duration::from_millis(250);
 const MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS: u64 = 100_000;
 const GIT_LOCATOR_MIN_CANDIDATES: usize = 256;
 
@@ -2954,23 +2963,15 @@ fn push_lock_wait_delay(attempt: u32, remaining: Duration) -> Duration {
     Duration::from_nanos(pick)
 }
 
-fn push_admission_wait_delay(attempt: u32, writers_ahead: usize, remaining: Duration) -> Duration {
+fn push_admission_wait_delay(attempt: u32, remaining: Duration) -> Duration {
     let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
     let exp = PUSH_ADMISSION_WAIT_BACKOFF_BASE.saturating_mul(shift);
-    let waves_ahead = writers_ahead / PUSH_ADMISSION_SLOTS;
-    let rank_floor = PUSH_ADMISSION_WAIT_PER_WAVE
-        .saturating_mul(u32::try_from(waves_ahead).unwrap_or(u32::MAX))
-        .min(PUSH_ADMISSION_WAIT_BACKOFF_CAP.saturating_sub(PUSH_ADMISSION_WAIT_BACKOFF_BASE));
-    let bound = exp
-        .max(rank_floor.saturating_add(PUSH_ADMISSION_WAIT_BACKOFF_BASE))
-        .min(PUSH_ADMISSION_WAIT_BACKOFF_CAP)
-        .min(remaining);
+    let bound = exp.min(PUSH_ADMISSION_WAIT_BACKOFF_CAP).min(remaining);
     let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
     if bound_nanos == 0 {
         return Duration::ZERO;
     }
-    let floor_nanos = u64::try_from(rank_floor.min(bound).as_nanos()).unwrap_or(bound_nanos);
-    let pick = rand::rng().random_range(floor_nanos.max(1)..=bound_nanos);
+    let pick = rand::rng().random_range(1..=bound_nanos);
     Duration::from_nanos(pick)
 }
 
@@ -4662,18 +4663,15 @@ async fn acquire_push_admission_lock(
     ttl: Duration,
     cancel: &CancellationToken,
 ) -> Result<crab_coordination::PushAdmissionTicket> {
-    // Admission is a capacity queue, not a correctness lease. Give queued
-    // writers more than one lease lifetime so a healthy long push cannot
-    // make an unrelated branch fail only because all slots remained busy.
+    // Admission bounds expensive repository-wide work, while per-ref locks
+    // provide correctness. Waiting contenders own no object-store state.
     let deadline = Instant::now() + ttl.saturating_mul(PUSH_ADMISSION_WAIT_TTL_MULTIPLIER);
-    let mut ticket = crab_coordination::PushAdmissionTicket::enqueue(
+    let mut ticket = crab_coordination::PushAdmissionTicket::new(
         store.inner(),
         prefix,
         PUSH_ADMISSION_SLOTS,
         ttl,
-        PUSH_ADMISSION_QUEUED_TTL,
     )
-    .await
     .map_err(CrabError::from)?;
     let mut attempt = 0;
     loop {
@@ -4693,16 +4691,14 @@ async fn acquire_push_admission_lock(
                     }
                     return Err(CrabError::Throttled { retry_after: None });
                 }
-                let delay = push_admission_wait_delay(
-                    attempt,
-                    ticket.writers_ahead(),
-                    deadline.saturating_duration_since(now),
-                );
+                let delay =
+                    push_admission_wait_delay(attempt, deadline.saturating_duration_since(now));
                 attempt = attempt.saturating_add(1);
                 debug!(
                     attempt,
                     delay_ms = delay.as_millis(),
-                    "push admission ticket is queued"
+                    occupied_slots = ticket.occupied_slots(),
+                    "push admission capacity is occupied"
                 );
                 tokio::select! {
                     () = tokio::time::sleep(delay) => {}
@@ -4805,6 +4801,119 @@ async fn while_admitted_until_commit<T>(
     }
 }
 
+fn validate_locator_pack_evidence(
+    pack: &PackManifestEntry,
+    idx_path: &Path,
+    rev_path: &Path,
+    expected_git_sha1: &str,
+    error_path: &str,
+) -> Result<()> {
+    let locations = crab_git::pack_locator::PackLocationIter::open(idx_path, rev_path, pack.size)
+        .map_err(crab_git::pack::PackError::from)?;
+    if locations.object_count() != pack.object_count {
+        return Err(CrabError::CorruptObject {
+            path: error_path.to_owned(),
+            reason: format!(
+                "manifest records {} objects but verified index contains {}",
+                pack.object_count,
+                locations.object_count()
+            ),
+        });
+    }
+    if locations.pack_checksum().to_string() != expected_git_sha1 {
+        return Err(CrabError::CorruptObject {
+            path: error_path.to_owned(),
+            reason: "pack index checksum disagrees with verified pack trailer".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+async fn download_locator_pack_evidence(
+    store: &Store,
+    router: &StoreLayout,
+    pack: &PackManifestEntry,
+) -> Result<LocatorPackEvidence> {
+    if pack.size < 20 {
+        return Err(CrabError::CorruptObject {
+            path: router.pack_path(&pack.pack_id).as_ref().to_owned(),
+            reason: "canonical Git pack is too short for its trailer".to_owned(),
+        });
+    }
+    let trailer = store
+        .range_get(&router.pack_path(&pack.pack_id), pack.size - 20..pack.size)
+        .await?;
+    let expected_git_sha1 =
+        gix_hash::ObjectId::from(<[u8; 20]>::try_from(trailer.as_ref()).map_err(|_| {
+            CrabError::CorruptObject {
+                path: router.pack_path(&pack.pack_id).as_ref().to_owned(),
+                reason: "canonical Git pack trailer is not 20 bytes".to_owned(),
+            }
+        })?)
+        .to_string();
+    let temp = tempfile::tempdir().map_err(CrabError::Io)?;
+    let idx_path = temp.path().join("pack.idx");
+    let rev_path = temp.path().join("pack.rev");
+    store
+        .download_to_path(&router.pack_index_path(&pack.pack_id), &idx_path)
+        .await?;
+    match store
+        .download_to_path(&router.pack_reverse_index_path(&pack.pack_id), &rev_path)
+        .await
+    {
+        Ok(_) => {}
+        // v1.0.14 and earlier direct pushes published `.idx` without `.rev`.
+        // Rebuilding that deterministic evidence is the tagged-data migration.
+        Err(CrabError::NotFound { .. }) => {
+            let index = idx_path.clone();
+            let reverse = rev_path.clone();
+            let (reverse_hash, reverse_size) = tokio::task::spawn_blocking(move || {
+                crab_git::pack_locator::write_pack_reverse_index(&index, &reverse)
+                    .map_err(crab_git::pack::PackError::from)
+                    .map_err(CrabError::from)?;
+                hash_file_blake3(&reverse)
+            })
+            .await
+            .map_err(|error| {
+                CrabError::Internal(format!(
+                    "legacy reverse-index generation worker failed: {error}"
+                ))
+            })??;
+            store
+                .put_multipart_file_retry(
+                    &router.pack_reverse_index_path(&pack.pack_id),
+                    &rev_path,
+                    reverse_size,
+                    reverse_hash,
+                    8 * 1024 * 1024,
+                    &CancellationToken::new(),
+                    None,
+                )
+                .await?;
+        }
+        Err(error) => return Err(error),
+    }
+    validate_locator_pack_evidence(
+        pack,
+        &idx_path,
+        &rev_path,
+        &expected_git_sha1,
+        router.pack_index_path(&pack.pack_id).as_ref(),
+    )?;
+    let pack_id = MerkleHash::from_hex(&pack.pack_id).map_err(|error| {
+        CrabError::Internal(format!(
+            "committed pack id is invalid for locator publication: {error}"
+        ))
+    })?;
+    Ok(LocatorPackEvidence {
+        pack_id,
+        idx_path,
+        rev_path,
+        git_sha1: expected_git_sha1,
+        _temp: Some(temp),
+    })
+}
+
 pub(crate) async fn publish_committed_pack_locators(
     store: &Store,
     router: &StoreLayout,
@@ -4812,48 +4921,38 @@ pub(crate) async fn publish_committed_pack_locators(
     anchor: CommittedManifestAnchor,
     lock_ttl: Duration,
 ) -> Result<crab_metadata::git_object_locator::LocatorWriteStats> {
-    let mut records = Vec::with_capacity(packs.len());
+    let mut local_evidence = HashMap::with_capacity(packs.len());
     for published in packs {
         let pack = published.pack;
-        let locations = crab_git::pack_locator::PackLocationIter::open(
+        validate_locator_pack_evidence(
+            pack,
             published.idx_path,
             published.rev_path,
-            pack.size,
-        )
-        .map_err(crab_git::pack::PackError::from)?;
-        if locations.object_count() != pack.object_count {
-            return Err(CrabError::CorruptObject {
-                path: router.pack_path(&pack.pack_id).as_ref().to_owned(),
-                reason: format!(
-                    "manifest records {} objects but verified index contains {}",
-                    pack.object_count,
-                    locations.object_count()
-                ),
-            });
-        }
-        if locations.pack_checksum().to_string() != published.git_sha1 {
-            return Err(CrabError::CorruptObject {
-                path: published.idx_path.display().to_string(),
-                reason: "pack index checksum disagrees with verified pack trailer".to_owned(),
-            });
-        }
-        drop(locations);
+            published.git_sha1,
+            &published.idx_path.display().to_string(),
+        )?;
         let pack_id = MerkleHash::from_hex(&pack.pack_id).map_err(|error| {
             CrabError::Internal(format!(
                 "committed pack id is invalid for locator publication: {error}"
             ))
         })?;
-        records.push((
-            crab_metadata::git_object_locator::GitPackLocatorRecord {
+        if local_evidence
+            .insert(
                 pack_id,
-                committed_generation: anchor.generation,
-                pack_index_hash: anchor.pack_index_hash,
-                object_count: pack.object_count,
-                pack_size: pack.size,
-            },
-            published.idx_path,
-            published.rev_path,
-        ));
+                LocatorPackEvidence {
+                    pack_id,
+                    idx_path: published.idx_path.to_owned(),
+                    rev_path: published.rev_path.to_owned(),
+                    git_sha1: published.git_sha1.to_owned(),
+                    _temp: None,
+                },
+            )
+            .is_some()
+        {
+            return Err(CrabError::Internal(
+                "locator publication received duplicate pack evidence".to_owned(),
+            ));
+        }
     }
 
     // Most fanout writers are stale by the time they reach derived indexing.
@@ -4882,10 +4981,6 @@ pub(crate) async fn publish_committed_pack_locators(
             return Ok(crab_metadata::git_object_locator::LocatorWriteStats::default());
         }
         let current_packs = read_bulk_pack_list(store, router, &current.pack_index_hash).await?;
-        let published_ids = records
-            .iter()
-            .map(|(record, _, _)| record.pack_id)
-            .collect::<HashSet<_>>();
 
         let mut writer = crab_metadata::git_object_locator::GitObjectLocatorWriter::open(
             Arc::clone(store.inner()),
@@ -4894,18 +4989,85 @@ pub(crate) async fn publish_committed_pack_locators(
         .await?;
         let operation = async {
             let prior_coverage = writer.coverage();
-            let pack_records = records
+            let covered_packs = if let Some(coverage) = prior_coverage {
+                read_bulk_pack_list(store, router, &coverage.pack_index_hash.hex()).await?
+            } else {
+                Vec::new()
+            };
+            let covered = covered_packs
                 .iter()
-                .map(|(record, _, _)| *record)
-                .collect::<Vec<_>>();
+                .map(|pack| (pack.pack_id.as_str(), (pack.object_count, pack.size)))
+                .collect::<HashMap<_, _>>();
+            let mut pack_records = Vec::with_capacity(current_packs.len());
+            for pack in &current_packs {
+                let pack_id = MerkleHash::from_hex(&pack.pack_id).map_err(|error| {
+                    CrabError::Internal(format!(
+                        "committed pack id is invalid for locator publication: {error}"
+                    ))
+                })?;
+                pack_records.push(crab_metadata::git_object_locator::GitPackLocatorRecord {
+                    pack_id,
+                    committed_generation: anchor.generation,
+                    pack_index_hash: anchor.pack_index_hash,
+                    object_count: pack.object_count,
+                    pack_size: pack.size,
+                });
+            }
             let bindings = writer.bind_packs(&pack_records).await?;
-            for (binding, (_, idx_path, rev_path)) in bindings.into_iter().zip(&records) {
+            let retained_slots = bindings
+                .iter()
+                .map(|binding| binding.pack_slot)
+                .collect::<HashSet<_>>();
+            let sweep = writer.sweep_unreferenced(&retained_slots).await?;
+            let rebuild_all = sweep.pack_rows_deleted != 0;
+            let mut evidence = Vec::new();
+            for pack in &current_packs {
+                if !rebuild_all
+                    && covered.get(pack.pack_id.as_str()) == Some(&(pack.object_count, pack.size))
+                {
+                    continue;
+                }
+                let pack_id = MerkleHash::from_hex(&pack.pack_id).map_err(|error| {
+                    CrabError::Internal(format!(
+                        "committed pack id is invalid for locator publication: {error}"
+                    ))
+                })?;
+                let pack_evidence = if let Some(local) = local_evidence.remove(&pack_id) {
+                    validate_locator_pack_evidence(
+                        pack,
+                        &local.idx_path,
+                        &local.rev_path,
+                        &local.git_sha1,
+                        &local.idx_path.display().to_string(),
+                    )?;
+                    local
+                } else {
+                    download_locator_pack_evidence(store, router, pack).await?
+                };
+                evidence.push(pack_evidence);
+            }
+            let bindings = bindings
+                .into_iter()
+                .map(|binding| (binding.record.pack_id, binding))
+                .collect::<HashMap<_, _>>();
+            for pack_evidence in &evidence {
+                let binding = *bindings.get(&pack_evidence.pack_id).ok_or_else(|| {
+                    CrabError::Internal(
+                        "locator evidence has no current manifest pack binding".to_owned(),
+                    )
+                })?;
                 let mut locations = crab_git::pack_locator::PackLocationIter::open(
-                    idx_path,
-                    rev_path,
+                    &pack_evidence.idx_path,
+                    &pack_evidence.rev_path,
                     binding.record.pack_size,
                 )
                 .map_err(crab_git::pack::PackError::from)?;
+                if locations.pack_checksum().to_string() != pack_evidence.git_sha1 {
+                    return Err(CrabError::CorruptObject {
+                        path: pack_evidence.idx_path.display().to_string(),
+                        reason: "pack index checksum changed during locator publication".to_owned(),
+                    });
+                }
                 let mut entries = Vec::with_capacity(25_000);
                 for location in &mut locations {
                     let location = location.map_err(crab_git::pack::PackError::from)?;
@@ -4939,37 +5101,12 @@ pub(crate) async fn publish_committed_pack_locators(
             {
                 return Ok(());
             }
-            let all_current_published = current_packs.iter().all(|pack| {
-                MerkleHash::from_hex(&pack.pack_id)
-                    .ok()
-                    .is_some_and(|pack_id| published_ids.contains(&pack_id))
-            });
-            let prior_covers_remainder = if all_current_published {
-                true
-            } else if let Some(coverage) = prior_coverage {
-                let covered_packs =
-                    read_bulk_pack_list(store, router, &coverage.pack_index_hash.hex()).await?;
-                current_packs.iter().all(|current| {
-                    MerkleHash::from_hex(&current.pack_id)
-                        .ok()
-                        .is_some_and(|pack_id| published_ids.contains(&pack_id))
-                        || covered_packs.iter().any(|covered| {
-                            covered.pack_id == current.pack_id
-                                && covered.object_count == current.object_count
-                                && covered.size == current.size
-                        })
+            writer
+                .set_coverage(crab_metadata::git_object_locator::GitLocatorCoverage {
+                    generation: anchor.generation,
+                    pack_index_hash: anchor.pack_index_hash,
                 })
-            } else {
-                false
-            };
-            if prior_covers_remainder {
-                writer
-                    .set_coverage(crab_metadata::git_object_locator::GitLocatorCoverage {
-                        generation: anchor.generation,
-                        pack_index_hash: anchor.pack_index_hash,
-                    })
-                    .await?;
-            }
+                .await?;
             Ok(())
         }
         .await;
@@ -5331,10 +5468,7 @@ impl PushPipeline {
 
         match crate::metadata::manifest::read_repository_snapshot(store, &self.router).await {
             Ok(snapshot) => {
-                let mut manifest = snapshot.manifest;
-                manifest.refs = snapshot.journal.refs;
-                manifest.peeled_refs = snapshot.journal.peeled_refs;
-                manifest.head = snapshot.journal.head;
+                let manifest = snapshot.materialized_manifest();
                 debug!(
                     generation = manifest.generation,
                     refs = manifest.refs.len(),
@@ -6659,10 +6793,7 @@ impl PushPipeline {
                 }
                 Err(error) => return Err(error),
             };
-        let mut current = current_snapshot.manifest;
-        current.refs = current_snapshot.journal.refs;
-        current.peeled_refs = current_snapshot.journal.peeled_refs;
-        current.head = current_snapshot.journal.head;
+        let current = current_snapshot.materialized_manifest();
         let conflicts = ref_base_conflicts(&self.specs, &decisions, base.as_ref(), &current);
         if self.config.atomic
             && let Some(conflict) = conflicts.first()
@@ -6845,12 +6976,30 @@ impl PushPipeline {
             warn!(%error, "ref journal committed; compaction lock release requires repair");
         }
         match compacted {
-            Ok(Some(compacted_manifest)) => match committed_manifest_anchor(&compacted_manifest) {
-                Ok(anchor) => *self.committed_manifest_anchor.lock().await = anchor,
-                Err(error) => {
-                    warn!(%error, "ref journal committed; compacted anchor requires repair")
+            Ok(Some(compacted_manifest)) => {
+                match committed_manifest_anchor(&compacted_manifest) {
+                    Ok(anchor) => *self.committed_manifest_anchor.lock().await = anchor,
+                    Err(error) => {
+                        warn!(%error, "ref journal committed; compacted anchor requires repair")
+                    }
                 }
-            },
+                let visibility_published = match self
+                    .publish_git_visibility_index(&compacted_manifest, store)
+                    .await
+                {
+                    Ok(()) => true,
+                    Err(error) => {
+                        warn!(
+                            error = %error,
+                            generation = compacted_manifest.generation,
+                            "ref journal committed; Git visibility proof requires repair"
+                        );
+                        false
+                    }
+                };
+                self.git_visibility_published
+                    .store(visibility_published, std::sync::atomic::Ordering::Relaxed);
+            }
             Ok(None) => {}
             Err(error) => {
                 warn!(%error, "ref journal committed; manifest compaction requires repair")
@@ -10514,14 +10663,20 @@ impl PushPipeline {
                 // the staged pack; `.idx` is not an accepted wire object.
                 if store.staging_write_prefix().is_none() {
                     let idx_path = installed.idx_path.clone();
-                    let (idx_hash, idx_size) =
-                        tokio::task::spawn_blocking(move || hash_file_blake3(&idx_path))
-                            .await
-                            .map_err(|error| {
-                                CrabError::Internal(format!(
-                                    "pack index hashing join failed: {error}"
-                                ))
-                            })??;
+                    let rev_path = installed.rev_path.clone();
+                    let ((idx_hash, idx_size), (rev_hash, rev_size)) =
+                        tokio::task::spawn_blocking(move || {
+                            Ok::<_, CrabError>((
+                                hash_file_blake3(&idx_path)?,
+                                hash_file_blake3(&rev_path)?,
+                            ))
+                        })
+                        .await
+                        .map_err(|error| {
+                            CrabError::Internal(format!(
+                                "pack evidence hashing join failed: {error}"
+                            ))
+                        })??;
                     let remote_idx_path = self.router.pack_index_path(&pack_sha);
                     store
                         .put_multipart_file_retry(
@@ -10529,6 +10684,18 @@ impl PushPipeline {
                             &installed.idx_path,
                             idx_size,
                             idx_hash,
+                            8 * 1024 * 1024,
+                            &self.cancel,
+                            None,
+                        )
+                        .await?;
+                    let remote_rev_path = self.router.pack_reverse_index_path(&pack_sha);
+                    store
+                        .put_multipart_file_retry(
+                            &remote_rev_path,
+                            &installed.rev_path,
+                            rev_size,
+                            rev_hash,
                             8 * 1024 * 1024,
                             &self.cancel,
                             None,
@@ -10564,7 +10731,7 @@ impl PushPipeline {
                     pack_bytes = packed.pack_size,
                     object_count = packed.object_count,
                     git_sha1 = %installed.git_sha1,
-                    "step 10: bounded pack and canonical index uploaded"
+                    "step 10: bounded pack and immutable locator evidence uploaded"
                 );
                 uploaded.push(UploadedGitPack {
                     entry,
@@ -12237,7 +12404,10 @@ impl PushPipeline {
         if txn.is_empty() {
             return Ok(());
         }
-        let receipt = Box::pin(guard.commit(txn)).await?;
+        // These indexes are post-commit acceleration. Buffering several
+        // batches avoids one object-store WAL PUT per 2,048 rows; the
+        // explicit memtable boundaries below make the group durable.
+        let receipt = Box::pin(guard.commit_buffered(txn)).await?;
         aggregate.file_ops_written += receipt.file_ops_written;
         aggregate.chunk_ops_written += receipt.chunk_ops_written;
         aggregate.bytes_written += receipt.bytes_written;
@@ -13625,9 +13795,13 @@ impl PushPipeline {
             let visibility_published = self
                 .git_visibility_published
                 .load(std::sync::atomic::Ordering::Relaxed);
-            if visibility_published
-                && let (Some(anchor), Some(store)) = (anchor, self.store.as_ref())
-            {
+            if !visibility_published {
+                git_indexed = false;
+                info!(
+                    "Git visibility proof requires repair; publishing exact locators independently"
+                );
+            }
+            if let (Some(anchor), Some(store)) = (anchor, self.store.as_ref()) {
                 match publish_uploaded_pack_locators(
                     store,
                     &self.router,
@@ -13665,11 +13839,6 @@ impl PushPipeline {
                         );
                     }
                 }
-            } else if anchor.is_some() && self.store.is_some() {
-                git_indexed = false;
-                info!(
-                    "skipping synchronous Git locator publication until the visibility proof is repairable"
-                );
             }
             if file_indexed
                 && git_indexed
@@ -14391,8 +14560,11 @@ mod tests {
         (store, router)
     }
 
-    fn locator_pack_fixture() -> (
+    fn locator_pack_fixture_for(
+        content: &[u8],
+    ) -> (
         tempfile::TempDir,
+        PathBuf,
         PathBuf,
         PathBuf,
         String,
@@ -14442,7 +14614,7 @@ mod tests {
                 "-w",
                 "--stdin",
             ],
-            Some(b"locator fixture object\n"),
+            Some(content),
         ))
         .expect("object ID UTF-8");
         let base = temp.path().join("fixture");
@@ -14477,9 +14649,24 @@ mod tests {
             gix_pack::index::File::at(&idx_path, gix_hash::Kind::Sha1).expect("open fixture index");
         let git_sha1 = index.pack_checksum().to_string();
         let oid = gix_hash::ObjectId::from_hex(oid_text.trim().as_bytes()).expect("fixture oid");
-        let pack_size = std::fs::metadata(pack_path)
+        let pack_size = std::fs::metadata(&pack_path)
             .expect("fixture pack metadata")
             .len();
+        (
+            temp, pack_path, idx_path, rev_path, git_sha1, oid, pack_size,
+        )
+    }
+
+    fn locator_pack_fixture() -> (
+        tempfile::TempDir,
+        PathBuf,
+        PathBuf,
+        String,
+        gix_hash::ObjectId,
+        u64,
+    ) {
+        let (temp, _pack_path, idx_path, rev_path, git_sha1, oid, pack_size) =
+            locator_pack_fixture_for(b"locator fixture object\n");
         (temp, idx_path, rev_path, git_sha1, oid, pack_size)
     }
 
@@ -16499,15 +16686,11 @@ mod tests {
     }
 
     #[test]
-    fn push_admission_backoff_scales_with_fifo_distance() {
-        let front = push_admission_wait_delay(0, PUSH_ADMISSION_SLOTS, Duration::from_secs(60));
-        let tail = push_admission_wait_delay(0, 95, Duration::from_secs(60));
-        let bounded = push_admission_wait_delay(32, 95, Duration::from_secs(1));
+    fn push_admission_backoff_is_bounded_by_remaining_wait() {
+        let first = push_admission_wait_delay(0, Duration::from_secs(60));
+        let bounded = push_admission_wait_delay(32, Duration::from_secs(1));
 
-        assert!(front >= PUSH_ADMISSION_WAIT_PER_WAVE);
-        assert!(front <= PUSH_ADMISSION_WAIT_PER_WAVE + PUSH_ADMISSION_WAIT_BACKOFF_BASE);
-        assert!(tail >= Duration::from_millis(4_750));
-        assert!(tail <= PUSH_ADMISSION_WAIT_BACKOFF_CAP);
+        assert!(first <= PUSH_ADMISSION_WAIT_BACKOFF_BASE);
         assert!(bounded <= Duration::from_secs(1));
     }
 
@@ -16866,6 +17049,16 @@ mod tests {
         *pipeline.planned_ref_decisions.lock().await = Some(decisions.clone());
         pipeline.prepare_git_pack().await.expect("prepare pack");
         pipeline.upload_packs().await.expect("upload pack");
+        for uploaded in pipeline.uploaded_packs.lock().await.iter() {
+            store
+                .head(&router.pack_index_path(&uploaded.entry.pack_id))
+                .await
+                .expect("canonical pack index evidence");
+            store
+                .head(&router.pack_reverse_index_path(&uploaded.entry.pack_id))
+                .await
+                .expect("canonical pack reverse-index evidence");
+        }
         let (candidate, bulk) = pipeline
             .apply_decisions_with_sha_map(&decisions, false, &sha_map)
             .await
@@ -17269,14 +17462,12 @@ mod tests {
         let store = Store::new(inner);
         let mut blockers = Vec::new();
         for _ in 0..PUSH_ADMISSION_SLOTS {
-            let mut blocker = crab_coordination::PushAdmissionTicket::enqueue(
+            let mut blocker = crab_coordination::PushAdmissionTicket::new(
                 store.inner(),
                 "repo",
                 PUSH_ADMISSION_SLOTS,
                 Duration::from_secs(60),
-                PUSH_ADMISSION_QUEUED_TTL,
             )
-            .await
             .unwrap();
             assert!(blocker.try_admit().await.unwrap());
             blockers.push(blocker);
@@ -17308,14 +17499,12 @@ mod tests {
         let inner: Arc<dyn object_store::ObjectStore> =
             Arc::new(object_store::memory::InMemory::new());
         let store = Store::new(inner);
-        let mut permit = crab_coordination::PushAdmissionTicket::enqueue(
+        let mut permit = crab_coordination::PushAdmissionTicket::new(
             store.inner(),
             "repo",
             1,
             Duration::from_secs(60),
-            PUSH_ADMISSION_QUEUED_TTL,
         )
-        .await
         .unwrap();
         assert!(permit.try_admit().await.unwrap());
         let (committed_tx, committed_rx) = tokio::sync::oneshot::channel();
@@ -17334,14 +17523,12 @@ mod tests {
         });
 
         let contender = tokio::time::timeout(Duration::from_secs(1), async {
-            let mut ticket = crab_coordination::PushAdmissionTicket::enqueue(
+            let mut ticket = crab_coordination::PushAdmissionTicket::new(
                 store.inner(),
                 "repo",
                 1,
                 Duration::from_secs(60),
-                PUSH_ADMISSION_QUEUED_TTL,
             )
-            .await
             .unwrap();
             loop {
                 if ticket.try_admit().await.unwrap() {
@@ -18304,7 +18491,8 @@ mod tests {
     #[tokio::test]
     async fn git_object_locator_cli_publisher_advances_generations_without_new_packs() {
         let (store, router) = test_store_router("locator-publisher");
-        let (_fixture, idx_path, rev_path, git_sha1, oid, pack_size) = locator_pack_fixture();
+        let (_fixture, pack_path, idx_path, rev_path, git_sha1, oid, pack_size) =
+            locator_pack_fixture_for(b"locator fixture object\n");
         let pack_id = "a".repeat(64);
         let pack = PackManifestEntry {
             pack_id: pack_id.clone(),
@@ -18333,6 +18521,27 @@ mod tests {
         crate::metadata::manifest::create_manifest(&store, &router, &manifest)
             .await
             .expect("publish manifest");
+        store
+            .put(
+                &router.pack_path(&pack_id),
+                Bytes::from(std::fs::read(&pack_path).expect("read fixture pack")),
+            )
+            .await
+            .expect("upload fixture pack");
+        store
+            .put(
+                &router.pack_index_path(&pack_id),
+                Bytes::from(std::fs::read(&idx_path).expect("read fixture index")),
+            )
+            .await
+            .expect("upload fixture index");
+        store
+            .put(
+                &router.pack_reverse_index_path(&pack_id),
+                Bytes::from(std::fs::read(&rev_path).expect("read fixture reverse index")),
+            )
+            .await
+            .expect("upload fixture reverse index");
 
         let anchor = CommittedManifestAnchor {
             generation: 7,
@@ -18392,6 +18601,65 @@ mod tests {
                     && locator.location.entry_len > 0
         ));
 
+        let location = match lookup[0] {
+            crab_metadata::git_object_locator::GitObjectLookup::Hit(locator) => locator.location,
+            _ => unreachable!("initial locator must hit"),
+        };
+        let stale_pack_id = MerkleHash::from_hex(&"b".repeat(64)).expect("stale pack id");
+        let mut stale_writer = crab_metadata::git_object_locator::GitObjectLocatorWriter::open(
+            Arc::clone(store.inner()),
+            router.repo_prefix(),
+        )
+        .await
+        .expect("open stale locator writer");
+        let stale_binding = stale_writer
+            .bind_packs(&[crab_metadata::git_object_locator::GitPackLocatorRecord {
+                pack_id: stale_pack_id,
+                committed_generation: 8,
+                pack_index_hash: MerkleHash::from([8, 9, 10, 11]),
+                object_count: 1,
+                pack_size,
+            }])
+            .await
+            .expect("bind stale pack")[0];
+        stale_writer
+            .write_locations(
+                stale_binding,
+                &[crab_metadata::git_object_locator::GitObjectLocatorEntry {
+                    oid: oid_bytes,
+                    location,
+                }],
+            )
+            .await
+            .expect("overwrite covered object with stale pack");
+        stale_writer.flush_objects().await.expect("flush stale row");
+        stale_writer.close().await.expect("close stale writer");
+
+        let repaired =
+            publish_uploaded_pack_locators(&store, &router, &[], anchor, Duration::from_secs(60))
+                .await
+                .expect("repair stale duplicate row");
+        assert_eq!(repaired.object_rows_written, 1);
+        let repaired_session = crab_metadata::git_object_locator::GitObjectLocatorSession::open(
+            Arc::clone(store.inner()),
+            router.repo_prefix(),
+        )
+        .await
+        .expect("open repaired locator session");
+        let repaired_lookup = repaired_session
+            .lookup_batch(&[oid_bytes], &inventory)
+            .await
+            .expect("lookup repaired object");
+        assert!(matches!(
+            repaired_lookup.as_slice(),
+            [crab_metadata::git_object_locator::GitObjectLookup::Hit(locator)]
+                if locator.pack_id == parsed_pack_id
+        ));
+        repaired_session
+            .close()
+            .await
+            .expect("close repaired locator session");
+
         let (mut next_manifest, etag) = read_manifest(&store, &router)
             .await
             .expect("read next manifest base");
@@ -18433,6 +18701,144 @@ mod tests {
             .close()
             .await
             .expect("close advanced locator session");
+    }
+
+    #[tokio::test]
+    async fn git_object_locator_cli_publisher_recovers_concurrent_sibling_evidence() {
+        let (store, router) = test_store_router("locator-concurrent-sibling");
+        let (
+            _first_fixture,
+            first_pack_path,
+            first_idx_path,
+            first_rev_path,
+            _first_git_sha1,
+            first_oid,
+            first_pack_size,
+        ) = locator_pack_fixture_for(b"first concurrent locator object\n");
+        let (
+            _second_fixture,
+            _second_pack_path,
+            second_idx_path,
+            second_rev_path,
+            second_git_sha1,
+            second_oid,
+            second_pack_size,
+        ) = locator_pack_fixture_for(b"second concurrent locator object\n");
+        let first_pack_bytes = std::fs::read(&first_pack_path).expect("read first pack");
+        let first_pack_id = blake3::hash(&first_pack_bytes).to_hex().to_string();
+        let second_pack_bytes = std::fs::read(&_second_pack_path).expect("read second pack");
+        let second_pack_id = blake3::hash(&second_pack_bytes).to_hex().to_string();
+        store
+            .put(
+                &router.pack_path(&first_pack_id),
+                Bytes::from(first_pack_bytes),
+            )
+            .await
+            .expect("upload first pack body");
+        store
+            .put(
+                &router.pack_index_path(&first_pack_id),
+                Bytes::from(std::fs::read(&first_idx_path).expect("read first index")),
+            )
+            .await
+            .expect("upload first index evidence");
+        store
+            .put(
+                &router.pack_reverse_index_path(&first_pack_id),
+                Bytes::from(std::fs::read(&first_rev_path).expect("read first reverse index")),
+            )
+            .await
+            .expect("upload first reverse-index evidence");
+
+        let first_pack = PackManifestEntry {
+            pack_id: first_pack_id.clone(),
+            size: first_pack_size,
+            content_hash: first_pack_id,
+            ref_tips: vec!["1".repeat(40)],
+            object_count: 1,
+        };
+        let second_pack = PackManifestEntry {
+            pack_id: second_pack_id.clone(),
+            size: second_pack_size,
+            content_hash: second_pack_id,
+            ref_tips: vec!["2".repeat(40)],
+            object_count: 1,
+        };
+        let current_packs = vec![first_pack.clone(), second_pack.clone()];
+        let (pack_index_hash, _, pack_write) =
+            crate::metadata::manifest::compact_pack_index(9, &current_packs)
+                .expect("build concurrent pack index");
+        upload_segmented_bulk(
+            &store,
+            &router,
+            &BulkData {
+                shard_index: crab_metadata::segmented::SegmentWrite::default(),
+                pack_index: pack_write,
+            },
+        )
+        .await
+        .expect("upload concurrent pack index");
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 9;
+        manifest.pack_index_hash = pack_index_hash.clone();
+        manifest.seal_git_validation();
+        crate::metadata::manifest::create_manifest(&store, &router, &manifest)
+            .await
+            .expect("publish concurrent manifest");
+        let anchor = CommittedManifestAnchor {
+            generation: manifest.generation,
+            shard_index_hash: MerkleHash::default(),
+            pack_index_hash: MerkleHash::from_hex(&pack_index_hash).expect("pack index hash"),
+        };
+
+        let stats = publish_committed_pack_locators(
+            &store,
+            &router,
+            &[CommittedPackIndex {
+                pack: &second_pack,
+                idx_path: &second_idx_path,
+                rev_path: &second_rev_path,
+                git_sha1: &second_git_sha1,
+            }],
+            anchor,
+            Duration::from_secs(60),
+        )
+        .await
+        .expect("publish complete concurrent generation");
+
+        assert!(stats.coverage_updated);
+        assert_eq!(stats.object_rows_written, 2);
+        let inventory = current_packs
+            .iter()
+            .map(|pack| {
+                let pack_id = MerkleHash::from_hex(&pack.pack_id).expect("pack id");
+                (
+                    pack_id,
+                    crab_metadata::git_object_locator::GitPackInventoryEntry {
+                        pack_id,
+                        object_count: pack.object_count,
+                        pack_size: pack.size,
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        let object_ids =
+            [first_oid, second_oid].map(|oid| oid.as_bytes().try_into().expect("SHA-1 oid"));
+        let session = crab_metadata::git_object_locator::GitObjectLocatorSession::open(
+            Arc::clone(store.inner()),
+            router.repo_prefix(),
+        )
+        .await
+        .expect("open concurrent locator session");
+        let lookups = session
+            .lookup_batch(&object_ids, &inventory)
+            .await
+            .expect("lookup both concurrent objects");
+        assert!(lookups.iter().all(|lookup| matches!(
+            lookup,
+            crab_metadata::git_object_locator::GitObjectLookup::Hit(_)
+        )));
+        session.close().await.expect("close locator session");
     }
 
     #[tokio::test]

--- a/crab/src/git/push_native.rs
+++ b/crab/src/git/push_native.rs
@@ -211,6 +211,7 @@ pub async fn run_native_push(
         cancel,
         mut pre_acquired_locks,
     } = inputs;
+    let operation_metrics = metrics.clone();
 
     if let Some(result) = duplicate_destination_result(specs) {
         if let Some(leases) = pre_acquired_locks.take() {
@@ -559,6 +560,10 @@ pub async fn run_native_push(
                 None,
             );
         }
+    }
+
+    if let Some(metrics) = operation_metrics {
+        metrics.add_push_duration_ms(pipeline_start.elapsed().as_millis() as u64);
     }
 
     Ok(result)

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -16,6 +16,7 @@ use tracing::{Instrument, warn};
 
 use crate::audit::default_log_path;
 use crate::core::error::{CrabError, Result};
+use crate::core::metrics::{Metrics, MetricsSummary, persist_metrics_delta};
 use crate::core::output::{JsonlStream, OutputMode};
 use crate::git::fetch::{CommitGraphProvider, FetchConfig, PackInfo, PackStore, run_fetch_batch};
 use crate::git::push::{
@@ -517,6 +518,8 @@ struct SessionCache {
     pack_list: Option<crab_metadata::manifests::PackList>,
     /// Cached result of the `has_commit_graph_summary` probe.
     has_commit_graph: Option<bool>,
+    metrics: Arc<Metrics>,
+    persisted_metrics: MetricsSummary,
 }
 
 impl SessionCache {
@@ -525,6 +528,8 @@ impl SessionCache {
             config,
             pack_list: None,
             has_commit_graph: None,
+            metrics: Arc::new(Metrics::new()),
+            persisted_metrics: MetricsSummary::zeroed(),
         }
     }
 
@@ -536,6 +541,17 @@ impl SessionCache {
     /// the store. Called after a push that creates or updates the summary.
     fn invalidate_commit_graph(&mut self) {
         self.has_commit_graph = None;
+    }
+
+    fn persist_pending_metrics(&mut self) -> Result<()> {
+        if !self.config.perf_persist {
+            return Ok(());
+        }
+        let current = self.metrics.snapshot().summary();
+        let delta = current.delta_since(&self.persisted_metrics);
+        persist_metrics_delta(std::path::Path::new(&self.config.perf_path), &delta)?;
+        self.persisted_metrics = current;
+        Ok(())
     }
 }
 
@@ -746,6 +762,7 @@ async fn run_remote_helper_with_context(
         };
         if let Batch::StatelessConnect { service } = &batch {
             let hidden_ref_patterns = cache.config().transfer_hide_refs.clone();
+            let fetch_policy = fetch_admission_policy(cache.config());
             let result = if service == "git-upload-pack" {
                 crate::git::upload_pack_wire::serve(
                     &mut reader,
@@ -753,6 +770,7 @@ async fn run_remote_helper_with_context(
                     store.as_storage(),
                     &prefix,
                     &hidden_ref_patterns,
+                    &fetch_policy,
                     options.progress,
                     &cancel,
                 )
@@ -1374,7 +1392,7 @@ async fn dispatch_batch<W: tokio::io::AsyncWrite + Unpin>(
                             push_state,
                             remote_name,
                             push_state_remote_url,
-                            None,
+                            Some(Arc::clone(&cache.metrics)),
                             cancel.clone(),
                         ),
                     )
@@ -1429,6 +1447,9 @@ async fn dispatch_batch<W: tokio::io::AsyncWrite + Unpin>(
                     .any(|o| matches!(o, RefPushOutcome::Ok));
                 if any_ref_succeeded {
                     cache.invalidate_commit_graph();
+                }
+                if let Err(error) = cache.persist_pending_metrics() {
+                    warn!(%error, "failed to persist performance counters");
                 }
 
                 let response = format_push_response(&result, &ordered_specs);
@@ -1805,10 +1826,7 @@ async fn read_remote_refs(
     hidden_ref_patterns: &[String],
 ) -> Result<ListOutput> {
     let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
-    let mut manifest = snapshot.manifest;
-    manifest.refs = snapshot.journal.refs;
-    manifest.peeled_refs = snapshot.journal.peeled_refs;
-    manifest.head = snapshot.journal.head;
+    let manifest = snapshot.materialized_manifest();
     let advertisement = crab_read::manifest_ref_advertisement(&manifest, hidden_ref_patterns);
 
     let refs = advertisement
@@ -2118,10 +2136,7 @@ async fn fetch_packs(
     check_connectivity: bool,
 ) -> Result<Option<std::path::PathBuf>> {
     let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
-    let mut manifest = snapshot.manifest;
-    manifest.refs = snapshot.journal.refs;
-    manifest.peeled_refs = snapshot.journal.peeled_refs;
-    manifest.head = snapshot.journal.head;
+    let manifest = snapshot.materialized_manifest();
 
     let fetch_store = Arc::new(RemoteFetchStore::new(
         store.clone(),
@@ -2143,8 +2158,6 @@ async fn fetch_packs(
                 "raw object fetches cannot be mixed with ref fetches".to_owned(),
             ));
         }
-        fetch_promisor_objects(store, router.repo_prefix(), entries, config, cancel).await?;
-        return Ok(None);
     }
 
     // Upload-pack policy gate. Raw-SHA `fetch <sha> <ref>` lines
@@ -2201,6 +2214,11 @@ async fn fetch_packs(
             writer.flush().await?;
             return Ok(None);
         }
+    }
+
+    if raw_object_count > 0 {
+        fetch_promisor_objects(store, router.repo_prefix(), entries, config, cancel).await?;
+        return Ok(None);
     }
 
     let git_dir = super::discover::discover_git_dir()?;

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 
 use crab_metadata::git_visibility::GitVisibilityIndex;
 use crab_read::{
-    UploadPackFilter, UploadPackRequest, combine_upload_pack_filters, parse_upload_pack_filter,
-    plan_upload_pack,
+    FetchAdmissionPolicy, UploadPackFilter, UploadPackRequest, combine_upload_pack_filters,
+    parse_upload_pack_filter, plan_upload_pack,
 };
 use crab_remote_git::{
     RemoteGitRepository, RemoteGitRuntime, RepositoryIdentity, RepositoryOptions,
@@ -91,6 +91,7 @@ pub async fn serve<R, W>(
     store: &crab_storage::Store,
     prefix: &str,
     hidden_ref_patterns: &[String],
+    fetch_policy: &FetchAdmissionPolicy,
     progress: bool,
     cancellation: &CancellationToken,
 ) -> Result<()>
@@ -154,6 +155,15 @@ where
                         return reject_protocol_request(writer, error, cancellation).await;
                     }
                 };
+                if let Err(error) = validate_fetch_admission(
+                    &repository,
+                    &visibility,
+                    &visible_ref_names,
+                    &fetch,
+                    fetch_policy,
+                ) {
+                    return reject_protocol_request(writer, error, cancellation).await;
+                }
                 if !fetch.done {
                     let common_haves = common_haves(&fetch, &visibility, &visible_ref_names);
                     if common_haves.is_empty() {
@@ -194,6 +204,55 @@ where
             }
         }
     }
+}
+
+fn validate_fetch_admission(
+    repository: &RemoteGitRepository,
+    visibility: &GitVisibilityIndex,
+    visible_ref_names: &[String],
+    request: &FetchRequest,
+    policy: &FetchAdmissionPolicy,
+) -> Result<()> {
+    let advertised_tips = repository
+        .refs()
+        .entries
+        .iter()
+        .filter(|reference| visible_ref_names.contains(&reference.name))
+        .flat_map(|reference| [Some(reference.target), reference.peeled])
+        .flatten()
+        .collect::<HashSet<_>>();
+    validate_fetch_wants(
+        &advertised_tips,
+        visibility,
+        visible_ref_names,
+        request,
+        policy,
+    )
+}
+
+fn validate_fetch_wants(
+    advertised_tips: &HashSet<ObjectId>,
+    visibility: &GitVisibilityIndex,
+    visible_ref_names: &[String],
+    request: &FetchRequest,
+    policy: &FetchAdmissionPolicy,
+) -> Result<()> {
+    for want in &request.wants {
+        if policy.allow_any_sha_in_want
+            || (policy.allow_tip_sha_in_want && advertised_tips.contains(want))
+            || (policy.allow_reachable_sha_in_want
+                && visibility.contains_for_refs(
+                    visible_ref_names.iter().map(String::as_str),
+                    &want.to_hex().to_string(),
+                ))
+        {
+            continue;
+        }
+        return Err(protocol(format!(
+            "want {want} is denied by upload-pack policy"
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) async fn open_repository(
@@ -1139,5 +1198,68 @@ mod tests {
                 .to_string()
                 .contains("invalid transfer.hideRefs pattern")
         );
+    }
+
+    #[test]
+    fn reachable_non_tip_want_is_denied_by_default() {
+        let ancestor = parse_oid(&"a".repeat(40)).expect("ancestor oid");
+        let tip = parse_oid(&"b".repeat(40)).expect("tip oid");
+        let request = FetchRequest {
+            wants: vec![ancestor],
+            ..FetchRequest::default()
+        };
+        let visible_refs = vec!["refs/heads/main".to_owned()];
+        let visibility = GitVisibilityIndex::new(
+            1,
+            "c".repeat(64),
+            std::collections::BTreeMap::from([(
+                visible_refs[0].clone(),
+                vec![ancestor.to_string(), tip.to_string()],
+            )]),
+        );
+
+        let error = validate_fetch_wants(
+            &HashSet::from([tip]),
+            &visibility,
+            &visible_refs,
+            &request,
+            &FetchAdmissionPolicy::default(),
+        )
+        .expect_err("a reachable non-tip want must be denied without opt-in");
+
+        assert!(error.to_string().contains("denied by upload-pack policy"));
+    }
+
+    #[test]
+    fn reachable_non_tip_want_is_accepted_when_enabled() {
+        let ancestor = parse_oid(&"a".repeat(40)).expect("ancestor oid");
+        let tip = parse_oid(&"b".repeat(40)).expect("tip oid");
+        let request = FetchRequest {
+            wants: vec![ancestor],
+            ..FetchRequest::default()
+        };
+        let visible_refs = vec!["refs/heads/main".to_owned()];
+        let visibility = GitVisibilityIndex::new(
+            1,
+            "c".repeat(64),
+            std::collections::BTreeMap::from([(
+                visible_refs[0].clone(),
+                vec![ancestor.to_string(), tip.to_string()],
+            )]),
+        );
+        let policy = FetchAdmissionPolicy {
+            allow_reachable_sha_in_want: true,
+            ..FetchAdmissionPolicy::default()
+        };
+
+        let result = validate_fetch_wants(
+            &HashSet::from([tip]),
+            &visibility,
+            &visible_refs,
+            &request,
+            &policy,
+        );
+
+        assert!(result.is_ok());
     }
 }

--- a/crab/src/metadata/metadb/db.rs
+++ b/crab/src/metadata/metadb/db.rs
@@ -228,7 +228,15 @@ impl Db {
     ) -> Result<Self> {
         let span = tracing::debug_span!("metadb.open", db = label, path = %path, mode = "rw");
         let start = std::time::Instant::now();
+        let settings = slatedb::config::Settings {
+            // Crab owns explicit durability boundaries. Disabling SlateDB's
+            // 100 ms timer prevents idle and post-commit batch work from
+            // generating one WAL object per timer tick.
+            flush_interval: None,
+            ..slatedb::config::Settings::default()
+        };
         match slatedb::Db::builder(path.clone(), store)
+            .with_settings(settings)
             .with_db_cache(Arc::clone(&cache))
             .build()
             .instrument(span.clone())
@@ -571,6 +579,15 @@ impl Db {
     /// Fails fast with [`MetaDbError::ReadOnly`] when called on a
     /// handle opened via [`Self::open_readonly`].
     pub async fn write(&self, batch: slatedb::WriteBatch) -> Result<()> {
+        self.write_inner(batch, true).await
+    }
+
+    /// Buffer one repairable acceleration batch until the caller's flush boundary.
+    pub(crate) async fn write_buffered(&self, batch: slatedb::WriteBatch) -> Result<()> {
+        self.write_inner(batch, false).await
+    }
+
+    async fn write_inner(&self, batch: slatedb::WriteBatch, durable: bool) -> Result<()> {
         let db = match &self.inner {
             Inner::Writer(db) => Arc::clone(db),
             Inner::Reader(_) => {
@@ -585,18 +602,44 @@ impl Db {
         let start = std::time::Instant::now();
         if let Some(m) = self.metrics.as_ref() {
             m.inc_metadb_batch_write_count();
+            if !durable {
+                m.inc_metadb_buffered_batch_write_count();
+            }
         }
         let res = db
-            .write(batch)
+            .write_with_options(
+                batch,
+                &slatedb::config::WriteOptions {
+                    await_durable: false,
+                    ..slatedb::config::WriteOptions::default()
+                },
+            )
             .instrument(span.clone())
             .await
-            .map(|_handle| ())
             .map_err(|source| {
                 CrabError::from(MetaDbError::Write {
                     db: String::from(self.label),
                     source,
                 })
             });
+        let res = match (res, durable) {
+            (Ok(_), true) => {
+                let result = db.flush().await.map_err(|source| {
+                    CrabError::from(MetaDbError::Write {
+                        db: String::from(self.label),
+                        source,
+                    })
+                });
+                if result.is_ok()
+                    && let Some(metrics) = self.metrics.as_ref()
+                {
+                    metrics.inc_metadb_wal_flush_count();
+                }
+                result
+            }
+            (Ok(_), false) => Ok(()),
+            (Err(error), _) => Err(error),
+        };
         if res.is_ok() {
             let _enter = span.enter();
             tracing::trace!(
@@ -634,17 +677,24 @@ impl Db {
             Inner::Writer(db) => Arc::clone(db),
             Inner::Reader(_) => return Ok(()),
         };
-        db.flush_with_options(slatedb::config::FlushOptions {
-            flush_type: slatedb::config::FlushType::MemTable,
-        })
-        .await
-        .map_err(|source| {
-            MetaDbError::Write {
-                db: String::from(self.label),
-                source,
-            }
-            .into()
-        })
+        let result = db
+            .flush_with_options(slatedb::config::FlushOptions {
+                flush_type: slatedb::config::FlushType::MemTable,
+            })
+            .await
+            .map_err(|source| {
+                MetaDbError::Write {
+                    db: String::from(self.label),
+                    source,
+                }
+                .into()
+            });
+        if result.is_ok()
+            && let Some(metrics) = self.metrics.as_ref()
+        {
+            metrics.inc_metadb_memtable_flush_count();
+        }
+        result
     }
 
     /// Full-range scan over all keys in the database.
@@ -799,6 +849,38 @@ mod tests {
             assert_eq!(got.as_ref(), v.as_bytes());
         }
 
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn buffered_writes_do_not_trigger_timer_wal_flushes() {
+        let store = stub_store();
+        let path = ObjectPath::from("t/buffered");
+        let wal_prefix = ObjectPath::from("t/buffered/wal");
+        let metrics = Arc::new(crate::core::metrics::Metrics::new());
+        let db = Db::open_with_metrics(
+            Arc::clone(&store),
+            path,
+            "chunk_index_db",
+            Arc::clone(&metrics),
+        )
+        .await
+        .expect("open");
+        let initial_wals = store.list(Some(&wal_prefix)).count().await;
+
+        for index in 0_u8..8 {
+            let mut batch = slatedb::WriteBatch::new();
+            batch.put([index].as_slice(), [index].as_slice());
+            db.write_buffered(batch).await.expect("buffered write");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        assert_eq!(store.list(Some(&wal_prefix)).count().await, initial_wals);
+        db.flush_memtable().await.expect("explicit batch flush");
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.metadb_buffered_batch_write_count, 8);
+        assert_eq!(snapshot.metadb_wal_flush_count, 0);
+        assert_eq!(snapshot.metadb_memtable_flush_count, 1);
         db.close().await.expect("close");
     }
 
@@ -983,6 +1065,7 @@ mod tests {
         batch.put(b"k".as_slice(), b"v".as_slice());
         db.write(batch).await.expect("write");
         assert_eq!(metrics.snapshot().metadb_batch_write_count, 1);
+        assert_eq!(metrics.snapshot().metadb_wal_flush_count, 1);
 
         let _ = db.get(b"k").await.expect("get");
         assert_eq!(metrics.snapshot().metadb_get_count, 1);

--- a/crab/src/metadata/metadb/guard.rs
+++ b/crab/src/metadata/metadb/guard.rs
@@ -98,6 +98,11 @@ impl MetaDbGuard {
         Box::pin(self.metadb()?.commit(txn)).await
     }
 
+    /// Buffer repairable metadata until the push's explicit flush boundary.
+    pub(crate) async fn commit_buffered(&self, txn: Transaction) -> Result<PushWriteReceipt> {
+        Box::pin(self.metadb()?.commit_buffered(txn)).await
+    }
+
     /// Flush every opened writer memtable without closing the session.
     pub async fn flush_memtables(&self) -> Result<()> {
         self.metadb()?.flush_memtables().await

--- a/crab/src/metadata/metadb/mod.rs
+++ b/crab/src/metadata/metadb/mod.rs
@@ -409,6 +409,15 @@ impl MetaDb {
     /// opening either database if the session was configured with
     /// `read_only = true`.
     pub async fn commit(&self, txn: Transaction) -> Result<PushWriteReceipt> {
+        self.commit_inner(txn, true).await
+    }
+
+    /// Buffer repairable metadata until the caller explicitly flushes the session.
+    pub(crate) async fn commit_buffered(&self, txn: Transaction) -> Result<PushWriteReceipt> {
+        self.commit_inner(txn, false).await
+    }
+
+    async fn commit_inner(&self, txn: Transaction, durable: bool) -> Result<PushWriteReceipt> {
         if self.config.read_only {
             return Err(crate::core::error::MetaDbError::ReadOnly {
                 db: String::from("metadb"),
@@ -445,14 +454,22 @@ impl MetaDb {
                 return Ok::<(), crate::core::error::CrabError>(());
             }
             let db = self.open_file_index_db().await?;
-            db.write(fi_batch).await
+            if durable {
+                db.write(fi_batch).await
+            } else {
+                db.write_buffered(fi_batch).await
+            }
         };
         let chunk_future = async {
             if chunk_ops == 0 {
                 return Ok::<(), crate::core::error::CrabError>(());
             }
             let db = self.open_chunk_index_db().await?;
-            db.write(ci_batch).await
+            if durable {
+                db.write(ci_batch).await
+            } else {
+                db.write_buffered(ci_batch).await
+            }
         };
 
         tokio::try_join!(file_future, chunk_future)?;

--- a/crab/src/read/mod.rs
+++ b/crab/src/read/mod.rs
@@ -413,10 +413,7 @@ impl Inner {
 
     async fn remote_snapshot_git_dir(&self, rev: &str) -> Result<(String, PathBuf)> {
         let snapshot = self.read_remote_snapshot().await?;
-        let mut manifest = snapshot.manifest;
-        manifest.refs = snapshot.journal.refs;
-        manifest.peeled_refs = snapshot.journal.peeled_refs;
-        manifest.head = snapshot.journal.head;
+        let manifest = snapshot.materialized_manifest();
         let resolved = resolve_manifest_rev(&manifest, rev).ok_or_else(|| CrabError::NotFound {
             path: format!("revision:{rev}"),
         })?;

--- a/crates/crab-auth-server/src/receive.rs
+++ b/crates/crab-auth-server/src/receive.rs
@@ -1,6 +1,6 @@
 //! Protected-push receive validation helpers.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Cursor;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -1048,6 +1048,109 @@ async fn while_renewing_git_locator_lock<T>(
     }
 }
 
+#[derive(Debug)]
+struct ServiceLocatorEvidence {
+    pack_id: MerkleHash,
+    _temp: tempfile::TempDir,
+    idx_path: std::path::PathBuf,
+    rev_path: std::path::PathBuf,
+    git_sha1: String,
+}
+
+fn validate_service_locator_evidence(
+    pack: &PackManifestEntry,
+    idx_path: &Path,
+    rev_path: &Path,
+    expected_git_sha1: &str,
+) -> Result<()> {
+    let locations = crab_git::pack_locator::PackLocationIter::open(idx_path, rev_path, pack.size)
+        .map_err(crab_git::pack::PackError::from)?;
+    if locations.object_count() != pack.object_count {
+        return Err(invalid(format!(
+            "committed pack index has {} objects, expected {}",
+            locations.object_count(),
+            pack.object_count
+        )));
+    }
+    if locations.pack_checksum().to_string() != expected_git_sha1 {
+        return Err(invalid(
+            "committed pack index checksum disagrees with pack trailer",
+        ));
+    }
+    Ok(())
+}
+
+async fn download_service_locator_evidence(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    pack: &PackManifestEntry,
+) -> Result<ServiceLocatorEvidence> {
+    if pack.size < 20 {
+        return Err(invalid("committed Git pack is too short for its trailer"));
+    }
+    let trailer = store
+        .range_get(&router.pack_path(&pack.pack_id), pack.size - 20..pack.size)
+        .await?;
+    let git_sha1 = gix_hash::ObjectId::from(
+        <[u8; 20]>::try_from(trailer.as_ref())
+            .map_err(|_| invalid("committed Git pack trailer is not 20 bytes"))?,
+    )
+    .to_string();
+    let temp = tempfile::tempdir()?;
+    let idx_path = temp.path().join("pack.idx");
+    let rev_path = temp.path().join("pack.rev");
+    store
+        .download_to_path(&router.pack_index_path(&pack.pack_id), &idx_path)
+        .await?;
+    match store
+        .download_to_path(&router.pack_reverse_index_path(&pack.pack_id), &rev_path)
+        .await
+    {
+        Ok(_) => {}
+        // v1.0.14 and earlier direct pushes did not persist `.rev` evidence.
+        Err(StorageError::NotFound { .. }) => {
+            let index = idx_path.clone();
+            let reverse = rev_path.clone();
+            let (reverse_size, reverse_hash) = tokio::task::spawn_blocking(move || {
+                crab_git::pack_locator::write_pack_reverse_index(&index, &reverse)
+                    .map_err(crab_git::pack::PackError::from)
+                    .map_err(AuthServerError::from)?;
+                let mut file = std::fs::File::open(&reverse)?;
+                let size = file.metadata()?.len();
+                let mut hasher = blake3::Hasher::new();
+                std::io::copy(&mut file, &mut hasher)?;
+                Ok::<_, AuthServerError>((size, *hasher.finalize().as_bytes()))
+            })
+            .await
+            .map_err(|error| {
+                AuthServerError::Internal(format!(
+                    "legacy reverse-index generation worker failed: {error}"
+                ))
+            })??;
+            store
+                .put_multipart_file_retry(
+                    &router.pack_reverse_index_path(&pack.pack_id),
+                    &rev_path,
+                    reverse_size,
+                    reverse_hash,
+                    8 * 1024 * 1024,
+                    &tokio_util::sync::CancellationToken::new(),
+                    None,
+                )
+                .await?;
+        }
+        Err(error) => return Err(error.into()),
+    }
+    validate_service_locator_evidence(pack, &idx_path, &rev_path, &git_sha1)?;
+    Ok(ServiceLocatorEvidence {
+        pack_id: merkle_hash_from_hex(&pack.pack_id, "committed pack id")?,
+        _temp: temp,
+        idx_path,
+        rev_path,
+        git_sha1,
+    })
+}
+
 /// Publish exact Git object locators after the manifest commit.
 pub async fn commit_service_git_locators(
     store: &Store,
@@ -1076,59 +1179,74 @@ pub async fn commit_service_git_locators(
         }
         let canonical_name = pack.pack_id.clone();
         let expected_object_count = pack.object_count;
-        let (actual_pack_id, temp, idx_path, rev_path, git_sha1, idx_size, idx_hash) =
-            tokio::task::spawn_blocking(move || {
-                let pack_dir = temp.path().join("objects/pack");
-                std::fs::create_dir_all(&pack_dir)?;
-                let installed = crab_git::pack::install_pack_file_from_path(
-                    &pack_dir,
-                    &source,
-                    &canonical_name,
-                    0,
-                    // Receive validation already fscked the complete repository. This
-                    // isolated acceleration directory lacks objects retained in older
-                    // packs, so object fsck would reject valid incremental packs.
-                    false,
-                )?;
-                let locations = crab_git::pack_locator::PackLocationIter::open(
-                    &installed.idx_path,
-                    &installed.rev_path,
-                    downloaded,
-                )
-                .map_err(crab_git::pack::PackError::from)?;
-                if locations.object_count() != expected_object_count {
-                    return Err(invalid(format!(
-                        "committed pack index has {} objects, expected {}",
-                        locations.object_count(),
-                        expected_object_count
-                    )));
-                }
-                if locations.pack_checksum().to_string() != installed.git_sha1 {
-                    return Err(invalid(
-                        "committed pack index checksum disagrees with pack trailer",
-                    ));
-                }
-                let mut file = std::fs::File::open(&source)?;
-                let mut hasher = blake3::Hasher::new();
-                std::io::copy(&mut file, &mut hasher)?;
-                let mut idx_file = std::fs::File::open(&installed.idx_path)?;
-                let idx_size = idx_file.metadata()?.len();
-                let mut idx_hasher = blake3::Hasher::new();
-                std::io::copy(&mut idx_file, &mut idx_hasher)?;
-                Ok::<_, AuthServerError>((
-                    hasher.finalize().to_hex().to_string(),
-                    temp,
-                    installed.idx_path,
-                    installed.rev_path,
-                    installed.git_sha1,
-                    idx_size,
-                    *idx_hasher.finalize().as_bytes(),
-                ))
-            })
-            .await
-            .map_err(|error| {
-                AuthServerError::Internal(format!("pack indexing join failed: {error}"))
-            })??;
+        let (
+            actual_pack_id,
+            temp,
+            idx_path,
+            rev_path,
+            git_sha1,
+            idx_size,
+            idx_hash,
+            rev_size,
+            rev_hash,
+        ) = tokio::task::spawn_blocking(move || {
+            let pack_dir = temp.path().join("objects/pack");
+            std::fs::create_dir_all(&pack_dir)?;
+            let installed = crab_git::pack::install_pack_file_from_path(
+                &pack_dir,
+                &source,
+                &canonical_name,
+                0,
+                // Receive validation already fscked the complete repository. This
+                // isolated acceleration directory lacks objects retained in older
+                // packs, so object fsck would reject valid incremental packs.
+                false,
+            )?;
+            let locations = crab_git::pack_locator::PackLocationIter::open(
+                &installed.idx_path,
+                &installed.rev_path,
+                downloaded,
+            )
+            .map_err(crab_git::pack::PackError::from)?;
+            if locations.object_count() != expected_object_count {
+                return Err(invalid(format!(
+                    "committed pack index has {} objects, expected {}",
+                    locations.object_count(),
+                    expected_object_count
+                )));
+            }
+            if locations.pack_checksum().to_string() != installed.git_sha1 {
+                return Err(invalid(
+                    "committed pack index checksum disagrees with pack trailer",
+                ));
+            }
+            let mut file = std::fs::File::open(&source)?;
+            let mut hasher = blake3::Hasher::new();
+            std::io::copy(&mut file, &mut hasher)?;
+            let mut idx_file = std::fs::File::open(&installed.idx_path)?;
+            let idx_size = idx_file.metadata()?.len();
+            let mut idx_hasher = blake3::Hasher::new();
+            std::io::copy(&mut idx_file, &mut idx_hasher)?;
+            let mut rev_file = std::fs::File::open(&installed.rev_path)?;
+            let rev_size = rev_file.metadata()?.len();
+            let mut rev_hasher = blake3::Hasher::new();
+            std::io::copy(&mut rev_file, &mut rev_hasher)?;
+            Ok::<_, AuthServerError>((
+                hasher.finalize().to_hex().to_string(),
+                temp,
+                installed.idx_path,
+                installed.rev_path,
+                installed.git_sha1,
+                idx_size,
+                *idx_hasher.finalize().as_bytes(),
+                rev_size,
+                *rev_hasher.finalize().as_bytes(),
+            ))
+        })
+        .await
+        .map_err(|error| {
+            AuthServerError::Internal(format!("pack indexing join failed: {error}"))
+        })??;
         if actual_pack_id != pack.pack_id {
             return Err(invalid(format!(
                 "committed pack {} body hash mismatch",
@@ -1146,7 +1264,24 @@ pub async fn commit_service_git_locators(
                 None,
             )
             .await?;
-        derived.push((pack, pack_id, temp, idx_path, rev_path, git_sha1));
+        store
+            .put_multipart_file_retry(
+                &router.pack_reverse_index_path(&pack.pack_id),
+                &rev_path,
+                rev_size,
+                rev_hash,
+                8 * 1024 * 1024,
+                &tokio_util::sync::CancellationToken::new(),
+                None,
+            )
+            .await?;
+        derived.push(ServiceLocatorEvidence {
+            pack_id,
+            _temp: temp,
+            idx_path,
+            rev_path,
+            git_sha1,
+        });
     }
 
     let lock = crab_coordination::PushLock::acquire_internal_default(
@@ -1174,22 +1309,6 @@ pub async fn commit_service_git_locators(
             )
             .await?
         };
-        let published_ids = derived
-            .iter()
-            .map(|(_, pack_id, _, _, _, _)| *pack_id)
-            .collect::<BTreeSet<_>>();
-        let records = derived
-            .iter()
-            .map(|(pack, pack_id, _, _, _, _)| {
-                crab_metadata::git_object_locator::GitPackLocatorRecord {
-                    pack_id: *pack_id,
-                    committed_generation: manifest.generation,
-                    pack_index_hash,
-                    object_count: pack.object_count,
-                    pack_size: pack.size,
-                }
-            })
-            .collect::<Vec<_>>();
         let mut writer = crab_metadata::git_object_locator::GitObjectLocatorWriter::open(
             Arc::clone(store.inner()),
             router.repo_prefix(),
@@ -1197,17 +1316,77 @@ pub async fn commit_service_git_locators(
         .await?;
         let operation = async {
             let prior_coverage = writer.coverage();
+            let covered_packs = if let Some(coverage) = prior_coverage {
+                crab_metadata::manifest_store::read_bulk_pack_list(
+                    store,
+                    router,
+                    &coverage.pack_index_hash.hex(),
+                )
+                .await?
+            } else {
+                Vec::new()
+            };
+            let covered = covered_packs
+                .iter()
+                .map(|pack| (pack.pack_id.as_str(), (pack.object_count, pack.size)))
+                .collect::<HashMap<_, _>>();
+            let records = current_packs
+                .iter()
+                .map(|pack| {
+                    Ok(crab_metadata::git_object_locator::GitPackLocatorRecord {
+                        pack_id: merkle_hash_from_hex(&pack.pack_id, "committed pack id")?,
+                        committed_generation: manifest.generation,
+                        pack_index_hash,
+                        object_count: pack.object_count,
+                        pack_size: pack.size,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
             let bindings = writer.bind_packs(&records).await?;
-            for (binding, (_, _, _, idx_path, rev_path, git_sha1)) in
-                bindings.into_iter().zip(&derived)
-            {
+            let retained_slots = bindings
+                .iter()
+                .map(|binding| binding.pack_slot)
+                .collect::<HashSet<_>>();
+            let sweep = writer.sweep_unreferenced(&retained_slots).await?;
+            let rebuild_all = sweep.pack_rows_deleted != 0;
+            let mut pending_ids = HashSet::new();
+            for pack in &current_packs {
+                if !rebuild_all
+                    && covered.get(pack.pack_id.as_str()) == Some(&(pack.object_count, pack.size))
+                {
+                    continue;
+                }
+                let pack_id = merkle_hash_from_hex(&pack.pack_id, "committed pack id")?;
+                pending_ids.insert(pack_id);
+                if let Some(local) = derived.iter().find(|item| item.pack_id == pack_id) {
+                    validate_service_locator_evidence(
+                        pack,
+                        &local.idx_path,
+                        &local.rev_path,
+                        &local.git_sha1,
+                    )?;
+                    continue;
+                }
+                derived.push(download_service_locator_evidence(store, router, pack).await?);
+            }
+            let bindings = bindings
+                .into_iter()
+                .map(|binding| (binding.record.pack_id, binding))
+                .collect::<HashMap<_, _>>();
+            for evidence in &derived {
+                if !pending_ids.contains(&evidence.pack_id) {
+                    continue;
+                }
+                let Some(binding) = bindings.get(&evidence.pack_id).copied() else {
+                    continue;
+                };
                 let mut locations = crab_git::pack_locator::PackLocationIter::open(
-                    idx_path,
-                    rev_path,
+                    &evidence.idx_path,
+                    &evidence.rev_path,
                     binding.record.pack_size,
                 )
                 .map_err(crab_git::pack::PackError::from)?;
-                if locations.pack_checksum().to_string() != *git_sha1 {
+                if locations.pack_checksum().to_string() != evidence.git_sha1 {
                     return Err(invalid(
                         "committed pack index checksum changed before locator publication",
                     ));
@@ -1244,38 +1423,6 @@ pub async fn commit_service_git_locators(
             {
                 return Err(invalid(
                     "committed manifest changed during Git locator publication",
-                ));
-            }
-            let all_current_published = current_packs.iter().all(|pack| {
-                merkle_hash_from_hex(&pack.pack_id, "committed pack id")
-                    .ok()
-                    .is_some_and(|pack_id| published_ids.contains(&pack_id))
-            });
-            let prior_covers_remainder = if all_current_published {
-                true
-            } else if let Some(coverage) = prior_coverage {
-                let covered_packs = crab_metadata::manifest_store::read_bulk_pack_list(
-                    store,
-                    router,
-                    &coverage.pack_index_hash.hex(),
-                )
-                .await?;
-                current_packs.iter().all(|current| {
-                    merkle_hash_from_hex(&current.pack_id, "committed pack id")
-                        .ok()
-                        .is_some_and(|pack_id| published_ids.contains(&pack_id))
-                        || covered_packs.iter().any(|covered| {
-                            covered.pack_id == current.pack_id
-                                && covered.object_count == current.object_count
-                                && covered.size == current.size
-                        })
-                })
-            } else {
-                false
-            };
-            if !prior_covers_remainder {
-                return Err(invalid(
-                    "Git locator prior coverage does not cover retained committed packs",
                 ));
             }
             writer

--- a/crates/crab-auth-server/src/receive/workflow.rs
+++ b/crates/crab-auth-server/src/receive/workflow.rs
@@ -822,6 +822,9 @@ mod tests {
             ctx.store()
                 .head(&ctx.router().pack_index_path(&pack.pack_id))
                 .await?;
+            ctx.store()
+                .head(&ctx.router().pack_reverse_index_path(&pack.pack_id))
+                .await?;
         }
         let committed_pack_inventory = committed_packs
             .iter()

--- a/crates/crab-coordination/Cargo.toml
+++ b/crates/crab-coordination/Cargo.toml
@@ -36,4 +36,4 @@ reqwest = { workspace = true, features = ["rustls-tls", "json"], optional = true
 urlencoding = { version = "2.1", optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/crab-coordination/README.md
+++ b/crates/crab-coordination/README.md
@@ -22,7 +22,7 @@ Single repository mutation                 Active-active mutation
         │                                          │
         ├─ PushLock: short-TTL CAS lease           ▼
         │                              WriteCoordinator: durable state machine
-        └─ PushAdmissionTicket: FIFO queue          ├─ Pending
+        └─ PushAdmissionTicket: fixed CAS slots     ├─ Pending
                    │                                ├─ ObjectsUploaded
                    └─ object-store CAS              ├─ Committed
                                                    ├─ Materialized
@@ -33,11 +33,12 @@ Single repository mutation                 Active-active mutation
 It has a default five-minute TTL, holder-checked release, renewal, and
 expired-lease reclamation. Enable it with `object-store-lock`.
 
-`PushAdmissionTicket` bounds expensive single-repository push pipelines without
-random slot selection or a shared mutable queue object. Each writer creates one
-time-ordered ticket object, the oldest live tickets enter first, and writers
-refresh only their own short lease. Observers ignore expired tickets and remove
-a bounded number per poll, so enqueue and renewal do not contend on one hot key.
+`PushAdmissionTicket` bounds expensive single-repository push pipelines with a
+fixed number of reusable CAS lease slots. Waiting writers own no object and
+probe slots in rotating order, so admission work and stored coordination state
+remain bounded independently of queue depth. Slot expiry uses backend-authored
+object time from one reusable clock key; admission is best-effort fair rather
+than FIFO.
 
 `WriteCoordinator` exposes health, begin/upload/commit/materialize/abort,
 ref lookup, GC safety snapshots, repair snapshots, and write fencing. The

--- a/crates/crab-coordination/src/push_admission.rs
+++ b/crates/crab-coordination/src/push_admission.rs
@@ -1,45 +1,40 @@
-//! Fair object-store admission for repository push pipelines.
+//! Bounded object-store admission for repository push pipelines.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use bytes::Bytes;
-use futures_util::StreamExt;
+use object_store::ObjectStore;
 use object_store::path::Path;
-use object_store::{ObjectStore, ObjectStoreExt};
 use tracing::warn;
 
 use crate::error::{CoordinationError, Result};
 use crate::push_lock::{
-    create_strict, generate_holder_id, get_with_version, push_locks_prefix, store_error, unix_now,
-    update,
+    PushLockPayload, backend_unix_time, create_strict, deserialize_payload,
+    get_with_version_and_modified, push_locks_prefix, release_if_holder, serialize_payload,
+    store_error, unix_now, update,
 };
 
-const MAX_TICKET_CREATE_ATTEMPTS: usize = 8;
-const MAX_ADMISSION_RETRIES: usize = 16;
-const MAX_EXPIRED_CLEANUP_PER_OBSERVATION: usize = 2;
-
-/// Durable FIFO ticket that becomes a bounded push-admission permit.
+/// Contender that becomes one of a fixed number of push-admission leases.
 pub struct PushAdmissionTicket {
     store: Arc<dyn ObjectStore>,
     prefix: String,
-    path: String,
     holder: String,
     capacity: usize,
     lease_ttl: Duration,
-    writers_ahead: usize,
-    admitted: bool,
+    attempt: usize,
+    occupied_slots: usize,
+    backend_clock: Option<(i64, Instant)>,
+    path: Option<String>,
     released: bool,
 }
 
 impl PushAdmissionTicket {
-    /// Creates one independently writable ticket in the repository queue.
-    pub async fn enqueue(
+    /// Creates a contender for one repository's bounded admission slots.
+    pub fn new(
         store: &Arc<dyn ObjectStore>,
         prefix: &str,
         capacity: usize,
-        active_ttl: Duration,
-        queued_ttl: Duration,
+        lease_ttl: Duration,
     ) -> Result<Self> {
         if capacity == 0 {
             return Err(CoordinationError::Configuration {
@@ -47,142 +42,122 @@ impl PushAdmissionTicket {
                 origin: "push admission capacity must be positive".to_owned(),
             });
         }
-        validate_ttl(active_ttl, "active")?;
-        validate_ttl(queued_ttl, "queued")?;
+        validate_ttl(lease_ttl)?;
 
-        let prefix = push_admission_prefix(prefix)?;
-        let lease_ttl = active_ttl.min(queued_ttl);
-        for _ in 0..MAX_TICKET_CREATE_ATTEMPTS {
-            let holder = generate_holder_id();
-            let path = format!("{prefix}/{}", uuid::Uuid::now_v7());
-            match create_strict(
-                store,
-                &Path::from(path.as_str()),
-                Bytes::from(holder.clone()),
-            )
-            .await
-            {
-                Ok(_) => {
-                    return Ok(Self {
-                        store: Arc::clone(store),
-                        prefix,
-                        path,
-                        holder,
-                        capacity,
-                        lease_ttl,
-                        writers_ahead: usize::MAX,
-                        admitted: false,
-                        released: false,
-                    });
-                }
-                Err(error) if is_cas_conflict(&error) => {}
-                Err(source) => return Err(store_error(&path, source)),
-            }
-        }
-        Err(CoordinationError::CasConflict {
-            path: prefix,
-            expected_etag: None,
+        Ok(Self {
+            store: Arc::clone(store),
+            prefix: push_admission_prefix(prefix)?,
+            holder: crate::push_lock::generate_holder_id(),
+            capacity,
+            lease_ttl,
+            attempt: 0,
+            occupied_slots: 0,
+            backend_clock: None,
+            path: None,
+            released: false,
         })
     }
 
-    /// Attempts to convert this FIFO ticket into an active bounded permit.
+    /// Attempts to acquire one slot without listing repository objects.
     pub async fn try_admit(&mut self) -> Result<bool> {
-        if self.admitted {
+        if self.path.is_some() {
             return Ok(true);
         }
-        for _ in 0..MAX_ADMISSION_RETRIES {
-            let now = unix_now();
-            let mut live = Vec::new();
-            let mut expired = Vec::new();
-            let mut stream = self.store.list(Some(&Path::from(self.prefix.as_str())));
-            while let Some(item) = stream.next().await {
-                let meta = item.map_err(|source| store_error(&self.prefix, source))?;
-                let modified = u64::try_from(meta.last_modified.timestamp()).unwrap_or(0);
-                if modified.saturating_add(self.lease_ttl.as_secs().max(1)) <= now {
-                    expired.push(meta);
-                } else {
-                    live.push(meta);
-                }
-            }
-            // Renewal changes object metadata, so queue order must live in the
-            // immutable UUIDv7 key rather than the mutable last-modified time.
-            live.sort_unstable_by(|left, right| left.location.cmp(&right.location));
-            self.cleanup_expired(expired).await;
 
-            let Some(position) = live
-                .iter()
-                .position(|meta| meta.location.as_ref() == self.path)
-            else {
-                return Err(expired_ticket(&self.path));
-            };
-            self.writers_ahead = position;
-            let admitted = position < self.capacity;
-            let own = &live[position];
-            let modified = u64::try_from(own.last_modified.timestamp()).unwrap_or(0);
-            let refresh_margin = self.lease_ttl.as_secs().max(1).div_ceil(4).min(30);
-            let needs_refresh = admitted
-                || modified.saturating_add(self.lease_ttl.as_secs().max(1))
-                    <= now.saturating_add(refresh_margin);
-            if !needs_refresh {
-                return Ok(false);
-            }
-            let (body, version) = get_with_version(&self.store, &own.location)
-                .await
-                .map_err(|source| store_error(&self.path, source))?;
-            if body.as_ref() != self.holder.as_bytes() {
-                return Err(expired_ticket(&self.path));
-            }
-            match update(
-                &self.store,
-                &own.location,
-                Bytes::from(self.holder.clone()),
-                version,
-            )
-            .await
-            {
-                Ok(_) => {
-                    self.admitted = admitted;
-                    return Ok(admitted);
+        let body = serialize_payload(
+            &self.prefix,
+            &PushLockPayload::new(
+                &self.holder,
+                unix_now().saturating_add(self.lease_ttl.as_secs()),
+                self.lease_ttl.as_secs(),
+            ),
+        )?;
+        let offset = slot_offset(&self.holder, self.attempt, self.capacity);
+        self.attempt = self.attempt.saturating_add(1);
+        let mut live = Vec::with_capacity(self.capacity);
+
+        for step in 0..self.capacity {
+            let path = Path::from(push_admission_slot_path(
+                &self.prefix,
+                (offset + step) % self.capacity,
+            ));
+            let (existing_body, version, last_modified) =
+                match get_with_version_and_modified(&self.store, &path).await {
+                    Ok(existing) => existing,
+                    Err(object_store::Error::NotFound { .. }) => {
+                        match create_strict(&self.store, &path, body.clone()).await {
+                            Ok(_) => return Ok(self.admit(path)),
+                            Err(error) if is_cas_conflict(&error) => continue,
+                            Err(source) => return Err(store_error(path.as_ref(), source)),
+                        }
+                    }
+                    Err(source) => return Err(store_error(path.as_ref(), source)),
+                };
+            let payload = deserialize_payload(path.as_ref(), &existing_body)?;
+            if payload.is_released() {
+                match update(&self.store, &path, body.clone(), version).await {
+                    Ok(_) => return Ok(self.admit(path)),
+                    Err(error) if is_cas_conflict(&error) => continue,
+                    Err(source) => return Err(store_error(path.as_ref(), source)),
                 }
-                Err(error) if is_cas_conflict(&error) => continue,
-                Err(source) => return Err(store_error(&self.path, source)),
+            }
+            live.push((path, payload, version, last_modified));
+        }
+
+        self.occupied_slots = live.len();
+        if live.is_empty() {
+            return Ok(false);
+        }
+        let now = self.backend_now().await?;
+        for (path, payload, version, last_modified) in live {
+            if !lease_expired(&payload, last_modified, now) {
+                continue;
+            }
+            match update(&self.store, &path, body.clone(), version).await {
+                Ok(_) => return Ok(self.admit(path)),
+                Err(error) if is_cas_conflict(&error) => {}
+                Err(source) => return Err(store_error(path.as_ref(), source)),
             }
         }
-        Err(CoordinationError::CasConflict {
-            path: self.path.clone(),
-            expected_etag: None,
-        })
+        Ok(false)
     }
 
     /// Extends an active permit's lease.
     pub async fn renew(&self) -> Result<()> {
-        if !self.admitted {
+        let Some(path) = self.path.as_deref() else {
             return Err(CoordinationError::Configuration {
-                key: self.path.clone(),
-                origin: "cannot renew a queued push admission ticket".to_owned(),
+                key: self.prefix.clone(),
+                origin: "cannot renew an unadmitted push contender".to_owned(),
             });
-        }
-        let path = Path::from(self.path.as_str());
-        let (body, version) = get_with_version(&self.store, &path)
+        };
+        let object_path = Path::from(path);
+        let (body, version, _) = get_with_version_and_modified(&self.store, &object_path)
             .await
-            .map_err(|source| store_error(&self.path, source))?;
-        if body.as_ref() != self.holder.as_bytes() {
-            return Err(expired_ticket(&self.path));
+            .map_err(|source| store_error(path, source))?;
+        let payload = deserialize_payload(path, &body)?;
+        if payload.holder != self.holder || payload.is_released() {
+            return Err(expired_ticket(path));
         }
-        update(
-            &self.store,
-            &path,
-            Bytes::from(self.holder.clone()),
-            version,
-        )
-        .await
-        .map(|_| ())
-        .map_err(|source| store_error(&self.path, source))
+        let body = serialize_payload(
+            path,
+            &PushLockPayload::new(
+                &self.holder,
+                unix_now().saturating_add(self.lease_ttl.as_secs()),
+                self.lease_ttl.as_secs(),
+            ),
+        )?;
+        update(&self.store, &object_path, body, version)
+            .await
+            .map(|_| ())
+            .map_err(|source| store_error(path, source))
     }
 
-    /// Removes this writer from the queue and hands capacity to its successor.
+    /// Releases this writer's slot for another push.
     pub async fn release(mut self) -> Result<()> {
-        let result = delete_ticket(&self.store, &self.path).await;
+        let result = match self.path.as_deref() {
+            Some(path) => release_if_holder(&self.store, path, &self.holder).await,
+            None => Ok(()),
+        };
         self.released = true;
         result
     }
@@ -193,41 +168,27 @@ impl PushAdmissionTicket {
         self.lease_ttl
     }
 
-    /// Returns the last observed number of live writers ahead in FIFO order.
+    /// Returns the number of live slots observed in the last attempt.
     #[must_use]
-    pub fn writers_ahead(&self) -> usize {
-        self.writers_ahead
+    pub fn occupied_slots(&self) -> usize {
+        self.occupied_slots
     }
 
-    async fn cleanup_expired(&self, expired: Vec<object_store::ObjectMeta>) {
-        for meta in expired
-            .into_iter()
-            .filter(|meta| meta.location.as_ref() != self.path)
-            .take(MAX_EXPIRED_CLEANUP_PER_OBSERVATION)
-        {
-            let version = object_store::UpdateVersion {
-                e_tag: meta.e_tag,
-                version: meta.version,
-            };
-            match update(
-                &self.store,
-                &meta.location,
-                Bytes::from_static(b"expired"),
-                version,
-            )
-            .await
-            {
-                Ok(_) => {
-                    if let Err(error) = self.store.delete(&meta.location).await {
-                        warn!(path = %meta.location, %error, "failed to delete expired push admission ticket");
-                    }
-                }
-                Err(error) if is_cas_conflict(&error) => {}
-                Err(error) => {
-                    warn!(path = %meta.location, %error, "failed to claim expired push admission ticket");
-                }
-            }
+    fn admit(&mut self, path: Path) -> bool {
+        self.path = Some(path.as_ref().to_owned());
+        self.occupied_slots = self.capacity;
+        true
+    }
+
+    async fn backend_now(&mut self) -> Result<i64> {
+        if let Some((sample, sampled_at)) = self.backend_clock {
+            return Ok(sample.saturating_add(
+                i64::try_from(sampled_at.elapsed().as_secs()).unwrap_or(i64::MAX),
+            ));
         }
+        let sample = backend_unix_time(&self.store, &Path::from(self.prefix.as_str())).await?;
+        self.backend_clock = Some((sample, Instant::now()));
+        Ok(sample)
     }
 }
 
@@ -236,40 +197,57 @@ impl Drop for PushAdmissionTicket {
         if self.released {
             return;
         }
+        let Some(path) = self.path.clone() else {
+            return;
+        };
         let store = Arc::clone(&self.store);
-        let path = self.path.clone();
+        let holder = self.holder.clone();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                if let Err(error) = delete_ticket(&store, &path).await {
-                    warn!(path, %error, "failed to release push admission ticket on drop");
+                if let Err(error) = release_if_holder(&store, &path, &holder).await {
+                    warn!(path, %error, "failed to release push admission slot on drop");
                 }
             });
         }
     }
 }
 
-/// Canonical object-key prefix for one repository's FIFO admission tickets.
+/// Canonical object-key prefix for one repository's fixed admission slots.
 pub fn push_admission_prefix(prefix: &str) -> Result<String> {
     Ok(format!(
-        "{}/internal/push-admission/tickets",
+        "{}/internal/push-admission/slots",
         push_locks_prefix(prefix)?
     ))
 }
 
-async fn delete_ticket(store: &Arc<dyn ObjectStore>, path: &str) -> Result<()> {
-    match store.delete(&Path::from(path)).await {
-        Ok(()) | Err(object_store::Error::NotFound { .. }) => Ok(()),
-        Err(source) => Err(store_error(path, source)),
-    }
+fn push_admission_slot_path(prefix: &str, slot: usize) -> String {
+    format!("{prefix}/{slot}")
 }
 
-fn validate_ttl(ttl: Duration, kind: &str) -> Result<()> {
-    if !ttl.is_zero() {
+fn slot_offset(holder: &str, attempt: usize, capacity: usize) -> usize {
+    let digest = blake3::hash(holder.as_bytes());
+    let mut bytes = [0_u8; std::mem::size_of::<u64>()];
+    bytes.copy_from_slice(&digest.as_bytes()[..std::mem::size_of::<u64>()]);
+    (usize::try_from(u64::from_le_bytes(bytes)).unwrap_or(0) + attempt) % capacity
+}
+
+fn lease_expired(payload: &PushLockPayload, last_modified: i64, backend_now: i64) -> bool {
+    if payload.lease_secs == 0 {
+        return false;
+    }
+    let Ok(lease_secs) = i64::try_from(payload.lease_secs) else {
+        return false;
+    };
+    last_modified.saturating_add(lease_secs) <= backend_now
+}
+
+fn validate_ttl(ttl: Duration) -> Result<()> {
+    if ttl.as_secs() > 0 {
         return Ok(());
     }
     Err(CoordinationError::Configuration {
         key: ttl.as_secs().to_string(),
-        origin: format!("push admission {kind} TTL must be positive"),
+        origin: "push admission TTL must be at least one second".to_owned(),
     })
 }
 
@@ -289,192 +267,173 @@ fn is_cas_conflict(error: &object_store::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::StreamExt;
+    use object_store::ObjectStoreExt;
     use object_store::memory::InMemory;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn memory_store() -> Arc<dyn ObjectStore> {
         Arc::new(InMemory::new())
     }
 
-    #[tokio::test]
-    async fn one_hundred_tickets_complete_in_fifo_capacity_windows() {
-        let store = memory_store();
-        let mut tickets = Vec::new();
-        for _ in 0..100 {
-            tickets.push(
-                PushAdmissionTicket::enqueue(
-                    &store,
-                    "org/repo",
-                    5,
-                    Duration::from_secs(60),
-                    Duration::from_secs(60),
-                )
-                .await
-                .unwrap(),
-            );
-        }
-        let expected = tickets
-            .iter()
-            .map(|ticket| ticket.path.clone())
-            .collect::<Vec<_>>();
-        let (admitted_tx, mut admitted_rx) = tokio::sync::mpsc::channel(100);
-        let workers = tickets
-            .into_iter()
-            .map(|mut ticket| {
-                let admitted_tx = admitted_tx.clone();
-                tokio::spawn(async move {
-                    loop {
-                        if ticket.try_admit().await.unwrap() {
-                            admitted_tx.send(ticket).await.unwrap();
-                            return;
-                        }
-                        tokio::task::yield_now().await;
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-        drop(admitted_tx);
+    fn contender(
+        store: &Arc<dyn ObjectStore>,
+        capacity: usize,
+        ttl: Duration,
+    ) -> PushAdmissionTicket {
+        PushAdmissionTicket::new(store, "org/repo", capacity, ttl).unwrap()
+    }
 
-        for window in 0..20 {
-            let mut admitted = Vec::new();
-            for _ in 0..5 {
-                admitted.push(admitted_rx.recv().await.unwrap());
-            }
-            tokio::task::yield_now().await;
-            assert!(
-                admitted_rx.try_recv().is_err(),
-                "more than five tickets entered in window {window}"
-            );
-            admitted.sort_by(|left, right| left.path.cmp(&right.path));
-            assert_eq!(
-                admitted
-                    .iter()
-                    .map(|ticket| ticket.path.clone())
-                    .collect::<Vec<_>>(),
-                expected[(window * 5)..(window * 5 + 5)]
-            );
-            for ticket in admitted {
-                ticket.release().await.unwrap();
-            }
+    #[tokio::test]
+    async fn capacity_is_bounded_without_per_writer_objects() {
+        let store = memory_store();
+        let mut admitted = Vec::new();
+        for _ in 0..5 {
+            let mut ticket = contender(&store, 5, Duration::from_secs(60));
+            assert!(ticket.try_admit().await.unwrap());
+            admitted.push(ticket);
         }
-        for worker in workers {
-            worker.await.unwrap();
+        let mut blocked = contender(&store, 5, Duration::from_secs(60));
+
+        assert!(!blocked.try_admit().await.unwrap());
+        assert_eq!(blocked.occupied_slots(), 5);
+        assert_eq!(
+            store
+                .list(Some(&Path::from(
+                    push_admission_prefix("org/repo").unwrap()
+                )))
+                .count()
+                .await,
+            6
+        );
+
+        admitted.pop().unwrap().release().await.unwrap();
+        assert!(blocked.try_admit().await.unwrap());
+        blocked.release().await.unwrap();
+        for ticket in admitted {
+            ticket.release().await.unwrap();
         }
     }
 
     #[tokio::test]
-    async fn expired_front_ticket_does_not_block_its_successor() {
+    async fn blocked_contender_samples_backend_clock_once() {
         let store = memory_store();
-        let abandoned = PushAdmissionTicket::enqueue(
-            &store,
-            "org/repo",
-            1,
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-        )
+        let mut active = contender(&store, 1, Duration::from_secs(60));
+        assert!(active.try_admit().await.unwrap());
+        let mut blocked = contender(&store, 1, Duration::from_secs(60));
+        assert!(!blocked.try_admit().await.unwrap());
+        let clock = Path::from(format!(
+            "{}/clock",
+            push_admission_prefix("org/repo").unwrap()
+        ));
+        store.delete(&clock).await.unwrap();
+
+        assert!(!blocked.try_admit().await.unwrap());
+        assert!(matches!(
+            store.head(&clock).await,
+            Err(object_store::Error::NotFound { .. })
+        ));
+
+        active.release().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_contenders_never_exceed_capacity() {
+        const CAPACITY: usize = 5;
+        let store = memory_store();
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let workers = (0..40)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let active = Arc::clone(&active);
+                let peak = Arc::clone(&peak);
+                tokio::spawn(async move {
+                    let mut ticket = contender(&store, CAPACITY, Duration::from_secs(60));
+                    while !ticket.try_admit().await.unwrap() {
+                        tokio::task::yield_now().await;
+                    }
+                    let admitted = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(admitted, Ordering::SeqCst);
+                    assert!(admitted <= CAPACITY);
+                    tokio::time::sleep(Duration::from_millis(2)).await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    ticket.release().await.unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            for worker in workers {
+                worker.await.unwrap();
+            }
+        })
         .await
-        .unwrap();
+        .expect("all contenders should eventually acquire a slot");
+
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+        assert_eq!(peak.load(Ordering::SeqCst), CAPACITY);
+    }
+
+    #[tokio::test]
+    async fn expired_slot_does_not_reduce_capacity() {
+        let store = memory_store();
+        let mut abandoned = contender(&store, 1, Duration::from_secs(1));
+        assert!(abandoned.try_admit().await.unwrap());
         std::mem::forget(abandoned);
         tokio::time::sleep(Duration::from_millis(1_100)).await;
-        let mut successor = PushAdmissionTicket::enqueue(
-            &store,
-            "org/repo",
-            1,
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-        )
-        .await
-        .unwrap();
+        let mut successor = contender(&store, 1, Duration::from_secs(1));
 
         assert!(successor.try_admit().await.unwrap());
         successor.release().await.unwrap();
     }
 
     #[tokio::test]
-    async fn release_removes_ticket_object() {
+    async fn release_leaves_reusable_tombstone() {
         let store = memory_store();
-        let ticket = PushAdmissionTicket::enqueue(
-            &store,
-            "org/repo",
-            1,
-            Duration::from_secs(60),
-            Duration::from_secs(60),
-        )
-        .await
-        .unwrap();
-        let path = Path::from(ticket.path.as_str());
+        let mut ticket = contender(&store, 1, Duration::from_secs(60));
+        assert!(ticket.try_admit().await.unwrap());
+        let path = Path::from(push_admission_slot_path(
+            &push_admission_prefix("org/repo").unwrap(),
+            0,
+        ));
 
         ticket.release().await.unwrap();
 
-        assert!(matches!(
-            store.head(&path).await,
-            Err(object_store::Error::NotFound { .. })
-        ));
+        let body = store.get(&path).await.unwrap().bytes().await.unwrap();
+        assert!(
+            deserialize_payload(path.as_ref(), &body)
+                .unwrap()
+                .is_released()
+        );
     }
 
     #[tokio::test]
-    async fn stale_cleanup_does_not_delete_a_renewed_ticket() {
+    async fn previous_holder_cannot_renew_reacquired_slot() {
         let store = memory_store();
-        let mut active = PushAdmissionTicket::enqueue(
-            &store,
-            "org/repo",
-            1,
-            Duration::from_secs(60),
-            Duration::from_secs(60),
-        )
-        .await
-        .unwrap();
-        assert!(active.try_admit().await.unwrap());
-        let cleaner = PushAdmissionTicket::enqueue(
-            &store,
-            "org/repo",
-            1,
-            Duration::from_secs(60),
-            Duration::from_secs(60),
-        )
-        .await
-        .unwrap();
-        let path = Path::from(active.path.as_str());
-        let stale = store.head(&path).await.unwrap();
-
-        active.renew().await.unwrap();
-        cleaner.cleanup_expired(vec![stale]).await;
-
-        store.head(&path).await.unwrap();
-        active.release().await.unwrap();
-        cleaner.release().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn claimed_expired_ticket_cannot_be_renewed() {
-        let store = memory_store();
-        let mut ticket = PushAdmissionTicket::enqueue(
-            &store,
-            "org/repo",
-            1,
-            Duration::from_secs(60),
-            Duration::from_secs(60),
-        )
-        .await
-        .unwrap();
-        assert!(ticket.try_admit().await.unwrap());
-        let path = Path::from(ticket.path.as_str());
-        let (_, version) = get_with_version(&store, &path).await.unwrap();
-        update(&store, &path, Bytes::from_static(b"expired"), version)
+        let mut previous = contender(&store, 1, Duration::from_secs(60));
+        assert!(previous.try_admit().await.unwrap());
+        let path = previous.path.clone().unwrap();
+        release_if_holder(&store, &path, &previous.holder)
             .await
             .unwrap();
+        let mut current = contender(&store, 1, Duration::from_secs(60));
+        assert!(current.try_admit().await.unwrap());
 
         assert!(matches!(
-            ticket.renew().await,
+            previous.renew().await,
             Err(CoordinationError::NotFound { .. })
         ));
-        ticket.release().await.unwrap();
+
+        previous.released = true;
+        current.release().await.unwrap();
     }
 
     #[test]
-    fn queue_prefix_is_repository_scoped() {
+    fn slot_prefix_is_repository_scoped() {
         assert_eq!(
             push_admission_prefix("org/repo").unwrap(),
-            "org/repo/locks/internal/push-admission/tickets"
+            "org/repo/locks/internal/push-admission/slots"
         );
     }
 }

--- a/crates/crab-coordination/src/push_lock.rs
+++ b/crates/crab-coordination/src/push_lock.rs
@@ -33,17 +33,21 @@ pub const REPOSITORY_MAINTENANCE_RESOURCE: &str = "repository-maintenance";
 pub struct PushLockPayload {
     /// Unique holder identity for one push attempt.
     pub holder: String,
-    /// Unix timestamp in seconds when the lock expires; zero means released.
+    /// Client-estimated Unix expiry used for diagnostics; zero means released.
     pub expires_at: u64,
+    /// Lease duration measured from the backend-authored object modification time.
+    #[serde(default)]
+    pub lease_secs: u64,
 }
 
 impl PushLockPayload {
     /// Creates a live push-lock payload for `holder`.
     #[must_use]
-    pub fn new(holder: impl Into<String>, expires_at: u64) -> Self {
+    pub fn new(holder: impl Into<String>, expires_at: u64, lease_secs: u64) -> Self {
         Self {
             holder: holder.into(),
             expires_at,
+            lease_secs,
         }
     }
 
@@ -53,6 +57,7 @@ impl PushLockPayload {
         Self {
             holder: holder.into(),
             expires_at: 0,
+            lease_secs: 0,
         }
     }
 
@@ -258,7 +263,7 @@ impl PushLock {
             .into_iter()
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|source| store_error(locks_prefix.as_ref(), source))?;
-        let now = unix_now();
+        let now = backend_unix_time(store, &locks_prefix).await?;
         let mut reclaimed = 0;
         for meta in objects {
             let key = meta.location.as_ref();
@@ -283,15 +288,9 @@ impl PushLock {
     }
 
     /// Repairs one expired lease by writing a released tombstone.
-    pub async fn repair_expired(
-        store: &Arc<dyn ObjectStore>,
-        key: &str,
-        now: SystemTime,
-    ) -> Result<bool> {
-        let now = now
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or(Duration::ZERO)
-            .as_secs();
+    pub async fn repair_expired(store: &Arc<dyn ObjectStore>, key: &str) -> Result<bool> {
+        let object_path = Path::from(key);
+        let now = backend_unix_time(store, &object_path).await?;
         expire_stale_lock_at(store, &Path::from(key), key, now).await
     }
 }
@@ -323,7 +322,10 @@ async fn acquire_one(
     ttl: Duration,
 ) -> Result<UpdateVersion> {
     let object_path = Path::from(path);
-    let body = serialize_payload(path, &PushLockPayload::new(holder, expires_at))?;
+    let body = serialize_payload(
+        path,
+        &PushLockPayload::new(holder, expires_at, ttl.as_secs()),
+    )?;
     let etag = match create_strict(store, &object_path, body.clone()).await {
         Ok(etag) => etag,
         Err(object_store::Error::AlreadyExists { .. })
@@ -368,7 +370,7 @@ async fn renew_one(
     }
     let body = serialize_payload(
         path,
-        &PushLockPayload::new(holder, unix_now() + ttl.as_secs()),
+        &PushLockPayload::new(holder, unix_now() + ttl.as_secs(), ttl.as_secs()),
     )?;
     update(store, &object_path, body, etag)
         .await
@@ -384,30 +386,68 @@ enum ContendedAcquire {
     },
 }
 
+fn authoritative_expiry(payload: &PushLockPayload, last_modified: i64) -> Option<u64> {
+    if payload.is_released() {
+        return None;
+    }
+    // Locks written before backend-authored leases shipped have no
+    // `lease_secs`. Their client expiry remains the migration boundary;
+    // otherwise a crashed legacy writer would hold the ref forever.
+    if payload.lease_secs == 0 {
+        return Some(payload.expires_at);
+    }
+    u64::try_from(last_modified)
+        .ok()
+        .map(|modified| modified.saturating_add(payload.lease_secs))
+}
+
+fn lease_expired(payload: &PushLockPayload, last_modified: i64, backend_now: i64) -> bool {
+    authoritative_expiry(payload, last_modified)
+        .and_then(|expires| i64::try_from(expires).ok())
+        .is_some_and(|expires| expires <= backend_now)
+}
+
+pub(crate) async fn backend_unix_time(store: &Arc<dyn ObjectStore>, anchor: &Path) -> Result<i64> {
+    // One reusable clock object supplies backend time without leaking a key
+    // for every blocked contender when cleanup fails.
+    let probe = Path::from(format!("{}/clock", anchor.as_ref()));
+    store
+        .put(&probe, Bytes::new().into())
+        .await
+        .map_err(|source| store_error(probe.as_ref(), source))?;
+    store
+        .head(&probe)
+        .await
+        .map(|metadata| metadata.last_modified.timestamp())
+        .map_err(|source| store_error(probe.as_ref(), source))
+}
+
 async fn acquire_contended(
     store: &Arc<dyn ObjectStore>,
     object_path: &Path,
     ref_name: &str,
     body: Bytes,
 ) -> Result<ContendedAcquire> {
-    let (existing_body, reclaim_etag) = match get_with_version(store, object_path).await {
-        Ok(existing) => existing,
-        Err(object_store::Error::NotFound { .. }) => {
-            return match create_strict(store, object_path, body).await {
-                Ok(etag) => Ok(ContendedAcquire::Acquired(etag)),
-                Err(object_store::Error::AlreadyExists { .. })
-                | Err(object_store::Error::Precondition { .. }) => {
-                    let (holder, expires_at_unix) = lock_holder_snapshot(store, object_path).await;
-                    Ok(ContendedAcquire::Held {
-                        holder,
-                        expires_at_unix,
-                    })
-                }
-                Err(source) => Err(store_error(object_path.as_ref(), source)),
-            };
-        }
-        Err(source) => return Err(store_error(object_path.as_ref(), source)),
-    };
+    let (existing_body, reclaim_etag, last_modified) =
+        match get_with_version_and_modified(store, object_path).await {
+            Ok(existing) => existing,
+            Err(object_store::Error::NotFound { .. }) => {
+                return match create_strict(store, object_path, body).await {
+                    Ok(etag) => Ok(ContendedAcquire::Acquired(etag)),
+                    Err(object_store::Error::AlreadyExists { .. })
+                    | Err(object_store::Error::Precondition { .. }) => {
+                        let (holder, expires_at_unix) =
+                            lock_holder_snapshot(store, object_path).await;
+                        Ok(ContendedAcquire::Held {
+                            holder,
+                            expires_at_unix,
+                        })
+                    }
+                    Err(source) => Err(store_error(object_path.as_ref(), source)),
+                };
+            }
+            Err(source) => return Err(store_error(object_path.as_ref(), source)),
+        };
 
     let existing = match serde_json::from_slice::<PushLockPayload>(&existing_body) {
         Ok(existing) => existing,
@@ -418,10 +458,12 @@ async fn acquire_contended(
             });
         }
     };
-    if existing.expires_at > unix_now() {
+    let now = backend_unix_time(store, object_path).await?;
+    if !existing.is_released() && !lease_expired(&existing, last_modified, now) {
+        let expires_at_unix = authoritative_expiry(&existing, last_modified);
         return Ok(ContendedAcquire::Held {
             holder: existing.holder,
-            expires_at_unix: Some(existing.expires_at),
+            expires_at_unix,
         });
     }
 
@@ -448,9 +490,12 @@ async fn lock_holder_snapshot(
     store: &Arc<dyn ObjectStore>,
     object_path: &Path,
 ) -> (String, Option<u64>) {
-    match get_with_version(store, object_path).await {
-        Ok((body, _)) => match serde_json::from_slice::<PushLockPayload>(&body) {
-            Ok(payload) => (payload.holder, Some(payload.expires_at)),
+    match get_with_version_and_modified(store, object_path).await {
+        Ok((body, _, last_modified)) => match serde_json::from_slice::<PushLockPayload>(&body) {
+            Ok(payload) => {
+                let expires_at_unix = authoritative_expiry(&payload, last_modified);
+                (payload.holder, expires_at_unix)
+            }
             Err(_) => (String::new(), None),
         },
         Err(_) => (String::new(), None),
@@ -481,7 +526,11 @@ async fn release_with_known_etag(
     release_if_holder(store, path, holder).await
 }
 
-async fn release_if_holder(store: &Arc<dyn ObjectStore>, path: &str, holder: &str) -> Result<()> {
+pub(crate) async fn release_if_holder(
+    store: &Arc<dyn ObjectStore>,
+    path: &str,
+    holder: &str,
+) -> Result<()> {
     let object_path = Path::from(path);
     let (body, etag) = match get_with_version(store, &object_path).await {
         Ok(lock) => lock,
@@ -506,15 +555,16 @@ async fn expire_stale_lock_at(
     store: &Arc<dyn ObjectStore>,
     object_path: &Path,
     path: &str,
-    now: u64,
+    now: i64,
 ) -> Result<bool> {
-    let (body, etag) = match get_with_version(store, object_path).await {
+    let (body, etag, last_modified) = match get_with_version_and_modified(store, object_path).await
+    {
         Ok(lock) => lock,
         Err(object_store::Error::NotFound { .. }) => return Ok(true),
         Err(source) => return Err(store_error(path, source)),
     };
     let payload = deserialize_payload(path, &body)?;
-    if payload.expires_at == 0 || payload.expires_at > now {
+    if !lease_expired(&payload, last_modified, now) {
         return Ok(false);
     }
     let body = serialize_payload(path, &PushLockPayload::released(&payload.holder))?;
@@ -541,12 +591,22 @@ pub(crate) async fn get_with_version(
     store: &Arc<dyn ObjectStore>,
     path: &Path,
 ) -> object_store::Result<(Bytes, UpdateVersion)> {
+    get_with_version_and_modified(store, path)
+        .await
+        .map(|(body, version, _)| (body, version))
+}
+
+pub(crate) async fn get_with_version_and_modified(
+    store: &Arc<dyn ObjectStore>,
+    path: &Path,
+) -> object_store::Result<(Bytes, UpdateVersion, i64)> {
     let result = store.get(path).await?;
     let version = UpdateVersion {
         e_tag: result.meta.e_tag.clone(),
         version: result.meta.version.clone(),
     };
-    Ok((result.bytes().await?, version))
+    let last_modified = result.meta.last_modified.timestamp();
+    Ok((result.bytes().await?, version, last_modified))
 }
 
 pub(crate) async fn update(
@@ -572,7 +632,7 @@ pub(crate) fn store_error(path: &str, source: object_store::Error) -> Coordinati
     }
 }
 
-fn serialize_payload(path: &str, payload: &PushLockPayload) -> Result<Bytes> {
+pub(crate) fn serialize_payload(path: &str, payload: &PushLockPayload) -> Result<Bytes> {
     serde_json::to_vec(payload)
         .map(Bytes::from)
         .map_err(|source| CoordinationError::Serialize {
@@ -582,7 +642,7 @@ fn serialize_payload(path: &str, payload: &PushLockPayload) -> Result<Bytes> {
         })
 }
 
-fn deserialize_payload(path: &str, body: &[u8]) -> Result<PushLockPayload> {
+pub(crate) fn deserialize_payload(path: &str, body: &[u8]) -> Result<PushLockPayload> {
     serde_json::from_slice(body).map_err(|source| CoordinationError::MalformedPushLock {
         path: path.to_owned(),
         source,
@@ -612,6 +672,7 @@ pub fn unix_now() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::StreamExt;
     use object_store::memory::InMemory;
     use std::sync::Arc;
     use std::time::Duration;
@@ -683,39 +744,90 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn expired_lock_can_be_reacquired_and_repaired() {
+    async fn backend_age_prevents_fast_client_from_reclaiming_live_lock() {
         let store = memory_store();
         let path = push_lock_path("org/repo", "refs/heads/main").unwrap();
-        let body = serde_json::to_vec(&PushLockPayload::new("dead-holder", 1)).unwrap();
+        let body = serde_json::to_vec(&PushLockPayload::new("live-holder", 1, 60)).unwrap();
         create_strict(&store, &Path::from(path.as_str()), Bytes::from(body))
             .await
             .unwrap();
+
+        let contender = PushLock::acquire_ref_default(&store, "org/repo", "refs/heads/main").await;
+
+        assert!(matches!(
+            contender,
+            Err(CoordinationError::PushLockHeld { holder, .. }) if holder == "live-holder"
+        ));
+    }
+
+    #[tokio::test]
+    async fn expired_lock_can_be_reacquired_and_repaired() {
+        let store = memory_store();
+        let path = push_lock_path("org/repo", "refs/heads/main").unwrap();
+        let body = serde_json::to_vec(&PushLockPayload::new("dead-holder", 1, 1)).unwrap();
+        create_strict(&store, &Path::from(path.as_str()), Bytes::from(body))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(1100)).await;
 
         let lock = PushLock::acquire_ref_default(&store, "org/repo", "refs/heads/main")
             .await
             .unwrap();
         lock.release().await.unwrap();
 
-        let repaired = PushLock::repair_expired(&store, &path, SystemTime::now())
+        let repaired = PushLock::repair_expired(&store, &path).await.unwrap();
+        assert!(!repaired, "released tombstones are not expired live leases");
+    }
+
+    #[tokio::test]
+    async fn expired_legacy_payload_does_not_hold_ref_forever() {
+        let store = memory_store();
+        let path = push_lock_path("org/repo", "refs/heads/main").unwrap();
+        create_strict(
+            &store,
+            &Path::from(path.as_str()),
+            Bytes::from_static(br#"{"holder":"legacy-holder","expires_at":1}"#),
+        )
+        .await
+        .unwrap();
+
+        let lock = PushLock::acquire_ref_default(&store, "org/repo", "refs/heads/main")
             .await
             .unwrap();
-        assert!(!repaired, "released tombstones are not expired live leases");
+
+        lock.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backend_clock_uses_one_reusable_object() {
+        let store = memory_store();
+        let anchor = Path::from("org/repo/locks/internal/push-admission/slots");
+
+        backend_unix_time(&store, &anchor).await.unwrap();
+        backend_unix_time(&store, &anchor).await.unwrap();
+
+        let objects = store
+            .list(Some(&anchor))
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<object_store::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(objects.len(), 1);
+        assert_eq!(objects[0].location.as_ref(), format!("{anchor}/clock"));
     }
 
     #[tokio::test]
     async fn repair_marks_expired_live_lock_released() {
         let store = memory_store();
         let path = push_lock_path("org/repo", "refs/heads/main").unwrap();
-        let body = serde_json::to_vec(&PushLockPayload::new("dead-holder", 1)).unwrap();
+        let body = serde_json::to_vec(&PushLockPayload::new("dead-holder", 1, 1)).unwrap();
         create_strict(&store, &Path::from(path.as_str()), Bytes::from(body))
             .await
             .unwrap();
+        tokio::time::sleep(Duration::from_millis(1100)).await;
 
-        assert!(
-            PushLock::repair_expired(&store, &path, SystemTime::now())
-                .await
-                .unwrap()
-        );
+        assert!(PushLock::repair_expired(&store, &path).await.unwrap());
         let (body, _) = get_with_version(&store, &Path::from(path.as_str()))
             .await
             .unwrap();
@@ -725,7 +837,7 @@ mod tests {
 
     #[test]
     fn payload_round_trips_json() {
-        let payload = PushLockPayload::new("holder-a", 42);
+        let payload = PushLockPayload::new("holder-a", 42, 30);
 
         let bytes = serde_json::to_vec(&payload).unwrap();
         let parsed: PushLockPayload = serde_json::from_slice(&bytes).unwrap();
@@ -744,7 +856,7 @@ mod tests {
 
     #[test]
     fn expiry_ignores_released_tombstones() {
-        let payload = PushLockPayload::new("holder-a", 99);
+        let payload = PushLockPayload::new("holder-a", 99, 30);
 
         assert!(!payload.is_expired_at(98));
         assert!(payload.is_expired_at(99));

--- a/crates/crab-metadata/src/git_object_locator/writer.rs
+++ b/crates/crab-metadata/src/git_object_locator/writer.rs
@@ -300,6 +300,13 @@ impl GitObjectLocatorWriter {
                 "Git locator sweep retained an invalid pack slot".to_owned(),
             ));
         }
+        if self
+            .bindings
+            .keys()
+            .all(|slot| retained_slots.contains(slot))
+        {
+            return Ok(LocatorSweepStats::default());
+        }
 
         let mut stats = LocatorSweepStats::default();
         let mut object_rows = self
@@ -730,6 +737,37 @@ mod tests {
             .expect("sweep stale slot");
         assert_eq!(stats.object_rows_deleted, 1);
         assert_eq!(stats.pack_rows_deleted, 1);
+        writer.close().await.expect("close writer");
+    }
+
+    #[tokio::test]
+    async fn sweep_skips_object_scan_when_every_binding_is_retained() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut writer = GitObjectLocatorWriter::open(Arc::clone(&store), "org/repo")
+            .await
+            .expect("open writer");
+        let bindings = writer
+            .bind_packs(&[pack(1), pack(2)])
+            .await
+            .expect("bind packs");
+        writer
+            .write_locations(bindings[0], &[entry(1)])
+            .await
+            .expect("write first");
+        writer
+            .write_locations(bindings[1], &[entry(2)])
+            .await
+            .expect("write second");
+
+        let stats = writer
+            .sweep_unreferenced(&HashSet::from([
+                bindings[0].pack_slot,
+                bindings[1].pack_slot,
+            ]))
+            .await
+            .expect("skip retained sweep");
+
+        assert_eq!(stats, LocatorSweepStats::default());
         writer.close().await.expect("close writer");
     }
 

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -44,6 +44,19 @@ pub struct RepositorySnapshot {
     pub journal: RefJournalSnapshot,
 }
 
+impl RepositorySnapshot {
+    /// Return the current journal-projected manifest with a matching validation digest.
+    #[must_use]
+    pub fn materialized_manifest(&self) -> Manifest {
+        let mut manifest = self.manifest.clone();
+        manifest.refs.clone_from(&self.journal.refs);
+        manifest.peeled_refs.clone_from(&self.journal.peeled_refs);
+        manifest.head.clone_from(&self.journal.head);
+        manifest.seal_git_validation();
+        manifest
+    }
+}
+
 fn serialize_manifest(manifest: &Manifest) -> Result<Vec<u8>> {
     serde_json::to_vec_pretty(manifest)
         .map_err(|e| MetadataError::Internal(format!("manifest serialize: {e}")))
@@ -1076,5 +1089,41 @@ mod tests {
             after_rewrite.journal.transactions,
             vec![second.id().unwrap()]
         );
+    }
+
+    #[tokio::test]
+    async fn materialized_manifest_reseals_journal_projected_refs() {
+        let store = memory_store();
+        let router = test_layout(store.clone());
+        let mut base = Manifest::default_for_repo("refs/heads/main");
+        base.refs
+            .insert("refs/heads/main".to_owned(), "a".repeat(40));
+        base.seal_git_validation();
+        create_manifest(&store, &router, &base).await.unwrap();
+        let head = read_ref_head(&store, &router, "refs/heads/feature")
+            .await
+            .unwrap();
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([("refs/heads/feature".to_owned(), None)]),
+            vec![RefJournalEdit {
+                ref_name: "refs/heads/feature".to_owned(),
+                old_oid: None,
+                new_oid: Some("b".repeat(40)),
+                peeled_oid: None,
+            }],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        commit_ref_transaction(&store, &router, &transaction, &[head])
+            .await
+            .unwrap();
+
+        let snapshot = read_repository_snapshot(&store, &router).await.unwrap();
+        let materialized = snapshot.materialized_manifest();
+
+        assert_eq!(materialized.refs["refs/heads/feature"], "b".repeat(40));
+        validate_manifest_payload(&materialized).unwrap();
     }
 }

--- a/packages/web/content/docs/cli/authentication/environment-info.mdx
+++ b/packages/web/content/docs/cli/authentication/environment-info.mdx
@@ -60,6 +60,10 @@ are visible to the current process. Secret values are still your
 responsibility: avoid sharing raw keys, tokens, service account JSON, SAS
 tokens, or connection strings.
 
+`AWS_PROFILE` is displayed for diagnostics, but the current S3 provider does
+not consume profiles or shared AWS configuration files. Use one of the
+credential sources documented under [Static Credentials](static-credentials).
+
 ### Include in a bug report
 
 ```bash

--- a/packages/web/content/docs/cli/authentication/static-credentials.mdx
+++ b/packages/web/content/docs/cli/authentication/static-credentials.mdx
@@ -7,8 +7,8 @@ description: "How the Crab CLI discovers static cloud credentials from environme
 
 `static` is Crab's default auth provider. In this mode, Crab does not run
 `crab login` and does not store long-lived cloud access keys in Crab config.
-It builds an object-store client from environment variables or the cloud SDK
-default credential chain.
+It builds an object-store client from the credential sources supported by the
+selected object-store provider.
 
 Use static credentials for local development, CI, S3-compatible stores, and
 small-team deployments where cloud IAM already controls bucket access.
@@ -17,8 +17,8 @@ small-team deployments where cloud IAM already controls bucket access.
 flowchart TD
     Process["Process environment"] --> RepoEnv["Repository .env / .crab/.env"]
     RepoEnv --> UserEnv["User Crab .env"]
-    UserEnv --> Sdk["Cloud SDK default chain"]
-    Sdk --> Store["Object-store client"]
+    UserEnv --> Provider["Provider credential chain"]
+    Provider --> Store["Object-store client"]
     Store --> Bucket["S3 / GCS / Azure bucket"]
 ```
 
@@ -31,7 +31,8 @@ credentials in this order:
 2. `.env` in the Git repository root.
 3. `.env` or `.crab/.env` while walking up from the current directory.
 4. `~/.config/crab/.env`.
-5. The cloud SDK default credential chain used by the object-store provider.
+5. Provider-native sources such as workload identity, instance/task identity,
+   GCP Application Default Credentials, or Azure CLI when supported.
 
 Earlier sources win. Crab only fills in missing variables from later `.env`
 files, so an explicit shell export overrides project and user-global files.
@@ -59,11 +60,17 @@ export AWS_ENDPOINT_URL=http://localhost:9000
 export AWS_ALLOW_HTTP=true
 ```
 
-You can also use AWS profiles instead of explicit keys:
+For production and CI, prefer web identity or an attached ECS/EC2 role:
 
 ```bash
-export AWS_PROFILE=ml-team
+export AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/oidc-token
+export AWS_ROLE_ARN=arn:aws:iam::123456789012:role/crab-writer
 ```
+
+The current S3 provider does not read `AWS_PROFILE`, `~/.aws/config`, or
+`~/.aws/credentials`. If an SSO/profile workflow produces temporary
+credentials, export `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+`AWS_SESSION_TOKEN` into the Crab process.
 
 ## GCS and Azure Variables
 
@@ -82,10 +89,13 @@ export AZURE_STORAGE_ACCOUNT_NAME=myaccount
 export AZURE_STORAGE_ACCOUNT_KEY=...
 ```
 
-or:
+For Azure workload identity:
 
 ```bash
-export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;..."
+export AZURE_STORAGE_ACCOUNT_NAME=myaccount
+export AZURE_CLIENT_ID=...
+export AZURE_TENANT_ID=...
+export AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token
 ```
 
 ## Selecting the Storage Provider
@@ -114,9 +124,10 @@ Crab repository config stores the remote URL and auth mode, not secret values.
 Do not put cloud access keys in `.crab/config.toml`, `.crab.toml`, Git config,
 or committed docs.
 
-For static mode, any long-lived secret storage is owned by your shell,
-`.env` files, cloud SDK config, CI secret store, or OS credential store. Crab
-only reads the resolved values at runtime to build the cloud client.
+For static mode, any long-lived secret storage is owned by your shell, `.env`
+files, CI secret store, or OS credential store. Crab only reads resolved values
+at runtime. Team deployments should avoid committed `.env` files and use
+short-lived workload credentials wherever the provider supports them.
 
 For federated providers such as `aws-oidc`, `gcp-workload-identity`,
 `azure-entra`, and `crab-auth`, Crab stores encrypted login tokens under the

--- a/packages/web/content/docs/cli/diagnostics/health-check.mdx
+++ b/packages/web/content/docs/cli/diagnostics/health-check.mdx
@@ -56,7 +56,7 @@ crab doctor
 | Filter driver not configured | Run `crab install` or `crab init <url>` |
 | No crab patterns in .gitattributes | Run `crab track '*.bin'` |
 | Remote URL not configured | Run `crab init <url>` |
-| Credentials check failed | Verify `AWS_PROFILE`, `AWS_REGION`, and `~/.aws/credentials` |
+| Credentials check failed | Verify supported environment, web identity, ECS task, or EC2 instance credentials and `AWS_REGION` |
 | Large staging area warning | Run `git push` to upload, then `crab staging clean` |
 
 ## Typical Workflows

--- a/packages/web/content/docs/cli/diagnostics/integrity-check.mdx
+++ b/packages/web/content/docs/cli/diagnostics/integrity-check.mdx
@@ -5,7 +5,9 @@ description: "How to verify repository integrity by checking for dangling refs, 
 
 ## Verifying Repository Integrity
 
-`crab fsck` performs a comprehensive integrity check on your repository, examining both local and remote state for inconsistencies. It detects dangling refs, missing blobs, orphan shards, expired push locks, abandoned multipart uploads, and manifest divergence.
+`crab fsck` cross-checks Crab manifests, pack/index presence, the shard/xorb
+data chain, and coordination state against the object store. It is not yet a
+full reconstruction and Git-connectivity check of current head.
 
 Think of it as `git fsck` extended to cover Crab's object store layer.
 
@@ -36,19 +38,15 @@ crab fsck
 
 | Issue | Description | Auto-repairable |
 |-------|-------------|:---:|
-| Dangling ref | Ref points to a non-existent commit | ✗ |
-| Missing tree | Commit references a missing tree object | ✗ |
-| Missing blob | Tree references a missing blob | ✗ |
 | Missing file index | Pointer references a missing file index | ✗ |
 | Missing xorb | File index references a non-existent xorb | ✗ |
+| Pack list divergence | Manifest-selected pack or index is absent | ✗ |
 
 ### Warnings (operational)
 
 | Issue | Description | Auto-repairable |
 |-------|-------------|:---:|
 | Expired push lock | Lock from a crashed process | ✓ |
-| Abandoned multipart upload | Upload never completed | ✓ |
-| Pack list divergence | Manifest doesn't match actual packs | ✓ |
 | Orphan shard | Shard not referenced by any file index | ✗ |
 | Shard list divergence | Shard list doesn't match actual shards | ✗ |
 
@@ -60,10 +58,12 @@ crab fsck --repair
 
 Repair is conservative:
 - Expired locks are deleted
-- Abandoned uploads are aborted
-- Missing manifest entries are re-added
+- Derivable historical Git visibility proofs can be rebuilt
 
-No data is ever deleted by `--repair` — only metadata cleanup. Critical issues (missing blobs, trees, xorbs) require manual intervention.
+Repair is limited to issues explicitly marked repairable. Missing content
+requires history, replica, cache, or backup recovery. Provider-side incomplete
+multipart uploads require a provider lifecycle rule because the generic
+object-store API cannot enumerate them.
 
 ## When to Run
 

--- a/packages/web/content/docs/cli/diagnostics/store-verification.mdx
+++ b/packages/web/content/docs/cli/diagnostics/store-verification.mdx
@@ -24,7 +24,9 @@ The verifier loads `pack-list.json` and cross-references it against actual pack 
 - **Listed but missing** — a pack ID is in the manifest but the object doesn't exist in storage
 - **Present but unlisted** — a pack object exists but isn't in the manifest
 
-The "present but unlisted" direction is repairable — `--repair` re-adds the manifest entry after confirming the pack exists.
+Unreferenced immutable packs are expected after interrupted or conflicted
+pushes and are protected by the normal GC grace period. `fsck` does not add
+them to the committed manifest.
 
 ### Shard-list vs. storage
 
@@ -36,7 +38,8 @@ For each file-index entry, the verifier confirms the referenced shard exists eit
 
 ### Push lock expiry
 
-Push locks under `<prefix>/locks/` are checked against current time. Expired locks indicate a previous push that crashed without cleanup — safely deletable with `--repair`.
+Push locks are checked against their backend-clock lease. Holder-safe repair
+can remove a genuinely expired lock.
 
 ## Usage
 
@@ -76,11 +79,22 @@ Only specific issue types are auto-repaired:
 
 | Issue | Repair action |
 |-------|--------------|
-| Missing pack-list entry (pack exists in storage) | Re-add manifest entry |
 | Expired push lock | Delete the lock |
-| Abandoned multipart upload | Abort the upload |
 
-Repairs are reversible and conservative. No data is deleted.
+Repairs are conservative. Expired lock objects are deleted only after the
+holder-safe expiry check; committed repository content is not deleted.
+
+## Current Boundaries
+
+- The current Git-object check does not reconstruct current head and run full
+  Git reachability. Monitor an independent clone/fetch; use `crab recover
+  history verify <generation>` for strict Git fsck of a historical root.
+- The generic object-store API cannot enumerate provider-side incomplete
+  multipart uploads, so configure the provider lifecycle rule that aborts old
+  incomplete uploads.
+- Locator or visibility acceleration damage requires `crab metadb rebuild`
+  followed by another verification run.
+- Same-bucket manifest history is recovery history, not an independent backup.
 
 ## Exit Codes
 

--- a/packages/web/content/docs/cli/file-inspection/file-statistics.mdx
+++ b/packages/web/content/docs/cli/file-inspection/file-statistics.mdx
@@ -55,7 +55,7 @@ Performance counters track cumulative metrics across all crab operations:
 | Counter | Description |
 |---------|-------------|
 | `push_duration_ms` | Total time spent pushing |
-| `bytes_uploaded` | Total bytes uploaded to remote |
+| `bytes_uploaded` | Total xorb payload bytes uploaded; excludes Git packs, indexes, manifests, refs, locks, and metadb objects |
 | `fetch_duration_ms` | Total time spent fetching |
 | `bytes_downloaded` | Total bytes downloaded from remote |
 | `gc_duration_ms` | Total time spent in garbage collection |
@@ -71,8 +71,19 @@ Performance counters track cumulative metrics across all crab operations:
 | `xorb_fetch_requests_coalesced` | Number of coalesced xorb fetch requests |
 | `xorb_fetch_bytes_saved` | Bytes saved by request coalescing |
 | `multipart_resumed_uploads` | Number of resumed multipart uploads |
+| `head_list_requests` | LIST requests issued by batched xorb resume checks |
+| `head_point_requests` | Individual HEAD requests issued by xorb resume checks |
+| `metadb_buffered_batch_write_count` | Buffered metadb batches submitted during pushes |
+| `metadb_wal_flush_count` | Explicit metadb WAL flushes |
+| `metadb_memtable_flush_count` | Explicit metadb memory-table-to-L0 flushes |
 
-If the perf-state file doesn't exist or is corrupt, zeroed counters are shown.
+Pushes update the file cumulatively under an advisory file lock. If the
+perf-state file doesn't exist or is corrupt, zeroed counters are shown.
+
+These counters cover selected Crab operations. They do not count every object
+store `GET`, `HEAD`, `PUT`, `LIST`, retry, pack byte, or metadata byte, so do
+not use them as a billing ledger. Correlate them with provider or RustFS server
+metrics for request and transfer cost.
 
 ## Examples
 

--- a/packages/web/content/docs/cli/getting-started/mirror-mode.mdx
+++ b/packages/web/content/docs/cli/getting-started/mirror-mode.mdx
@@ -5,7 +5,7 @@ description: "Use GitHub or GitLab for code review while Crab handles large-file
 
 # Mirror Mode (GitHub + Crab)
 
-Mirror mode lets you keep GitHub (or GitLab) for code review and pull requests while Crab handles large-file storage. Code goes to GitHub, large files go to your cloud bucket — your team's workflow stays unchanged.
+Mirror mode keeps GitHub (or GitLab) as the collaboration control plane for pull requests, reviews, branch protection, CI, issues, and webhooks. Crab is a second Git remote backed by object storage and stores both the pushed Git graph and large-file data.
 
 ## Data Flow
 
@@ -71,10 +71,15 @@ needs the mirror remote and hooks installed locally.
 #!/bin/sh
 # Crab mirror: push xorbs before refs go to origin
 crab add . --skip-git-add 2>/dev/null
-crab push crab 2>/dev/null
+crab push --remote crab --quiet 2>/dev/null
 ```
 
 Ensures large-file content reaches your bucket before pointer blobs reach GitHub. If the Crab push fails, the git push is aborted — preventing dangling pointers.
+
+The two remote updates are not one distributed transaction. Crab can be ahead
+if its push succeeds and GitHub later rejects the push. Server-side merges,
+bots, and clients without the hook can also advance GitHub without advancing
+Crab. Retry to converge and monitor ref divergence.
 
 ### `post-checkout` — After switching branches or cloning
 
@@ -136,6 +141,22 @@ crab_remote = "crab"        # Crab storage remote name
 - Crab is your only remote (no GitHub/GitLab)
 - You don't need code review on a separate platform
 - You want the simplest possible setup
+
+## Production Team Posture
+
+- Keep GitHub/GitLab canonical for collaboration and policy. Crab does not
+  provide pull requests, branch protection, merge queues, CI, issues, or
+  webhooks.
+- Keep Crab/object storage canonical for large data, using workload identity
+  and least-privilege bucket policy instead of shared static keys.
+- Install hooks on every developer and automation clone, then enforce pointer
+  availability in CI because client hooks are bypassable.
+- Use `crab mirror SOURCE DESTINATION` only as a scheduled one-way full-ref DR
+  sync. It uses `git push --mirror`, which deletes destination-only refs; never
+  schedule it in both directions.
+- Before using Crab as the sole Git backbone, qualify multi-node storage
+  failures and prove monitoring, backup restore, RPO, and RTO in your own
+  environment.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- replace the per-writer admission queue with five reusable CAS lease slots, backend-derived expiry, bounded probes, and migration-safe lock payload handling
- publish immutable per-pack index and reverse-index evidence, then reconcile generation-owned locator coverage across concurrent CLI and auth-server pushes without downloading sibling pack bodies
- harden metadata lifecycle and materialization, add push/fetch request metrics, and update credential, doctor, fsck, stat, mirror-mode, and operator documentation

## Verification

- `cargo test -p crab-coordination`: 73 passed
- `cargo test -p crab-metadata --features remote-index,storage --lib`: 189 passed
- `cargo test -p crab-auth-server --lib`: 70 passed
- focused CLI locator and non-atomic CAS retry tests: passed
- staged Rust files: `rustfmt --edition 2024 --check` passed
- web: Vitest, TypeScript, and 181-page/1,894-fragment link checks passed

## Existing repository gate failures

- full Rust run reached 3,591 passed, then reported 16 existing snapshot, environment-sensitive, and stale direct-store inventory failures outside the changed implementations
- repository-wide format flags unchanged `crab/tests/replica_live_preflight.rs`
- clippy stops on five unchanged `crab-vfs` findings
- architecture policy checks report broad existing dependency and feature-budget drift
- web lint reports existing generated and UI findings; no changed MDX file appears in the report

## CI

GitHub Actions did not start any jobs because the repository account has a failed payment or exhausted spending limit. No CI job reached checkout or code execution.
