### PR TITLE
perf: reduce concurrent push request amplification

### DIFF
--- a/.github/workflows/workflow-native.yml
+++ b/.github/workflows/workflow-native.yml
@@ -33,6 +33,21 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install macOS FUSE dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew install pkg-config
+          brew install --cask macfuse
+          fuse_pc="$(find "$(brew --prefix)" /usr/local /Library/Frameworks \
+            -path '*/pkgconfig/fuse.pc' -print -quit 2>/dev/null || true)"
+          if [ -z "${fuse_pc}" ]; then
+            echo "::error::macFUSE fuse.pc was not found after installation"
+            exit 1
+          fi
+          echo "PKG_CONFIG_PATH=$(dirname "${fuse_pc}")${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" >> "${GITHUB_ENV}"
+
       - name: Run workflow crate tests
         run: cargo test -p crab-workflow --locked
 

--- a/crab/docs/design/push.md
+++ b/crab/docs/design/push.md
@@ -1367,6 +1367,14 @@ addressed. This section tracks both resolved and open items.
 | B8 | Late lock acquisition                             | Lock now acquired between step 4 and step 5 — no wasted uploads from lock losers |
 | B9 | Double rev-parse                                  | `batch_rev_parse` consolidates refs in a single `git rev-parse` invocation |
 | B11 | Lock renewal failure propagation                 | Heartbeat loss, deletion, CAS conflict, fatal error, or failed transient retry cancels the push through its shared token |
+| — | Locator point-read amplification                   | Each read session uses a 16 MiB SST block/metadata cache; concurrent exact lookups coalesce shared provider reads without SlateDB's 640 MiB default |
+
+The cache bound is per process: 32 simultaneous fetchers can retain at most
+512 MiB in aggregate. In the 32-agent same-branch RustFS profile it reduced
+locator HTTP attempts from 17,065 to 3,806, compacted-SST GETs from 11,222 to
+940, and total HTTP attempts from 25,211 to 12,722. All 32 agent commits were
+present in a fresh protocol-v2 clone and strict Git fsck passed. This is a
+workload comparison, not a provider price claim.
 
 #### Partially Resolved
 
@@ -1456,7 +1464,7 @@ Impact ▲
 
 | Item | Description | Bottleneck | Effort |
 |------|-------------|------------|--------|
-| 1.1  | Coalesce exact-locator publication or replace per-generation SlateDB sessions; 32 same-branch writers currently amplify locator reads as integration retries accumulate | locator publication | L |
+| 1.1  | Qualify bounded locator caching and workload-specific request budgets on S3, GCS, and Azure | locator reads | M |
 | 1.2  | Qualify request-timeout recovery and provider-specific transient errors | B11 | S |
 | 1.3  | Progress sideband via remote-helper protocol | B10 | S |
 | 1.4  | Stabilize adaptive xorb-size EMA feedback | B12 | S |

--- a/crab/docs/design/push.md
+++ b/crab/docs/design/push.md
@@ -1368,6 +1368,7 @@ addressed. This section tracks both resolved and open items.
 | B9 | Double rev-parse                                  | `batch_rev_parse` consolidates refs in a single `git rev-parse` invocation |
 | B11 | Lock renewal failure propagation                 | Heartbeat loss, deletion, CAS conflict, fatal error, or failed transient retry cancels the push through its shared token |
 | — | Locator point-read amplification                   | Each read session uses a 16 MiB SST block/metadata cache; concurrent exact lookups coalesce shared provider reads without SlateDB's 640 MiB default |
+| — | Contended lock polling amplification               | One acquisition context remembers existing lock objects and reuses its backend clock sample; repeated live-holder checks need one GET instead of a failed create plus GET, clock PUT, and clock HEAD |
 
 The cache bound is per process: 32 simultaneous fetchers can retain at most
 512 MiB in aggregate. In the 32-agent same-branch RustFS profile it reduced
