### PR TITLE
fix: harden concurrent Git push publication

### DIFF
--- a/crab/docs/architecture/git-integration.md
+++ b/crab/docs/architecture/git-integration.md
@@ -48,7 +48,11 @@ git ↔ helper:  protocol-v2 pkt-lines over the same stdio
 
 The helper performs the temporary upload-pack role locally. It does not start
 a listener or require a Crab service. Repositories without a current locator
-and visibility proof remain on the legacy complete-pack path.
+and visibility proof remain on the legacy complete-pack path. That legacy path
+downloads and installs the immutable packs named by the manifest, then lets
+local Git satisfy the fetch; it is retained for older Git clients, repositories
+above the synchronous 100,000-object proof profile, and recovery while derived
+proof coverage is unavailable.
 
 Source: `crab/src/git/remote_helper.rs`
 
@@ -216,18 +220,20 @@ Phase 3: UPLOAD (steps 7-10)
   10. Upload bounded Git pack set (.pack + .idx + .meta per pack)
 
 Phase 4: COMMIT (steps 11-14)
-  11. Upload immutable segmented indexes, then CAS the unified manifest
-  12. Publish the generation's locators through one renewed SlateDB writer lease
+  11. Publish ref-scoped visibility evidence, then commit the ref journal marker
+  12. One owner compacts the journal and publishes generation proof + locators
   13. Post-success cleanup (staging → cache, shard install)
   14. On failure before CAS: refs and manifest remain unchanged
 ```
 
 ### Critical Ordering Invariant
 
-Steps 7-10 (immutable data uploads) must complete before steps 11-12
-(mutable manifest/ref updates). This ensures the fail-forward property:
-an interrupted push may leave orphaned immutable data (cleaned by GC) but
-never creates dangling references.
+Steps 7-10 (immutable data uploads) and the supported-profile visibility
+evidence must complete before the ref marker in step 11. This ensures the
+fail-forward property: an interrupted push may leave orphaned immutable data
+(cleaned by GC) but never creates dangling or proofless supported-profile
+references. Protected/service paths apply the same rule to the candidate
+generation proof before manifest or coordinator commit.
 
 Source: `crab/src/git/push.rs`, `crab/src/git/push_manifest.rs`,
 `crates/crab-git/src/push_state.rs`

--- a/crab/docs/architecture/git-integration.md
+++ b/crab/docs/architecture/git-integration.md
@@ -233,7 +233,14 @@ evidence must complete before the ref marker in step 11. This ensures the
 fail-forward property: an interrupted push may leave orphaned immutable data
 (cleaned by GC) but never creates dangling or proofless supported-profile
 references. Protected/service paths apply the same rule to the candidate
-generation proof before manifest or coordinator commit.
+generation proof before manifest or coordinator commit. Protected receive
+builds that proof from its existing verified materialization workspace, so the
+commit boundary does not download the candidate pack inventory a second time.
+
+Current proof keys use the manifest Git-validation digest. Crab 1.0.15's
+generation-and-pack-index key remains readable and GC-rooted only as a shipped
+data migration; the next write or explicit metadata repair backfills the
+digest-bound proof.
 
 Source: `crab/src/git/push.rs`, `crab/src/git/push_manifest.rs`,
 `crates/crab-git/src/push_state.rs`

--- a/crab/docs/architecture/git-protocol-v2.md
+++ b/crab/docs/architecture/git-protocol-v2.md
@@ -75,9 +75,13 @@ Failures detected before the `packfile` response section use Git's terminal
 keeps request rejections distinguishable from truncated pack generation.
 
 Every requested OID is admitted from the immutable visibility proof before the
-remote reader obtains object bytes. The proof and locator are tied to the same
-manifest generation and pack-index hash. Invalid or missing proof suppresses
-v2 advertisement; it never triggers a silent complete filtered fetch.
+remote reader obtains object bytes. Current proofs are keyed by and carry the
+manifest Git-validation digest, which binds generation, pack inventory, HEAD,
+refs, and peeled refs. Invalid or missing proof suppresses v2 advertisement; it
+never triggers a silent complete filtered fetch. Crab 1.0.15 proofs keyed only
+by generation and pack-index hash remain an explicit read migration: write and
+repair owners backfill the digest-bound key, and GC retains both roots while
+that tagged-data migration is supported.
 
 Each direct ref update uploads content-addressed visibility evidence before its
 journal marker becomes visible. Fast-forward and ordinary updates encode only
@@ -126,10 +130,13 @@ can request one of the supported filter forms directly.
 ## Operations and repair
 
 Direct pushes and protected/service publication paths publish visibility
-before the corresponding ref or manifest commit. If a supported current
-generation predates that ordering or loses derived coverage, upload-pack can
-rebuild the proof from generation-pinned locator data before advertising v2.
-The repair reads commit, tree, and tag objects once; blob IDs come from verified
+before the corresponding ref or manifest commit. Protected receive extracts
+the closure from the already-verified materialization ODB before that workspace
+is released; it does not download the candidate packs again to build proof. If
+a supported current generation predates that ordering or loses derived
+coverage, upload-pack can rebuild the proof from generation-pinned locator data
+before advertising v2. The repair reads commit, tree, and tag objects once;
+blob IDs come from verified
 tree entries, so blob bodies are not downloaded. Repack, history recovery, and
 `crab metadb rebuild` also rebuild visibility. `crab doctor --metadb` reports
 locator and visibility coverage separately. `crab fsck --store` checks current

--- a/crab/docs/architecture/git-protocol-v2.md
+++ b/crab/docs/architecture/git-protocol-v2.md
@@ -86,6 +86,10 @@ cannot read the prior local closure publishes a complete replacement. The
 single journal-compaction owner applies the ordered evidence and uploads the
 generation proof before advancing the compacted manifest. Concurrent writers
 therefore do not need one another's pack bodies or local Git object databases.
+Transient evidence or proof publication failures abort before the ref becomes
+visible. Repositories whose conservative per-ref proof bound exceeds the
+synchronous 100,000-entry profile explicitly remain on complete-pack fetch
+instead of turning a proof failure into a successful push.
 The RustFS concurrency qualification follows each independent-ref and hot-ref
 write swarm with fresh protocol-v2 clones, strict Git fsck, and byte checks so
 ref visibility alone cannot satisfy the gate.
@@ -121,10 +125,14 @@ can request one of the supported filter forms directly.
 
 ## Operations and repair
 
-Direct pushes and protected/service publication paths rebuild the visibility
-proof for each committed generation. Repack, history recovery, and
-`crab metadb rebuild` do the same. `crab doctor --metadb` reports locator and
-visibility coverage separately. `crab fsck --store` checks current and
-historical proof roots; `crab fsck --store --repair` verifies the historical
+Direct pushes and protected/service publication paths publish visibility
+before the corresponding ref or manifest commit. If a supported current
+generation predates that ordering or loses derived coverage, upload-pack can
+rebuild the proof from generation-pinned locator data before advertising v2.
+The repair reads commit, tree, and tag objects once; blob IDs come from verified
+tree entries, so blob bodies are not downloaded. Repack, history recovery, and
+`crab metadb rebuild` also rebuild visibility. `crab doctor --metadb` reports
+locator and visibility coverage separately. `crab fsck --store` checks current
+and historical proof roots; `crab fsck --store --repair` verifies the historical
 pack closure and idempotently backfills missing roots. Until repair completes,
 v2 stays disabled for that repository.

--- a/crab/docs/design/push.md
+++ b/crab/docs/design/push.md
@@ -1174,6 +1174,10 @@ retryable `transient` outcome and runs the normal holder-checked release path;
 the ref remains invisible. If the immutable marker was stored but its success
 response was lost, the exact-byte create retry observes the existing marker
 and reconciles the write as success instead of reporting an ambiguous push.
+The Git-facing rejection tag remains `transient`. The local push audit adds a
+stable `failure_stage` such as `lock`, `xorb-upload`, `git-pack-upload`, or
+`ref-commit`, allowing qualification reports to attribute retries without
+parsing backend messages or changing the remote-helper protocol.
 
 ### Heartbeat
 

--- a/crab/docs/design/push.md
+++ b/crab/docs/design/push.md
@@ -1178,6 +1178,10 @@ The Git-facing rejection tag remains `transient`. The local push audit adds a
 stable `failure_stage` such as `lock`, `xorb-upload`, `git-pack-upload`, or
 `ref-commit`, allowing qualification reports to attribute retries without
 parsing backend messages or changing the remote-helper protocol.
+Retryable failures before pipeline delegation use `store-resolve` or
+`discovery` and enter the same structured command-level retry path. Legacy
+protected-push prepare failures remain terminal because that endpoint has no
+idempotency contract.
 
 ### Heartbeat
 

--- a/crab/docs/guides/local-dev-rustfs.md
+++ b/crab/docs/guides/local-dev-rustfs.md
@@ -223,6 +223,10 @@ retries and LIST pages. It groups requests by method, inferred S3 operation,
 and bounded Crab storage-layout class without retaining object keys or
 credentials. The snapshots bracket only the push commands, so the subsequent
 clone, strict fsck, and AWS CLI inventory reads do not inflate push cost.
+Each push record also contains `failure_stages`, counted from only the audit
+events appended by that command. These stable stage names retain lock or
+transient failures that an integration retry later hides behind a successful
+terminal result, without depending on provider-specific error text.
 
 The request trace is suitable for applying a provider's current request rates;
 it is not itself a bill. Provider free tiers, minimum billable object sizes,

--- a/crab/docs/guides/local-dev-rustfs.md
+++ b/crab/docs/guides/local-dev-rustfs.md
@@ -226,7 +226,9 @@ clone, strict fsck, and AWS CLI inventory reads do not inflate push cost.
 Each push record also contains `failure_stages`, counted from only the audit
 events appended by that command. These stable stage names retain lock or
 transient failures that an integration retry later hides behind a successful
-terminal result, without depending on provider-specific error text.
+terminal result, without depending on provider-specific error text. The
+terminal JSON `integration_retry_stages` map must account for the same retries
+without requiring audit-file access.
 
 The request trace is suitable for applying a provider's current request rates;
 it is not itself a bill. Provider free tiers, minimum billable object sizes,

--- a/crab/docs/guides/structured-output.md
+++ b/crab/docs/guides/structured-output.md
@@ -252,6 +252,9 @@ These commands accept both flags. `--json` emits only the terminal result;
 `crab push --rebase-on-non-fast-forward` result payloads include
 `integration_retries` and `integration_retry_limit` so agent orchestrators can
 distinguish a first-attempt conflict from an exhausted integration retry budget.
+When retries occur, `integration_retry_stages` groups them by bounded stage
+name, such as `preflight`, `lock`, `xorb-upload`, or `ref-commit`; its counts
+sum to `integration_retries`.
 Per-ref push outcomes also include `retryable` and `retry_after_secs` when Crab
 can classify the rejection. If Crab's automatic rebase cannot integrate the
 agent's commit, the ref status is `integration-failed` with `retryable: false`.

--- a/crab/schemas/push.json
+++ b/crab/schemas/push.json
@@ -1,96 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "PushSummaryPayload",
-  "description": "Summary payload for `--json` / `--jsonl` result events.",
-  "type": "object",
-  "required": [
-    "duration_ms",
-    "refs",
-    "refs_pushed",
-    "remote_url"
-  ],
-  "properties": {
-    "commit_state": {
-      "description": "Coordinator transaction state for active-active push.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "coordinator_epoch": {
-      "description": "Coordinator epoch that accepted the push.",
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
-    },
-    "duration_ms": {
-      "description": "Wall-clock duration of the operation in milliseconds.",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
-    "integration_retries": {
-      "description": "Command-layer integration retries consumed before this terminal result.",
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint32",
-      "minimum": 0.0
-    },
-    "integration_retry_limit": {
-      "description": "Configured retry budget for agent integration mode.",
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint32",
-      "minimum": 0.0
-    },
-    "operation_id": {
-      "description": "Active-active operation id when the push is coordinator-backed.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "refs": {
-      "description": "Per-ref outcomes.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PushRefOutcome"
-      }
-    },
-    "refs_pushed": {
-      "description": "Number of refs pushed.",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
-    "remote_url": {
-      "description": "Remote URL that was pushed to.",
-      "type": "string"
-    },
-    "writer_region": {
-      "description": "Writer region used by active-active push ingress.",
-      "type": [
-        "string",
-        "null"
-      ]
-    }
-  },
   "definitions": {
     "PushRefOutcome": {
       "description": "Serializable per-ref outcome for structured output.",
-      "type": "object",
-      "required": [
-        "dst",
-        "src",
-        "status"
-      ],
       "properties": {
         "dst": {
           "description": "Destination refspec.",
@@ -105,12 +17,12 @@
         },
         "retry_after_secs": {
           "description": "Suggested delay before retrying, in seconds.",
+          "format": "uint64",
+          "minimum": 0.0,
           "type": [
             "integer",
             "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          ]
         },
         "retryable": {
           "description": "Whether retrying can reasonably succeed without user edits.",
@@ -127,7 +39,107 @@
           "description": "`\"ok\"` or `\"error\"`.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "dst",
+        "src",
+        "status"
+      ],
+      "type": "object"
     }
