### PR TITLE
fix(ci): avoid macOS FUSE dependency in native gate

### DIFF
--- a/.github/workflows/workflow-native.yml
+++ b/.github/workflows/workflow-native.yml
@@ -37,7 +37,7 @@ jobs:
         run: cargo test -p crab-workflow --locked
 
       - name: Run CLI migration contract tests
-        run: cargo test -p crab --test workflow_migration --locked
+        run: cargo test -p crab --test workflow_migration --no-default-features --features simd-accel,tier,watch --locked
 
       - name: Build release CLI on Windows feature contract
         if: runner.os == 'Windows'
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build release CLI on Unix
         if: runner.os != 'Windows'
-        run: cargo build -p crab --release --locked
+        run: cargo build -p crab --release --locked --no-default-features --features simd-accel,tier,watch
 
       - name: Smoke the native Windows release binary
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
- run the workflow migration contract on the minimal non-FUSE CLI feature set
- build the Unix native workflow smoke binary without the unavailable macOS FUSE dependency

This follows up on merged PR #39, whose macOS Workflow Native job failed because fuser requires fuse.pc on the hosted macOS image.

## Validation
- cargo test -p crab --test workflow_migration --no-default-features --features simd-accel,tier,watch --locked
- cargo build -p crab --release --no-default-features --features simd-accel,tier,watch --locked
- actionlint