@@ -1375,6 +1376,14 @@ locator HTTP attempts from 17,065 to 3,806, compacted-SST GETs from 11,222 to
 940, and total HTTP attempts from 25,211 to 12,722. All 32 agent commits were
 present in a fresh protocol-v2 clone and strict Git fsck passed. This is a
 workload comparison, not a provider price claim.
+
+The same 32-agent profile with reusable lock acquisition reduced ref-lock HTTP
+attempts from 2,556 to 947 and total attempts from 12,722 to 11,117, or 347.41
+per successful push. A four-agent comparison reduced ref-lock attempts from 80
+to 34 and total attempts from 1,275 to 1,076. Both runs integrated every commit,
+served an exact protocol-v2 clone, and passed strict Git fsck. Retry scheduling
+and SlateDB compaction are nondeterministic, so the request budget—not one run's
+wall time—is the regression signal.
 
 #### Partially Resolved
 

--- a/crab/docs/guides/local-dev-rustfs.md
+++ b/crab/docs/guides/local-dev-rustfs.md
@@ -239,8 +239,13 @@ same-branch cohort fail when `git_locator_db/*` HTTP attempts divided by
 successful pushes exceed `N`. This is a workload-specific regression budget,
 not a provider bill: record the agent count, integration mode, and parallelism
 with the result. The CI four-agent integration profile uses 180; larger swarms
-can exceed that while repeatedly waiting, fetching, and rebasing against one
-serialized branch tip.
+or repositories can exceed it while repeatedly waiting, fetching, and rebasing
+against one serialized branch tip. The retained 32-agent RustFS comparison for
+the bounded locator reader cache measured 3,806 locator attempts, or 118.94 per
+successful push, down from 17,065, or 533.28 per push. Total HTTP attempts fell
+from 25,211 to 12,722 and provider 5xx responses from 1,040 to zero. Apply real
+provider request, storage, and transfer prices before treating those counts as
+a team cost estimate.
 
 Add `--crash-boundary --crash-lock-ttl-secs 21` to SIGKILL one push after its
 prepared ref head and another after its active marker. The first ref must stay

--- a/crab/docs/guides/local-dev-rustfs.md
+++ b/crab/docs/guides/local-dev-rustfs.md
@@ -247,6 +247,14 @@ from 25,211 to 12,722 and provider 5xx responses from 1,040 to zero. Apply real
 provider request, storage, and transfer prices before treating those counts as
 a team cost estimate.
 