-  }
+  },
+  "description": "Summary payload for `--json` / `--jsonl` result events.",
+  "properties": {
+    "commit_state": {
+      "description": "Coordinator transaction state for active-active push.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "coordinator_epoch": {
+      "description": "Coordinator epoch that accepted the push.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "duration_ms": {
+      "description": "Wall-clock duration of the operation in milliseconds.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "integration_retries": {
+      "description": "Command-layer integration retries consumed before this terminal result.",
+      "format": "uint32",
+      "minimum": 0.0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "integration_retry_limit": {
+      "description": "Configured retry budget for agent integration mode.",
+      "format": "uint32",
+      "minimum": 0.0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "integration_retry_stages": {
+      "additionalProperties": {
+        "format": "uint32",
+        "minimum": 0.0,
+        "type": "integer"
+      },
+      "description": "Retried attempts grouped by stable push failure stage.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "operation_id": {
+      "description": "Active-active operation id when the push is coordinator-backed.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "refs": {
+      "description": "Per-ref outcomes.",
+      "items": {
+        "$ref": "#/definitions/PushRefOutcome"
+      },
+      "type": "array"
+    },
+    "refs_pushed": {
+      "description": "Number of refs pushed.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "remote_url": {
+      "description": "Remote URL that was pushed to.",
+      "type": "string"
+    },
+    "writer_region": {
+      "description": "Writer region used by active-active push ingress.",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "duration_ms",
+    "refs",
+    "refs_pushed",
+    "remote_url"
+  ],
+  "title": "PushSummaryPayload",
+  "type": "object"
 }

--- a/crab/scripts/e2e/run_concurrent_push_smoke.py
+++ b/crab/scripts/e2e/run_concurrent_push_smoke.py
@@ -470,6 +470,7 @@ class PushRecord:
     retry_after_secs: int | None = None
     integration_retries: int | None = None
     integration_retry_limit: int | None = None
+    integration_retry_stages: dict[str, int] = field(default_factory=dict)
     failure_stages: dict[str, int] = field(default_factory=dict)
 
 
@@ -568,6 +569,18 @@ def first_json_object(text: str, schema: str) -> dict[str, Any] | None:
     return None
 
 
+def parse_stage_counts(value: object) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    return dict(
+        sorted(
+            (str(stage), count)
+            for stage, count in value.items()
+            if isinstance(count, int) and not isinstance(count, bool) and count >= 0
+        )
+    )
+
+
 def push_failure_stages(audit_path: Path, start_offset: int) -> dict[str, int]:
     """Count attributed push failures appended after ``start_offset``."""
     if not audit_path.is_file():
@@ -618,7 +631,7 @@ class ConcurrentPushSmoke:
         self.store_inventory: dict[str, int] = {}
         self.report = SmokeReport(
             schema="crab.concurrent-push-smoke",
-            version="1.7",
+            version="1.8",
             run_id=self.run_id,
             status="running",
             remote_url=self.remote_url,
@@ -1569,15 +1582,33 @@ class ConcurrentPushSmoke:
             clone["protocol_v2"] and actual == content,
             {"protocol_v2": clone["protocol_v2"], "content_visible": actual == content},
         )
+        expected_failure_attempts = 1
+        retry_telemetry_ok = (
+            failed.integration_retries is None
+            and failed.integration_retry_limit is None
+            and not failed.integration_retry_stages
+        )
+        if self.args.rebase_on_non_fast_forward:
+            expected_failure_attempts += self.args.rebase_retry_limit
+            retry_telemetry_ok = (
+                failed.integration_retries == self.args.rebase_retry_limit
+                and failed.integration_retry_limit == self.args.rebase_retry_limit
+                and failed.integration_retry_stages
+                == {"ref-commit": self.args.rebase_retry_limit}
+            )
         self.check(
             "marker-write-failure-is-structured-retryable",
             failed.status == "transient"
             and failed.retryable is True
-            and failed.failure_stages == {"ref-commit": 1},
+            and failed.failure_stages == {"ref-commit": expected_failure_attempts}
+            and retry_telemetry_ok,
             {
                 "status": failed.status,
                 "retryable": failed.retryable,
                 "failure_stages": failed.failure_stages,
+                "integration_retries": failed.integration_retries,
+                "integration_retry_limit": failed.integration_retry_limit,
+                "integration_retry_stages": failed.integration_retry_stages,
             },
         )
         self.request_snapshot(
@@ -1758,9 +1789,13 @@ class ConcurrentPushSmoke:
         retry_after_secs = None
         integration_retries = None
         integration_retry_limit = None
+        integration_retry_stages: dict[str, int] = {}
         if payload and payload.get("data"):
             integration_retries = payload["data"].get("integration_retries")
             integration_retry_limit = payload["data"].get("integration_retry_limit")
+            integration_retry_stages = parse_stage_counts(
+                payload["data"].get("integration_retry_stages")
+            )
             refs = payload["data"].get("refs") or []
             if refs:
                 status = str(refs[0].get("status"))
@@ -1777,6 +1812,7 @@ class ConcurrentPushSmoke:
             retry_after_secs,
             integration_retries,
             integration_retry_limit,
+            integration_retry_stages,
             push_failure_stages(audit_path, audit_offset),
         )
 
@@ -1862,6 +1898,8 @@ class ConcurrentPushSmoke:
             telemetry_ok = all(
                 result.integration_retries is not None
                 and result.integration_retry_limit == self.args.rebase_retry_limit
+                and sum(result.integration_retry_stages.values())
+                == result.integration_retries
                 for result in results
             )
             self.check(
@@ -1873,6 +1911,19 @@ class ConcurrentPushSmoke:
                     "statuses": sorted({r.status for r in results}),
                     "telemetry_ok": telemetry_ok,
                     "max_integration_retries": max(retry_counts) if retry_counts else None,
+                    "integration_retry_stages": {
+                        stage: sum(
+                            result.integration_retry_stages.get(stage, 0)
+                            for result in results
+                        )
+                        for stage in sorted(
+                            {
+                                stage
+                                for result in results
+                                for stage in result.integration_retry_stages
+                            }
+                        )
+                    },
                     "retry_limit": self.args.rebase_retry_limit,
                     "bad_statuses": [asdict(result) for result in bad],
                 },

--- a/crab/scripts/e2e/run_concurrent_push_smoke.py
+++ b/crab/scripts/e2e/run_concurrent_push_smoke.py
@@ -18,7 +18,9 @@ two AI-agent push cases:
 
 The retained report is written atomically across worker threads and includes
 per-phase S3 HTTP attempts plus RustFS object-count and stored-byte deltas for
-cost analysis.
+cost analysis. Each push record also retains stable failure-stage counts from
+the command's local audit slice, including failed attempts hidden by a later
+successful integration retry.
 """
 
 from __future__ import annotations
@@ -468,6 +470,7 @@ class PushRecord:
     retry_after_secs: int | None = None
     integration_retries: int | None = None
     integration_retry_limit: int | None = None
+    failure_stages: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -565,6 +568,26 @@ def first_json_object(text: str, schema: str) -> dict[str, Any] | None:
     return None
 
 
+def push_failure_stages(audit_path: Path, start_offset: int) -> dict[str, int]:
+    """Count attributed push failures appended after ``start_offset``."""
+    if not audit_path.is_file():
+        return {}
+    counts: dict[str, int] = {}
+    with audit_path.open("rb") as audit:
+        audit.seek(start_offset)
+        for raw_line in audit:
+            try:
+                event = json.loads(raw_line)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            if event.get("operation") != "push" or event.get("outcome") != "failure":
+                continue
+            stage = event.get("details", {}).get("failure_stage")
+            if isinstance(stage, str):
+                counts[stage] = counts.get(stage, 0) + 1
+    return dict(sorted(counts.items()))
+
+
 class ConcurrentPushSmoke:
     def __init__(self, args: argparse.Namespace) -> None:
         self.args = args
@@ -595,7 +618,7 @@ class ConcurrentPushSmoke:
         self.store_inventory: dict[str, int] = {}
         self.report = SmokeReport(
             schema="crab.concurrent-push-smoke",
-            version="1.6",
+            version="1.7",
             run_id=self.run_id,
             status="running",
             remote_url=self.remote_url,
@@ -1548,8 +1571,14 @@ class ConcurrentPushSmoke:
         )
         self.check(
             "marker-write-failure-is-structured-retryable",
-            failed.status == "transient" and failed.retryable is True,
-            {"status": failed.status, "retryable": failed.retryable},
+            failed.status == "transient"
+            and failed.retryable is True
+            and failed.failure_stages == {"ref-commit": 1},
+            {
+                "status": failed.status,
+                "retryable": failed.retryable,
+                "failure_stages": failed.failure_stages,
+            },
         )
         self.request_snapshot(
             "marker-write-failure",
@@ -1615,11 +1644,13 @@ class ConcurrentPushSmoke:
             fault_reached
             and pushed.command.exit_code == 0
             and pushed.status == "ok"
+            and not pushed.failure_stages
             and f"{tip}\t{remote_ref}" in advertised_lines,
             {
                 "fault_reached": fault_reached,
                 "status": pushed.status,
                 "exit_code": pushed.command.exit_code,
+                "failure_stages": pushed.failure_stages,
                 "ref_visible": f"{tip}\t{remote_ref}" in advertised_lines,
             },
         )
@@ -1712,6 +1743,8 @@ class ConcurrentPushSmoke:
         refspec: str,
         lock_wait_secs: int | None = None,
     ) -> PushRecord:
+        audit_path = repo / ".crab" / "audit" / "events.jsonl"
+        audit_offset = audit_path.stat().st_size if audit_path.is_file() else 0
         record = self.run_cmd(
             f"{agent} crab push",
             self.push_args(refspec, lock_wait_secs),
@@ -1744,6 +1777,7 @@ class ConcurrentPushSmoke:
             retry_after_secs,
             integration_retries,
             integration_retry_limit,
+            push_failure_stages(audit_path, audit_offset),
         )
 
     def push_concurrently(self, jobs: list[tuple[str, str, Path, str]]) -> list[PushRecord]:

--- a/crab/scripts/e2e/test_run_concurrent_push_smoke.py
+++ b/crab/scripts/e2e/test_run_concurrent_push_smoke.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import json
 import sys
+import tempfile
 import threading
 import time
 import unittest
@@ -17,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from run_concurrent_push_smoke import (
     RequestCountingProxy,
     locator_requests_per_success,
+    push_failure_stages,
     store_category,
 )
 
@@ -40,6 +43,49 @@ class LocatorRequestBudgetTest(unittest.TestCase):
                 {"successful_pushes": 0, "categories": {"git_locator_db/wal": 1}}
             )
         )
+
+
+class PushFailureStagesTest(unittest.TestCase):
+    def test_counts_only_attributed_failures_from_current_command_slice(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.jsonl"
+            previous = {
+                "operation": "push",
+                "outcome": "failure",
+                "details": {"failure_stage": "lock"},
+            }
+            path.write_text(json.dumps(previous) + "\n", encoding="utf-8")
+            offset = path.stat().st_size
+            events = [
+                {
+                    "operation": "push",
+                    "outcome": "failure",
+                    "details": {"failure_stage": "ref-commit"},
+                },
+                {
+                    "operation": "push",
+                    "outcome": "failure",
+                    "details": {"failure_stage": "ref-commit"},
+                },
+                {
+                    "operation": "push",
+                    "outcome": "success",
+                    "details": {},
+                },
+                {
+                    "operation": "fetch",
+                    "outcome": "failure",
+                    "details": {"failure_stage": "remote-state"},
+                },
+            ]
+            with path.open("a", encoding="utf-8") as audit:
+                for event in events:
+                    audit.write(json.dumps(event) + "\n")
+
+            self.assertEqual(
+                push_failure_stages(path, offset),
+                {"ref-commit": 2},
+            )
 
 
 class UpstreamHandler(BaseHTTPRequestHandler):

--- a/crab/scripts/e2e/test_run_concurrent_push_smoke.py
+++ b/crab/scripts/e2e/test_run_concurrent_push_smoke.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from run_concurrent_push_smoke import (
     RequestCountingProxy,
     locator_requests_per_success,
+    parse_stage_counts,
     push_failure_stages,
     store_category,
 )
@@ -46,6 +47,14 @@ class LocatorRequestBudgetTest(unittest.TestCase):
 
 
 class PushFailureStagesTest(unittest.TestCase):
+    def test_parses_only_nonnegative_integer_stage_counts(self) -> None:
+        self.assertEqual(
+            parse_stage_counts(
+                {"ref-commit": 2, "lock": 1, "bad": -1, "bool": True}
+            ),
+            {"lock": 1, "ref-commit": 2},
+        )
+
     def test_counts_only_attributed_failures_from_current_command_slice(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "events.jsonl"

--- a/crab/src/cmd/fsck_store.rs
+++ b/crab/src/cmd/fsck_store.rs
@@ -287,6 +287,7 @@ impl StoreChecker {
             &storage_router,
             manifest.generation,
             &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
         )
         .await
         {

--- a/crab/src/cmd/gc/mod.rs
+++ b/crab/src/cmd/gc/mod.rs
@@ -943,7 +943,15 @@ async fn extend_reachable_bulk_objects(
     if !manifest.refs.is_empty() && !manifest.pack_index_hash.is_empty() {
         reachable.insert(
             router
-                .git_visibility_path(manifest.generation, &manifest.pack_index_hash)
+                .git_visibility_path(&manifest.git_validation_digest)
+                .as_ref()
+                .to_string(),
+        );
+        // Crab 1.0.15 readers still use the v1 key. Retain it while the
+        // explicit read/backfill migration remains supported.
+        reachable.insert(
+            router
+                .git_visibility_v1_path(manifest.generation, &manifest.pack_index_hash)
                 .as_ref()
                 .to_string(),
         );
@@ -1848,7 +1856,7 @@ mod tests {
 
         // The reachable set should contain both segmented index objects and
         // the immutable segments they reference.
-        assert_eq!(reachable.len(), 5);
+        assert_eq!(reachable.len(), 6);
         assert!(reachable.contains(&format!(
             "org/repo/metadata/shard/indexes/{shard_hash}.json"
         )));
@@ -1856,8 +1864,12 @@ mod tests {
         assert!(reachable.contains(&format!("org/repo/metadata/pack/indexes/{pack_hash}.json")));
         assert!(reachable.contains(&format!("org/repo/{pack_segment_path}")));
         assert!(reachable.contains(&format!(
+            "org/repo/metadata/git-visibility/v2/{}.json",
+            manifest.git_validation_digest
+        )));
+        assert!(reachable.contains(&format!(
             "org/repo/metadata/git-visibility/{:020}-{pack_hash}.json",
-            manifest.generation
+            manifest.generation,
         )));
 
         // An object NOT in the reachable set is unreachable.

--- a/crab/src/cmd/metadb.rs
+++ b/crab/src/cmd/metadb.rs
@@ -2151,20 +2151,12 @@ async fn diagnose_acceleration_health(
             &router,
             manifest.generation,
             &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
         )
         .await
         {
             Ok(index) => {
-                let covers_manifest = index.refs.len() == manifest.refs.len()
-                    && manifest.refs.iter().all(|(name, oid)| {
-                        index.refs.get(name).is_some_and(|objects| {
-                            objects.binary_search(oid).is_ok()
-                                && manifest
-                                    .peeled_refs
-                                    .get(name)
-                                    .is_none_or(|peeled| objects.binary_search(peeled).is_ok())
-                        })
-                    });
+                let covers_manifest = index.matches_manifest(&manifest);
                 if !covers_manifest {
                     notes.push(
                         "Git visibility proof does not cover the current manifest refs; run `crab metadb rebuild`"

--- a/crab/src/cmd/push.rs
+++ b/crab/src/cmd/push.rs
@@ -580,36 +580,79 @@ async fn run_push_once(
         }));
     }
 
+    let retryable_setup_failure =
+        |error: CrabError, stage: PushFailureStage| -> Result<PushAttempt> {
+            let Some(result) = push_result_from_retryable_error(&specs, &error, stage) else {
+                return Err(error);
+            };
+            let elapsed = start.elapsed();
+            if let Err(err) = record_push_audit_event(
+                &repo_root.join(default_log_path()),
+                Some(&remote_url),
+                &parsed_url.repo_path,
+                &specs,
+                &result,
+                Some(elapsed.as_millis() as u64),
+            ) {
+                warn!(%err, "failed to append push audit event");
+            }
+            Ok(PushAttempt::Failed(Box::new(PushAttemptFailure {
+                repo_root: repo_root.clone(),
+                remote_name: remote_name.clone(),
+                remote_url: remote_url.clone(),
+                specs: specs.clone(),
+                result,
+                elapsed,
+                integration: push_integration_summary(args, integration_retries),
+                agent_integration_lock: false,
+            })))
+        };
+
     // Build push config from resolved Config + CLI overrides.
     let mut push_config = PushConfig::from_config(&config);
     apply_push_cli_overrides(args, &mut push_config);
-    configure_active_active_push_coordinator(
+    if let Err(error) = configure_active_active_push_coordinator(
         &config,
         Some(&remote_url),
         &parsed_url.repo_path,
         &mut push_config,
     )
-    .await?;
+    .await
+    {
+        return retryable_setup_failure(error, PushFailureStage::StoreResolve);
+    }
     let (store, router) = if matches!(
         config.auth.provider,
         crate::core::config::AuthProvider::CrabAuth
     ) {
-        let protected = crate::git::protected_push::prepare_crab_auth_push(
+        let protected = match crate::git::protected_push::prepare_crab_auth_push(
             &config,
             &parsed_url,
             &specs,
             cancel,
         )
-        .await?;
+        .await
+        {
+            Ok(protected) => protected,
+            Err(error) => {
+                return retryable_setup_failure(error, PushFailureStage::StoreResolve);
+            }
+        };
         push_config.atomic = true;
         push_config.protected_push = Some(protected.session);
         let store = protected.store;
         let router = StoreLayout::new(store.clone(), parsed_url.repo_path.clone());
         (store, router)
     } else {
-        let selection = StoreResolver::new(&config, &parsed_url, cancel)
+        let selection = match StoreResolver::new(&config, &parsed_url, cancel)
             .write_store("push")
-            .await?;
+            .await
+        {
+            Ok(selection) => selection,
+            Err(error) => {
+                return retryable_setup_failure(error, PushFailureStage::StoreResolve);
+            }
+        };
         (selection.store, selection.router)
     };
     let repo_prefix = router.repo_prefix().to_owned();
@@ -726,7 +769,7 @@ async fn run_push_once(
     native_config.progress = mode == OutputMode::Text;
     native_config.followtags = args.follow_tags;
 
-    let result: PushResult = run_native_push(
+    let native_result = run_native_push(
         &native_config,
         &specs,
         NativePushInputs::new(
@@ -742,7 +785,11 @@ async fn run_push_once(
         )
         .with_pre_acquired_locks(pre_acquired_locks),
     )
-    .await?;
+    .await;
+    let result = match native_result {
+        Ok(result) => result,
+        Err(error) => return retryable_setup_failure(error, PushFailureStage::Discovery),
+    };
 
     if result.all_ok() {
         if let Err(err) = record_push_audit_event(
@@ -917,6 +964,20 @@ fn transient_retry_branch<'a>(
 
 fn push_result_from_error(specs: &[PushSpec], error: &CrabError) -> PushResult {
     push_result_from_reason(specs, PushRejectReason::from_error(error))
+}
+
+fn push_result_from_retryable_error(
+    specs: &[PushSpec],
+    error: &CrabError,
+    stage: PushFailureStage,
+) -> Option<PushResult> {
+    // Legacy protected-push prepare is not idempotent and maps failures to
+    // AuthFailed, so only transport types with an explicit retry contract enter this loop.
+    matches!(
+        error,
+        CrabError::NetworkTransient(_) | CrabError::Throttled { .. }
+    )
+    .then(|| push_result_from_error(specs, error).with_failure_stage(stage))
 }
 
 fn push_result_from_reason(specs: &[PushSpec], reason: PushRejectReason) -> PushResult {
@@ -2140,6 +2201,30 @@ mod tests {
             push_failure_source(std::slice::from_ref(&spec), &network_result),
             CrabError::NetworkTransient(_)
         ));
+
+        let setup_error = CrabError::Throttled {
+            retry_after: Some(std::time::Duration::from_secs(3)),
+        };
+        let setup_result = push_result_from_retryable_error(
+            std::slice::from_ref(&spec),
+            &setup_error,
+            PushFailureStage::StoreResolve,
+        )
+        .expect("transient setup failure");
+        assert_eq!(
+            setup_result.failure_stage,
+            Some(PushFailureStage::StoreResolve)
+        );
+        assert!(
+            push_result_from_retryable_error(
+                std::slice::from_ref(&spec),
+                &CrabError::AuthFailed {
+                    path: "ambiguous protected-push prepare".to_owned(),
+                },
+                PushFailureStage::Discovery,
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/crab/src/cmd/push.rs
+++ b/crab/src/cmd/push.rs
@@ -6,6 +6,7 @@
 //! Produces identical remote state to `git push` via the remote helper,
 //! just faster for multi-file pushes.
 
+use std::collections::BTreeMap;
 use std::io::Stdout;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -119,6 +120,9 @@ pub struct PushSummaryPayload {
     /// Configured retry budget for agent integration mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub integration_retry_limit: Option<u32>,
+    /// Retried attempts grouped by stable push failure stage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub integration_retry_stages: Option<BTreeMap<String, u32>>,
     /// Active-active operation id when the push is coordinator-backed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation_id: Option<String>,
@@ -182,10 +186,11 @@ enum PushAttempt {
     Failed(Box<PushAttemptFailure>),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct PushIntegrationSummary {
     retries: u32,
     retry_limit: u32,
+    retry_stages: BTreeMap<String, u32>,
 }
 
 /// Entry point for `crab push`, following the existing subcommand pattern.
@@ -211,9 +216,10 @@ async fn execute_push(
 ) -> Result<PushSummaryPayload> {
     let mode = OutputMode::from_flags(args.json, args.jsonl);
     let mut retry_attempts = 0u32;
+    let mut retry_stages = BTreeMap::new();
 
     loop {
-        match run_push_once(args, cancel, retry_attempts, emit_terminal).await? {
+        match run_push_once(args, cancel, retry_attempts, &retry_stages, emit_terminal).await? {
             PushAttempt::Done(summary) => return Ok(summary),
             PushAttempt::Failed(mut failure) => {
                 if args.rebase_on_non_fast_forward
@@ -222,6 +228,7 @@ async fn execute_push(
                     && current_branch().as_deref() == Some(branch)
                 {
                     let branch = branch.to_owned();
+                    record_integration_retry_stage(&mut retry_stages, &failure.result);
                     retry_attempts += 1;
                     if !mode.is_machine() {
                         eprintln!(
@@ -245,6 +252,7 @@ async fn execute_push(
                     && current_branch().as_deref() == Some(branch)
                 {
                     let branch = branch.to_owned();
+                    record_integration_retry_stage(&mut retry_stages, &failure.result);
                     retry_attempts += 1;
                     if !mode.is_machine() {
                         let action = if failure.agent_integration_lock {
@@ -275,6 +283,7 @@ async fn execute_push(
                         transient_retry_branch(&failure.specs, &failure.result)
                     && current_branch().as_deref() == Some(branch)
                 {
+                    record_integration_retry_stage(&mut retry_stages, &failure.result);
                     retry_attempts += 1;
                     if !mode.is_machine() {
                         eprintln!(
@@ -382,6 +391,7 @@ pub(crate) async fn run_push_repair_refspecs(
             remote_url,
             integration_retries: None,
             integration_retry_limit: None,
+            integration_retry_stages: None,
             operation_id: None,
             coordinator_epoch: None,
             writer_region: None,
@@ -488,6 +498,7 @@ async fn run_push_once(
     args: &PushArgs,
     cancel: &CancellationToken,
     integration_retries: u32,
+    integration_retry_stages: &BTreeMap<String, u32>,
     emit_terminal: bool,
 ) -> Result<PushAttempt> {
     let start = Instant::now();
@@ -527,14 +538,19 @@ async fn run_push_once(
         if mode == OutputMode::Text {
             println!("Everything up-to-date");
         }
-        let integration = push_integration_summary(args, integration_retries);
+        let integration =
+            push_integration_summary(args, integration_retries, integration_retry_stages);
         let summary = PushSummaryPayload {
             refs_pushed: 0,
             refs: vec![],
             duration_ms: start.elapsed().as_millis() as u64,
             remote_url: remote_url.clone(),
-            integration_retries: integration.map(|summary| summary.retries),
-            integration_retry_limit: integration.map(|summary| summary.retry_limit),
+            integration_retries: integration.as_ref().map(|summary| summary.retries),
+            integration_retry_limit: integration.as_ref().map(|summary| summary.retry_limit),
+            integration_retry_stages: integration
+                .as_ref()
+                .filter(|summary| !summary.retry_stages.is_empty())
+                .map(|summary| summary.retry_stages.clone()),
             operation_id: None,
             coordinator_epoch: None,
             writer_region: None,
@@ -565,14 +581,19 @@ async fn run_push_once(
     // Dry-run: print what would be pushed and return.
     if args.dry_run {
         print_dry_run(&remote_name, &remote_url, &specs);
-        let integration = push_integration_summary(args, integration_retries);
+        let integration =
+            push_integration_summary(args, integration_retries, integration_retry_stages);
         return Ok(PushAttempt::Done(PushSummaryPayload {
             refs_pushed: 0,
             refs: Vec::new(),
             duration_ms: start.elapsed().as_millis() as u64,
             remote_url,
-            integration_retries: integration.map(|summary| summary.retries),
-            integration_retry_limit: integration.map(|summary| summary.retry_limit),
+            integration_retries: integration.as_ref().map(|summary| summary.retries),
+            integration_retry_limit: integration.as_ref().map(|summary| summary.retry_limit),
+            integration_retry_stages: integration
+                .as_ref()
+                .filter(|summary| !summary.retry_stages.is_empty())
+                .map(|summary| summary.retry_stages.clone()),
             operation_id: None,
             coordinator_epoch: None,
             writer_region: None,
@@ -603,7 +624,11 @@ async fn run_push_once(
                 specs: specs.clone(),
                 result,
                 elapsed,
-                integration: push_integration_summary(args, integration_retries),
+                integration: push_integration_summary(
+                    args,
+                    integration_retries,
+                    integration_retry_stages,
+                ),
                 agent_integration_lock: false,
             })))
         };
@@ -724,7 +749,11 @@ async fn run_push_once(
                         specs: specs.clone(),
                         result,
                         elapsed: start.elapsed(),
-                        integration: push_integration_summary(args, integration_retries),
+                        integration: push_integration_summary(
+                            args,
+                            integration_retries,
+                            integration_retry_stages,
+                        ),
                         agent_integration_lock: true,
                     };
                     if emit_terminal || mode == OutputMode::Text {
@@ -755,7 +784,11 @@ async fn run_push_once(
                     specs: specs.clone(),
                     result,
                     elapsed: start.elapsed(),
-                    integration: push_integration_summary(args, integration_retries),
+                    integration: push_integration_summary(
+                        args,
+                        integration_retries,
+                        integration_retry_stages,
+                    ),
                     agent_integration_lock: true,
                 })));
             }
@@ -805,9 +838,11 @@ async fn run_push_once(
         push_state.save(&repo_root)?;
 
         let elapsed = start.elapsed();
-        let integration = push_integration_summary(args, integration_retries);
+        let integration =
+            push_integration_summary(args, integration_retries, integration_retry_stages);
 
-        let summary = build_push_summary(&specs, &result, &remote_url, elapsed, integration);
+        let summary =
+            build_push_summary(&specs, &result, &remote_url, elapsed, integration.as_ref());
         match mode {
             OutputMode::Text => {
                 print_push_summary(&remote_name, &remote_url, &specs, &result, elapsed);
@@ -847,7 +882,7 @@ async fn run_push_once(
         specs,
         result,
         elapsed,
-        integration: push_integration_summary(args, integration_retries),
+        integration: push_integration_summary(args, integration_retries, integration_retry_stages),
         agent_integration_lock: false,
     })))
 }
@@ -867,7 +902,7 @@ fn emit_push_failure(failure: &PushAttemptFailure, mode: OutputMode) {
                 &failure.result,
                 &failure.remote_url,
                 failure.elapsed,
-                failure.integration,
+                failure.integration.as_ref(),
             );
             emit_json("push", "1.0", &summary);
         }
@@ -877,7 +912,7 @@ fn emit_push_failure(failure: &PushAttemptFailure, mode: OutputMode) {
                 &failure.result,
                 &failure.remote_url,
                 failure.elapsed,
-                failure.integration,
+                failure.integration.as_ref(),
             );
             let mut stream = JsonlStream::new("push.event", "1.0", std::io::stdout());
             stream.emit_result(&summary);
@@ -885,11 +920,25 @@ fn emit_push_failure(failure: &PushAttemptFailure, mode: OutputMode) {
     }
 }
 
-fn push_integration_summary(args: &PushArgs, retries: u32) -> Option<PushIntegrationSummary> {
+fn record_integration_retry_stage(stages: &mut BTreeMap<String, u32>, result: &PushResult) {
+    let stage = result
+        .failure_stage
+        .map(PushFailureStage::as_str)
+        .unwrap_or("unattributed");
+    let count = stages.entry(stage.to_owned()).or_default();
+    *count = count.saturating_add(1);
+}
+
+fn push_integration_summary(
+    args: &PushArgs,
+    retries: u32,
+    retry_stages: &BTreeMap<String, u32>,
+) -> Option<PushIntegrationSummary> {
     args.rebase_on_non_fast_forward
         .then_some(PushIntegrationSummary {
             retries,
             retry_limit: args.rebase_retry_limit,
+            retry_stages: retry_stages.clone(),
         })
 }
 
@@ -1162,7 +1211,7 @@ fn build_push_summary(
     result: &PushResult,
     remote_url: &str,
     elapsed: std::time::Duration,
-    integration: Option<PushIntegrationSummary>,
+    integration: Option<&PushIntegrationSummary>,
 ) -> PushSummaryPayload {
     let refs: Vec<PushRefOutcome> = specs
         .iter()
@@ -1212,6 +1261,9 @@ fn build_push_summary(
         remote_url: remote_url.to_owned(),
         integration_retries: integration.map(|summary| summary.retries),
         integration_retry_limit: integration.map(|summary| summary.retry_limit),
+        integration_retry_stages: integration
+            .filter(|summary| !summary.retry_stages.is_empty())
+            .map(|summary| summary.retry_stages.clone()),
         operation_id: result
             .active_active_commit
             .as_ref()
@@ -2109,9 +2161,10 @@ mod tests {
             &result,
             "crab://primary/org/repo",
             std::time::Duration::from_millis(9),
-            Some(PushIntegrationSummary {
+            Some(&PushIntegrationSummary {
                 retries: 5,
                 retry_limit: 256,
+                retry_stages: BTreeMap::from([("lock".to_owned(), 5)]),
             }),
         );
 
@@ -2120,6 +2173,21 @@ mod tests {
         assert_eq!(summary.refs[0].retry_after_secs, Some(7));
         assert_eq!(summary.integration_retries, Some(5));
         assert_eq!(summary.integration_retry_limit, Some(256));
+        assert_eq!(
+            summary.integration_retry_stages,
+            Some(BTreeMap::from([("lock".to_owned(), 5)]))
+        );
+    }
+
+    #[test]
+    fn integration_retry_stage_counter_matches_attempts() {
+        let result = PushResult::empty().with_failure_stage(PushFailureStage::Lock);
+        let mut stages = BTreeMap::new();
+
+        record_integration_retry_stage(&mut stages, &result);
+        record_integration_retry_stage(&mut stages, &result);
+
+        assert_eq!(stages, BTreeMap::from([("lock".to_owned(), 2)]));
     }
 
     #[test]
@@ -2256,6 +2324,7 @@ mod tests {
             integration: Some(PushIntegrationSummary {
                 retries: 1,
                 retry_limit: 256,
+                retry_stages: BTreeMap::from([("preflight".to_owned(), 1)]),
             }),
             agent_integration_lock: false,
         };
@@ -2271,7 +2340,7 @@ mod tests {
             &failure.result,
             &failure.remote_url,
             failure.elapsed,
-            failure.integration,
+            failure.integration.as_ref(),
         );
 
         assert_eq!(summary.refs[0].status, "integration-failed");

--- a/crab/src/cmd/push.rs
+++ b/crab/src/cmd/push.rs
@@ -23,8 +23,9 @@ use crate::core::error::{CrabError, Result};
 use crate::core::output::{JsonlStream, OutputMode, emit_json};
 use crate::core::perf_phase::PerfPhaseSink;
 use crate::git::push::{
-    PushConfig, PushRejectReason, PushResult, RefPushOutcome, acquire_push_lock_leases,
-    configure_active_active_push_coordinator, record_push_audit_event, release_push_lock_leases,
+    PushConfig, PushFailureStage, PushRejectReason, PushResult, RefPushOutcome,
+    acquire_push_lock_leases, configure_active_active_push_coordinator, record_push_audit_event,
+    release_push_lock_leases,
 };
 use crate::git::push_native::{NativePushConfig, NativePushInputs, run_native_push};
 use crate::git::push_state::PushState;
@@ -692,7 +693,8 @@ async fn run_push_once(
                 pre_acquired_locks = Some(leases);
             }
             Err(e) => {
-                let result = push_result_from_error(&specs, &e);
+                let result =
+                    push_result_from_error(&specs, &e).with_failure_stage(PushFailureStage::Lock);
                 if let Err(err) = record_push_audit_event(
                     &repo_root.join(default_log_path()),
                     Some(&remote_url),
@@ -904,8 +906,9 @@ fn transient_retry_branch<'a>(
         return None;
     };
     let reason = match result.outcomes.get(&spec.dst)? {
-        RefPushOutcome::Rejected(reason @ PushRejectReason::NetworkTransient(_))
-        | RefPushOutcome::Rejected(reason @ PushRejectReason::Throttled { .. }) => reason,
+        RefPushOutcome::Rejected(
+            reason @ (PushRejectReason::NetworkTransient(_) | PushRejectReason::Throttled { .. }),
+        ) => reason,
         _ => return None,
     };
 

--- a/crab/src/cmd/repack.rs
+++ b/crab/src/cmd/repack.rs
@@ -324,21 +324,30 @@ async fn read_current_visibility(
     }
     let storage_router =
         crab_storage::StoreLayout::new(store.as_storage().clone(), router.repo_prefix().to_owned());
-    match crab_metadata::git_visibility::read(
+    match crab_metadata::git_visibility::read_with_format(
         store.as_storage(),
         &storage_router,
         manifest.generation,
         &manifest.pack_index_hash,
+        &manifest.git_validation_digest,
     )
     .await
     {
-        Ok(index) => {
-            if visibility_matches_manifest(&index, manifest) {
-                Ok(Some(index))
+        Ok(read) => {
+            if read.index.matches_manifest(manifest) {
+                if read.format == crab_metadata::git_visibility::GitVisibilityFormat::V1 {
+                    crab_metadata::git_visibility::upload_if_absent(
+                        store.as_storage(),
+                        &storage_router,
+                        &read.index,
+                    )
+                    .await?;
+                }
+                Ok(Some(read.index))
             } else {
                 Err(CrabError::CorruptObject {
                     path: storage_router
-                        .git_visibility_path(manifest.generation, &manifest.pack_index_hash)
+                        .git_visibility_path(&manifest.git_validation_digest)
                         .as_ref()
                         .to_owned(),
                     reason: "Git visibility proof does not match manifest refs".to_owned(),
@@ -352,22 +361,6 @@ async fn read_current_visibility(
     }
 }
 
-fn visibility_matches_manifest(
-    visibility: &crab_metadata::git_visibility::GitVisibilityIndex,
-    manifest: &Manifest,
-) -> bool {
-    visibility.refs.len() == manifest.refs.len()
-        && manifest.refs.iter().all(|(name, tip)| {
-            visibility.refs.get(name).is_some_and(|objects| {
-                objects.binary_search(tip).is_ok()
-                    && manifest
-                        .peeled_refs
-                        .get(name)
-                        .is_none_or(|peeled| objects.binary_search(peeled).is_ok())
-            })
-        })
-}
-
 fn rebind_visibility(
     mut visibility: crab_metadata::git_visibility::GitVisibilityIndex,
     manifest: &Manifest,
@@ -376,6 +369,9 @@ fn rebind_visibility(
     visibility
         .pack_index_hash
         .clone_from(&manifest.pack_index_hash);
+    visibility
+        .git_validation_digest
+        .clone_from(&manifest.git_validation_digest);
     visibility
 }
 
@@ -746,16 +742,25 @@ mod tests {
     fn rebind_visibility_changes_only_generation_anchor() {
         let mut refs = std::collections::BTreeMap::new();
         refs.insert("refs/heads/main".to_owned(), vec!["a".repeat(40)]);
-        let visibility =
-            crab_metadata::git_visibility::GitVisibilityIndex::new(3, "b".repeat(64), refs.clone());
+        let visibility = crab_metadata::git_visibility::GitVisibilityIndex::new(
+            3,
+            "b".repeat(64),
+            "d".repeat(64),
+            refs.clone(),
+        );
         let mut manifest = Manifest::default_for_repo("refs/heads/main");
         manifest.generation = 4;
         manifest.pack_index_hash = "c".repeat(64);
+        manifest.seal_git_validation();
 
         let rebound = rebind_visibility(visibility, &manifest);
 
         assert_eq!(rebound.generation, 4);
         assert_eq!(rebound.pack_index_hash, "c".repeat(64));
+        assert_eq!(
+            rebound.git_validation_digest,
+            manifest.git_validation_digest
+        );
         assert_eq!(rebound.refs, refs);
     }
 
@@ -889,6 +894,7 @@ mod tests {
             &storage_router,
             committed.generation,
             &committed.pack_index_hash,
+            &committed.git_validation_digest,
         )
         .await?;
         assert_eq!(visibility.refs.len(), 1);

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -5305,11 +5305,16 @@ pub(crate) async fn publish_committed_pack_locators(
         }
         let current_packs = read_bulk_pack_list(store, router, &current.pack_index_hash).await?;
 
-        let mut writer = crab_metadata::git_object_locator::GitObjectLocatorWriter::open(
-            Arc::clone(store.inner()),
-            router.repo_prefix(),
-        )
-        .await?;
+        let planned_object_rows = current_packs
+            .iter()
+            .fold(0_u64, |total, pack| total.saturating_add(pack.object_count));
+        let mut writer =
+            crab_metadata::git_object_locator::GitObjectLocatorWriter::open_for_publication(
+                Arc::clone(store.inner()),
+                router.repo_prefix(),
+                planned_object_rows,
+            )
+            .await?;
         let operation = async {
             let prior_coverage = writer.coverage();
             let covered_packs = if let Some(coverage) = prior_coverage {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -2441,8 +2441,46 @@ const PUSH_ADMISSION_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(5);
 const REF_JOURNAL_COMPACTION_LOCK_WAIT_TTL_MULTIPLIER: u32 = 2;
 const MAX_REF_JOURNAL_COMPACTION_PASSES: usize = PUSH_ADMISSION_SLOTS;
 const GIT_LOCATOR_LOCK_WAIT_TTL_MULTIPLIER: u32 = 2;
-const MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS: u64 = 100_000;
+const GIT_VISIBILITY_LOCK_WAIT_TTL_MULTIPLIER: u32 = 2;
 const GIT_LOCATOR_MIN_CANDIDATES: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GitVisibilityCapacity {
+    observed: u64,
+    maximum: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitVisibilityPublication {
+    Published,
+    CompletePackOnly(GitVisibilityCapacity),
+}
+
+fn git_visibility_capacity_exceeded<'a>(
+    packs: impl IntoIterator<Item = &'a PackManifestEntry>,
+    ref_count: usize,
+) -> Result<Option<GitVisibilityCapacity>> {
+    let mut seen = HashSet::new();
+    let packed_objects = packs
+        .into_iter()
+        .filter(|pack| seen.insert(pack.pack_id.as_str()))
+        .try_fold(0u64, |total, pack| total.checked_add(pack.object_count))
+        .ok_or_else(|| CrabError::Internal("Git pack object count overflow".to_owned()))?;
+    let ref_count = u64::try_from(ref_count)
+        .map_err(|_| CrabError::Internal("Git ref count overflow".to_owned()))?;
+    // The serialized proof stores one closure per ref. This conservative bound
+    // keeps publication cost bounded without walking every closure twice.
+    let proof_objects = packed_objects
+        .checked_mul(ref_count)
+        .ok_or_else(|| CrabError::Internal("Git visibility object count overflow".to_owned()))?;
+    Ok(
+        (proof_objects > crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS)
+            .then_some(GitVisibilityCapacity {
+                observed: proof_objects,
+                maximum: crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS,
+            }),
+    )
+}
 
 /// Multipart threshold: xorbs larger than this use multipart upload.
 const XORB_MULTIPART_THRESHOLD: usize = 8 * 1024 * 1024;
@@ -5487,6 +5525,298 @@ pub(crate) async fn repair_git_object_locator_if_current(
     Ok(stats.coverage_updated)
 }
 
+pub(crate) async fn repair_git_visibility_if_current(
+    store: &Store,
+    router: &StoreLayout,
+    required_generation: u64,
+    lock_ttl: Duration,
+    cancel: &CancellationToken,
+) -> Result<Option<GitVisibilityPublication>> {
+    let (manifest, _) = read_manifest(store, router).await?;
+    if manifest.generation != required_generation {
+        return Ok(None);
+    }
+    if git_visibility_index_exists_for_manifest(store, router, &manifest).await? {
+        return Ok(Some(GitVisibilityPublication::Published));
+    }
+    if manifest.refs.is_empty() {
+        return Ok(Some(GitVisibilityPublication::Published));
+    }
+    if let Some(capacity) = git_visibility_capacity_exceeded(
+        read_bulk_pack_list(store, router, &manifest.pack_index_hash)
+            .await?
+            .iter(),
+        manifest.refs.len(),
+    )? {
+        return Ok(Some(GitVisibilityPublication::CompletePackOnly(capacity)));
+    }
+
+    // Visibility traversal depends on exact locator ranges but owns a separate
+    // manifest-generation lock. Finish locator repair before taking that lock
+    // so no cross-resource lock order can deadlock another publisher.
+    let _ =
+        repair_git_object_locator_if_current(store, router, required_generation, lock_ttl, cancel)
+            .await?;
+    let Some(mut lock) =
+        acquire_current_git_manifest_lock(store, router, required_generation, lock_ttl, cancel)
+            .await?
+    else {
+        return Ok(None);
+    };
+    let repair = while_renewing_internal_lock(&mut lock, async {
+        let (current, _) = read_manifest(store, router).await?;
+        if current.generation != required_generation
+            || current.pack_index_hash != manifest.pack_index_hash
+            || current.git_validation_digest != manifest.git_validation_digest
+        {
+            return Ok(None);
+        }
+        if git_visibility_index_exists_for_manifest(store, router, &current).await? {
+            return Ok(Some(GitVisibilityPublication::Published));
+        }
+
+        let storage = store.as_storage().clone();
+        let storage_router =
+            crab_storage::StoreLayout::new(storage.clone(), router.repo_prefix().to_owned());
+        let bucket = storage.bucket_identity();
+        let provider = format!("{:?}:{}:{}", bucket.cloud, bucket.host, bucket.container);
+        let identity =
+            crab_remote_git::RepositoryIdentity::new(provider, router.repo_prefix().to_owned(), 1)
+                .map_err(remote_git_visibility_error)?;
+        let operation_limits = crab_remote_git::OperationLimits {
+            max_logical_objects:
+                crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS,
+            max_storage_requests:
+                crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS
+                    .saturating_mul(10),
+            max_fetched_bytes: 2 * 1024 * 1024 * 1024,
+            max_inflated_bytes: 2 * 1024 * 1024 * 1024,
+            ..crab_remote_git::OperationLimits::default()
+        };
+        let options = crab_remote_git::RepositoryOptions::new(
+            crab_remote_git::ObjectLimits::default(),
+            operation_limits,
+        )
+        .map_err(remote_git_visibility_error)?;
+        let runtime = Arc::new(crab_remote_git::RemoteGitRuntime::default());
+        let repository = crab_remote_git::RemoteGitRepository::open(
+            storage.clone(),
+            storage_router.clone(),
+            identity,
+            runtime,
+            options,
+            cancel,
+        )
+        .await
+        .map_err(remote_git_visibility_error)?;
+        let index = match repository.rebuild_visibility_index(cancel).await {
+            Ok(index) => index,
+            Err(crab_remote_git::Error::LimitExceeded {
+                limit: "visibility proof objects",
+                actual,
+                maximum,
+            }) => {
+                return Ok(Some(GitVisibilityPublication::CompletePackOnly(
+                    GitVisibilityCapacity {
+                        observed: actual,
+                        maximum,
+                    },
+                )));
+            }
+            Err(error) => return Err(remote_git_visibility_error(error)),
+        };
+        let (before_upload, _) = read_manifest(store, router).await?;
+        if before_upload.generation != required_generation
+            || before_upload.pack_index_hash != current.pack_index_hash
+            || before_upload.git_validation_digest != current.git_validation_digest
+        {
+            return Ok(None);
+        }
+        crab_metadata::git_visibility::upload_if_absent(&storage, &storage_router, &index)
+            .await
+            .map_err(CrabError::from)?;
+        let (after_upload, _) = read_manifest(store, router).await?;
+        if after_upload.generation != required_generation
+            || after_upload.pack_index_hash != current.pack_index_hash
+            || after_upload.git_validation_digest != current.git_validation_digest
+        {
+            return Ok(None);
+        }
+        Ok(Some(GitVisibilityPublication::Published))
+    })
+    .await;
+    let release = lock.release().await.map_err(CrabError::from);
+    match (repair, release) {
+        (Ok(result), Ok(())) => Ok(result),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Err(release_error)) => {
+            warn!(
+                error = %release_error,
+                "Git visibility lock release also failed after repair error"
+            );
+            Err(error)
+        }
+    }
+}
+
+async fn ensure_current_git_visibility(
+    store: &Store,
+    router: &StoreLayout,
+    lock_ttl: Duration,
+    max_retries: u32,
+    cancel: &CancellationToken,
+) -> Result<GitVisibilityPublication> {
+    for _ in 0..max_retries.max(1) {
+        check_cancelled(cancel)?;
+        let (current, _) = read_manifest(store, router).await?;
+        let Some(publication) =
+            repair_git_visibility_if_current(store, router, current.generation, lock_ttl, cancel)
+                .await?
+        else {
+            continue;
+        };
+        let (after, _) = read_manifest(store, router).await?;
+        if after.generation == current.generation
+            && after.pack_index_hash == current.pack_index_hash
+            && after.git_validation_digest == current.git_validation_digest
+        {
+            return Ok(publication);
+        }
+    }
+    Err(CrabError::CasConflict {
+        path: router.manifest_path().to_string(),
+        expected_etag: None,
+    })
+}
+
+async fn acquire_current_git_manifest_lock(
+    store: &Store,
+    router: &StoreLayout,
+    required_generation: u64,
+    lock_ttl: Duration,
+    cancel: &CancellationToken,
+) -> Result<Option<PushLock>> {
+    let deadline =
+        Instant::now() + lock_ttl.saturating_mul(GIT_VISIBILITY_LOCK_WAIT_TTL_MULTIPLIER);
+    let mut attempt = 0;
+    let mut acquire_context = PushLockAcquireContext::new(Arc::clone(store.inner()));
+    loop {
+        check_cancelled(cancel)?;
+        let (current, _) = read_manifest(store, router).await?;
+        if current.generation != required_generation {
+            return Ok(None);
+        }
+        match acquire_context
+            .acquire_internal(
+                router.repo_prefix(),
+                crab_coordination::GIT_MANIFEST_RESOURCE,
+                lock_ttl,
+            )
+            .await
+            .map_err(CrabError::from)
+        {
+            Ok(lock) => return Ok(Some(lock)),
+            Err(error @ CrabError::PushLockHeld { .. }) => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(error);
+                }
+                let delay = push_lock_wait_delay(attempt, deadline.saturating_duration_since(now));
+                attempt = attempt.saturating_add(1);
+                debug!(
+                    attempt,
+                    delay_ms = delay.as_millis(),
+                    generation = required_generation,
+                    "current Git visibility generation is waiting for the manifest owner"
+                );
+                tokio::select! {
+                    () = tokio::time::sleep(delay) => {}
+                    () = cancel.cancelled() => return Err(CrabError::Cancelled),
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+async fn git_visibility_index_exists_for_manifest(
+    store: &Store,
+    router: &StoreLayout,
+    manifest: &Manifest,
+) -> Result<bool> {
+    let storage = store.as_storage();
+    let storage_router =
+        crab_storage::StoreLayout::new(storage.clone(), router.repo_prefix().to_owned());
+    match crab_metadata::git_visibility::read(
+        storage,
+        &storage_router,
+        manifest.generation,
+        &manifest.pack_index_hash,
+    )
+    .await
+    {
+        Ok(index) => {
+            ensure_git_visibility_matches_manifest(&index, manifest, router)?;
+            Ok(true)
+        }
+        Err(crab_metadata::error::MetadataError::Storage {
+            source: StorageError::NotFound { .. },
+        }) => Ok(false),
+        Err(error) => Err(CrabError::from(error)),
+    }
+}
+
+fn ensure_git_visibility_matches_manifest(
+    index: &crab_metadata::git_visibility::GitVisibilityIndex,
+    manifest: &Manifest,
+    router: &StoreLayout,
+) -> Result<()> {
+    let matches = index.generation == manifest.generation
+        && index.pack_index_hash == manifest.pack_index_hash
+        && index.refs.keys().eq(manifest.refs.keys())
+        && manifest.refs.iter().all(|(name, tip)| {
+            index
+                .refs
+                .get(name)
+                .is_some_and(|objects| objects.binary_search(tip).is_ok())
+        })
+        && manifest.peeled_refs.iter().all(|(name, peeled)| {
+            index
+                .refs
+                .get(name)
+                .is_some_and(|objects| objects.binary_search(peeled).is_ok())
+        });
+    if matches {
+        return Ok(());
+    }
+    Err(CrabError::CorruptObject {
+        path: router
+            .git_visibility_path(manifest.generation, &manifest.pack_index_hash)
+            .as_ref()
+            .to_owned(),
+        reason: "Git visibility proof does not match its manifest refs".to_owned(),
+    })
+}
+
+fn remote_git_visibility_error(error: crab_remote_git::Error) -> CrabError {
+    match error {
+        crab_remote_git::Error::Storage(source) => CrabError::from(source),
+        crab_remote_git::Error::Metadata(source)
+        | crab_remote_git::Error::Manifest { source }
+        | crab_remote_git::Error::Inventory { source } => CrabError::from(source),
+        crab_remote_git::Error::Cancelled => CrabError::Cancelled,
+        crab_remote_git::Error::RepositoryIndexing { .. } => CrabError::CasConflict {
+            path: "Git visibility source generation".to_owned(),
+            expected_etag: None,
+        },
+        error => CrabError::CorruptObject {
+            path: "Git visibility source generation".to_owned(),
+            reason: error.to_string(),
+        },
+    }
+}
+
 async fn publish_uploaded_pack_locators(
     store: &Store,
     router: &StoreLayout,
@@ -6956,23 +7286,25 @@ impl PushPipeline {
         self.register_active_active_coordinator_for_bucket_gc(replication)
             .await?;
         upload_segmented_bulk(store, &self.router, bulk).await?;
-        // The coordinator owns ref publication, but the local helper still
-        // owns the immutable object-visibility proof used by v2 admission.
-        // Publish it before the coordinator can expose the candidate refs;
-        // a failure keeps v2 gated and remains repairable without weakening
-        // the existing push commit contract.
-        let visibility_proof_published =
-            match self.publish_git_visibility_index(manifest, store).await {
-                Ok(()) => true,
-                Err(error) => {
-                    warn!(
-                        error = %error,
-                        generation = manifest.generation,
-                        "active-active push committed; Git visibility proof requires repair"
-                    );
-                    false
-                }
-            };
+        // The coordinator owns ref publication, but the local helper owns the
+        // immutable proof used by v2 admission. Supported repositories cannot
+        // cross that commit boundary after a transient publication failure.
+        let visibility_proof_published = match self
+            .publish_git_visibility_index(manifest, store)
+            .await
+        {
+            Ok(GitVisibilityPublication::Published) => true,
+            Ok(GitVisibilityPublication::CompletePackOnly(capacity)) => {
+                warn!(
+                    generation = manifest.generation,
+                    proof_objects = capacity.observed,
+                    maximum = capacity.maximum,
+                    "active-active push exceeds the synchronous Git visibility profile; complete-pack fetch remains available"
+                );
+                false
+            }
+            Err(error) => return Err(error),
+        };
         self.git_visibility_published.store(
             visibility_proof_published,
             std::sync::atomic::Ordering::Relaxed,
@@ -7256,15 +7588,51 @@ impl PushPipeline {
             });
         }
         // Evidence precedes the active marker so a sibling compactor can prove
-        // the ref. Failure retains the evidence-less repair path and withholds v2.
-        if let Err(error) = self
-            .publish_ref_visibility_edits(store, &current_snapshot.manifest, &current, &mut edits)
+        // the ref without this client's ODB. Only repositories outside the
+        // synchronous proof profile may intentionally commit without it.
+        let uploaded_packs = self
+            .uploaded_packs
+            .lock()
             .await
-        {
-            warn!(
-                %error,
-                "Git visibility evidence could not be published; ref commit remains repairable"
-            );
+            .iter()
+            .map(|uploaded| uploaded.entry.clone())
+            .collect::<Vec<_>>();
+        let visibility = if let Some(capacity) = git_visibility_capacity_exceeded(
+            current_snapshot
+                .journal
+                .packs
+                .iter()
+                .chain(uploaded_packs.iter()),
+            manifest.refs.len(),
+        )? {
+            GitVisibilityPublication::CompletePackOnly(capacity)
+        } else {
+            ensure_current_git_visibility(
+                store,
+                &self.router,
+                self.config.lock_ttl,
+                self.config.max_cas_retries,
+                &self.cancel,
+            )
+            .await?
+        };
+        match visibility {
+            GitVisibilityPublication::Published => {
+                self.publish_ref_visibility_edits(
+                    store,
+                    &current_snapshot.manifest,
+                    &current,
+                    &mut edits,
+                )
+                .await?;
+            }
+            GitVisibilityPublication::CompletePackOnly(capacity) => {
+                warn!(
+                    proof_objects = capacity.observed,
+                    maximum = capacity.maximum,
+                    "push exceeds the synchronous Git visibility profile; complete-pack fetch remains available"
+                );
+            }
         }
         let mut expected_heads = Vec::with_capacity(edits.len());
         let mut parents = BTreeMap::new();
@@ -7379,7 +7747,16 @@ impl PushPipeline {
                         .publish_git_visibility_index(&compacted_manifest, store)
                         .await
                     {
-                        Ok(()) => true,
+                        Ok(GitVisibilityPublication::Published) => true,
+                        Ok(GitVisibilityPublication::CompletePackOnly(capacity)) => {
+                            warn!(
+                                generation = compacted_manifest.generation,
+                                proof_objects = capacity.observed,
+                                maximum = capacity.maximum,
+                                "compacted repository exceeds the synchronous Git visibility profile; complete-pack fetch remains available"
+                            );
+                            false
+                        }
                         Err(error) => {
                             warn!(
                                 error = %error,
@@ -7418,16 +7795,23 @@ impl PushPipeline {
         let compacted_visibility = if compacted.refs.is_empty() {
             None
         } else {
-            Some(
-                crab_metadata::git_visibility::read(
-                    storage,
-                    &storage_router,
-                    compacted.generation,
-                    &compacted.pack_index_hash,
-                )
-                .await
-                .map_err(CrabError::from)?,
+            match crab_metadata::git_visibility::read(
+                storage,
+                &storage_router,
+                compacted.generation,
+                &compacted.pack_index_hash,
             )
+            .await
+            {
+                Ok(visibility) => {
+                    ensure_git_visibility_matches_manifest(&visibility, compacted, &self.router)?;
+                    Some(visibility)
+                }
+                Err(crab_metadata::error::MetadataError::Storage {
+                    source: StorageError::NotFound { .. },
+                }) => None,
+                Err(error) => return Err(CrabError::from(error)),
+            }
         };
         let plans = edits
             .iter()
@@ -7534,25 +7918,34 @@ impl PushPipeline {
         &self,
         manifest: &Manifest,
         store: &crate::storage::store::Store,
-    ) -> Result<()> {
+    ) -> Result<GitVisibilityPublication> {
         if self.git_visibility_index_exists(manifest, store).await? {
-            return Ok(());
+            return Ok(GitVisibilityPublication::Published);
         }
-        let packs = read_bulk_pack_list(store, &self.router, &manifest.pack_index_hash).await?;
-        let packed_objects = packs
-            .iter()
-            .try_fold(0u64, |total, pack| total.checked_add(pack.object_count))
-            .ok_or_else(|| CrabError::Internal("Git pack object count overflow".to_owned()))?;
-        if packed_objects > MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS {
-            return Err(CrabError::Internal(format!(
-                "Git visibility proof deferred: {packed_objects} packed objects exceed the synchronous push budget of {MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS}"
-            )));
+        if let Some(capacity) = self
+            .git_visibility_capacity_exceeded(manifest, store)
+            .await?
+        {
+            return Ok(GitVisibilityPublication::CompletePackOnly(capacity));
         }
         let git_dir = self
             .git_dir_override()
             .map(Path::to_path_buf)
             .unwrap_or_else(crab_git::discover::discover_git_dir);
-        publish_git_visibility_index_from_git_dir(&git_dir, manifest, store, &self.router).await
+        publish_git_visibility_index_from_git_dir(&git_dir, manifest, store, &self.router).await?;
+        Ok(GitVisibilityPublication::Published)
+    }
+
+    async fn git_visibility_capacity_exceeded(
+        &self,
+        manifest: &Manifest,
+        store: &crate::storage::store::Store,
+    ) -> Result<Option<GitVisibilityCapacity>> {
+        if manifest.refs.is_empty() {
+            return Ok(None);
+        }
+        let packs = read_bulk_pack_list(store, &self.router, &manifest.pack_index_hash).await?;
+        git_visibility_capacity_exceeded(packs.iter(), manifest.refs.len())
     }
 
     async fn git_visibility_index_exists(
@@ -7560,23 +7953,7 @@ impl PushPipeline {
         manifest: &Manifest,
         store: &crate::storage::store::Store,
     ) -> Result<bool> {
-        let storage = store.as_storage();
-        let storage_router =
-            crab_storage::StoreLayout::new(storage.clone(), self.router.repo_prefix().to_owned());
-        match crab_metadata::git_visibility::read(
-            storage,
-            &storage_router,
-            manifest.generation,
-            &manifest.pack_index_hash,
-        )
-        .await
-        {
-            Ok(_) => Ok(true),
-            Err(crab_metadata::error::MetadataError::Storage {
-                source: StorageError::NotFound { .. },
-            }) => Ok(false),
-            Err(error) => return Err(CrabError::from(error)),
-        }
+        git_visibility_index_exists_for_manifest(store, &self.router, manifest).await
     }
 
     async fn record_current_git_visibility(
@@ -14742,7 +15119,7 @@ pub(crate) async fn build_git_visibility_index_from_storage_git_dir(
     git_dir: &Path,
     manifest: &Manifest,
 ) -> Result<crab_metadata::git_visibility::GitVisibilityIndex> {
-    if manifest.refs.is_empty() || manifest.pack_index_hash.is_empty() {
+    if manifest.refs.is_empty() {
         return Ok(crab_metadata::git_visibility::GitVisibilityIndex::new(
             manifest.generation,
             manifest.pack_index_hash.clone(),
@@ -16310,7 +16687,8 @@ mod tests {
     #[derive(Debug)]
     struct DelayedFailurePutStore {
         inner: object_store::memory::InMemory,
-        fail_path: Path,
+        fail_path: Option<Path>,
+        fail_path_prefix: Option<String>,
         delay: std::time::Duration,
         completed_puts: Arc<AtomicUsize>,
     }
@@ -16323,10 +16701,35 @@ mod tests {
         ) -> Self {
             Self {
                 inner: object_store::memory::InMemory::new(),
-                fail_path,
+                fail_path: Some(fail_path),
+                fail_path_prefix: None,
                 delay,
                 completed_puts,
             }
+        }
+
+        fn for_prefix(
+            fail_path_prefix: String,
+            delay: std::time::Duration,
+            completed_puts: Arc<AtomicUsize>,
+        ) -> Self {
+            Self {
+                inner: object_store::memory::InMemory::new(),
+                fail_path: None,
+                fail_path_prefix: Some(fail_path_prefix),
+                delay,
+                completed_puts,
+            }
+        }
+
+        fn matches(&self, location: &Path) -> bool {
+            self.fail_path
+                .as_ref()
+                .is_some_and(|path| location.as_ref() == path.as_ref())
+                || self
+                    .fail_path_prefix
+                    .as_deref()
+                    .is_some_and(|prefix| location.as_ref().starts_with(prefix))
         }
     }
 
@@ -16344,7 +16747,7 @@ mod tests {
             payload: PutPayload,
             opts: PutOptions,
         ) -> object_store::Result<PutResult> {
-            if location.as_ref() == self.fail_path.as_ref() {
+            if self.matches(location) {
                 return Err(object_store::Error::NotFound {
                     path: location.to_string(),
                     source: Box::<dyn std::error::Error + Send + Sync>::from("injected missing"),
@@ -16874,6 +17277,45 @@ mod tests {
             ref_tips,
             object_count: 1,
         }
+    }
+
+    #[test]
+    fn git_visibility_capacity_deduplicates_packs_and_reports_complete_pack_fallback() {
+        let mut pack = pack_manifest_entry_with_tips(Vec::new());
+        pack.object_count =
+            crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS.saturating_add(1);
+
+        let capacity = git_visibility_capacity_exceeded([&pack, &pack], 1)
+            .expect("count packs")
+            .expect("oversized repository should use complete-pack fallback");
+
+        assert_eq!(capacity.observed, pack.object_count);
+        assert_eq!(
+            capacity.maximum,
+            crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS
+        );
+    }
+
+    #[test]
+    fn git_visibility_must_match_manifest_refs() {
+        let (_, router) = test_store_router("visibility-manifest-match");
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 3;
+        manifest.pack_index_hash = "a".repeat(64);
+        manifest
+            .refs
+            .insert("refs/heads/main".to_owned(), "1".repeat(40));
+        manifest.seal_git_validation();
+        let index = crab_metadata::git_visibility::GitVisibilityIndex::new(
+            manifest.generation,
+            manifest.pack_index_hash.clone(),
+            BTreeMap::from([("refs/heads/main".to_owned(), vec!["2".repeat(40)])]),
+        );
+
+        assert!(matches!(
+            ensure_git_visibility_matches_manifest(&index, &manifest, &router),
+            Err(CrabError::CorruptObject { .. })
+        ));
     }
 
     #[test]
@@ -17823,12 +18265,19 @@ mod tests {
             .apply_decisions_with_sha_map(&decisions, false, &sha_map)
             .await
             .expect("build candidate");
+        upload_segmented_bulk(&store, &router, &bulk)
+            .await
+            .expect("publish concurrent pack inventory");
 
         let (mut concurrent, etag) = read_manifest(&store, &router)
             .await
             .expect("read concurrent base");
-        let concurrent_main = "f".repeat(40);
+        let concurrent_main = sha_map
+            .get("refs/heads/main")
+            .cloned()
+            .expect("resolved concurrent main");
         concurrent.generation += 1;
+        concurrent.pack_index_hash = candidate.pack_index_hash.clone();
         concurrent
             .refs
             .insert("refs/heads/main".to_owned(), concurrent_main.clone());
@@ -18090,6 +18539,53 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn visibility_evidence_failure_does_not_commit_ref_marker() {
+        let _guard = GitDirGuard::new();
+        let repo_prefix = "visibility-evidence-failure";
+        let inner: Arc<dyn object_store::ObjectStore> =
+            Arc::new(DelayedFailurePutStore::for_prefix(
+                format!("{repo_prefix}/metadata/git-visibility-edits/"),
+                Duration::ZERO,
+                Arc::new(AtomicUsize::new(0)),
+            ));
+        let store = Store::new(inner);
+        let router = StoreLayout::new(store.clone(), repo_prefix.to_owned());
+        create_manifest_with_etag(
+            &store,
+            &router,
+            &Manifest::default_for_repo("refs/heads/main"),
+        )
+        .await
+        .expect("create initial manifest");
+
+        let result = PushPipeline::new(
+            PushConfig::default(),
+            vec![make_spec("refs/heads/main")],
+            Some(store.clone()),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router.clone(),
+            None,
+            CancellationToken::new(),
+            None,
+        )
+        .execute()
+        .await;
+
+        assert_ne!(
+            result.outcomes.get("refs/heads/main"),
+            Some(&RefPushOutcome::Ok),
+            "proof publication failure must reject the ref"
+        );
+        let snapshot = crate::metadata::manifest::read_repository_snapshot(&store, &router)
+            .await
+            .expect("read failed push state");
+        assert!(snapshot.manifest.refs.is_empty());
+        assert!(snapshot.journal.transactions.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn next_writer_repairs_publication_cancelled_at_active_marker() {
         let _guard = GitDirGuard::new();
         let cancel = CancellationToken::new();
@@ -18288,6 +18784,74 @@ mod tests {
             .close()
             .await
             .expect("close repaired locator session");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn upload_pack_repairs_missing_visibility_for_current_manifest_generation() {
+        let _guard = GitDirGuard::new();
+        let repo_prefix = "upload-pack-visibility-repair";
+        let (store, router) = test_store_router(repo_prefix);
+        let initial = Manifest::default_for_repo("refs/heads/main");
+        create_manifest_with_etag(&store, &router, &initial)
+            .await
+            .expect("create initial manifest");
+        let pushed = PushPipeline::new(
+            PushConfig::default(),
+            vec![make_spec("refs/heads/main")],
+            Some(store.clone()),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router.clone(),
+            None,
+            CancellationToken::new(),
+            None,
+        )
+        .execute()
+        .await;
+        assert_eq!(
+            pushed.outcomes.get("refs/heads/main"),
+            Some(&RefPushOutcome::Ok)
+        );
+
+        let (manifest, _) = read_manifest(&store, &router)
+            .await
+            .expect("read pushed manifest");
+        let visibility_path =
+            router.git_visibility_path(manifest.generation, &manifest.pack_index_hash);
+        store
+            .delete(&visibility_path)
+            .await
+            .expect("remove derived visibility proof");
+        assert!(matches!(
+            store.head(&visibility_path).await,
+            Err(CrabError::NotFound { .. })
+        ));
+
+        assert!(
+            crate::git::upload_pack_wire::snapshot_available(
+                store.as_storage(),
+                repo_prefix,
+                &CancellationToken::new(),
+            )
+            .await,
+            "upload-pack admission should rebuild current visibility from locator-backed objects"
+        );
+        let repaired = crab_metadata::git_visibility::read(
+            store.as_storage(),
+            &crab_storage::StoreLayout::new(store.as_storage().clone(), repo_prefix.to_owned()),
+            manifest.generation,
+            &manifest.pack_index_hash,
+        )
+        .await
+        .expect("read repaired visibility proof");
+        assert!(repaired.refs.keys().eq(manifest.refs.keys()));
+        assert!(manifest.refs.iter().all(|(name, tip)| {
+            repaired
+                .refs
+                .get(name)
+                .is_some_and(|objects| objects.binary_search(tip).is_ok())
+        }));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -1904,6 +1904,15 @@ fn decisions_to_outcomes(
         .collect()
 }
 
+fn decisions_to_push_result(decisions: &HashMap<String, RefUpdateDecision>) -> PushResult {
+    let result = PushResult::new(decisions_to_outcomes(decisions));
+    if result.all_ok() {
+        result
+    } else {
+        result.with_failure_stage(PushFailureStage::Preflight)
+    }
+}
+
 fn ref_edits_are_manifest_noop(
     specs: &[PushSpec],
     base_manifest: Option<&Manifest>,
@@ -3396,6 +3405,31 @@ pub enum PushFailureStage {
     CommitGraph,
     /// Manifest/ref transaction commit.
     RefCommit,
+}
+
+impl PushFailureStage {
+    /// Return the stable name used by audit and structured push telemetry.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Admission => "admission",
+            Self::StoreResolve => "store-resolve",
+            Self::Discovery => "discovery",
+            Self::RemoteState => "remote-state",
+            Self::Preflight => "preflight",
+            Self::Classify => "classify",
+            Self::Lock => "lock",
+            Self::XorbPack => "xorb-pack",
+            Self::XorbUpload => "xorb-upload",
+            Self::GitPackPrepare => "git-pack-prepare",
+            Self::ShardBuild => "shard-build",
+            Self::ShardUpload => "shard-upload",
+            Self::GitPackUpload => "git-pack-upload",
+            Self::Connectivity => "connectivity",
+            Self::CommitGraph => "commit-graph",
+            Self::RefCommit => "ref-commit",
+        }
+    }
 }
 
 /// Result of a push batch: per-ref outcomes keyed by destination ref name.
@@ -14038,7 +14072,7 @@ impl PushPipeline {
                 .values()
                 .any(|decision| matches!(decision, RefUpdateDecision::Proceed { .. }))
             {
-                return Ok(PushResult::new(decisions_to_outcomes(&decisions)));
+                return Ok(decisions_to_push_result(&decisions));
             }
             *self.planned_ref_decisions.lock().await = Some(decisions.clone());
             Some((sha_map, decisions))
@@ -14441,16 +14475,15 @@ impl PushPipeline {
         // rejection reason even though the pipeline committed the
         // other refs successfully. When decisions are unavailable
         // (no store path), fall back to the historical all-Ok shape.
-        let outcomes = if let Some(decisions) = decisions {
-            decisions_to_outcomes(&decisions)
+        let result = if let Some(decisions) = decisions {
+            decisions_to_push_result(&decisions)
         } else {
             let mut outcomes = HashMap::new();
             for spec in &self.specs {
                 outcomes.insert(spec.dst.clone(), RefPushOutcome::Ok);
             }
-            outcomes
+            PushResult::new(outcomes)
         };
-        let result = PushResult::new(outcomes);
         Ok(match active_active_commit {
             Some(commit) => result.with_active_active_commit(commit),
             None => result,
@@ -17251,6 +17284,51 @@ mod tests {
                 want: "new111".to_owned(),
             })
         );
+    }
+
+    #[test]
+    fn rejected_preflight_result_retains_stage() {
+        let decisions = HashMap::from([(
+            "refs/heads/main".to_owned(),
+            RefUpdateDecision::Reject(PushRejectReason::NonFastForward {
+                have: "old000".to_owned(),
+                want: "new111".to_owned(),
+            }),
+        )]);
+
+        assert_eq!(
+            decisions_to_push_result(&decisions).failure_stage,
+            Some(PushFailureStage::Preflight)
+        );
+    }
+
+    #[test]
+    fn failure_stage_names_match_serialized_audit_values() {
+        let stages = [
+            PushFailureStage::Admission,
+            PushFailureStage::StoreResolve,
+            PushFailureStage::Discovery,
+            PushFailureStage::RemoteState,
+            PushFailureStage::Preflight,
+            PushFailureStage::Classify,
+            PushFailureStage::Lock,
+            PushFailureStage::XorbPack,
+            PushFailureStage::XorbUpload,
+            PushFailureStage::GitPackPrepare,
+            PushFailureStage::ShardBuild,
+            PushFailureStage::ShardUpload,
+            PushFailureStage::GitPackUpload,
+            PushFailureStage::Connectivity,
+            PushFailureStage::CommitGraph,
+            PushFailureStage::RefCommit,
+        ];
+
+        for stage in stages {
+            assert_eq!(
+                serde_json::to_value(stage).expect("serialize failure stage"),
+                serde_json::Value::String(stage.as_str().to_owned())
+            );
+        }
     }
 
     // --- PushConfig defaults ---

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -2146,7 +2146,7 @@ fn active_active_uploaded_objects(
     {
         keys.insert(
             router
-                .git_visibility_path(candidate.generation, &candidate.pack_index_hash)
+                .git_visibility_path(&candidate.git_validation_digest)
                 .as_ref()
                 .to_owned(),
         );
@@ -5748,16 +5748,26 @@ async fn git_visibility_index_exists_for_manifest(
     let storage = store.as_storage();
     let storage_router =
         crab_storage::StoreLayout::new(storage.clone(), router.repo_prefix().to_owned());
-    match crab_metadata::git_visibility::read(
+    match crab_metadata::git_visibility::read_with_format(
         storage,
         &storage_router,
         manifest.generation,
         &manifest.pack_index_hash,
+        &manifest.git_validation_digest,
     )
     .await
     {
-        Ok(index) => {
-            ensure_git_visibility_matches_manifest(&index, manifest, router)?;
+        Ok(read) => {
+            ensure_git_visibility_matches_manifest(&read.index, manifest, router)?;
+            if read.format == crab_metadata::git_visibility::GitVisibilityFormat::V1 {
+                crab_metadata::git_visibility::upload_if_absent(
+                    storage,
+                    &storage_router,
+                    &read.index,
+                )
+                .await
+                .map_err(CrabError::from)?;
+            }
             Ok(true)
         }
         Err(crab_metadata::error::MetadataError::Storage {
@@ -5772,27 +5782,12 @@ fn ensure_git_visibility_matches_manifest(
     manifest: &Manifest,
     router: &StoreLayout,
 ) -> Result<()> {
-    let matches = index.generation == manifest.generation
-        && index.pack_index_hash == manifest.pack_index_hash
-        && index.refs.keys().eq(manifest.refs.keys())
-        && manifest.refs.iter().all(|(name, tip)| {
-            index
-                .refs
-                .get(name)
-                .is_some_and(|objects| objects.binary_search(tip).is_ok())
-        })
-        && manifest.peeled_refs.iter().all(|(name, peeled)| {
-            index
-                .refs
-                .get(name)
-                .is_some_and(|objects| objects.binary_search(peeled).is_ok())
-        });
-    if matches {
+    if index.matches_manifest(manifest) {
         return Ok(());
     }
     Err(CrabError::CorruptObject {
         path: router
-            .git_visibility_path(manifest.generation, &manifest.pack_index_hash)
+            .git_visibility_path(&manifest.git_validation_digest)
             .as_ref()
             .to_owned(),
         reason: "Git visibility proof does not match its manifest refs".to_owned(),
@@ -7800,6 +7795,7 @@ impl PushPipeline {
                 &storage_router,
                 compacted.generation,
                 &compacted.pack_index_hash,
+                &compacted.git_validation_digest,
             )
             .await
             {
@@ -15123,6 +15119,7 @@ pub(crate) async fn build_git_visibility_index_from_storage_git_dir(
         return Ok(crab_metadata::git_visibility::GitVisibilityIndex::new(
             manifest.generation,
             manifest.pack_index_hash.clone(),
+            manifest.git_validation_digest.clone(),
             BTreeMap::new(),
         ));
     }
@@ -15159,6 +15156,7 @@ pub(crate) async fn build_git_visibility_index_from_storage_git_dir(
     let index = crab_metadata::git_visibility::GitVisibilityIndex::new(
         manifest.generation,
         manifest.pack_index_hash.clone(),
+        manifest.git_validation_digest.clone(),
         refs,
     );
     Ok(index)
@@ -17309,6 +17307,7 @@ mod tests {
         let index = crab_metadata::git_visibility::GitVisibilityIndex::new(
             manifest.generation,
             manifest.pack_index_hash.clone(),
+            manifest.git_validation_digest.clone(),
             BTreeMap::from([("refs/heads/main".to_owned(), vec!["2".repeat(40)])]),
         );
 
@@ -17316,6 +17315,94 @@ mod tests {
             ensure_git_visibility_matches_manifest(&index, &manifest, &router),
             Err(CrabError::CorruptObject { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn mismatched_v1_visibility_is_rejected_without_v2_backfill() {
+        let (store, router) = test_store_router("visibility-v1-mismatch");
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 3;
+        manifest.pack_index_hash = "a".repeat(64);
+        manifest
+            .refs
+            .insert("refs/heads/main".to_owned(), "1".repeat(40));
+        manifest.seal_git_validation();
+        let storage = store.as_storage();
+        let storage_router =
+            crab_storage::StoreLayout::new(storage.clone(), router.repo_prefix().to_owned());
+        let legacy = serde_json::json!({
+            "version": 1,
+            "generation": manifest.generation,
+            "pack_index_hash": manifest.pack_index_hash.clone(),
+            "refs": {"refs/heads/main": ["2".repeat(40)]},
+        });
+        storage
+            .put(
+                &storage_router
+                    .git_visibility_v1_path(manifest.generation, &manifest.pack_index_hash),
+                Bytes::from(serde_json::to_vec(&legacy).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            git_visibility_index_exists_for_manifest(&store, &router, &manifest).await,
+            Err(CrabError::CorruptObject { .. })
+        ));
+        assert!(matches!(
+            storage
+                .head(&storage_router.git_visibility_path(&manifest.git_validation_digest),)
+                .await,
+            Err(StorageError::NotFound { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn matching_v1_visibility_is_backfilled_by_writer() {
+        let (store, router) = test_store_router("visibility-v1-backfill");
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 3;
+        manifest.pack_index_hash = "a".repeat(64);
+        manifest
+            .refs
+            .insert("refs/heads/main".to_owned(), "1".repeat(40));
+        manifest.seal_git_validation();
+        let storage = store.as_storage();
+        let storage_router =
+            crab_storage::StoreLayout::new(storage.clone(), router.repo_prefix().to_owned());
+        let legacy = serde_json::json!({
+            "version": 1,
+            "generation": manifest.generation,
+            "pack_index_hash": manifest.pack_index_hash.clone(),
+            "refs": {"refs/heads/main": ["1".repeat(40)]},
+        });
+        storage
+            .put(
+                &storage_router
+                    .git_visibility_v1_path(manifest.generation, &manifest.pack_index_hash),
+                Bytes::from(serde_json::to_vec(&legacy).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            git_visibility_index_exists_for_manifest(&store, &router, &manifest)
+                .await
+                .unwrap()
+        );
+        let current = crab_metadata::git_visibility::read_with_format(
+            &storage,
+            &storage_router,
+            manifest.generation,
+            &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            current.format,
+            crab_metadata::git_visibility::GitVisibilityFormat::V2
+        );
     }
 
     #[test]
@@ -18724,13 +18811,16 @@ mod tests {
             &storage_router,
             manifest.generation,
             &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
         )
         .await
         .expect("read pushed visibility proof");
         manifest.generation = manifest.generation.saturating_add(1);
+        manifest.seal_git_validation();
         let next_visibility = crab_metadata::git_visibility::GitVisibilityIndex::new(
             manifest.generation,
             manifest.pack_index_hash.clone(),
+            manifest.git_validation_digest.clone(),
             visibility.refs,
         );
         crab_metadata::git_visibility::upload_if_absent(
@@ -18740,7 +18830,6 @@ mod tests {
         )
         .await
         .expect("upload next visibility proof");
-        manifest.seal_git_validation();
         write_manifest_cas(&store, &router, &manifest, &etag)
             .await
             .expect("advance manifest without locator publication");
@@ -18817,8 +18906,7 @@ mod tests {
         let (manifest, _) = read_manifest(&store, &router)
             .await
             .expect("read pushed manifest");
-        let visibility_path =
-            router.git_visibility_path(manifest.generation, &manifest.pack_index_hash);
+        let visibility_path = router.git_visibility_path(&manifest.git_validation_digest);
         store
             .delete(&visibility_path)
             .await
@@ -18842,6 +18930,7 @@ mod tests {
             &crab_storage::StoreLayout::new(store.as_storage().clone(), repo_prefix.to_owned()),
             manifest.generation,
             &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
         )
         .await
         .expect("read repaired visibility proof");
@@ -19963,6 +20052,7 @@ mod tests {
             &storage_router,
             manifest.generation,
             &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
         )
         .await
         .expect("journal compaction publishes visibility evidence");

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -261,7 +261,9 @@ pub(crate) struct CommittedManifestAnchor {
     pub(crate) pack_index_hash: MerkleHash,
 }
 
-fn committed_manifest_anchor(manifest: &Manifest) -> Result<Option<CommittedManifestAnchor>> {
+pub(crate) fn committed_manifest_anchor(
+    manifest: &Manifest,
+) -> Result<Option<CommittedManifestAnchor>> {
     if manifest.shard_index_hash.is_empty() && manifest.pack_index_hash.is_empty() {
         return Ok(None);
     }
@@ -5462,6 +5464,27 @@ pub(crate) async fn publish_committed_pack_locators(
     let stats = write_result?;
     release_result?;
     Ok(stats)
+}
+
+pub(crate) async fn repair_git_object_locator_if_current(
+    store: &Store,
+    router: &StoreLayout,
+    required_generation: u64,
+    lock_ttl: Duration,
+    cancel: &CancellationToken,
+) -> Result<bool> {
+    let (manifest, _) = read_manifest(store, router).await?;
+    // An active ref-journal transaction asks readers for the next generation.
+    // Repair only an already-canonical generation or a read could bless stale state.
+    if manifest.generation != required_generation {
+        return Ok(false);
+    }
+    let Some(anchor) = committed_manifest_anchor(&manifest)? else {
+        return Ok(false);
+    };
+    let stats =
+        publish_committed_pack_locators(store, router, &[], anchor, lock_ttl, cancel).await?;
+    Ok(stats.coverage_updated)
 }
 
 async fn publish_uploaded_pack_locators(
@@ -18167,6 +18190,107 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn upload_pack_repairs_locator_for_current_manifest_generation() {
+        let _guard = GitDirGuard::new();
+        let repo_prefix = "upload-pack-locator-repair";
+        let (store, router) = test_store_router(repo_prefix);
+        let initial = Manifest::default_for_repo("refs/heads/main");
+        create_manifest_with_etag(&store, &router, &initial)
+            .await
+            .expect("create initial manifest");
+        let pushed = PushPipeline::new(
+            PushConfig::default(),
+            vec![make_spec("refs/heads/main")],
+            Some(store.clone()),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router.clone(),
+            None,
+            CancellationToken::new(),
+            None,
+        )
+        .execute()
+        .await;
+        assert_eq!(
+            pushed.outcomes.get("refs/heads/main"),
+            Some(&RefPushOutcome::Ok)
+        );
+
+        let (mut manifest, etag) = read_manifest(&store, &router)
+            .await
+            .expect("read pushed manifest");
+        let covered_generation = manifest.generation;
+        let storage_router =
+            crab_storage::StoreLayout::new(store.as_storage().clone(), repo_prefix.to_owned());
+        let visibility = crab_metadata::git_visibility::read(
+            store.as_storage(),
+            &storage_router,
+            manifest.generation,
+            &manifest.pack_index_hash,
+        )
+        .await
+        .expect("read pushed visibility proof");
+        manifest.generation = manifest.generation.saturating_add(1);
+        let next_visibility = crab_metadata::git_visibility::GitVisibilityIndex::new(
+            manifest.generation,
+            manifest.pack_index_hash.clone(),
+            visibility.refs,
+        );
+        crab_metadata::git_visibility::upload_if_absent(
+            store.as_storage(),
+            &storage_router,
+            &next_visibility,
+        )
+        .await
+        .expect("upload next visibility proof");
+        manifest.seal_git_validation();
+        write_manifest_cas(&store, &router, &manifest, &etag)
+            .await
+            .expect("advance manifest without locator publication");
+
+        let stale = crab_metadata::git_object_locator::GitObjectLocatorSession::open(
+            Arc::clone(store.inner()),
+            repo_prefix,
+        )
+        .await
+        .expect("open stale locator session");
+        assert_eq!(
+            stale.coverage().map(|coverage| coverage.generation),
+            Some(covered_generation)
+        );
+        stale.close().await.expect("close stale locator session");
+
+        let repository = crate::git::upload_pack_wire::open_repository(
+            store.as_storage(),
+            repo_prefix,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("upload-pack should repair current locator coverage");
+        assert_eq!(repository.generation(), manifest.generation);
+        repository
+            .visibility_index(&CancellationToken::new())
+            .await
+            .expect("repaired repository should remain exactly authorized");
+
+        let repaired = crab_metadata::git_object_locator::GitObjectLocatorSession::open(
+            Arc::clone(store.inner()),
+            repo_prefix,
+        )
+        .await
+        .expect("open repaired locator session");
+        assert_eq!(
+            repaired.coverage().map(|coverage| coverage.generation),
+            Some(manifest.generation)
+        );
+        repaired
+            .close()
+            .await
+            .expect("close repaired locator session");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn under_lock_refresh_rebases_plan_before_pack_work() {
         let _guard = GitDirGuard::new();
         let (store, router) = test_store_router("under-lock-refresh");
@@ -19743,17 +19867,27 @@ mod tests {
             ..anchor
         };
 
-        let stats = publish_uploaded_pack_locators(
+        let skipped = repair_git_object_locator_if_current(
             &store,
             &router,
-            &[],
-            next_anchor,
+            next_anchor.generation + 1,
             Duration::from_secs(60),
             &CancellationToken::new(),
         )
         .await
-        .expect("advance locator coverage without new packs");
-        assert!(stats.coverage_updated);
+        .expect("skip repair for a future generation");
+        assert!(!skipped);
+
+        let repaired = repair_git_object_locator_if_current(
+            &store,
+            &router,
+            next_anchor.generation,
+            Duration::from_secs(60),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("repair current locator coverage without new packs");
+        assert!(repaired);
 
         let session = crab_metadata::git_object_locator::GitObjectLocatorSession::open(
             Arc::clone(store.inner()),

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -3366,6 +3366,10 @@ impl fmt::Display for RefPushOutcome {
 pub enum PushFailureStage {
     /// Repository admission ticket acquisition or renewal.
     Admission,
+    /// Write-store, control-plane, or protected-push setup.
+    StoreResolve,
+    /// Native Git and remote-frontier discovery before pipeline delegation.
+    Discovery,
     /// Canonical manifest or repository snapshot read.
     RemoteState,
     /// Ref policy, ancestry, and base-bound decision planning.

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -3356,6 +3356,44 @@ impl fmt::Display for RefPushOutcome {
     }
 }
 
+/// Stable push-pipeline stage attached to a rejected batch for diagnostics.
+///
+/// This is deliberately separate from [`PushRejectReason::protocol_tag`]: Git
+/// consumes the reason tag, while operators need the stage to attribute a
+/// transient failure without parsing provider-specific error text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PushFailureStage {
+    /// Repository admission ticket acquisition or renewal.
+    Admission,
+    /// Canonical manifest or repository snapshot read.
+    RemoteState,
+    /// Ref policy, ancestry, and base-bound decision planning.
+    Preflight,
+    /// Pointer, staging, and chunk classification.
+    Classify,
+    /// Per-ref push-lock acquisition or renewal.
+    Lock,
+    /// Xorb payload packing.
+    XorbPack,
+    /// Xorb payload upload or durability verification.
+    XorbUpload,
+    /// Git reachability and pack preparation.
+    GitPackPrepare,
+    /// Reconstruction shard construction.
+    ShardBuild,
+    /// Reconstruction shard and file-index upload.
+    ShardUpload,
+    /// Git pack upload.
+    GitPackUpload,
+    /// Reachability verification before refs move.
+    Connectivity,
+    /// Commit-graph summary publication.
+    CommitGraph,
+    /// Manifest/ref transaction commit.
+    RefCommit,
+}
+
 /// Result of a push batch: per-ref outcomes keyed by destination ref name.
 #[derive(Debug, Clone)]
 pub struct PushResult {
@@ -3363,6 +3401,8 @@ pub struct PushResult {
     pub outcomes: HashMap<String, RefPushOutcome>,
     /// Coordinator commit metadata when active-active mode accepted this push.
     pub active_active_commit: Option<PushCommitMetadata>,
+    /// Pipeline stage responsible for a rejected batch, when known.
+    pub failure_stage: Option<PushFailureStage>,
 }
 
 /// Coordinator metadata attached to a successful active-active push.
@@ -3408,6 +3448,7 @@ impl PushResult {
         Self {
             outcomes,
             active_active_commit: None,
+            failure_stage: None,
         }
     }
 
@@ -3419,6 +3460,12 @@ impl PushResult {
     #[must_use]
     pub fn with_active_active_commit(mut self, commit: PushCommitMetadata) -> Self {
         self.active_active_commit = Some(commit);
+        self
+    }
+
+    #[must_use]
+    pub fn with_failure_stage(mut self, stage: PushFailureStage) -> Self {
+        self.failure_stage = Some(stage);
         self
     }
 
@@ -3436,6 +3483,8 @@ struct PushAuditPayload<'a> {
     repo_prefix: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failure_stage: Option<PushFailureStage>,
     refs: Vec<PushAuditRef<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     active_active: Option<PushAuditActiveActive<'a>>,
@@ -3478,6 +3527,7 @@ pub fn record_push_audit_event(
     let details = PushAuditPayload {
         repo_prefix,
         duration_ms,
+        failure_stage: result.failure_stage,
         refs: push_audit_refs(specs, result),
         active_active: result
             .active_active_commit
@@ -3725,6 +3775,10 @@ pub struct PushPipeline {
     /// Whether this generation has the complete bounded visibility proof that
     /// protocol-v2 admission requires alongside exact locator coverage.
     git_visibility_published: std::sync::atomic::AtomicBool,
+    /// First failing stage observed by this single-use pipeline. The first
+    /// error wins so admission cleanup cannot overwrite a more precise inner
+    /// upload or commit stage.
+    failure_stage: std::sync::OnceLock<PushFailureStage>,
     /// Base-bound dependency receipt rebuilt whenever manifest CAS replans.
     push_commit_receipt: tokio::sync::Mutex<Option<crab_metadata::receipts::PushCommitReceipt>>,
     /// Current pre-commit ref decisions. Dependency discovery reads this so
@@ -5487,6 +5541,7 @@ impl PushPipeline {
             manifest_etag: tokio::sync::Mutex::new(None),
             committed_manifest_anchor: tokio::sync::Mutex::new(None),
             git_visibility_published: std::sync::atomic::AtomicBool::new(false),
+            failure_stage: std::sync::OnceLock::new(),
             push_commit_receipt: tokio::sync::Mutex::new(None),
             planned_ref_decisions: tokio::sync::Mutex::new(None),
             dependency_plan: tokio::sync::Mutex::new(None),
@@ -13822,6 +13877,20 @@ impl PushPipeline {
         }
     }
 
+    fn record_failure_stage(&self, stage: PushFailureStage) {
+        let _ = self.failure_stage.set(stage);
+    }
+
+    fn at_stage<T>(&self, stage: PushFailureStage, result: Result<T>) -> Result<T> {
+        result.inspect_err(|_| {
+            self.record_failure_stage(stage);
+        })
+    }
+
+    fn observed_failure_stage(&self) -> Option<PushFailureStage> {
+        self.failure_stage.get().copied()
+    }
+
     /// Execute the full 14-step push pipeline.
     ///
     /// Returns per-ref outcomes. On any step failure before the ref
@@ -13845,15 +13914,17 @@ impl PushPipeline {
         } else {
             Ok(None)
         };
+        let admission_lock = self.at_stage(PushFailureStage::Admission, admission_lock);
         let result = match admission_lock {
             Ok(Some(lock)) => {
                 let (committed_tx, committed_rx) = tokio::sync::oneshot::channel();
-                while_admitted_until_commit(
+                let result = while_admitted_until_commit(
                     lock,
                     self.execute_inner(Some(committed_tx)),
                     committed_rx,
                 )
-                .await
+                .await;
+                self.at_stage(PushFailureStage::Admission, result)
             }
             Ok(None) => Box::pin(self.execute_inner(None)).await,
             Err(error) => Err(error),
@@ -13884,8 +13955,9 @@ impl PushPipeline {
             // every ref with the aggregate error — otherwise a user
             // pushing three refs sees "all failed" when only one
             // actually did.
-            Err(CrabError::PushPartialOutcome { outcomes, .. }) => {
+            Err(CrabError::PushPartialOutcome { mut outcomes, .. }) => {
                 self.on_failure().await;
+                outcomes.failure_stage = self.observed_failure_stage();
                 *outcomes
             }
             Err(e) => {
@@ -13895,7 +13967,9 @@ impl PushPipeline {
                 for spec in &self.specs {
                     outcomes.insert(spec.dst.clone(), RefPushOutcome::Rejected(reason.clone()));
                 }
-                PushResult::new(outcomes)
+                let mut result = PushResult::new(outcomes);
+                result.failure_stage = self.observed_failure_stage();
+                result
             }
         }
     }
@@ -13926,26 +14000,35 @@ impl PushPipeline {
 
         // Read the current manifest pointer before any pipeline steps.
         // This establishes the base state for `build_manifest` later.
-        self.read_base_manifest().await?;
+        self.at_stage(
+            PushFailureStage::RemoteState,
+            self.read_base_manifest().await,
+        )?;
 
         // Resolve policy and ref preconditions before dependency discovery or
         // immutable uploads. In non-atomic mode only proceeding refs may add
         // pointer, Git-object, or connectivity requirements. In atomic mode a
         // single rejection terminates the batch before remote mutation.
         let mut preflight = if self.store.is_some() {
-            let sha_map = self.resolve_src_ref_map()?;
-            let decisions = self.evaluate_decisions_with_sha_map(&sha_map).await?;
+            let sha_map = self.at_stage(PushFailureStage::Preflight, self.resolve_src_ref_map())?;
+            let decisions = self.at_stage(
+                PushFailureStage::Preflight,
+                self.evaluate_decisions_with_sha_map(&sha_map).await,
+            )?;
             if (self.config.atomic || self.config.protected_push.is_some())
                 && decisions
                     .values()
                     .any(|decision| matches!(decision, RefUpdateDecision::Reject(_)))
             {
-                return Err(CrabError::PushPartialOutcome {
-                    outcomes: Box::new(PushResult::new(aborted_batch_outcomes(&decisions))),
-                    source: Box::new(CrabError::Internal(
-                        "indivisible push aborted during ref preflight".to_owned(),
-                    )),
-                });
+                return self.at_stage(
+                    PushFailureStage::Preflight,
+                    Err(CrabError::PushPartialOutcome {
+                        outcomes: Box::new(PushResult::new(aborted_batch_outcomes(&decisions))),
+                        source: Box::new(CrabError::Internal(
+                            "indivisible push aborted during ref preflight".to_owned(),
+                        )),
+                    }),
+                );
             }
             if !decisions
                 .values()
@@ -13960,7 +14043,7 @@ impl PushPipeline {
         };
 
         // Steps 1–4: data preparation (classify phase)
-        async {
+        let classify_result = async {
             self.enumerate_pointers().await?;
             // Pure Git pushes never consult file/chunk metadata. Avoid
             // opening and draining shared SlateDB readers for every branch
@@ -13981,7 +14064,8 @@ impl PushPipeline {
             self.classify_chunks().await
         }
         .instrument(info_span!("push.classify"))
-        .await?;
+        .await;
+        self.at_stage(PushFailureStage::Classify, classify_result)?;
 
         // Cancellation check: after classify, before pack.
         check_cancelled(&self.cancel)?;
@@ -13990,11 +14074,13 @@ impl PushPipeline {
         // hand this lock in after discovery; direct callers acquire it here.
         // This preserves lock-then-push serialization while immutable xorb
         // uploads overlap the remaining staged reads.
-        self.acquire_push_lock().await?;
+        self.at_stage(PushFailureStage::Lock, self.acquire_push_lock().await)?;
         if let Some((sha_map, decisions)) = preflight.as_mut() {
-            *decisions = self
-                .refresh_base_bound_plan_after_lock(sha_map, decisions)
-                .await?;
+            *decisions = self.at_stage(
+                PushFailureStage::Preflight,
+                self.refresh_base_bound_plan_after_lock(sha_map, decisions)
+                    .await,
+            )?;
         }
         if self.config.protected_push.is_none()
             && self.config.active_active_replication.is_none()
@@ -14044,9 +14130,9 @@ impl PushPipeline {
             self.upload_packed_xorb_stream(packed_rx),
             self.prepare_git_pack(),
         );
-        let pack_summary = pack_result?;
-        let upload_summary = upload_result?;
-        git_prepare_result?;
+        let pack_summary = self.at_stage(PushFailureStage::XorbPack, pack_result)?;
+        let upload_summary = self.at_stage(PushFailureStage::XorbUpload, upload_result)?;
+        self.at_stage(PushFailureStage::GitPackPrepare, git_prepare_result)?;
         if pack_summary.xorb_count != upload_summary.planned_xorbs
             || pack_summary.payload_bytes != upload_summary.planned_bytes
         {
@@ -14086,7 +14172,7 @@ impl PushPipeline {
         // Cancellation is checked between each upload step so Ctrl-C during
         // a long upload phase responds within one step boundary rather than
         // waiting for all four steps to complete.
-        self.build_shard().await?;
+        self.at_stage(PushFailureStage::ShardBuild, self.build_shard().await)?;
         check_cancelled(&self.cancel)?;
         let (shard_upload_bytes, shard_upload_count) = {
             let shards = self.shard_results.lock().await;
@@ -14099,11 +14185,12 @@ impl PushPipeline {
             )
         };
         let shard_upload_phase = PhaseTimer::start("push", "shard_upload");
-        Box::pin(self.upload_shard_and_file_index()).await?;
+        let shard_upload_result = Box::pin(self.upload_shard_and_file_index()).await;
+        self.at_stage(PushFailureStage::ShardUpload, shard_upload_result)?;
         self.emit_perf_phase(shard_upload_phase.finish(0, shard_upload_bytes, shard_upload_count));
         check_cancelled(&self.cancel)?;
         let pack_upload_phase = PhaseTimer::start("push", "pack_upload");
-        self.upload_packs().await?;
+        self.at_stage(PushFailureStage::GitPackUpload, self.upload_packs().await)?;
         let (pack_upload_bytes, pack_upload_count) = {
             let packs = self.uploaded_packs.lock().await;
             (
@@ -14129,7 +14216,10 @@ impl PushPipeline {
         // [`CrabError::PushConnectivityMissing`] which is mapped to
         // [`PushRejectReason::ConnectivityMissing`] by the per-ref
         // outcome collapse in `execute`.
-        self.verify_connectivity().await?;
+        self.at_stage(
+            PushFailureStage::Connectivity,
+            self.verify_connectivity().await,
+        )?;
 
         // Cancellation check: after connectivity, before manifest CAS.
         check_cancelled(&self.cancel)?;
@@ -14137,7 +14227,10 @@ impl PushPipeline {
         // Publish the shallow-fetch graph before exposing refs. Extra entries
         // are harmless if the later manifest CAS loses a race because fetch
         // traversal is rooted only at the committed ref tips.
-        self.publish_commit_graph_summary().await?;
+        self.at_stage(
+            PushFailureStage::CommitGraph,
+            self.publish_commit_graph_summary().await,
+        )?;
 
         // Steps 11-12: Build manifest and CAS-write the pointer.
         // When no store is available (tests without S3), skip the manifest
@@ -14150,31 +14243,44 @@ impl PushPipeline {
         // "every ref is Ok" assumption.
         let mut active_active_commit = None;
         let decisions = if self.store.is_some() {
-            let (sha_map, decisions) = preflight.ok_or_else(|| {
+            let preflight = preflight.ok_or_else(|| {
                 CrabError::Internal("push ref preflight result is missing".to_owned())
-            })?;
-            let (manifest, bulk) = self
+            });
+            let (sha_map, decisions) = self.at_stage(PushFailureStage::RefCommit, preflight)?;
+            let apply_result = self
                 .apply_decisions_with_sha_map(&decisions, self.config.atomic, &sha_map)
-                .await?;
-            let manifest_bytes = serde_json::to_vec_pretty(&manifest)
-                .map_err(|e| CrabError::Internal(format!("manifest serialize: {e}")))?
+                .await;
+            let (manifest, bulk) = self.at_stage(PushFailureStage::RefCommit, apply_result)?;
+            let manifest_bytes = self
+                .at_stage(
+                    PushFailureStage::RefCommit,
+                    serde_json::to_vec_pretty(&manifest)
+                        .map_err(|e| CrabError::Internal(format!("manifest serialize: {e}"))),
+                )?
                 .len() as u64;
             let manifest_phase = PhaseTimer::start("push", "ref_journal_commit");
             let manifest_item_count = manifest.refs.len() as u64;
             let manifest_bytes_out = manifest_bytes + bulk_data_bytes(&bulk);
-            let committed_decisions = if let Some(outcome) = self
+            let active_active_result = self
                 .active_active_commit_and_materialize(&manifest, &bulk, &decisions, &sha_map)
-                .await?
+                .await;
+            let committed_decisions = if let Some(outcome) =
+                self.at_stage(PushFailureStage::RefCommit, active_active_result)?
             {
                 active_active_commit = Some(PushCommitMetadata::from(outcome));
                 debug!("steps 11-12: committed through active-active coordinator");
                 decisions
             } else if self.config.protected_push.is_some() {
-                active_active_commit = self.protected_push_finalize(manifest, bulk).await?;
+                active_active_commit = self.at_stage(
+                    PushFailureStage::RefCommit,
+                    self.protected_push_finalize(manifest, bulk).await,
+                )?;
                 decisions
             } else {
-                self.commit_ref_journal(manifest, bulk, &sha_map, decisions, &mut admission_commit)
-                    .await?
+                let commit_result = self
+                    .commit_ref_journal(manifest, bulk, &sha_map, decisions, &mut admission_commit)
+                    .await;
+                self.at_stage(PushFailureStage::RefCommit, commit_result)?
             };
             self.emit_perf_phase(manifest_phase.finish(0, manifest_bytes_out, manifest_item_count));
             Some(committed_decisions)
@@ -17275,6 +17381,37 @@ mod tests {
     }
 
     #[test]
+    fn pipeline_failure_stage_preserves_first_owner() {
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            Vec::new(),
+            None,
+            None,
+            None,
+            "repo".to_owned(),
+            test_router("repo"),
+            None,
+            CancellationToken::new(),
+            None,
+        );
+        let first: Result<()> = pipeline.at_stage(
+            PushFailureStage::XorbUpload,
+            Err(CrabError::Internal("upload failed".to_owned())),
+        );
+        let cleanup: Result<()> = pipeline.at_stage(
+            PushFailureStage::Admission,
+            Err(CrabError::Internal("admission renewal failed".to_owned())),
+        );
+
+        assert!(first.is_err());
+        assert!(cleanup.is_err());
+        assert_eq!(
+            pipeline.observed_failure_stage(),
+            Some(PushFailureStage::XorbUpload)
+        );
+    }
+
+    #[test]
     fn push_audit_event_records_per_ref_outcomes() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("events.jsonl");
@@ -17299,7 +17436,7 @@ mod tests {
                 want: "new".to_owned(),
             }),
         );
-        let result = PushResult::new(outcomes);
+        let result = PushResult::new(outcomes).with_failure_stage(PushFailureStage::Preflight);
 
         record_push_audit_event(
             &path,
@@ -17319,6 +17456,7 @@ mod tests {
         assert_eq!(event.repository.as_deref(), Some("crab://bucket/repo"));
         assert_eq!(event.details["repo_prefix"], "repo");
         assert_eq!(event.details["duration_ms"], 42);
+        assert_eq!(event.details["failure_stage"], "preflight");
         assert_eq!(event.details["refs"][0]["status"], "rejected");
         assert_eq!(event.details["refs"][0]["reason_tag"], "non-fast-forward");
         assert_eq!(event.details["refs"][1]["status"], "ok");

--- a/crab/src/git/push_native.rs
+++ b/crab/src/git/push_native.rs
@@ -19,8 +19,9 @@ use crate::core::perf_phase::PerfPhaseSink;
 use crate::git::discover;
 use crate::git::progress::NativePushProgress;
 use crate::git::push::{
-    PrePopulatedWalk, PushConfig, PushLockLease, PushResult, acquire_push_lock_leases,
-    duplicate_destination_result, release_push_lock_leases, run_push_batch_with_locks,
+    PrePopulatedWalk, PushConfig, PushFailureStage, PushLockLease, PushResult,
+    acquire_push_lock_leases, duplicate_destination_result, release_push_lock_leases,
+    run_push_batch_with_locks,
 };
 use crate::git::push_state::PushState;
 use crate::git::remote_helper::PushSpec;
@@ -620,7 +621,7 @@ fn push_lock_rejection_result(specs: &[PushSpec], err: &CrabError) -> PushResult
             super::push::RefPushOutcome::Rejected(reason.clone()),
         );
     }
-    PushResult::new(outcomes)
+    PushResult::new(outcomes).with_failure_stage(PushFailureStage::Lock)
 }
 
 async fn release_native_locks_on_error<T>(
@@ -1586,6 +1587,24 @@ mod tests {
         assert_eq!(
             prepared_ref_frontier(&updates),
             BTreeMap::from([("refs/heads/main".to_owned(), "a".repeat(40))])
+        );
+    }
+
+    #[test]
+    fn lock_rejection_retains_failure_stage() {
+        let result = push_lock_rejection_result(
+            &[main_push_spec()],
+            &CrabError::PushLockHeld {
+                ref_name: "refs/heads/main".to_owned(),
+                holder: "other-writer".to_owned(),
+                expires_at_unix: Some(1),
+            },
+        );
+
+        assert_eq!(result.failure_stage, Some(PushFailureStage::Lock));
+        assert_eq!(
+            result.outcomes["refs/heads/main"].protocol_tag(),
+            "lock-contention"
         );
     }
 

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -1,8 +1,8 @@
 //! Git protocol-v2 upload-pack over the helper's already-authenticated stdio.
 //!
-//! This module owns only wire framing and command semantics. Repository
-//! admission, generation pinning, object traversal, and pack production stay
-//! in the shared read and remote-git crates.
+//! This module owns wire framing, command semantics, and the product-level
+//! admission repair before a session starts. Generation pinning, object
+//! traversal, and pack production stay in the shared read and remote-git crates.
 
 use std::collections::HashSet;
 use std::fmt::Write as _;
@@ -14,7 +14,8 @@ use crab_read::{
     parse_upload_pack_filter, plan_upload_pack,
 };
 use crab_remote_git::{
-    RemoteGitRepository, RemoteGitRuntime, RepositoryIdentity, RepositoryOptions,
+    Error as RemoteGitError, RemoteGitRepository, RemoteGitRuntime, RepositoryIdentity,
+    RepositoryOptions,
 };
 use gix_hash::ObjectId;
 use gix_packetline::{PacketLineRef, decode::PacketLineOrWantedSize};
@@ -28,6 +29,7 @@ use crate::core::error::{CrabError, Result};
 const MAX_PACKET_BYTES: usize = 65_520;
 const MAX_REQUEST_PACKETS: usize = 4_096;
 const MAX_REQUEST_BYTES: usize = 4 * 1024 * 1024;
+const LOCATOR_READ_REPAIR_LOCK_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Packet {
@@ -67,8 +69,8 @@ struct FetchRequest {
     filter: UploadPackFilter,
 }
 
-/// Return whether the repository has the complete proof required to advertise
-/// protocol-v2 upload-pack.
+/// Ensure the repository has the complete proof required to advertise
+/// protocol-v2 upload-pack, repairing current derived locator lag when possible.
 pub async fn snapshot_available(
     store: &crab_storage::Store,
     prefix: &str,
@@ -264,11 +266,52 @@ pub(crate) async fn open_repository(
     let provider = format!("{:?}:{}:{}", bucket.cloud, bucket.host, bucket.container);
     let identity = RepositoryIdentity::new(provider, prefix.to_owned(), 1).map_err(remote_error)?;
     let layout = crab_storage::StoreLayout::new(store.clone(), prefix.to_owned());
+    let runtime = Arc::new(RemoteGitRuntime::default());
+    let open = RemoteGitRepository::open(
+        store.clone(),
+        layout.clone(),
+        identity.clone(),
+        Arc::clone(&runtime),
+        RepositoryOptions::default(),
+        cancellation,
+    )
+    .await;
+    let (observed_generation, required_generation) = match open {
+        Ok(repository) => return Ok(repository),
+        Err(RemoteGitError::RepositoryIndexing { observed, required }) => (observed, required),
+        Err(error) => return Err(remote_error(error)),
+    };
+
+    // The manifest generation check distinguishes derived publication lag from
+    // an active ref-journal transaction, which must remain unavailable.
+    let repair_store = crate::storage::Store::from_storage(store.clone());
+    let repair_layout =
+        crate::storage::StoreLayout::new(repair_store.clone(), layout.repo_prefix().to_owned());
+    let repaired = super::push::repair_git_object_locator_if_current(
+        &repair_store,
+        &repair_layout,
+        required_generation,
+        LOCATOR_READ_REPAIR_LOCK_TTL,
+        cancellation,
+    )
+    .await?;
+    if !repaired {
+        return Err(remote_error(RemoteGitError::RepositoryIndexing {
+            observed: observed_generation,
+            required: required_generation,
+        }));
+    }
+    tracing::info!(
+        observed_generation,
+        required_generation,
+        "repaired current Git locator before upload-pack admission"
+    );
+
     RemoteGitRepository::open(
         store.clone(),
         layout,
         identity,
-        Arc::new(RemoteGitRuntime::default()),
+        runtime,
         RepositoryOptions::default(),
         cancellation,
     )

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -1295,6 +1295,7 @@ mod tests {
         let visibility = GitVisibilityIndex::new(
             1,
             "c".repeat(64),
+            "d".repeat(64),
             std::collections::BTreeMap::from([(
                 visible_refs[0].clone(),
                 vec![ancestor.to_string(), tip.to_string()],
@@ -1325,6 +1326,7 @@ mod tests {
         let visibility = GitVisibilityIndex::new(
             1,
             "c".repeat(64),
+            "d".repeat(64),
             std::collections::BTreeMap::from([(
                 visible_refs[0].clone(),
                 vec![ancestor.to_string(), tip.to_string()],

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -79,7 +79,47 @@ pub async fn snapshot_available(
     let Ok(repository) = open_repository(store, prefix, cancellation).await else {
         return false;
     };
-    repository.visibility_index(cancellation).await.is_ok()
+    match repository.visibility_index(cancellation).await {
+        Ok(_) => true,
+        Err(error) if visibility_index_is_missing(&error) => {
+            let repair_store = crate::storage::Store::from_storage(store.clone());
+            let repair_layout =
+                crate::storage::StoreLayout::new(repair_store.clone(), prefix.to_owned());
+            match super::push::repair_git_visibility_if_current(
+                &repair_store,
+                &repair_layout,
+                repository.generation(),
+                LOCATOR_READ_REPAIR_LOCK_TTL,
+                cancellation,
+            )
+            .await
+            {
+                Ok(Some(super::push::GitVisibilityPublication::Published)) => {
+                    let Ok(repository) = open_repository(store, prefix, cancellation).await else {
+                        return false;
+                    };
+                    repository.visibility_index(cancellation).await.is_ok()
+                }
+                Ok(Some(super::push::GitVisibilityPublication::CompletePackOnly(_)) | None) => {
+                    false
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "current Git visibility repair failed");
+                    false
+                }
+            }
+        }
+        Err(_) => false,
+    }
+}
+
+fn visibility_index_is_missing(error: &RemoteGitError) -> bool {
+    matches!(
+        error,
+        RemoteGitError::Metadata(crab_metadata::error::MetadataError::Storage {
+            source: crab_storage::StorageError::NotFound { .. },
+        })
+    )
 }
 
 pub(crate) fn hidden_ref_patterns_are_valid(patterns: &[String]) -> bool {

--- a/crab/src/replication/mod.rs
+++ b/crab/src/replication/mod.rs
@@ -8004,22 +8004,30 @@ async fn replicate_git_visibility_index(
         source_store.as_storage().clone(),
         source_router.repo_prefix().to_owned(),
     );
-    let source_path =
-        source_storage_router.git_visibility_path(manifest.generation, &manifest.pack_index_hash);
-    match source_store.as_storage().head(&source_path).await {
-        Ok(_) => {}
-        Err(crab_storage::StorageError::NotFound { .. }) => return Ok(()),
-        Err(error) => return Err(CrabError::from(error)),
-    }
-
-    let index = crab_metadata::git_visibility::read(
+    let index = match crab_metadata::git_visibility::read(
         source_store.as_storage(),
         &source_storage_router,
         manifest.generation,
         &manifest.pack_index_hash,
+        &manifest.git_validation_digest,
     )
     .await
-    .map_err(CrabError::from)?;
+    {
+        Ok(index) => index,
+        Err(crab_metadata::error::MetadataError::Storage {
+            source: crab_storage::StorageError::NotFound { .. },
+        }) => return Ok(()),
+        Err(error) => return Err(CrabError::from(error)),
+    };
+    if !index.matches_manifest(manifest) {
+        return Err(CrabError::CorruptObject {
+            path: source_storage_router
+                .git_visibility_path(&manifest.git_validation_digest)
+                .as_ref()
+                .to_owned(),
+            reason: "Git visibility proof does not match its source manifest".to_owned(),
+        });
+    }
     let target_storage_router = crab_storage::StoreLayout::new(
         target_store.as_storage().clone(),
         target_router.repo_prefix().to_owned(),
@@ -12103,6 +12111,53 @@ mod tests {
 
         let (written, _) = read_manifest(&store, &router).await.unwrap();
         assert_eq!(written, manifest);
+    }
+
+    #[tokio::test]
+    async fn repair_refuses_to_replicate_mismatched_legacy_visibility() {
+        let source = Store::new(Arc::new(InMemory::new()));
+        let source_router = StoreLayout::new(source.clone(), "source/repo".to_owned());
+        let target = Store::new(Arc::new(InMemory::new()));
+        let target_router = StoreLayout::new(target.clone(), "target/repo".to_owned());
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 7;
+        manifest.pack_index_hash = "a".repeat(64);
+        manifest
+            .refs
+            .insert("refs/heads/main".to_owned(), "1".repeat(40));
+        manifest.seal_git_validation();
+        let legacy = serde_json::json!({
+            "version": 1,
+            "generation": manifest.generation,
+            "pack_index_hash": manifest.pack_index_hash,
+            "refs": {"refs/heads/main": ["2".repeat(40)]},
+        });
+        source
+            .put(
+                &source_router
+                    .git_visibility_v1_path(manifest.generation, &manifest.pack_index_hash),
+                Bytes::from(serde_json::to_vec(&legacy).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        let error = replicate_git_visibility_index(
+            &source,
+            &source_router,
+            &target,
+            &target_router,
+            &manifest,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, CrabError::CorruptObject { .. }));
+        assert!(matches!(
+            target
+                .head(&target_router.git_visibility_path(&manifest.git_validation_digest))
+                .await,
+            Err(CrabError::NotFound { .. })
+        ));
     }
 
     #[test]

--- a/crab/tests/schema_validate.rs
+++ b/crab/tests/schema_validate.rs
@@ -614,6 +614,10 @@ fn validate_push() {
             remote_url: "crab://bucket/repo".into(),
             integration_retries: Some(3),
             integration_retry_limit: Some(256),
+            integration_retry_stages: Some(std::collections::BTreeMap::from([
+                ("lock".to_owned(), 2),
+                ("ref-commit".to_owned(), 1),
+            ])),
             operation_id: None,
             coordinator_epoch: None,
             writer_region: None,

--- a/crates/crab-auth-server/src/error.rs
+++ b/crates/crab-auth-server/src/error.rs
@@ -35,6 +35,18 @@ pub enum AuthServerError {
     #[error("hash mismatch: requested {requested}, actual {actual}")]
     HashMismatch { requested: String, actual: String },
 
+    #[error("Git visibility traversal failed")]
+    GitVisibilityWalk {
+        #[source]
+        source: crab_git::walk::WalkError,
+    },
+
+    #[error("Git visibility traversal task failed")]
+    GitVisibilityJoin {
+        #[source]
+        source: tokio::task::JoinError,
+    },
+
     #[error("incomplete shard reconstruction for {file_hash}")]
     IncompleteShardReconstruction {
         file_hash: String,

--- a/crates/crab-auth-server/src/receive.rs
+++ b/crates/crab-auth-server/src/receive.rs
@@ -1309,11 +1309,16 @@ pub async fn commit_service_git_locators(
             )
             .await?
         };
-        let mut writer = crab_metadata::git_object_locator::GitObjectLocatorWriter::open(
-            Arc::clone(store.inner()),
-            router.repo_prefix(),
-        )
-        .await?;
+        let planned_object_rows = current_packs
+            .iter()
+            .fold(0_u64, |total, pack| total.saturating_add(pack.object_count));
+        let mut writer =
+            crab_metadata::git_object_locator::GitObjectLocatorWriter::open_for_publication(
+                Arc::clone(store.inner()),
+                router.repo_prefix(),
+                planned_object_rows,
+            )
+            .await?;
         let operation = async {
             let prior_coverage = writer.coverage();
             let covered_packs = if let Some(coverage) = prior_coverage {

--- a/crates/crab-auth-server/src/receive.rs
+++ b/crates/crab-auth-server/src/receive.rs
@@ -868,18 +868,35 @@ pub async fn install_manifest_packs(
     git_workspace::install_manifest_packs(store, router, manifest, git_dir).await
 }
 
-/// Publishes the complete Git object visibility proof for a committed view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitVisibilityPublication {
+    Published,
+    CompletePackOnly { observed: usize, maximum: usize },
+}
+
+enum GitVisibilityBuildError {
+    Prepare(AuthServerError),
+    Walk(crab_git::walk::WalkError),
+}
+
+impl GitVisibilityPublication {
+    #[must_use]
+    pub(crate) const fn is_published(self) -> bool {
+        matches!(self, Self::Published)
+    }
+}
+
+/// Publishes the complete Git object visibility proof from canonical packs.
 ///
-/// The proof is intentionally built from the same immutable packs named by
-/// the committed manifest. A failure leaves the manifest usable for legacy
-/// reads while keeping protocol-v2 advertisement gated.
-pub async fn publish_git_visibility_index(
+/// The proof is built from the same immutable packs named by the candidate
+/// manifest and may therefore be published before the manifest commit.
+pub(crate) async fn publish_git_visibility_index(
     store: &Store,
     router: &StoreLayout<Store>,
     manifest: &Manifest,
-) -> Result<()> {
-    if manifest.refs.is_empty() || manifest.pack_index_hash.is_empty() {
-        return Ok(());
+) -> Result<GitVisibilityPublication> {
+    if manifest.refs.is_empty() {
+        return Ok(GitVisibilityPublication::Published);
     }
 
     let temp = tempfile::tempdir()?;
@@ -897,28 +914,57 @@ pub async fn publish_git_visibility_index(
     }
     install_manifest_packs(store, router, manifest, &git_dir).await?;
 
+    publish_git_visibility_index_from_git_dir(store, router, manifest, &git_dir).await
+}
+
+pub(crate) async fn publish_git_visibility_index_from_git_dir(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    manifest: &Manifest,
+    git_dir: &Path,
+) -> Result<GitVisibilityPublication> {
+    if manifest.refs.is_empty() {
+        return Ok(GitVisibilityPublication::Published);
+    }
+
     let refs = manifest
         .refs
         .iter()
         .map(|(name, oid)| (name.clone(), oid.clone()))
         .collect::<Vec<_>>();
-    let git_dir_for_walk = git_dir.clone();
-    let closures = tokio::task::spawn_blocking(move || {
-        let peeled = derive_peeled_refs(&git_dir_for_walk, &refs)?;
-        crab_git::walk::walk_reachable_by_ref_bounded(
+    let git_dir_for_walk = git_dir.to_owned();
+    let walk = tokio::task::spawn_blocking(move || {
+        let peeled = derive_peeled_refs(&git_dir_for_walk, &refs)
+            .map_err(GitVisibilityBuildError::Prepare)?;
+        let closures = crab_git::walk::walk_reachable_by_ref_bounded(
             &git_dir_for_walk,
             &refs,
             &peeled,
-            crab_metadata::git_visibility::MAX_GIT_VISIBILITY_OBJECTS as usize,
+            crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS as usize,
         )
-        .map(|closures| (closures, peeled))
-        .map_err(|error| invalid(format!("Git visibility walk failed: {error}")))
+        .map_err(GitVisibilityBuildError::Walk)?;
+        Ok::<_, GitVisibilityBuildError>(closures)
     })
     .await
-    .map_err(|error| invalid(format!("Git visibility walk join failed: {error}")))??;
+    .map_err(|source| AuthServerError::GitVisibilityJoin { source })?;
+    let closures = match walk {
+        Ok(closures) => closures,
+        Err(GitVisibilityBuildError::Walk(crab_git::walk::WalkError::LimitExceeded {
+            actual,
+            maximum,
+        })) => {
+            return Ok(GitVisibilityPublication::CompletePackOnly {
+                observed: actual,
+                maximum,
+            });
+        }
+        Err(GitVisibilityBuildError::Walk(source)) => {
+            return Err(AuthServerError::GitVisibilityWalk { source });
+        }
+        Err(GitVisibilityBuildError::Prepare(error)) => return Err(error),
+    };
 
     let refs = closures
-        .0
         .into_iter()
         .map(|(name, closure)| {
             let mut objects = BTreeSet::new();
@@ -936,7 +982,8 @@ pub async fn publish_git_visibility_index(
     );
     crab_metadata::git_visibility::upload_if_absent(store, router, &index)
         .await
-        .map_err(AuthServerError::from)
+        .map_err(AuthServerError::from)?;
+    Ok(GitVisibilityPublication::Published)
 }
 
 fn path_str(path: &Path) -> Result<&str> {

--- a/crates/crab-auth-server/src/receive.rs
+++ b/crates/crab-auth-server/src/receive.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Cursor;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::sync::Arc;
 
 use crab_auth::{
@@ -102,6 +102,13 @@ pub struct MaterializedSourcePush {
     pub ref_updates: Vec<PushRefUpdate>,
     pub packs: Vec<PackManifestEntry>,
     pub peeled_refs: BTreeMap<String, String>,
+    pub(crate) git_visibility: MaterializedGitVisibility,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MaterializedGitVisibility {
+    Exact(BTreeMap<String, Vec<String>>),
+    CompletePackOnly { observed: usize, maximum: usize },
 }
 
 /// Prepared protected-push session state written after view authorization.
@@ -858,16 +865,6 @@ pub async fn install_base_packs(
     git_workspace::install_base_packs(store, router, git_dir).await
 }
 
-/// Installs the packs named by a candidate manifest into a temporary Git ODB.
-pub async fn install_manifest_packs(
-    store: &Store,
-    router: &StoreLayout<Store>,
-    manifest: &Manifest,
-    git_dir: &Path,
-) -> Result<()> {
-    git_workspace::install_manifest_packs(store, router, manifest, git_dir).await
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GitVisibilityPublication {
     Published,
@@ -875,7 +872,6 @@ pub(crate) enum GitVisibilityPublication {
 }
 
 enum GitVisibilityBuildError {
-    Prepare(AuthServerError),
     Walk(crab_git::walk::WalkError),
 }
 
@@ -886,35 +882,36 @@ impl GitVisibilityPublication {
     }
 }
 
-/// Publishes the complete Git object visibility proof from canonical packs.
-///
-/// The proof is built from the same immutable packs named by the candidate
-/// manifest and may therefore be published before the manifest commit.
-pub(crate) async fn publish_git_visibility_index(
+pub(crate) async fn publish_materialized_git_visibility(
     store: &Store,
     router: &StoreLayout<Store>,
     manifest: &Manifest,
+    visibility: &MaterializedGitVisibility,
 ) -> Result<GitVisibilityPublication> {
-    if manifest.refs.is_empty() {
-        return Ok(GitVisibilityPublication::Published);
+    let refs = match visibility {
+        MaterializedGitVisibility::Exact(refs) => refs,
+        MaterializedGitVisibility::CompletePackOnly { observed, maximum } => {
+            return Ok(GitVisibilityPublication::CompletePackOnly {
+                observed: *observed,
+                maximum: *maximum,
+            });
+        }
+    };
+    let index = crab_metadata::git_visibility::GitVisibilityIndex::new(
+        manifest.generation,
+        manifest.pack_index_hash.clone(),
+        manifest.git_validation_digest.clone(),
+        refs.clone(),
+    );
+    if !index.matches_manifest(manifest) {
+        return Err(invalid(
+            "materialized Git visibility does not match the candidate manifest",
+        ));
     }
-
-    let temp = tempfile::tempdir()?;
-    let git_dir = temp.path().join("visibility.git");
-    let init = Command::new("git")
-        .args(["init", "--bare", path_str(&git_dir)?])
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .output()?;
-    if !init.status.success() {
-        return Err(invalid(format!(
-            "visibility Git repository initialization failed: {}",
-            String::from_utf8_lossy(&init.stderr).trim()
-        )));
-    }
-    install_manifest_packs(store, router, manifest, &git_dir).await?;
-
-    publish_git_visibility_index_from_git_dir(store, router, manifest, &git_dir).await
+    crab_metadata::git_visibility::upload_if_absent(store, router, &index)
+        .await
+        .map_err(AuthServerError::from)?;
+    Ok(GitVisibilityPublication::Published)
 }
 
 pub(crate) async fn publish_git_visibility_index_from_git_dir(
@@ -923,23 +920,33 @@ pub(crate) async fn publish_git_visibility_index_from_git_dir(
     manifest: &Manifest,
     git_dir: &Path,
 ) -> Result<GitVisibilityPublication> {
-    if manifest.refs.is_empty() {
-        return Ok(GitVisibilityPublication::Published);
-    }
-
     let refs = manifest
         .refs
         .iter()
         .map(|(name, oid)| (name.clone(), oid.clone()))
         .collect::<Vec<_>>();
+    let visibility =
+        build_git_visibility_from_git_dir(git_dir, &refs, &manifest.peeled_refs).await?;
+    publish_materialized_git_visibility(store, router, manifest, &visibility).await
+}
+
+pub(crate) async fn build_git_visibility_from_git_dir(
+    git_dir: &Path,
+    refs: &[(String, String)],
+    peeled_refs: &BTreeMap<String, String>,
+) -> Result<MaterializedGitVisibility> {
+    if refs.is_empty() {
+        return Ok(MaterializedGitVisibility::Exact(BTreeMap::new()));
+    }
+
+    let refs = refs.to_vec();
+    let peeled_refs = peeled_refs.clone();
     let git_dir_for_walk = git_dir.to_owned();
     let walk = tokio::task::spawn_blocking(move || {
-        let peeled = derive_peeled_refs(&git_dir_for_walk, &refs)
-            .map_err(GitVisibilityBuildError::Prepare)?;
         let closures = crab_git::walk::walk_reachable_by_ref_bounded(
             &git_dir_for_walk,
             &refs,
-            &peeled,
+            &peeled_refs,
             crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS as usize,
         )
         .map_err(GitVisibilityBuildError::Walk)?;
@@ -953,7 +960,7 @@ pub(crate) async fn publish_git_visibility_index_from_git_dir(
             actual,
             maximum,
         })) => {
-            return Ok(GitVisibilityPublication::CompletePackOnly {
+            return Ok(MaterializedGitVisibility::CompletePackOnly {
                 observed: actual,
                 maximum,
             });
@@ -961,7 +968,6 @@ pub(crate) async fn publish_git_visibility_index_from_git_dir(
         Err(GitVisibilityBuildError::Walk(source)) => {
             return Err(AuthServerError::GitVisibilityWalk { source });
         }
-        Err(GitVisibilityBuildError::Prepare(error)) => return Err(error),
     };
 
     let refs = closures
@@ -975,15 +981,7 @@ pub(crate) async fn publish_git_visibility_index_from_git_dir(
             (name, objects.into_iter().collect::<Vec<_>>())
         })
         .collect();
-    let index = crab_metadata::git_visibility::GitVisibilityIndex::new(
-        manifest.generation,
-        manifest.pack_index_hash.clone(),
-        refs,
-    );
-    crab_metadata::git_visibility::upload_if_absent(store, router, &index)
-        .await
-        .map_err(AuthServerError::from)?;
-    Ok(GitVisibilityPublication::Published)
+    Ok(MaterializedGitVisibility::Exact(refs))
 }
 
 fn path_str(path: &Path) -> Result<&str> {
@@ -2327,6 +2325,29 @@ mod tests {
                 staged_object(format!("org/repo/metadata/pack/indexes/{}.json", hash('d'))),
             ],
         }
+    }
+
+    #[tokio::test]
+    async fn materialized_visibility_must_match_candidate_manifest() {
+        let store = store();
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        let manifest = candidate_manifest();
+        let visibility = MaterializedGitVisibility::Exact(BTreeMap::from([(
+            "refs/heads/main".to_owned(),
+            vec![oid('3')],
+        )]));
+
+        assert!(
+            publish_materialized_git_visibility(&store, &router, &manifest, &visibility)
+                .await
+                .is_err()
+        );
+        assert!(matches!(
+            store
+                .head(&router.git_visibility_path(&manifest.git_validation_digest))
+                .await,
+            Err(StorageError::NotFound { .. })
+        ));
     }
 
     #[test]

--- a/crates/crab-auth-server/src/receive/finalize.rs
+++ b/crates/crab-auth-server/src/receive/finalize.rs
@@ -15,7 +15,7 @@ use crab_storage::{Store, StoreLayout};
 
 use super::{
     ActiveActiveReceiveConfig, MaterializedSourcePush, ProtectedPushPlan,
-    active_active_coordinator_registration, non_empty, publish_git_visibility_index,
+    active_active_coordinator_registration, non_empty,
 };
 use crate::error::{AuthServerError, Result};
 
@@ -27,6 +27,7 @@ pub struct ReceiveManifestCommit<'a> {
     pub materialized: &'a MaterializedSourcePush,
     pub manifest: &'a Manifest,
     pub base_etag: Option<&'a str>,
+    pub visibility_proof_published: bool,
 }
 
 /// Commits a finalized receive manifest through normal CAS or active-active coordination.
@@ -69,25 +70,13 @@ async fn commit_active_active_manifest(
             force: false,
         })
         .collect::<Vec<_>>();
-    let visibility_proof_published =
-        match publish_git_visibility_index(store, router, commit.manifest).await {
-            Ok(()) => true,
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    generation = commit.manifest.generation,
-                    "active-active protected push committed; Git visibility proof requires repair"
-                );
-                false
-            }
-        };
     let uploaded_objects = active_active_uploaded_objects(
         store,
         router,
         commit.plan,
         commit.materialized,
         commit.manifest,
-        visibility_proof_published,
+        commit.visibility_proof_published,
     )
     .await?;
     let push_plan = coordination_active_active::plan_active_active_push(
@@ -279,6 +268,7 @@ mod tests {
                 materialized: &materialized,
                 manifest: &candidate,
                 base_etag: None,
+                visibility_proof_published: false,
             },
         )
         .await

--- a/crates/crab-auth-server/src/receive/finalize.rs
+++ b/crates/crab-auth-server/src/receive/finalize.rs
@@ -145,7 +145,7 @@ async fn active_active_uploaded_objects(
     {
         keys.insert(
             router
-                .git_visibility_path(manifest.generation, &manifest.pack_index_hash)
+                .git_visibility_path(&manifest.git_validation_digest)
                 .as_ref()
                 .to_owned(),
         );
@@ -256,6 +256,9 @@ mod tests {
             ref_updates: Vec::new(),
             packs: Vec::new(),
             peeled_refs: std::collections::BTreeMap::new(),
+            git_visibility: super::super::MaterializedGitVisibility::Exact(
+                std::collections::BTreeMap::new(),
+            ),
         };
 
         let err = commit_receive_manifest(

--- a/crates/crab-auth-server/src/receive/git_workspace.rs
+++ b/crates/crab-auth-server/src/receive/git_workspace.rs
@@ -19,8 +19,9 @@ use object_store::path::Path as ObjectPath;
 use crate::error::{AuthServerError, Result};
 
 use super::{
-    MaterializedSourcePush, ProtectedPushPlan, PushPrepareRecord, conflict, derive_peeled_refs,
-    invalid, validate_ref_update, validate_sha1,
+    MaterializedSourcePush, ProtectedPushPlan, PushPrepareRecord,
+    build_git_visibility_from_git_dir, conflict, derive_peeled_refs, invalid, validate_ref_update,
+    validate_sha1,
 };
 
 pub(super) async fn compute_changed_paths(
@@ -60,17 +61,6 @@ pub(super) async fn install_base_packs(
 ) -> Result<()> {
     GitReceiveWorkspace::new(store, router, router.repo_prefix())
         .install_base_packs(git_dir)
-        .await
-}
-
-pub(super) async fn install_manifest_packs(
-    store: &Store,
-    router: &StoreLayout<Store>,
-    manifest: &Manifest,
-    git_dir: &Path,
-) -> Result<()> {
-    GitReceiveWorkspace::new(store, router, router.repo_prefix())
-        .install_manifest_packs(router, manifest, git_dir)
         .await
 }
 
@@ -171,10 +161,13 @@ impl<'a> GitReceiveWorkspace<'a> {
         }
         let final_refs = final_refs.into_iter().collect::<Vec<_>>();
         let peeled_refs = derive_peeled_refs(&git_dir, &final_refs)?;
+        let git_visibility =
+            build_git_visibility_from_git_dir(&git_dir, &final_refs, &peeled_refs).await?;
         Ok(MaterializedSourcePush {
             ref_updates: final_updates,
             packs,
             peeled_refs,
+            git_visibility,
         })
     }
 

--- a/crates/crab-auth-server/src/receive/workflow.rs
+++ b/crates/crab-auth-server/src/receive/workflow.rs
@@ -7,11 +7,11 @@ use super::{
     PreparedViewScope, ReceiveContext, ReceiveManifestCommit, build_service_candidate_manifest,
     commit_receive_manifest, commit_service_git_locators, commit_service_metadata,
     compute_changed_paths, conflict, invalid, materialize_source_push,
-    parse_active_active_receive_config, promote_staged_objects, publish_git_visibility_index,
-    source_ref_updates_from_prepare, validate_candidate_manifest_shape,
-    validate_candidate_metadata, validate_protected_dependency_receipt,
-    validate_protected_shard_set_receipt, validate_push_plan_shape,
-    write_service_generation_index_receipt,
+    parse_active_active_receive_config, promote_staged_objects,
+    publish_materialized_git_visibility, source_ref_updates_from_prepare,
+    validate_candidate_manifest_shape, validate_candidate_metadata,
+    validate_protected_dependency_receipt, validate_protected_shard_set_receipt,
+    validate_push_plan_shape, write_service_generation_index_receipt,
 };
 use crate::error::Result;
 
@@ -131,8 +131,13 @@ pub async fn commit_receive(
         &materialized,
     )
     .await?;
-    let visibility_publication =
-        publish_git_visibility_index(ctx.store(), ctx.router(), &manifest).await?;
+    let visibility_publication = publish_materialized_git_visibility(
+        ctx.store(),
+        ctx.router(),
+        &manifest,
+        &materialized.git_visibility,
+    )
+    .await?;
     if let GitVisibilityPublication::CompletePackOnly { observed, maximum } = visibility_publication
     {
         tracing::warn!(
@@ -822,6 +827,7 @@ mod tests {
             ctx.router(),
             final_state.manifest().generation,
             &final_state.manifest().pack_index_hash,
+            &final_state.manifest().git_validation_digest,
         )
         .await?;
         assert!(

--- a/crates/crab-auth-server/src/receive/workflow.rs
+++ b/crates/crab-auth-server/src/receive/workflow.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use crab_auth::{PushFinalizeResponse, PushRefUpdate};
 
+use super::GitVisibilityPublication;
 use super::{
     PreparedViewScope, ReceiveContext, ReceiveManifestCommit, build_service_candidate_manifest,
     commit_receive_manifest, commit_service_git_locators, commit_service_metadata,
@@ -130,6 +131,17 @@ pub async fn commit_receive(
         &materialized,
     )
     .await?;
+    let visibility_publication =
+        publish_git_visibility_index(ctx.store(), ctx.router(), &manifest).await?;
+    if let GitVisibilityPublication::CompletePackOnly { observed, maximum } = visibility_publication
+    {
+        tracing::warn!(
+            generation = manifest.generation,
+            proof_objects = observed,
+            maximum,
+            "protected push exceeds the Git visibility proof profile; complete-pack fetch remains available"
+        );
+    }
     let committed_shards = if manifest.shard_index_hash.is_empty() {
         Vec::new()
     } else {
@@ -156,6 +168,7 @@ pub async fn commit_receive(
             materialized: &materialized,
             manifest: &manifest,
             base_etag: base.as_ref().map(|state| state.etag()),
+            visibility_proof_published: visibility_publication.is_published(),
         },
     )
     .await?;
@@ -222,13 +235,6 @@ pub async fn commit_receive(
             None
         }
     };
-    if let Err(error) = publish_git_visibility_index(ctx.store(), ctx.router(), &manifest).await {
-        tracing::warn!(
-            error = %error,
-            generation = manifest.generation,
-            "protected push committed; Git visibility proof requires repair"
-        );
-    }
     if let (Some(file_index_digest), Some(git_object_locator_digest)) =
         (file_index_digest, git_object_locator_digest)
         && let Err(error) = write_service_generation_index_receipt(
@@ -811,6 +817,20 @@ mod tests {
             .get("refs/heads/main")
             .ok_or_else(|| invalid("test final ref missing"))?;
         assert_eq!(final_oid, &final_update.new_oid);
+        let visibility = crab_metadata::git_visibility::read(
+            ctx.store(),
+            ctx.router(),
+            final_state.manifest().generation,
+            &final_state.manifest().pack_index_hash,
+        )
+        .await?;
+        assert!(
+            visibility
+                .refs
+                .get("refs/heads/main")
+                .is_some_and(|objects| objects.binary_search(final_oid).is_ok()),
+            "the visibility proof must be durable when the protected ref commits"
+        );
 
         let committed_packs = manifest_store::read_bulk_pack_list(
             ctx.store(),

--- a/crates/crab-auth-server/src/view.rs
+++ b/crates/crab-auth-server/src/view.rs
@@ -462,13 +462,7 @@ async fn publish_filtered_view(
     .await?;
     let pack = upload_view_git_pack(store, &router, filtered_git, &refs).await?;
     let packs_for_index: Vec<PackManifestEntry> = pack.iter().cloned().collect();
-    let gc_registry_generation = crab_metadata::ref_registry::union_register_repo_shards(
-        store,
-        &router,
-        uploaded_crab.shard_hashes.clone(),
-    )
-    .await?;
-    let manifest = write_view_manifest(
+    let manifest = prepare_view_manifest(
         store,
         &router,
         view_generation,
@@ -479,6 +473,30 @@ async fn publish_filtered_view(
         pack,
     )
     .await?;
+    let visibility_publication = crate::receive::publish_git_visibility_index_from_git_dir(
+        store,
+        &router,
+        &manifest,
+        filtered_git,
+    )
+    .await?;
+    if let crate::receive::GitVisibilityPublication::CompletePackOnly { observed, maximum } =
+        visibility_publication
+    {
+        tracing::warn!(
+            generation = manifest.generation,
+            proof_objects = observed,
+            maximum,
+            "ACL view exceeds the Git visibility proof profile; complete-pack fetch remains available"
+        );
+    }
+    let gc_registry_generation = crab_metadata::ref_registry::union_register_repo_shards(
+        store,
+        &router,
+        uploaded_crab.shard_hashes.clone(),
+    )
+    .await?;
+    create_manifest(store, &router, &manifest).await?;
     let file_index_digest = match commit_view_metadb(
         store,
         &router,
@@ -516,15 +534,6 @@ async fn publish_filtered_view(
             None
         }
     };
-    if let Err(error) =
-        crate::receive::publish_git_visibility_index(store, &router, &manifest).await
-    {
-        tracing::warn!(
-            error = %error,
-            generation = manifest.generation,
-            "ACL view committed; Git visibility proof requires repair"
-        );
-    }
     if let (Some(file_index_digest), Some(git_object_locator_digest)) =
         (file_index_digest, git_object_locator_digest)
         && let Err(error) = crate::receive::write_service_generation_index_receipt(
@@ -598,7 +607,7 @@ fn view_store_layout(store: &Store, repo_prefix: &str) -> StoreLayout {
     )
 }
 
-async fn write_view_manifest(
+async fn prepare_view_manifest(
     store: &Store,
     router: &StoreLayout,
     generation: u64,
@@ -635,7 +644,6 @@ async fn write_view_manifest(
     // View packs are generated from the already validated source workspace;
     // bind the final filtered refs and compacted inventory atomically.
     manifest.seal_git_validation();
-    create_manifest(store, router, &manifest).await?;
     Ok(manifest)
 }
 
@@ -847,7 +855,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let source_manifest = write_view_manifest(
+        let source_manifest = prepare_view_manifest(
             &store,
             &source_router,
             1,
@@ -859,6 +867,9 @@ mod tests {
         )
         .await
         .unwrap();
+        create_manifest(&store, &source_router, &source_manifest)
+            .await
+            .unwrap();
         commit_view_metadb(
             &store,
             &source_router,
@@ -935,6 +946,20 @@ mod tests {
 
         let view_router = view_store_layout(&store, view_prefix);
         let (manifest, _) = read_manifest(&store, &view_router).await.unwrap();
+        let visibility = crab_metadata::git_visibility::read(
+            &store,
+            &view_router,
+            manifest.generation,
+            &manifest.pack_index_hash,
+        )
+        .await
+        .unwrap();
+        assert!(manifest.refs.iter().all(|(name, tip)| {
+            visibility
+                .refs
+                .get(name)
+                .is_some_and(|objects| objects.binary_search(tip).is_ok())
+        }));
         let packs = read_bulk_pack_list(&store, &view_router, &manifest.pack_index_hash)
             .await
             .unwrap();

--- a/crates/crab-auth-server/src/view.rs
+++ b/crates/crab-auth-server/src/view.rs
@@ -951,6 +951,7 @@ mod tests {
             &view_router,
             manifest.generation,
             &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
         )
         .await
         .unwrap();

--- a/crates/crab-metadata/src/git_object_locator/writer.rs
+++ b/crates/crab-metadata/src/git_object_locator/writer.rs
@@ -24,6 +24,14 @@ use crate::error::{MetadataError, Result};
 const DB_LABEL: &str = "git_locator_db";
 const MAX_BATCH_ROWS: usize = 25_000;
 const MAX_BATCH_LOGICAL_BYTES: usize = 2 * 1024 * 1024;
+const LOCATOR_L0_SST_BYTES: usize = 64 * 1024 * 1024;
+const LOCATOR_L0_MAX_SSTS: usize = 32;
+const LOCATOR_COMPACTION_TRIGGER_SSTS: usize = LOCATOR_L0_MAX_SSTS / 2;
+// B-tree nodes and SlateDB bookkeeping make the in-memory row materially
+// larger than its 49 encoded bytes. This upper bound decides only whether to
+// start maintenance early; the hard L0 limit remains authoritative.
+const ESTIMATED_OBJECT_ROW_BYTES: u128 = 128;
+const FIXED_PUBLICATION_SSTS: usize = 4;
 // Amortize one directory scan over a normal fan-out while bounding the number
 // of superseded locator generations. This cadence is cost policy, not safety.
 const GC_GENERATION_INTERVAL: u64 = 32;
@@ -69,9 +77,31 @@ pub struct GitObjectLocatorWriter {
 impl GitObjectLocatorWriter {
     /// Open the compact locator and require its exact format metadata.
     pub async fn open(store: Arc<dyn ObjectStore>, repo_prefix: &str) -> Result<Self> {
+        Self::open_with_settings(store, repo_prefix, locator_settings(true)).await
+    }
+
+    /// Open a bounded publication writer, starting compaction only under L0 pressure.
+    ///
+    /// `planned_object_rows` must bound the object rows the caller may submit.
+    pub async fn open_for_publication(
+        store: Arc<dyn ObjectStore>,
+        repo_prefix: &str,
+        planned_object_rows: u64,
+    ) -> Result<Self> {
+        let path = git_object_locator_path(repo_prefix);
+        let compact =
+            locator_compaction_required(&path, Arc::clone(&store), planned_object_rows).await?;
+        Self::open_with_settings(store, repo_prefix, locator_settings(compact)).await
+    }
+
+    async fn open_with_settings(
+        store: Arc<dyn ObjectStore>,
+        repo_prefix: &str,
+        settings: Settings,
+    ) -> Result<Self> {
         let path = git_object_locator_path(repo_prefix);
         let db = slatedb::Db::builder(ObjectPath::from(path.as_str()), Arc::clone(&store))
-            .with_settings(locator_settings())
+            .with_settings(settings)
             // Publication writes each row once and stale-row cleanup performs
             // one sequential scan. Caching that scan in SlateDB's default
             // 640 MiB block/metadata cache only inflates writer RSS.
@@ -536,26 +566,63 @@ fn locator_gc_options() -> GarbageCollectorOptions {
     }
 }
 
-fn locator_settings() -> Settings {
-    let mut compactor = CompactorOptions {
-        commit_compacted_interval: std::time::Duration::from_millis(500),
-        ..CompactorOptions::default()
-    };
-    if let Some(worker) = &mut compactor.worker {
-        worker.compactions_poll_interval = std::time::Duration::from_millis(500);
-    }
+async fn locator_compaction_required(
+    path: &str,
+    store: Arc<dyn ObjectStore>,
+    planned_object_rows: u64,
+) -> Result<bool> {
+    let admin = slatedb::admin::AdminBuilder::new(ObjectPath::from(path), store).build();
+    let manifest =
+        admin
+            .read_manifest(None)
+            .await
+            .map_err(|source| MetadataError::SlateDbOpen {
+                db: DB_LABEL.to_owned(),
+                path: path.to_owned(),
+                source,
+            })?;
+    let l0_ssts = manifest.map_or(0, |manifest| manifest.l0().len());
+    Ok(should_start_compactor(l0_ssts, planned_object_rows))
+}
+
+fn should_start_compactor(l0_ssts: usize, planned_object_rows: u64) -> bool {
+    let object_bytes = u128::from(planned_object_rows).saturating_mul(ESTIMATED_OBJECT_ROW_BYTES);
+    let object_ssts = object_bytes.saturating_add(LOCATOR_L0_SST_BYTES as u128 - 1)
+        / LOCATOR_L0_SST_BYTES as u128;
+    let planned_ssts = object_ssts
+        .saturating_add(FIXED_PUBLICATION_SSTS as u128)
+        .min(usize::MAX as u128) as usize;
+    l0_ssts.saturating_add(planned_ssts) >= LOCATOR_COMPACTION_TRIGGER_SSTS
+}
+
+fn locator_settings(compact: bool) -> Settings {
+    let compactor_options = compact.then(|| {
+        let mut compactor = CompactorOptions {
+            commit_compacted_interval: std::time::Duration::from_millis(500),
+            ..CompactorOptions::default()
+        };
+        if let Some(worker) = &mut compactor.worker {
+            worker.compactions_poll_interval = std::time::Duration::from_millis(500);
+        }
+        compactor
+    });
     Settings {
         flush_interval: None,
         wal_enabled: false,
         // SlateDB excludes the active memtable from max_unflushed_bytes.
         // Keep both limits small so B-tree and flush-encoding amplification
         // cannot turn a compact locator rebuild into multi-GiB process RSS.
-        l0_sst_size_bytes: 64 * 1024 * 1024,
+        l0_sst_size_bytes: LOCATOR_L0_SST_BYTES,
         max_unflushed_bytes: 96 * 1024 * 1024,
+        // Publication reads the persisted L0 count under the locator lock and
+        // starts compaction before reaching half this ceiling. The remaining
+        // headroom covers one conservatively estimated publication.
+        l0_max_ssts: LOCATOR_L0_MAX_SSTS,
+        l0_max_ssts_per_key: LOCATOR_L0_MAX_SSTS,
         l0_flush_parallelism: 1,
-        // Locator writers are short-lived. The multi-second defaults can leave
-        // small compactions unclaimed until the next push hits L0 backpressure.
-        compactor_options: Some(compactor),
+        // SlateDB tickers fire immediately. Starting these tasks only under
+        // measured L0 pressure amortizes their fixed object-store request cost.
+        compactor_options,
         // SlateDB tickers fire immediately, so default background GC runs its
         // full directory scan on every short-lived publication session.
         garbage_collector_options: None,
@@ -704,9 +771,11 @@ mod tests {
 
     #[test]
     fn locator_settings_bound_writer_memory() {
-        let settings = locator_settings();
+        let settings = locator_settings(true);
         assert_eq!(settings.l0_sst_size_bytes, 64 * 1024 * 1024);
         assert_eq!(settings.max_unflushed_bytes, 96 * 1024 * 1024);
+        assert_eq!(settings.l0_max_ssts, LOCATOR_L0_MAX_SSTS);
+        assert_eq!(settings.l0_max_ssts_per_key, LOCATOR_L0_MAX_SSTS);
         assert_eq!(settings.l0_flush_parallelism, 1);
         assert!(settings.garbage_collector_options.is_none());
         let compactor = settings
@@ -727,6 +796,21 @@ mod tests {
                 .compactions_poll_interval,
             std::time::Duration::from_millis(500)
         );
+    }
+
+    #[test]
+    fn locator_publication_starts_compaction_before_bounded_l0_headroom_is_consumed() {
+        assert!(!should_start_compactor(0, 0));
+        assert!(!should_start_compactor(
+            LOCATOR_COMPACTION_TRIGGER_SSTS - FIXED_PUBLICATION_SSTS - 1,
+            0,
+        ));
+        assert!(should_start_compactor(
+            LOCATOR_COMPACTION_TRIGGER_SSTS - FIXED_PUBLICATION_SSTS,
+            0,
+        ));
+        assert!(should_start_compactor(0, u64::MAX));
+        assert!(locator_settings(false).compactor_options.is_none());
     }
 
     #[test]

--- a/crates/crab-metadata/src/git_visibility.rs
+++ b/crates/crab-metadata/src/git_visibility.rs
@@ -11,9 +11,10 @@ use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{MetadataError, Result};
+use crate::manifests::Manifest;
 
 /// Current serialized visibility-index format.
-pub const GIT_VISIBILITY_INDEX_VERSION: u32 = 1;
+pub const GIT_VISIBILITY_INDEX_VERSION: u32 = 2;
 
 /// Maximum serialized proof accepted from object storage.
 pub const MAX_GIT_VISIBILITY_INDEX_BYTES: u64 = 128 * 1024 * 1024;
@@ -175,6 +176,7 @@ fn validate_sorted_oids(objects: &[String], field: &str) -> Result<()> {
 
 /// Complete ref-rooted Git object visibility proof for one repository snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GitVisibilityIndex {
     /// Schema version of this object.
     pub version: u32,
@@ -182,6 +184,8 @@ pub struct GitVisibilityIndex {
     pub generation: u64,
     /// Pack-index hash this proof was built against.
     pub pack_index_hash: String,
+    /// Digest binding the complete manifest Git state described by this proof.
+    pub git_validation_digest: String,
     /// Complete object closure for each manifest ref, including the ref tip.
     pub refs: BTreeMap<String, Vec<String>>,
 }
@@ -192,6 +196,7 @@ impl GitVisibilityIndex {
     pub fn new(
         generation: u64,
         pack_index_hash: impl Into<String>,
+        git_validation_digest: impl Into<String>,
         refs: BTreeMap<String, Vec<String>>,
     ) -> Self {
         let refs = refs
@@ -207,6 +212,7 @@ impl GitVisibilityIndex {
             version: GIT_VISIBILITY_INDEX_VERSION,
             generation,
             pack_index_hash: pack_index_hash.into(),
+            git_validation_digest: git_validation_digest.into(),
             refs,
         }
     }
@@ -216,38 +222,48 @@ impl GitVisibilityIndex {
         if self.version != GIT_VISIBILITY_INDEX_VERSION {
             return Err(corrupt("visibility index version is unsupported"));
         }
-        if self.refs.len() > MAX_GIT_VISIBILITY_REFS {
-            return Err(corrupt("visibility index contains too many refs"));
-        }
         if !(self.pack_index_hash.is_empty() && self.refs.is_empty()) {
             validate_hash(&self.pack_index_hash, "pack index hash")?;
         }
-        let mut object_count = 0u64;
-        for (name, objects) in &self.refs {
-            if name.is_empty() || name.bytes().any(|byte| byte.is_ascii_control()) {
-                return Err(corrupt("visibility index contains an invalid ref name"));
-            }
-            object_count =
-                object_count
-                    .checked_add(u64::try_from(objects.len()).map_err(|_| {
-                        corrupt("visibility index object count cannot be represented")
-                    })?)
-                    .ok_or_else(|| corrupt("visibility index object count overflows"))?;
-            if object_count > MAX_GIT_VISIBILITY_OBJECTS {
-                return Err(corrupt("visibility index contains too many objects"));
-            }
-            let mut previous: Option<&str> = None;
-            for object in objects {
-                validate_oid(object)?;
-                if previous.is_some_and(|value| value >= object.as_str()) {
-                    return Err(corrupt(
-                        "visibility index object lists must be sorted and deduplicated",
-                    ));
-                }
-                previous = Some(object.as_str());
-            }
+        validate_hash(&self.git_validation_digest, "Git validation digest")?;
+        validate_ref_closures(&self.refs)
+    }
+
+    #[cfg(feature = "storage")]
+    fn validate_identity(
+        &self,
+        generation: u64,
+        pack_index_hash: &str,
+        git_validation_digest: &str,
+    ) -> Result<()> {
+        if self.generation != generation
+            || self.pack_index_hash != pack_index_hash
+            || self.git_validation_digest != git_validation_digest
+        {
+            return Err(corrupt(
+                "visibility index does not match its immutable identity",
+            ));
         }
         Ok(())
+    }
+
+    /// Return whether this proof covers the complete Git state of a manifest.
+    #[must_use]
+    pub fn matches_manifest(&self, manifest: &Manifest) -> bool {
+        self.generation == manifest.generation
+            && self.pack_index_hash == manifest.pack_index_hash
+            && self.git_validation_digest == manifest.git_validation_digest
+            && self.refs.keys().eq(manifest.refs.keys())
+            && manifest.refs.iter().all(|(name, tip)| {
+                self.refs
+                    .get(name)
+                    .is_some_and(|objects| objects.binary_search(tip).is_ok())
+            })
+            && manifest.peeled_refs.iter().all(|(name, peeled)| {
+                self.refs
+                    .get(name)
+                    .is_some_and(|objects| objects.binary_search(peeled).is_ok())
+            })
     }
 
     /// Return the union of objects rooted at the supplied visible refs.
@@ -310,6 +326,38 @@ impl GitVisibilityIndex {
     }
 }
 
+fn validate_ref_closures(refs: &BTreeMap<String, Vec<String>>) -> Result<()> {
+    if refs.len() > MAX_GIT_VISIBILITY_REFS {
+        return Err(corrupt("visibility index contains too many refs"));
+    }
+    let mut object_count = 0u64;
+    for (name, objects) in refs {
+        if name.is_empty() || name.bytes().any(|byte| byte.is_ascii_control()) {
+            return Err(corrupt("visibility index contains an invalid ref name"));
+        }
+        object_count = object_count
+            .checked_add(
+                u64::try_from(objects.len())
+                    .map_err(|_| corrupt("visibility index object count cannot be represented"))?,
+            )
+            .ok_or_else(|| corrupt("visibility index object count overflows"))?;
+        if object_count > MAX_GIT_VISIBILITY_OBJECTS {
+            return Err(corrupt("visibility index contains too many objects"));
+        }
+        let mut previous: Option<&str> = None;
+        for object in objects {
+            validate_oid(object)?;
+            if previous.is_some_and(|value| value >= object.as_str()) {
+                return Err(corrupt(
+                    "visibility index object lists must be sorted and deduplicated",
+                ));
+            }
+            previous = Some(object.as_str());
+        }
+    }
+    Ok(())
+}
+
 fn validate_oid(value: &str) -> Result<()> {
     if value.len() != 40
         || !value
@@ -345,23 +393,62 @@ mod storage {
 
     use bytes::Bytes;
     use crab_storage::{StorageError, Store, StoreLayout};
+    use object_store::path::Path as ObjectPath;
+    use serde::Deserialize;
 
     use super::{
         GitVisibilityEdit, GitVisibilityIndex, MAX_GIT_VISIBILITY_INDEX_BYTES, validate_hash,
+        validate_ref_closures,
     };
     use crate::error::Result;
     use crate::manifests::Manifest;
     use crate::ref_journal::RefJournalEdit;
 
-    /// Read and validate a generation-bound visibility proof.
-    pub async fn read(
-        store: &Store,
-        router: &StoreLayout<Store>,
+    const LEGACY_GIT_VISIBILITY_INDEX_VERSION: u32 = 1;
+
+    /// Stored format used to satisfy a visibility read.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum GitVisibilityFormat {
+        /// Digest-bound proof written by current Crab versions.
+        V2,
+        /// Generation-and-pack-bound proof shipped by Crab 1.0.15.
+        V1,
+    }
+
+    /// Validated visibility proof and its stored format.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct GitVisibilityRead {
+        /// Normalized current-format proof.
+        pub index: GitVisibilityIndex,
+        /// Stored format that supplied the proof.
+        pub format: GitVisibilityFormat,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct GitVisibilityIndexV1 {
+        version: u32,
         generation: u64,
-        pack_index_hash: &str,
-    ) -> Result<GitVisibilityIndex> {
-        let path = router.git_visibility_path(generation, pack_index_hash);
-        let metadata = store.head(&path).await?;
+        pack_index_hash: String,
+        refs: BTreeMap<String, Vec<String>>,
+    }
+
+    impl GitVisibilityIndexV1 {
+        fn validate(&self) -> Result<()> {
+            if self.version != LEGACY_GIT_VISIBILITY_INDEX_VERSION {
+                return Err(super::corrupt(
+                    "legacy visibility index version is unsupported",
+                ));
+            }
+            if !(self.pack_index_hash.is_empty() && self.refs.is_empty()) {
+                validate_hash(&self.pack_index_hash, "pack index hash")?;
+            }
+            validate_ref_closures(&self.refs)
+        }
+    }
+
+    async fn read_bounded(store: &Store, path: &ObjectPath) -> Result<Bytes> {
+        let metadata = store.head(path).await?;
         if metadata.size > MAX_GIT_VISIBILITY_INDEX_BYTES {
             return Err(crate::error::MetadataError::CorruptObject {
                 path: path.as_ref().to_owned(),
@@ -371,7 +458,7 @@ mod storage {
                 ),
             });
         }
-        let (body, _) = store.get_with_etag(&path).await?;
+        let (body, _) = store.get_with_etag(path).await?;
         if body.len() as u64 > MAX_GIT_VISIBILITY_INDEX_BYTES {
             return Err(crate::error::MetadataError::CorruptObject {
                 path: path.as_ref().to_owned(),
@@ -381,20 +468,118 @@ mod storage {
                 ),
             });
         }
+        Ok(body)
+    }
+
+    async fn read_v2(
+        store: &Store,
+        router: &StoreLayout<Store>,
+        generation: u64,
+        pack_index_hash: &str,
+        git_validation_digest: &str,
+    ) -> Result<GitVisibilityIndex> {
+        let path = router.git_visibility_path(git_validation_digest);
+        let body = read_bounded(store, &path).await?;
         let index: GitVisibilityIndex = serde_json::from_slice(&body).map_err(|error| {
             crate::error::MetadataError::CorruptObject {
                 path: path.as_ref().to_owned(),
                 reason: format!("invalid visibility index JSON: {error}"),
             }
         })?;
+        index.validate()?;
+        index.validate_identity(generation, pack_index_hash, git_validation_digest)?;
+        Ok(index)
+    }
+
+    async fn read_v1(
+        store: &Store,
+        router: &StoreLayout<Store>,
+        generation: u64,
+        pack_index_hash: &str,
+        git_validation_digest: &str,
+    ) -> Result<GitVisibilityIndex> {
+        let path = router.git_visibility_v1_path(generation, pack_index_hash);
+        let body = read_bounded(store, &path).await?;
+        let index: GitVisibilityIndexV1 = serde_json::from_slice(&body).map_err(|error| {
+            crate::error::MetadataError::CorruptObject {
+                path: path.as_ref().to_owned(),
+                reason: format!("invalid legacy visibility index JSON: {error}"),
+            }
+        })?;
+        index.validate()?;
         if index.generation != generation || index.pack_index_hash != pack_index_hash {
             return Err(crate::error::MetadataError::CorruptObject {
                 path: path.as_ref().to_owned(),
-                reason: "visibility index does not match its immutable path".to_owned(),
+                reason: "legacy visibility index does not match its immutable path".to_owned(),
             });
         }
+        let index = GitVisibilityIndex::new(
+            generation,
+            pack_index_hash,
+            git_validation_digest,
+            index.refs,
+        );
         index.validate()?;
         Ok(index)
+    }
+
+    /// Read a digest-bound proof, falling back to the shipped v1 location.
+    pub async fn read_with_format(
+        store: &Store,
+        router: &StoreLayout<Store>,
+        generation: u64,
+        pack_index_hash: &str,
+        git_validation_digest: &str,
+    ) -> Result<GitVisibilityRead> {
+        validate_hash(git_validation_digest, "Git validation digest")?;
+        match read_v2(
+            store,
+            router,
+            generation,
+            pack_index_hash,
+            git_validation_digest,
+        )
+        .await
+        {
+            Ok(index) => Ok(GitVisibilityRead {
+                index,
+                format: GitVisibilityFormat::V2,
+            }),
+            Err(crate::error::MetadataError::Storage {
+                source: StorageError::NotFound { .. },
+            }) => read_v1(
+                store,
+                router,
+                generation,
+                pack_index_hash,
+                git_validation_digest,
+            )
+            .await
+            .map(|index| GitVisibilityRead {
+                index,
+                format: GitVisibilityFormat::V1,
+            }),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Read and validate a visibility proof, including the shipped v1 migration path.
+    pub async fn read(
+        store: &Store,
+        router: &StoreLayout<Store>,
+        generation: u64,
+        pack_index_hash: &str,
+        git_validation_digest: &str,
+    ) -> Result<GitVisibilityIndex> {
+        read_with_format(
+            store,
+            router,
+            generation,
+            pack_index_hash,
+            git_validation_digest,
+        )
+        .await
+        .map(|read| read.index)
     }
 
     /// Upload a visibility proof once and verify an existing immutable value.
@@ -410,7 +595,7 @@ mod storage {
         if body.len() as u64 > MAX_GIT_VISIBILITY_INDEX_BYTES {
             return Err(crate::error::MetadataError::CorruptObject {
                 path: router
-                    .git_visibility_path(index.generation, &index.pack_index_hash)
+                    .git_visibility_path(&index.git_validation_digest)
                     .as_ref()
                     .to_owned(),
                 reason: format!(
@@ -419,7 +604,7 @@ mod storage {
                 ),
             });
         }
-        let path = router.git_visibility_path(index.generation, &index.pack_index_hash);
+        let path = router.git_visibility_path(&index.git_validation_digest);
         match store.put(&path, Bytes::from(body)).await {
             Ok(()) => Ok(()),
             Err(StorageError::StateConflict { .. }) => {
@@ -451,6 +636,11 @@ mod storage {
                         }
                     })?;
                 existing.validate()?;
+                existing.validate_identity(
+                    index.generation,
+                    &index.pack_index_hash,
+                    &index.git_validation_digest,
+                )?;
                 if existing == *index {
                     Ok(())
                 } else {
@@ -537,29 +727,35 @@ mod storage {
         edits: &[RefJournalEdit],
         generation: u64,
         pack_index_hash: &str,
+        git_validation_digest: &str,
         final_refs: &BTreeMap<String, String>,
     ) -> Result<Option<GitVisibilityIndex>> {
         let mut refs = if base.refs.is_empty() {
             BTreeMap::new()
         } else {
-            match read(store, router, base.generation, &base.pack_index_hash).await {
-                Ok(index) => {
-                    if index.refs.keys().ne(base.refs.keys())
-                        || base.refs.iter().any(|(name, tip)| {
-                            !index
-                                .refs
-                                .get(name)
-                                .is_some_and(|objects| objects.binary_search(tip).is_ok())
-                        })
-                    {
+            match read_with_format(
+                store,
+                router,
+                base.generation,
+                &base.pack_index_hash,
+                &base.git_validation_digest,
+            )
+            .await
+            {
+                Ok(read) => {
+                    let index = read.index;
+                    if !index.matches_manifest(base) {
                         return Err(crate::error::MetadataError::CorruptObject {
                             path: router
-                                .git_visibility_path(base.generation, &base.pack_index_hash)
+                                .git_visibility_path(&base.git_validation_digest)
                                 .as_ref()
                                 .to_owned(),
                             reason: "base visibility proof does not match its manifest refs"
                                 .to_owned(),
                         });
+                    }
+                    if read.format == GitVisibilityFormat::V1 {
+                        upload_if_absent(store, router, &index).await?;
                     }
                     index.refs
                 }
@@ -616,13 +812,17 @@ mod storage {
         Ok(Some(GitVisibilityIndex::new(
             generation,
             pack_index_hash,
+            git_validation_digest,
             refs,
         )))
     }
 }
 
 #[cfg(feature = "storage")]
-pub use storage::{compact_journal_edits, read, read_edit, upload_edit, upload_if_absent};
+pub use storage::{
+    GitVisibilityFormat, GitVisibilityRead, compact_journal_edits, read, read_edit,
+    read_with_format, upload_edit, upload_if_absent,
+};
 
 #[cfg(test)]
 mod tests {
@@ -633,6 +833,7 @@ mod tests {
         let index = GitVisibilityIndex::new(
             4,
             "a".repeat(64),
+            "c".repeat(64),
             BTreeMap::from([(
                 "refs/heads/main".to_owned(),
                 vec!["b".repeat(40), "a".repeat(40), "b".repeat(40)],
@@ -650,7 +851,7 @@ mod tests {
 
     #[test]
     fn rejects_stale_or_malformed_proof() {
-        let mut index = GitVisibilityIndex::new(4, "a".repeat(64), BTreeMap::new());
+        let mut index = GitVisibilityIndex::new(4, "a".repeat(64), "c".repeat(64), BTreeMap::new());
         index
             .refs
             .insert("refs/heads/main".to_owned(), vec!["A".repeat(40)]);
@@ -662,8 +863,35 @@ mod tests {
         let refs = (0..=MAX_GIT_VISIBILITY_REFS)
             .map(|index| (format!("refs/heads/{index}"), Vec::new()))
             .collect();
-        let index = GitVisibilityIndex::new(4, "a".repeat(64), refs);
+        let index = GitVisibilityIndex::new(4, "a".repeat(64), "c".repeat(64), refs);
         assert!(index.validate().is_err());
+    }
+
+    #[test]
+    fn manifest_match_requires_ref_and_peeled_tip_coverage() {
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 4;
+        manifest.pack_index_hash = "a".repeat(64);
+        manifest
+            .refs
+            .insert("refs/tags/release".to_owned(), "1".repeat(40));
+        manifest
+            .peeled_refs
+            .insert("refs/tags/release".to_owned(), "2".repeat(40));
+        manifest.seal_git_validation();
+        let mut index = GitVisibilityIndex::new(
+            manifest.generation,
+            &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
+            BTreeMap::from([(
+                "refs/tags/release".to_owned(),
+                vec!["1".repeat(40), "2".repeat(40)],
+            )]),
+        );
+
+        assert!(index.matches_manifest(&manifest));
+        index.refs.get_mut("refs/tags/release").unwrap().pop();
+        assert!(!index.matches_manifest(&manifest));
     }
 
     #[test]
@@ -677,6 +905,87 @@ mod tests {
                 .unwrap(),
             new.into_iter().collect::<Vec<_>>()
         );
+    }
+
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn digest_bound_keys_keep_ref_only_candidates_independent() {
+        use std::sync::Arc;
+
+        use crab_storage::{Store, StoreLayout};
+        use object_store::memory::InMemory;
+
+        let store = Store::new(Arc::new(InMemory::new()));
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        let pack_hash = "a".repeat(64);
+        let left = GitVisibilityIndex::new(
+            7,
+            &pack_hash,
+            "b".repeat(64),
+            BTreeMap::from([("refs/heads/left".to_owned(), vec!["1".repeat(40)])]),
+        );
+        let right = GitVisibilityIndex::new(
+            7,
+            &pack_hash,
+            "c".repeat(64),
+            BTreeMap::from([("refs/heads/right".to_owned(), vec!["2".repeat(40)])]),
+        );
+
+        upload_if_absent(&store, &router, &left).await.unwrap();
+        upload_if_absent(&store, &router, &right).await.unwrap();
+
+        let left_read = read(&store, &router, 7, &pack_hash, &left.git_validation_digest)
+            .await
+            .unwrap();
+        let right_read = read(&store, &router, 7, &pack_hash, &right.git_validation_digest)
+            .await
+            .unwrap();
+        assert_eq!(left_read, left);
+        assert_eq!(right_read, right);
+    }
+
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn shipped_v1_proof_is_read_and_can_be_backfilled_to_v2() {
+        use std::sync::Arc;
+
+        use bytes::Bytes;
+        use crab_storage::{Store, StoreLayout};
+        use object_store::memory::InMemory;
+
+        let store = Store::new(Arc::new(InMemory::new()));
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        let generation = 7;
+        let pack_hash = "a".repeat(64);
+        let digest = "b".repeat(64);
+        let legacy = serde_json::json!({
+            "version": 1,
+            "generation": generation,
+            "pack_index_hash": pack_hash.clone(),
+            "refs": {"refs/heads/main": ["1".repeat(40)]},
+        });
+        store
+            .put(
+                &router.git_visibility_v1_path(generation, &pack_hash),
+                Bytes::from(serde_json::to_vec(&legacy).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        let migrated = read_with_format(&store, &router, generation, &pack_hash, &digest)
+            .await
+            .unwrap();
+        assert_eq!(migrated.format, GitVisibilityFormat::V1);
+        assert_eq!(migrated.index.git_validation_digest, digest);
+
+        upload_if_absent(&store, &router, &migrated.index)
+            .await
+            .unwrap();
+        let current = read_with_format(&store, &router, generation, &pack_hash, &digest)
+            .await
+            .unwrap();
+        assert_eq!(current.format, GitVisibilityFormat::V2);
+        assert_eq!(current.index, migrated.index);
     }
 
     #[cfg(feature = "storage")]
@@ -704,6 +1013,7 @@ mod tests {
         let base_index = GitVisibilityIndex::new(
             4,
             &pack_hash,
+            &base.git_validation_digest,
             BTreeMap::from([
                 (
                     "refs/heads/left".to_owned(),
@@ -755,6 +1065,11 @@ mod tests {
             ("refs/heads/left".to_owned(), "c".repeat(40)),
             ("refs/heads/right".to_owned(), "d".repeat(40)),
         ]);
+        let mut final_manifest = base.clone();
+        final_manifest.generation = 5;
+        final_manifest.pack_index_hash = "e".repeat(64);
+        final_manifest.refs.clone_from(&final_refs);
+        final_manifest.seal_git_validation();
 
         let compacted = compact_journal_edits(
             &store,
@@ -763,6 +1078,7 @@ mod tests {
             &edits,
             5,
             &"e".repeat(64),
+            &final_manifest.git_validation_digest,
             &final_refs,
         )
         .await

--- a/crates/crab-metadata/src/git_visibility.rs
+++ b/crates/crab-metadata/src/git_visibility.rs
@@ -22,6 +22,9 @@ const MAX_GIT_VISIBILITY_REFS: usize = 100_000;
 /// Maximum number of ref-rooted object entries accepted in one proof.
 pub const MAX_GIT_VISIBILITY_OBJECTS: u64 = 10_000_000;
 
+/// Maximum ref-rooted object entries built synchronously on a push or repair path.
+pub const MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS: u64 = 100_000;
+
 /// Current serialized ref-update evidence format.
 pub const GIT_VISIBILITY_EDIT_VERSION: u32 = 1;
 

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -325,6 +325,22 @@ pub async fn compact_ref_journal(
     )
     .await?;
 
+    let mut manifest = snapshot.manifest.clone();
+    manifest.generation = generation;
+    manifest.created_at = created_at;
+    manifest.pusher = pusher;
+    manifest.session_id = session_id;
+    manifest.refs.clone_from(&snapshot.journal.refs);
+    manifest
+        .peeled_refs
+        .clone_from(&snapshot.journal.peeled_refs);
+    manifest.head.clone_from(&snapshot.journal.head);
+    manifest.shard_index_hash = shard_index_hash;
+    manifest.pack_index_hash = pack_index_hash;
+    // The old summary does not cover journal-only ref advances.
+    manifest.commit_graph_hash = None;
+    manifest.seal_git_validation();
+
     // Complete evidence publishes authorization before the compacted manifest;
     // otherwise no proof is written and upload-pack withholds protocol v2.
     let git_visibility_published = if let Some(visibility) =
@@ -334,8 +350,9 @@ pub async fn compact_ref_journal(
             &snapshot.manifest,
             &snapshot.journal.ordered_edits,
             generation,
-            &pack_index_hash,
-            &snapshot.journal.refs,
+            &manifest.pack_index_hash,
+            &manifest.git_validation_digest,
+            &manifest.refs,
         )
         .await?
     {
@@ -346,19 +363,6 @@ pub async fn compact_ref_journal(
     };
 
     let compacted_transactions = snapshot.journal.transactions.clone();
-    let mut manifest = snapshot.manifest;
-    manifest.generation = generation;
-    manifest.created_at = created_at;
-    manifest.pusher = pusher;
-    manifest.session_id = session_id;
-    manifest.refs = snapshot.journal.refs;
-    manifest.peeled_refs = snapshot.journal.peeled_refs;
-    manifest.head = snapshot.journal.head;
-    manifest.shard_index_hash = shard_index_hash;
-    manifest.pack_index_hash = pack_index_hash;
-    // The old summary does not cover journal-only ref advances.
-    manifest.commit_graph_hash = None;
-    manifest.seal_git_validation();
     write_ref_journal_frontier(store, router, &manifest, &snapshot.journal.visible_heads).await?;
     write_manifest_cas(store, router, &manifest, &snapshot.manifest_etag).await?;
     cleanup_compacted_transactions(store, router, &compacted_transactions).await;
@@ -1190,6 +1194,7 @@ mod tests {
             &router,
             compacted.manifest.generation,
             &compacted.manifest.pack_index_hash,
+            &compacted.manifest.git_validation_digest,
         )
         .await
         .unwrap();

--- a/crates/crab-read/src/upload_pack.rs
+++ b/crates/crab-read/src/upload_pack.rs
@@ -1192,6 +1192,7 @@ mod tests {
         GitVisibilityIndex::new(
             7,
             "a".repeat(64),
+            "b".repeat(64),
             [
                 (
                     "refs/heads/main".to_owned(),
@@ -1324,6 +1325,7 @@ mod tests {
         let proof = GitVisibilityIndex::new(
             7,
             "a".repeat(64),
+            "b".repeat(64),
             [("refs/heads/main".to_owned(), vec![oid('3').to_string()])]
                 .into_iter()
                 .collect(),

--- a/crates/crab-remote-git/src/lib.rs
+++ b/crates/crab-remote-git/src/lib.rs
@@ -18,6 +18,7 @@ mod runtime;
 mod snapshot;
 mod state;
 mod traversal;
+mod visibility;
 
 pub use budget::BudgetDimension;
 pub use crab_metadata::git_visibility::GitVisibilityIndex;

--- a/crates/crab-remote-git/src/operation.rs
+++ b/crates/crab-remote-git/src/operation.rs
@@ -51,6 +51,8 @@ pub enum OperationKind {
     Archive,
     /// Protocol-v2 upload-pack generation.
     UploadPack,
+    /// Rebuild of generation-bound ref visibility from canonical objects.
+    Visibility,
     /// Symbolic-link target metadata.
     Symlink,
     /// Submodule gitlink metadata.
@@ -75,6 +77,7 @@ impl OperationKind {
             Self::Blame => "blame",
             Self::Archive => "archive",
             Self::UploadPack => "upload_pack",
+            Self::Visibility => "visibility",
             Self::Symlink => "symlink",
             Self::Submodule => "submodule",
         }

--- a/crates/crab-remote-git/src/repository.rs
+++ b/crates/crab-remote-git/src/repository.rs
@@ -338,6 +338,7 @@ impl RemoteGitRepository {
                     identity,
                     options,
                     generation: manifest.generation,
+                    git_validation_digest: Arc::from(manifest.git_validation_digest.as_str()),
                     manifest_etag,
                     coverage: None,
                     inventory: std::collections::HashMap::new(),
@@ -424,6 +425,7 @@ impl RemoteGitRepository {
                     identity,
                     options,
                     generation: manifest.generation,
+                    git_validation_digest: Arc::from(manifest.git_validation_digest.as_str()),
                     manifest_etag,
                     coverage: Some(coverage),
                     inventory,
@@ -472,6 +474,10 @@ impl RemoteGitRepository {
         self.state.generation
     }
 
+    pub(crate) fn git_validation_digest(&self) -> &str {
+        &self.state.git_validation_digest
+    }
+
     /// Return complete references from the pinned manifest.
     #[must_use]
     pub fn refs(&self) -> &RepositoryRefs {
@@ -505,6 +511,7 @@ impl RemoteGitRepository {
                 &self.state.layout,
                 self.state.generation,
                 &pack_index_hash,
+                &self.state.git_validation_digest,
             );
             tokio::select! {
                 biased;
@@ -518,6 +525,7 @@ impl RemoteGitRepository {
             crab_metadata::git_visibility::GitVisibilityIndex::new(
                 self.state.generation,
                 String::new(),
+                self.state.git_validation_digest.as_ref(),
                 std::collections::BTreeMap::new(),
             )
         } else {

--- a/crates/crab-remote-git/src/repository.rs
+++ b/crates/crab-remote-git/src/repository.rs
@@ -547,6 +547,23 @@ impl RemoteGitRepository {
         Ok(index)
     }
 
+    /// Rebuild complete ref visibility from this locator-pinned generation.
+    ///
+    /// This does not read or trust an existing visibility proof. Canonical
+    /// commit, tree, and tag objects are fetched once, while the resulting
+    /// per-ref closures retain the proof format's aggregate object bound.
+    pub async fn rebuild_visibility_index(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> Result<crab_metadata::git_visibility::GitVisibilityIndex> {
+        let pack_index_hash = self
+            .state
+            .coverage
+            .map(|coverage| coverage.pack_index_hash.to_string())
+            .unwrap_or_default();
+        crate::visibility::rebuild(self, pack_index_hash, cancellation).await
+    }
+
     /// Check whether the canonical manifest still names this pinned generation.
     ///
     /// This performs one metadata-only provider request and never mutates the

--- a/crates/crab-remote-git/src/state.rs
+++ b/crates/crab-remote-git/src/state.rs
@@ -17,6 +17,7 @@ pub(crate) struct RepositoryState {
     pub(crate) identity: RepositoryIdentity,
     pub(crate) options: RepositoryOptions,
     pub(crate) generation: u64,
+    pub(crate) git_validation_digest: Arc<str>,
     pub(crate) manifest_etag: String,
     pub(crate) coverage: Option<GitLocatorCoverage>,
     pub(crate) inventory: HashMap<MerkleHash, GitPackInventoryEntry>,

--- a/crates/crab-remote-git/src/visibility.rs
+++ b/crates/crab-remote-git/src/visibility.rs
@@ -1,0 +1,221 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use gix_hash::ObjectId;
+use gix_object::Kind;
+use tokio_util::sync::CancellationToken;
+
+use crate::objects::{parse_commit, parse_tag, parse_tree_raw};
+use crate::{
+    CorruptionStage, EntryKind, Error, GitVisibilityIndex, OperationContext, OperationKind,
+    RemoteGitRepository, Result, RevisionError,
+};
+
+#[derive(Clone, Copy)]
+struct PendingObject {
+    oid: ObjectId,
+    expected: Option<Kind>,
+    corruption_stage: CorruptionStage,
+    tag_depth: usize,
+}
+
+struct ObjectLinks {
+    kind: Kind,
+    children: Vec<PendingObject>,
+    // A verified tree entry proves blob reachability. Reading blob bodies here
+    // would add one storage request per file without strengthening the proof.
+    terminals: Vec<ObjectId>,
+}
+
+pub(crate) async fn rebuild(
+    repository: &RemoteGitRepository,
+    pack_index_hash: String,
+    cancellation: &CancellationToken,
+) -> Result<GitVisibilityIndex> {
+    if repository.refs().is_empty() {
+        return Ok(GitVisibilityIndex::new(
+            repository.generation(),
+            pack_index_hash,
+            BTreeMap::new(),
+        ));
+    }
+
+    let operation = repository
+        .operation(OperationKind::Visibility, cancellation)
+        .await?;
+    let result = rebuild_with_operation(repository, pack_index_hash, &operation).await;
+    operation.finish(result).await
+}
+
+async fn rebuild_with_operation(
+    repository: &RemoteGitRepository,
+    pack_index_hash: String,
+    operation: &OperationContext,
+) -> Result<GitVisibilityIndex> {
+    let maximum = crab_metadata::git_visibility::MAX_SYNCHRONOUS_GIT_VISIBILITY_OBJECTS;
+    let mut cache = HashMap::<ObjectId, ObjectLinks>::new();
+    let mut total = 0u64;
+    let mut refs = BTreeMap::new();
+
+    for reference in &repository.refs().entries {
+        let mut objects = HashSet::new();
+        let mut pending = vec![PendingObject {
+            oid: reference.target,
+            expected: None,
+            corruption_stage: CorruptionStage::Tag,
+            tag_depth: 0,
+        }];
+
+        while let Some(next) = pending.pop() {
+            operation.ensure_active()?;
+            if !objects.insert(next.oid) {
+                if next.expected == Some(Kind::Tag) {
+                    return Err(Error::Revision {
+                        reason: RevisionError::TagCycle,
+                    });
+                }
+                continue;
+            }
+            total = total.saturating_add(1);
+            if total > maximum {
+                return Err(Error::LimitExceeded {
+                    limit: "visibility proof objects",
+                    actual: total,
+                    maximum,
+                });
+            }
+
+            if let Some(cached) = cache.get(&next.oid) {
+                ensure_kind(cached.kind, next)?;
+                insert_terminals(&mut objects, &cached.terminals, &mut total, maximum)?;
+                pending.extend(cached.children.iter().copied());
+                continue;
+            }
+
+            let object = operation.read_object(next.oid).await?;
+            ensure_kind(object.kind, next)?;
+            let links = object_links(&object, next.tag_depth, operation)?;
+            insert_terminals(&mut objects, &links.terminals, &mut total, maximum)?;
+            pending.extend(links.children.iter().copied());
+            cache.insert(next.oid, links);
+        }
+
+        if reference
+            .peeled
+            .is_some_and(|peeled| !objects.contains(&peeled))
+        {
+            return Err(Error::RepositoryState {
+                reason: crate::RepositoryStateError::VisibilityProofMismatch,
+            });
+        }
+        let mut objects = objects
+            .into_iter()
+            .map(|oid| oid.to_hex().to_string())
+            .collect::<Vec<_>>();
+        objects.sort_unstable();
+        refs.insert(reference.name.clone(), objects);
+    }
+
+    Ok(GitVisibilityIndex::new(
+        repository.generation(),
+        pack_index_hash,
+        refs,
+    ))
+}
+
+fn insert_terminals(
+    objects: &mut HashSet<ObjectId>,
+    terminals: &[ObjectId],
+    total: &mut u64,
+    maximum: u64,
+) -> Result<()> {
+    for oid in terminals {
+        if !objects.insert(*oid) {
+            continue;
+        }
+        *total = total.saturating_add(1);
+        if *total > maximum {
+            return Err(Error::LimitExceeded {
+                limit: "visibility proof objects",
+                actual: *total,
+                maximum,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn ensure_kind(actual: Kind, pending: PendingObject) -> Result<()> {
+    if pending.expected.is_none_or(|expected| expected == actual) {
+        Ok(())
+    } else {
+        Err(Error::Corrupt {
+            stage: pending.corruption_stage,
+        })
+    }
+}
+
+fn object_links(
+    object: &crate::RemoteGitObject,
+    tag_depth: usize,
+    operation: &OperationContext,
+) -> Result<ObjectLinks> {
+    let (children, terminals) = match object.kind {
+        Kind::Commit => {
+            let commit = parse_commit(object)?;
+            let mut children = Vec::with_capacity(commit.parents.len().saturating_add(1));
+            children.push(PendingObject {
+                oid: commit.tree,
+                expected: Some(Kind::Tree),
+                corruption_stage: CorruptionStage::Commit,
+                tag_depth: 0,
+            });
+            children.extend(commit.parents.into_iter().map(|oid| PendingObject {
+                oid,
+                expected: Some(Kind::Commit),
+                corruption_stage: CorruptionStage::Commit,
+                tag_depth: 0,
+            }));
+            (children, Vec::new())
+        }
+        Kind::Tree => {
+            let mut children = Vec::new();
+            let mut terminals = Vec::new();
+            for entry in parse_tree_raw(object)? {
+                match entry.kind {
+                    EntryKind::Submodule => {}
+                    EntryKind::Tree => children.push(PendingObject {
+                        oid: entry.oid,
+                        expected: Some(Kind::Tree),
+                        corruption_stage: CorruptionStage::Tree,
+                        tag_depth: 0,
+                    }),
+                    EntryKind::Blob | EntryKind::Symlink => terminals.push(entry.oid),
+                }
+            }
+            (children, terminals)
+        }
+        Kind::Blob => (Vec::new(), Vec::new()),
+        Kind::Tag => {
+            if tag_depth >= operation.object_limits().max_tag_depth {
+                return Err(Error::Revision {
+                    reason: RevisionError::TagDepth,
+                });
+            }
+            let tag = parse_tag(object)?;
+            (
+                vec![PendingObject {
+                    oid: tag.target,
+                    expected: Some(tag.target_kind),
+                    corruption_stage: CorruptionStage::Tag,
+                    tag_depth: tag_depth.saturating_add(1),
+                }],
+                Vec::new(),
+            )
+        }
+    };
+    Ok(ObjectLinks {
+        kind: object.kind,
+        children,
+        terminals,
+    })
+}

--- a/crates/crab-remote-git/src/visibility.rs
+++ b/crates/crab-remote-git/src/visibility.rs
@@ -35,6 +35,7 @@ pub(crate) async fn rebuild(
         return Ok(GitVisibilityIndex::new(
             repository.generation(),
             pack_index_hash,
+            repository.git_validation_digest(),
             BTreeMap::new(),
         ));
     }
@@ -118,6 +119,7 @@ async fn rebuild_with_operation(
     Ok(GitVisibilityIndex::new(
         repository.generation(),
         pack_index_hash,
+        repository.git_validation_digest(),
         refs,
     ))
 }

--- a/crates/crab-storage/src/layout.rs
+++ b/crates/crab-storage/src/layout.rs
@@ -262,7 +262,15 @@ impl<S> StoreLayout<S> {
 
     /// Path to one immutable Git object visibility proof.
     #[must_use]
-    pub fn git_visibility_path(&self, generation: u64, pack_index_hash: &str) -> ObjectPath {
+    pub fn git_visibility_path(&self, git_validation_digest: &str) -> ObjectPath {
+        self.repo_path(&format!(
+            "metadata/git-visibility/v2/{git_validation_digest}.json"
+        ))
+    }
+
+    /// Path to a v1 visibility proof shipped by Crab 1.0.15.
+    #[must_use]
+    pub fn git_visibility_v1_path(&self, generation: u64, pack_index_hash: &str) -> ObjectPath {
         self.repo_path(&format!(
             "metadata/git-visibility/{generation:020}-{pack_index_hash}.json"
         ))

--- a/packages/web/content/docs/cli/reference/structured-output.mdx
+++ b/packages/web/content/docs/cli/reference/structured-output.mdx
@@ -252,6 +252,12 @@ These commands accept both flags. `--json` emits only the terminal result;
 | `crab prune` | `prune` | `prune.event` |
 | `crab clone` | `clone` | `clone.event` |
 
+`crab push --rebase-on-non-fast-forward` result payloads include
+`integration_retries`, `integration_retry_limit`, and, when retries occur,
+`integration_retry_stages`. The stage map uses bounded names such as
+`preflight`, `lock`, `xorb-upload`, and `ref-commit`, and its counts sum to the
+total retry count.
+
 ### Remote Helper Exception
 
 The `git-remote-crab` remote helper (invoked by `git push`) cannot use


### PR DESCRIPTION
## Summary

- retain the first failing push-pipeline owner as a stable stage, retry only typed transient setup/discovery/ref-commit failures, and report bounded retry-stage totals in JSON/audit output
- replace unbounded push-admission records with five reusable CAS slots and amortize locator compaction under the existing writer lock
- publish Git visibility evidence before ref/manifest authority advances across direct, journal, protected-service, filtered-view, repack, and active-active paths
- bind visibility v2 to the full manifest Git-validation digest; read, semantically validate, backfill, replicate, and GC-root the shipped v1.0.15 format as an explicit data migration
- repair missing current-generation proof from immutable locator-pinned packs without fetching blob bodies
- reuse the protected receive path's already-verified Git ODB to produce proof, eliminating the second candidate-pack download
- reject corrupt, mismatched, or incomplete proof before it can be published or used

## Ownership and safety

Visibility evidence is a pre-commit requirement rather than a post-commit best effort. Evidence errors abort before the ref marker, manifest, coordinator, or generation receipt becomes authoritative. Existing proof is accepted only when its generation, pack inventory, validation digest, refs, and peeled tips match the exact candidate manifest.

The v2 immutable key includes the full Git-validation digest, so two ref candidates with the same generation and pack inventory cannot collide. The v1 reader is deliberately narrow: it is tried only when v2 returns exact `NotFound`; corrupt v2 fails closed; v1 must match the candidate manifest before any v2 backfill or replication. Current and historical v1 roots remain protected by GC while the tagged-data migration exists.

Protected receive walks the materialization ODB it has already installed and verified, carries typed exact/complete-pack evidence to the commit owner, checks that exact evidence matches the candidate manifest, and publishes it before commit. It no longer creates a second temporary ODB or re-downloads candidate pack bodies for proof construction.

The five admission slots are an operational cap, not a correctness constant or hot-ref batching mechanism. With the default eight upload workers, five admitted pushes bound one repository to roughly 40 concurrent upload tasks while keeping admission metadata fixed and reusable. A different value needs backend/large-repository evidence; adding an arbitrary user-facing knob is not justified yet.

## Proof

- `cargo test -p crab-storage -p crab-metadata -p crab-remote-git -p crab-read -p crab-auth-server --lib --locked --features crab-metadata/storage` — 523 passed
- `cargo test -p crab --lib --locked visibility` — 9 passed, including mismatched-v1 refusal, validated v1 backfill, replication refusal, and repack coverage
- focused ref-journal handoff, non-atomic CAS retry, GC reachability, and repack tests passed
- `cargo check -p crab-storage -p crab-metadata -p crab-remote-git -p crab-read -p crab-auth-server --locked --features crab-metadata/storage`
- `cargo check -p crab-metadata --no-default-features --locked`
- `cargo clippy -p crab-storage -p crab-metadata -p crab-remote-git -p crab-read -p crab-auth-server --lib --locked --features crab-metadata/storage -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- final RustFS independent-ref run: 4/4 pushes, no harness retries, fresh protocol-v2 clones and strict checks passed
- final RustFS same-ref run: 4/4 pushes, no harness retries, all commits integrated and strict checks passed

Top-level Crab `-D warnings` remains blocked by the existing Rust 1.97 lint backlog (338 warnings with `--no-deps`, plus untouched `crab-vfs` dependency lints). Existing CI also has unrelated baseline failures: actionlint's Go-version mismatch and an architecture inventory omission for the existing `crab-auth-store` `uuid` feature. This branch changes neither baseline surface.

## Measured request cost

The final-code RustFS runs use a tiny repository and count object-store attempts. They exclude retained bytes, egress, KMS, replication, versioning, monitoring, repair, and provider retries.

| Four concurrent pushes | Attempts/push | Class A-style/push | Class B-style/push | AWS S3 request cost/push | Cloudflare R2 request cost/push |
| --- | ---: | ---: | ---: | ---: | ---: |
| Independent refs | 151.25 | 44.75 | 105.50 | $0.00026595 | $0.00023936 |
| Same hot ref | 377.75 | 101.00 | 275.75 | $0.00061530 | $0.00055377 |

At current listed request rates, that linearizes to about $265.95/$615.30 per million independent/hot-ref pushes on S3 and $239.36/$553.77 on R2, before free tiers and billing-unit rounding. RustFS has no provider request bill, but the same attempts consume storage-node IOPS, CPU, bandwidth, and latency.

Pricing references: [AWS S3](https://aws.amazon.com/s3/pricing/) and [Cloudflare R2](https://developers.cloudflare.com/r2/pricing/).

## Legacy compatibility

Three paths should not be conflated:

1. The shipped v1.0.15 visibility reader is a persistent-data migration. It remains only because tagged Crab versions wrote those object keys; validated reads backfill v2.
2. The reverse-index migration deterministically creates `.rev` for v1.0.14-and-earlier packs that shipped only `.idx`. Locator rebuild cannot safely derive packed-entry lengths without it.
3. The line-oriented `git-remote-crab` fetch protocol remains the compatibility path for older Git and ordinary complete fetches when protocol v2 is unavailable.

The old protected-push proof helper that downloaded and installed the candidate packs a second time is not retained; this PR deletes that duplicate path.

## Remaining gaps and opportunities

1. **Hot-ref locator amplification (highest measured cost gap).** The same-ref run uses 2.50x the independent-ref attempts. Locator compacted-manifest reads, compaction, GC, and manifest reads dominate. Native same-ref writers acquire the ref lock before pipeline admission, so admission-slot batching cannot coalesce them. The next fix belongs at the ref-lock/locator publication/read boundary: coalesce successor publication, cache immutable generation inputs, and reduce SlateDB manifest/GC reads without introducing an availability window.
2. **Attribution and production-scale benchmark.** The hot harness includes the pull/rebase needed to integrate all writers. Split pull/fetch from push request accounting, then qualify large histories, many refs, large blobs, high RTT, throttling, and long-running contention. Tiny-fixture bytes are not a capacity forecast.
3. **Large-proof representation.** JSON repeats object IDs across refs and exact synchronous proof is capped at 100,000 logical objects. Above the bound, Crab deliberately retains complete-pack Git compatibility. A deduplicated closure/bitmap format and an asynchronous durable proof owner are needed for large monorepos.
4. **Provider and failure qualification.** Repeat active-active, protected, filtered-view, crash/lost-response, mixed-version migration, and cost suites against AWS S3, GCS, Azure, R2, and multi-region RustFS. Protected-service proof has real-store unit/integration coverage but still needs live deployed-auth qualification.
5. **Object lifecycle and restore SLOs.** Quantify pack/proof/locator object growth, compaction and GC debt, versioning retention, backup/restore time, and repair availability under team-scale histories.
6. **Git-hosting compatibility surface.** Protocol v2 intentionally supports a bounded filter matrix and rejects unlisted capabilities. Complete branch-policy/hook workflows, hosting migrations, and mixed native/Crab client qualification before presenting Crab as a drop-in replacement for every Git hosting feature.
7. **Team-backbone operations.** Add per-repository/team cost attribution, latency/error/throttle SLOs, alerts, audit/RBAC evidence, branch protection, disaster-recovery drills, quota/fairness policy, and documented upgrade/rollback procedures.

## Best-fix assessment

For the correctness failure, digest-bound pre-commit visibility publication at every commit owner plus fail-closed repair is the best fix: it closes the availability window and removes the sibling-pack dependency without creating a second lock or global client rebuild owner. The leading next investment is the hot-ref locator owner boundary, not more client retries or a larger admission slot count.
