### PR TITLE
fix: restore CI contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "crab-auth-server"
-version = "1.0.12"
+version = "1.0.14"
 dependencies = [
  "blake3",
  "bytes",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "crab-cache-server"
-version = "1.0.12"
+version = "1.0.14"
 dependencies = [
  "async-trait",
  "axum 0.8.9",

--- a/crates/crab-auth-server/Cargo.toml
+++ b/crates/crab-auth-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-auth-server"
-version = "1.0.12"
+version = "1.0.14"
 edition = "2024"
 license = "Apache-2.0"
 description = "Protected-push and path-scoped view helper binaries for Crab Auth."

--- a/crates/crab-auth-store/Cargo.toml
+++ b/crates/crab-auth-store/Cargo.toml
@@ -21,6 +21,7 @@ refreshing-store = [
     "dep:tokio",
     "dep:tracing",
     "dep:url",
+    "dep:uuid",
 ]
 managed-service = [
     "refreshing-store",

--- a/crates/crab-cache-server/Cargo.toml
+++ b/crates/crab-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-cache-server"
-version = "1.0.12"
+version = "1.0.14"
 edition = "2024"
 license = "Apache-2.0"
 description = "Cache server runtime contracts for Crab."

--- a/crates/crab-cache-server/tests/cache_server_preflight_cli.rs
+++ b/crates/crab-cache-server/tests/cache_server_preflight_cli.rs
@@ -494,7 +494,7 @@ fn release_workflow_requires_cache_service_smoke_evidence() {
         "cache-service-release-evidence-gate-${{ github.run_id }}-${{ github.run_attempt }}",
         "if-no-files-found: ignore",
         "cache-service-enterprise-gate",
-        "needs: [replica-enterprise-gate, cache-service-enterprise-gate]",
+        "needs: [prepare, workflow-release-gate, workflow-native-release-gate, replica-enterprise-gate, cache-service-enterprise-gate, nfs-native-evidence-gate, nfs-feature-gate]",
     ] {
         assert!(body.contains(needle), "{needle}");
     }

--- a/crates/crab-workflow/src/artifact.rs
+++ b/crates/crab-workflow/src/artifact.rs
@@ -1575,7 +1575,7 @@ fn parse_digest(value: &str) -> Result<[u8; 32]> {
     validate_digest("artifact_content_hash_invalid", value)?;
     let raw = value.strip_prefix("b3:").unwrap_or_default();
     let mut digest = [0_u8; 32];
-    for (index, pair) in raw.as_bytes().chunks_exact(2).enumerate() {
+    for (index, pair) in raw.as_bytes().as_chunks::<2>().0.iter().enumerate() {
         let high =
             hex_nibble(pair[0]).ok_or_else(|| invalid("artifact_content_hash_invalid", value))?;
         let low =

--- a/crates/crab-workflow/src/stage_cache_entry.rs
+++ b/crates/crab-workflow/src/stage_cache_entry.rs
@@ -247,7 +247,7 @@ pub(crate) fn decode_b3_hash(value: &str) -> Option<[u8; 32]> {
         return None;
     }
     let mut digest = [0_u8; 32];
-    for (index, pair) in bytes[3..].chunks_exact(2).enumerate() {
+    for (index, pair) in bytes[3..].as_chunks::<2>().0.iter().enumerate() {
         if !pair.iter().all(u8::is_ascii_hexdigit) {
             return None;
         }


### PR DESCRIPTION
## Summary

- Enable `uuid` for the `refreshing-store` feature.
- Replace fixed-size `chunks_exact` calls with `as_chunks` for current Clippy.
- Align the release preflight assertion with the workflow dependency graph.
- Align shipped auth/cache server package versions and lock metadata with Crab `1.0.14`.
- Restore six active `params_runtime` snapshot baselines removed during cleanup.

## Validation

- `make shipped-binary-version-check` — all 4 shipped binaries pass.
- `cargo clippy -p crab-workflow --all-targets --locked -- -D warnings`
- `cargo test -p crab-workflow --locked` — 691 passed.
- `cargo test -p crab-cache-server --test cache_server_preflight_cli --locked` — 39 passed.
- Targeted auth-store and workflow tests.
- `cargo fmt --all -- --check`