+The retained 32-agent follow-up for reusable lock acquisition measured 947
+`locks/refs/*` attempts, down from 2,556, and 11,117 total attempts, down from
+12,722. That is 347.41 total HTTP attempts per successful push. Its locator
+count was 3,901, or 121.91 per push, within the same 180-request budget. The
+four-agent comparison reduced ref-lock attempts from 80 to 34 and total
+attempts from 1,275 to 1,076. Use these paired profiles to detect request
+amplification; do not use their wall time as a deterministic performance gate.
+
 Add `--crash-boundary --crash-lock-ttl-secs 21` to SIGKILL one push after its
 prepared ref head and another after its active marker. The first ref must stay
 invisible and its immediate retry must honor the structured lease-expiry hint;

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -47,11 +47,11 @@ use crate::metadata::manifest::{
 use crate::replication::{ActiveActivePushPlan, ReplicationConfig};
 use crate::storage::StoreLayout;
 use crate::storage::store::{StagedWrite, Store};
-use crab_coordination::PushLock;
 use crab_coordination::write_coordinator::{
     CommitOutcome, CoordinatedRefUpdate, PushTransactionState, WriteCoordinator,
     commit_uploaded_push_refs,
 };
+use crab_coordination::{PushLock, PushLockAcquireContext};
 use crab_metadata::chunk_index::ChunkIndex;
 use crab_metadata::commit_graph::CommitEntry;
 use crab_metadata::pack_metadata::PackMetadata;
@@ -4632,6 +4632,7 @@ pub(crate) async fn acquire_push_lock_leases(
     let deadline = (!config.lock_wait.is_zero()).then(|| Instant::now() + config.lock_wait);
     let mut wait_attempt = 0;
     let mut checked_committed_holders = HashSet::new();
+    let mut acquire_context = PushLockAcquireContext::new(Arc::clone(store.inner()));
 
     loop {
         let mut leases = Vec::with_capacity(refs.len().max(1));
@@ -4647,17 +4648,19 @@ pub(crate) async fn acquire_push_lock_leases(
             let (target, acquired) = match ref_name {
                 Some(ref_name) => (
                     ref_name.as_str(),
-                    PushLock::acquire_ref(store.inner(), prefix, ref_name, config.lock_ttl).await,
+                    acquire_context
+                        .acquire_ref(prefix, ref_name, config.lock_ttl)
+                        .await,
                 ),
                 None => (
                     crab_coordination::BATCH_RESOURCE,
-                    PushLock::acquire_internal(
-                        store.inner(),
-                        prefix,
-                        crab_coordination::BATCH_RESOURCE,
-                        config.lock_ttl,
-                    )
-                    .await,
+                    acquire_context
+                        .acquire_internal(
+                            prefix,
+                            crab_coordination::BATCH_RESOURCE,
+                            config.lock_ttl,
+                        )
+                        .await,
                 ),
             };
             let acquired = acquired.map_err(CrabError::from);
@@ -4821,6 +4824,7 @@ async fn acquire_ref_journal_compaction_lock(
     let deadline =
         Instant::now() + ttl.saturating_mul(REF_JOURNAL_COMPACTION_LOCK_WAIT_TTL_MULTIPLIER);
     let mut attempt = 0;
+    let mut acquire_context = PushLockAcquireContext::new(Arc::clone(store.inner()));
     loop {
         if !crate::metadata::manifest::ref_journal_transaction_is_active(
             store,
@@ -4832,14 +4836,14 @@ async fn acquire_ref_journal_compaction_lock(
             return Ok(None);
         }
         check_cancelled(cancel)?;
-        match PushLock::acquire_internal(
-            store.inner(),
-            router.repo_prefix(),
-            crab_coordination::GIT_MANIFEST_RESOURCE,
-            ttl,
-        )
-        .await
-        .map_err(CrabError::from)
+        match acquire_context
+            .acquire_internal(
+                router.repo_prefix(),
+                crab_coordination::GIT_MANIFEST_RESOURCE,
+                ttl,
+            )
+            .await
+            .map_err(CrabError::from)
         {
             Ok(lock) => return Ok(Some(lock)),
             Err(error @ CrabError::PushLockHeld { .. }) => {
@@ -5110,6 +5114,7 @@ async fn acquire_current_git_locator_lock(
 ) -> Result<Option<PushLock>> {
     let deadline = Instant::now() + lock_ttl.saturating_mul(GIT_LOCATOR_LOCK_WAIT_TTL_MULTIPLIER);
     let mut attempt = 0;
+    let mut acquire_context = PushLockAcquireContext::new(Arc::clone(store.inner()));
     loop {
         check_cancelled(cancel)?;
         let (current, _) = read_manifest(store, router).await?;
@@ -5118,14 +5123,14 @@ async fn acquire_current_git_locator_lock(
         {
             return Ok(None);
         }
-        match PushLock::acquire_internal(
-            store.inner(),
-            router.repo_prefix(),
-            crab_coordination::GIT_OBJECT_LOCATOR_RESOURCE,
-            lock_ttl,
-        )
-        .await
-        .map_err(CrabError::from)
+        match acquire_context
+            .acquire_internal(
+                router.repo_prefix(),
+                crab_coordination::GIT_OBJECT_LOCATOR_RESOURCE,
+                lock_ttl,
+            )
+            .await
+            .map_err(CrabError::from)
         {
             Ok(lock) => return Ok(Some(lock)),
             Err(error @ CrabError::PushLockHeld { .. }) => {

--- a/crates/crab-coordination/src/push_admission.rs
+++ b/crates/crab-coordination/src/push_admission.rs
@@ -1,7 +1,7 @@
 //! Bounded object-store admission for repository push pipelines.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use object_store::path::Path;
 use object_store::{ObjectStore, UpdateVersion};
@@ -9,7 +9,7 @@ use tracing::warn;
 
 use crate::error::{CoordinationError, Result};
 use crate::push_lock::{
-    PushLockPayload, backend_unix_time, create_strict, deserialize_payload,
+    BackendClock, PushLockPayload, create_strict, deserialize_payload,
     get_with_version_and_modified, push_locks_prefix, serialize_payload, store_error, unix_now,
     update,
 };
@@ -23,7 +23,7 @@ pub struct PushAdmissionTicket {
     lease_ttl: Duration,
     attempt: usize,
     occupied_slots: usize,
-    backend_clock: Option<(i64, Instant)>,
+    backend_clock: BackendClock,
     path: Option<String>,
     etag: Option<UpdateVersion>,
     released: bool,
@@ -53,7 +53,7 @@ impl PushAdmissionTicket {
             lease_ttl,
             attempt: 0,
             occupied_slots: 0,
-            backend_clock: None,
+            backend_clock: BackendClock::default(),
             path: None,
             etag: None,
             released: false,
@@ -194,14 +194,9 @@ impl PushAdmissionTicket {
     }
 
     async fn backend_now(&mut self) -> Result<i64> {
-        if let Some((sample, sampled_at)) = self.backend_clock {
-            return Ok(sample.saturating_add(
-                i64::try_from(sampled_at.elapsed().as_secs()).unwrap_or(i64::MAX),
-            ));
-        }
-        let sample = backend_unix_time(&self.store, &Path::from(self.prefix.as_str())).await?;
-        self.backend_clock = Some((sample, Instant::now()));
-        Ok(sample)
+        self.backend_clock
+            .now(&self.store, &Path::from(self.prefix.as_str()))
+            .await
     }
 }
 

--- a/crates/crab-coordination/src/push_lock.rs
+++ b/crates/crab-coordination/src/push_lock.rs
@@ -1,7 +1,8 @@
 //! Storage-backed short-TTL lease for serializing repository mutations.
 
+use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use futures_util::StreamExt;
@@ -162,6 +163,106 @@ pub struct PushLock {
     released: bool,
 }
 
+#[derive(Default)]
+pub(crate) struct BackendClock {
+    sample: Option<(i64, Instant)>,
+}
+
+impl BackendClock {
+    pub(crate) async fn now(&mut self, store: &Arc<dyn ObjectStore>, anchor: &Path) -> Result<i64> {
+        // Backend time anchors lease age; monotonic elapsed avoids trusting the
+        // client's wall clock while a bounded acquisition owner is alive.
+        if let Some((sample, sampled_at)) = self.sample {
+            return Ok(sample.saturating_add(
+                i64::try_from(sampled_at.elapsed().as_secs()).unwrap_or(i64::MAX),
+            ));
+        }
+        let sample = backend_unix_time(store, anchor).await?;
+        self.sample = Some((sample, Instant::now()));
+        Ok(sample)
+    }
+}
+
+/// Reusable state for repeated lock acquisitions against one object store.
+///
+/// The context remembers paths that already exist and one backend clock
+/// sample. Reuse it only with the store supplied to [`Self::new`].
+pub struct PushLockAcquireContext {
+    store: Arc<dyn ObjectStore>,
+    known_paths: HashSet<String>,
+    backend_clock: BackendClock,
+}
+
+impl PushLockAcquireContext {
+    /// Creates an acquisition context scoped to one object store.
+    #[must_use]
+    pub fn new(store: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            store,
+            known_paths: HashSet::new(),
+            backend_clock: BackendClock::default(),
+        }
+    }
+
+    /// Acquires the lease protecting a full Git ref.
+    ///
+    /// Returns an error when the ref is invalid, another holder owns the
+    /// lease, or the object store cannot complete the conditional operation.
+    pub async fn acquire_ref(
+        &mut self,
+        prefix: &str,
+        ref_name: &str,
+        ttl: Duration,
+    ) -> Result<PushLock> {
+        let path = push_lock_path(prefix, ref_name)?;
+        self.acquire_path(ref_name, path, ttl).await
+    }
+
+    /// Acquires the lease protecting an internal repository resource.
+    ///
+    /// Returns an error when the resource is invalid, another holder owns the
+    /// lease, or the object store cannot complete the conditional operation.
+    pub async fn acquire_internal(
+        &mut self,
+        prefix: &str,
+        resource: &str,
+        ttl: Duration,
+    ) -> Result<PushLock> {
+        let path = internal_lock_path(prefix, resource)?;
+        self.acquire_path(resource, path, ttl).await
+    }
+
+    async fn acquire_path(
+        &mut self,
+        target: &str,
+        path: String,
+        ttl: Duration,
+    ) -> Result<PushLock> {
+        let holder = generate_holder_id();
+        let expires_at = unix_now() + ttl.as_secs();
+        let known_existing = !self.known_paths.insert(path.clone());
+        let etag = acquire_one(
+            &self.store,
+            &path,
+            target,
+            &holder,
+            expires_at,
+            ttl,
+            known_existing,
+            &mut self.backend_clock,
+        )
+        .await?;
+        Ok(PushLock {
+            store: Arc::clone(&self.store),
+            path,
+            ttl,
+            holder,
+            etag: Some(etag),
+            released: false,
+        })
+    }
+}
+
 impl PushLock {
     /// Acquires the lease protecting a full Git ref.
     pub async fn acquire_ref(
@@ -191,17 +292,9 @@ impl PushLock {
         path: String,
         ttl: Duration,
     ) -> Result<Self> {
-        let holder = generate_holder_id();
-        let expires_at = unix_now() + ttl.as_secs();
-        let etag = acquire_one(store, &path, target, &holder, expires_at, ttl).await?;
-        Ok(Self {
-            store: Arc::clone(store),
-            path,
-            ttl,
-            holder,
-            etag: Some(etag),
-            released: false,
-        })
+        PushLockAcquireContext::new(Arc::clone(store))
+            .acquire_path(target, path, ttl)
+            .await
     }
 
     /// Acquires the lease protecting a full Git ref with the default TTL.
@@ -332,31 +425,39 @@ async fn acquire_one(
     holder: &str,
     expires_at: u64,
     ttl: Duration,
+    known_existing: bool,
+    backend_clock: &mut BackendClock,
 ) -> Result<UpdateVersion> {
     let object_path = Path::from(path);
     let body = serialize_payload(
         path,
         &PushLockPayload::new(holder, expires_at, ttl.as_secs()),
     )?;
-    let etag = match create_strict(store, &object_path, body.clone()).await {
-        Ok(etag) => etag,
-        Err(object_store::Error::AlreadyExists { .. })
-        | Err(object_store::Error::Precondition { .. }) => {
-            match acquire_contended(store, &object_path, target, body).await? {
-                ContendedAcquire::Acquired(etag) => etag,
-                ContendedAcquire::Held {
+    let created = if known_existing {
+        None
+    } else {
+        match create_strict(store, &object_path, body.clone()).await {
+            Ok(etag) => Some(etag),
+            Err(object_store::Error::AlreadyExists { .. })
+            | Err(object_store::Error::Precondition { .. }) => None,
+            Err(source) => return Err(store_error(path, source)),
+        }
+    };
+    let etag = match created {
+        Some(etag) => etag,
+        None => match acquire_contended(store, &object_path, target, body, backend_clock).await? {
+            ContendedAcquire::Acquired(etag) => etag,
+            ContendedAcquire::Held {
+                holder,
+                expires_at_unix,
+            } => {
+                return Err(CoordinationError::PushLockHeld {
+                    ref_name: target.to_owned(),
                     holder,
                     expires_at_unix,
-                } => {
-                    return Err(CoordinationError::PushLockHeld {
-                        ref_name: target.to_owned(),
-                        holder,
-                        expires_at_unix,
-                    });
-                }
+                });
             }
-        }
-        Err(source) => return Err(store_error(path, source)),
+        },
     };
     debug!(lock_path = %path, holder, ttl_secs = ttl.as_secs(), "push lock acquired");
     Ok(etag)
@@ -438,6 +539,7 @@ async fn acquire_contended(
     object_path: &Path,
     ref_name: &str,
     body: Bytes,
+    backend_clock: &mut BackendClock,
 ) -> Result<ContendedAcquire> {
     let (existing_body, reclaim_etag, last_modified) =
         match get_with_version_and_modified(store, object_path).await {
@@ -470,7 +572,7 @@ async fn acquire_contended(
         }
     };
     if !existing.is_released() {
-        let now = backend_unix_time(store, object_path).await?;
+        let now = backend_clock.now(store, object_path).await?;
         if !lease_expired(&existing, last_modified, now) {
             let expires_at_unix = authoritative_expiry(&existing, last_modified);
             return Ok(ContendedAcquire::Held {
@@ -697,12 +799,90 @@ pub fn unix_now() -> u64 {
 mod tests {
     use super::*;
     use futures_util::StreamExt;
+    use futures_util::stream::BoxStream;
     use object_store::memory::InMemory;
+    use object_store::{
+        CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+        PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    };
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     fn memory_store() -> Arc<dyn ObjectStore> {
         Arc::new(InMemory::new())
+    }
+
+    #[derive(Debug)]
+    struct RequestCountingStore {
+        inner: Arc<InMemory>,
+        requests: Arc<AtomicUsize>,
+    }
+
+    impl std::fmt::Display for RequestCountingStore {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("request-counting-store")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for RequestCountingStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            options: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.requests.fetch_add(1, Ordering::Relaxed);
+            self.inner.put_opts(location, payload, options).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            options: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            self.requests.fetch_add(1, Ordering::Relaxed);
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, object_store::Result<Path>>,
+        ) -> BoxStream<'static, object_store::Result<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&Path>,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
     }
 
     #[tokio::test]
@@ -827,6 +1007,42 @@ mod tests {
             contender,
             Err(CoordinationError::PushLockHeld { holder, .. }) if holder == "live-holder"
         ));
+    }
+
+    #[tokio::test]
+    async fn repeated_contender_reuses_existing_path_and_backend_clock() {
+        let inner = Arc::new(InMemory::new());
+        let setup_store: Arc<dyn ObjectStore> = inner.clone();
+        let blocker = PushLock::acquire_ref_default(&setup_store, "org/repo", "refs/heads/main")
+            .await
+            .unwrap();
+        let lock_path = Path::from(blocker.path());
+        let requests = Arc::new(AtomicUsize::new(0));
+        let metered_store: Arc<dyn ObjectStore> = Arc::new(RequestCountingStore {
+            inner,
+            requests: Arc::clone(&requests),
+        });
+        let mut context = PushLockAcquireContext::new(metered_store);
+
+        for _ in 0..2 {
+            assert!(matches!(
+                context
+                    .acquire_ref("org/repo", "refs/heads/main", Duration::from_secs(60),)
+                    .await,
+                Err(CoordinationError::PushLockHeld { .. })
+            ));
+        }
+
+        assert_eq!(requests.load(Ordering::Relaxed), 5);
+        blocker.release().await.unwrap();
+        setup_store.delete(&lock_path).await.unwrap();
+        context
+            .acquire_ref("org/repo", "refs/heads/main", Duration::from_secs(60))
+            .await
+            .expect("known path may disappear between attempts")
+            .release()
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/crab-metadata/src/git_object_locator/reader.rs
+++ b/crates/crab-metadata/src/git_object_locator/reader.rs
@@ -6,6 +6,7 @@ use futures_util::stream::{self, StreamExt, TryStreamExt};
 use object_store::ObjectStore;
 use object_store::path::Path as ObjectPath;
 use slatedb::config::{DbReaderOptions, ScanOptions};
+use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
 
 use super::format::{
     METADATA_KEY, OBJECT_FAMILY, PACK_FAMILY, decode_metadata, decode_object_key,
@@ -26,6 +27,11 @@ const MIN_SCAN_LOOKUP_OBJECTS: usize = LOOKUP_CONCURRENCY;
 const MAX_SCAN_AMPLIFICATION: usize = 2;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
 const SCAN_FETCH_TASKS: usize = 4;
+// One cache is private to one short-lived reader process. This keeps 32
+// concurrent fetchers at a 512 MiB aggregate ceiling instead of SlateDB's
+// 20 GiB default while still coalescing repeated SST metadata/block reads.
+const SESSION_CACHE_BYTES: u64 = 16 * 1024 * 1024;
+const SESSION_CACHE_SHARDS: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LookupStrategy {
@@ -119,9 +125,10 @@ impl GitObjectLocatorSession {
             builder = builder.with_checkpoint_id(checkpoint.id);
         }
         let reader = match builder
-            // Push sessions are short-lived and query each candidate once. The
-            // default 640 MiB cache multiplies RSS across concurrent pushes.
-            .with_db_cache_disabled()
+            .with_db_cache(Arc::new(FoyerCache::new_with_opts(FoyerCacheOptions {
+                max_capacity: SESSION_CACHE_BYTES,
+                shards: SESSION_CACHE_SHARDS,
+            })))
             .build()
             .await
         {
@@ -512,9 +519,14 @@ async fn close_after_error<T>(
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use futures_util::stream::BoxStream;
     use object_store::memory::InMemory;
-    use object_store::{ObjectStore, ObjectStoreExt};
+    use object_store::{
+        CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+        ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    };
 
     use super::*;
     use crate::git_object_locator::{
@@ -526,6 +538,77 @@ mod tests {
         oid: [u8; 20],
         pack: GitPackLocatorRecord,
         inventory: GitPackInventoryEntry,
+    }
+
+    #[derive(Debug)]
+    struct ReadCountingStore {
+        inner: Arc<InMemory>,
+        reads: AtomicUsize,
+    }
+
+    impl std::fmt::Display for ReadCountingStore {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("read-counting-store")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for ReadCountingStore {
+        async fn put_opts(
+            &self,
+            location: &ObjectPath,
+            payload: PutPayload,
+            options: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, options).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjectPath,
+            options: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &ObjectPath,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, object_store::Result<ObjectPath>>,
+        ) -> BoxStream<'static, object_store::Result<ObjectPath>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&ObjectPath>,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjectPath>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &ObjectPath,
+            to: &ObjectPath,
+            options: CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
     }
 
     fn hash(seed: u64) -> MerkleHash {
@@ -778,6 +861,44 @@ mod tests {
                 GitObjectLookup::Miss
             ]
         ));
+        session.close().await.expect("close reader");
+    }
+
+    #[tokio::test]
+    async fn exact_batch_coalesces_shared_sst_reads() {
+        let inner = Arc::new(InMemory::new());
+        let writer_store: Arc<dyn ObjectStore> = inner.clone();
+        let (object_ids, inventory) = publish_many(writer_store, 64).await;
+        let store = Arc::new(ReadCountingStore {
+            inner,
+            reads: AtomicUsize::new(0),
+        });
+        let reader_store: Arc<dyn ObjectStore> = store.clone();
+        let session = GitObjectLocatorSession::open(reader_store, "org/repo")
+            .await
+            .expect("open reader");
+        store.reads.store(0, Ordering::Relaxed);
+
+        let lookups = session
+            .lookup_batch(&object_ids, &inventory)
+            .await
+            .expect("exact batch");
+        let first_batch_reads = store.reads.load(Ordering::Relaxed);
+        assert!(
+            first_batch_reads < object_ids.len(),
+            "shared SST reads were not coalesced: {first_batch_reads} reads"
+        );
+        assert!(
+            lookups
+                .iter()
+                .all(|lookup| matches!(lookup, GitObjectLookup::Hit(_)))
+        );
+
+        session
+            .lookup_batch(&object_ids, &inventory)
+            .await
+            .expect("cached exact batch");
+        assert_eq!(store.reads.load(Ordering::Relaxed), first_batch_reads);
         session.close().await.expect("close reader");
     }
 


### PR DESCRIPTION
## Summary

- give each short-lived locator reader a bounded 16 MiB SlateDB cache that coalesces concurrent SST metadata and block fetches
- reuse known lock paths and one backend-authored clock sample across a bounded acquisition loop
- preserve one-shot lock APIs, CAS/holder checks, expiry recovery, cancellation, and per-ref serialization
- share the backend clock owner with the existing five-slot push-admission path
- add provider-request regressions and document measured RustFS request cost

## Concurrent RustFS evidence

All profiles used same-ref integration, exact protocol-v2 clone verification, byte comparison, and strict Git fsck.

### 32 writers

Uncached baseline -> locator cache -> lock acquisition context:

- total HTTP attempts: 25,211 -> 12,722 -> 11,117
- attempts per successful push: 787.84 -> 397.56 -> 347.41
- locator attempts: 17,065 -> 3,806 -> 3,901 (the final difference is compaction scheduling noise)
- ref-lock attempts: 2,556 -> 947 after the lock context (-62.9%)
- provider 5xx responses: 1,040 -> 0 -> 0
- final clone: 3,292 ms -> 1,799 ms -> 1,790 ms

The lock-context run integrated 32/32 commits. Eight pushes retried once after same-ref contention; none exceeded one retry.

### 4 writers

Locator-cache baseline -> lock acquisition context:

- total HTTP attempts: 1,275 -> 1,076 (-15.6%)
- ref-lock attempts: 80 -> 34 (-57.5%)
- maximum push duration: 8,847 ms -> 5,899 ms
- retries: 0 -> 0

Request counts are workload-specific RustFS measurements, not provider bills.

## Proof

- cargo fmt --all and git diff --check
- cargo test -p crab-metadata --features remote-index,storage --locked (196 passed)
- cargo clippy -p crab-metadata --features remote-index,storage --lib --locked -- -D warnings
- cargo test -p crab-coordination --features object-store-lock --locked (77 passed)
- cargo clippy -p crab-coordination --features object-store-lock --all-targets --locked -- -D warnings
- cargo check -p crab-coordination --no-default-features --locked
- cargo check -p crab --locked
- focused Crab lock acquisition tests (4 passed)
- 4-writer and 32-writer live RustFS qualification, including exact clone and fsck

Broad Crab Clippy currently reaches five pre-existing Rust 1.97 lints in crab-vfs; the changed coordination crate is warning-free.

## Remaining gaps

- qualify request/error behavior and budgets on S3, GCS, and Azure
- measure locator-cache RSS/hit curves on large real repositories
- add direct stage attribution for transient retries
- translate request counts into provider-specific bills only with current regional pricing and transfer assumptions
- prefer per-agent branches plus a merge queue when a team would otherwise serialize a large swarm onto one ref

No configuration surface or serialized storage contract changes.