### PR TITLE
ci: pass stable toolchain to pinned Rust action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.tag }}
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
       - name: Install workflow smoke dependencies
         run: |
           sudo apt-get update -y
@@ -216,6 +218,8 @@ jobs:
           ref: ${{ needs.prepare.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
 
       - name: Install Linux system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfuse3-dev
@@ -345,6 +349,8 @@ jobs:
           ref: ${{ needs.prepare.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
 
       - name: Install Linux system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfuse3-dev
@@ -603,6 +609,8 @@ jobs:
           ref: ${{ needs.prepare.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
 
       - name: Install Linux system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfuse3-dev
@@ -631,6 +639,8 @@ jobs:
           fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
 
       - name: Run workflow contract tests
         run: cargo test -p crab-workflow --locked
@@ -770,6 +780,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2


### PR DESCRIPTION
## Summary

The v1.0.15 release run reached its pre-build gates but failed on the existing Windows native workflow gate because the pinned `dtolnay/rust-toolchain` commit requires an explicit `toolchain` input. Add `toolchain: stable` to every pinned invocation in the release workflow.

## Evidence

Run: https://github.com/crabbuild/crab-oss/actions/runs/32560546461

Failure: `dtolnay/rust-toolchain` reported `'toolchain' is a required input` on Windows.

## Validation

- `GOTOOLCHAIN=local go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `python3 crab/scripts/release/check-release-archive-contents.py`
- YAML parse and `git diff --check`

After merge, rerun the `v1.0.15` release workflow manually for the existing tag.
