### PR TITLE
perf(push): coalesce hot-ref locator publication

### DIFF
--- a/crab/src/cmd/history_recovery.rs
+++ b/crab/src/cmd/history_recovery.rs
@@ -1133,6 +1133,7 @@ async fn rebuild_locator_inventory(
             shard_index_hash,
             pack_index_hash,
         },
+        None,
         RECOVERY_LOCK_TTL,
         cancel,
     )

--- a/crab/src/cmd/repack.rs
+++ b/crab/src/cmd/repack.rs
@@ -263,6 +263,7 @@ async fn run_repack_locked(
             git_sha1: &generated.git_sha1,
         }],
         anchor,
+        Some(std::slice::from_ref(&replacement)),
         config.lock_ttl,
         cancel,
     )

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -18616,12 +18616,16 @@ mod tests {
             .apply_decisions_with_sha_map(&decisions, false, &sha_map)
             .await
             .expect("build candidate");
+        upload_segmented_bulk(&store, &router, &bulk)
+            .await
+            .expect("publish concurrent pack inventory");
 
         let (mut concurrent, etag) = read_manifest(&store, &router)
             .await
             .expect("read concurrent base");
-        let concurrent_main = "f".repeat(40);
+        let concurrent_main = crate::test::git_repo::TEST_GIT_REPO.commit_sha.clone();
         concurrent.generation += 1;
+        concurrent.pack_index_hash = candidate.pack_index_hash.clone();
         concurrent
             .refs
             .insert("refs/heads/main".to_owned(), concurrent_main.clone());
@@ -18937,7 +18941,7 @@ mod tests {
             .expect("create initial manifest");
         armed.store(true, Ordering::SeqCst);
 
-        let interrupted = PushPipeline::new(
+        let interrupted_pipeline = PushPipeline::new(
             PushConfig::default(),
             vec![make_spec("refs/heads/main")],
             Some(store.clone()),
@@ -18948,9 +18952,8 @@ mod tests {
             None,
             cancel.clone(),
             None,
-        )
-        .execute()
-        .await;
+        );
+        let interrupted = Box::pin(interrupted_pipeline.execute()).await;
 
         assert!(
             cancel.is_cancelled(),
@@ -18980,7 +18983,7 @@ mod tests {
             "protocol v2 must stay withheld while exact derived coverage is incomplete"
         );
 
-        let restarted = PushPipeline::new(
+        let restarted_pipeline = PushPipeline::new(
             PushConfig::default(),
             vec![make_spec("refs/heads/dev")],
             Some(store.clone()),
@@ -18991,9 +18994,8 @@ mod tests {
             None,
             CancellationToken::new(),
             None,
-        )
-        .execute()
-        .await;
+        );
+        let restarted = Box::pin(restarted_pipeline.execute()).await;
 
         assert_eq!(
             restarted.outcomes.get("refs/heads/dev"),

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -2432,6 +2432,9 @@ const PUSH_LOCK_WAIT_BACKOFF_BASE: Duration = Duration::from_millis(250);
 /// Cap for opt-in push-lock wait polling.
 const PUSH_LOCK_WAIT_BACKOFF_CAP: Duration = Duration::from_secs(2);
 
+/// Cap after a same-ref contender has published its successor signal.
+const PUSH_LOCK_SUCCESSOR_POLL_CAP: Duration = Duration::from_millis(250);
+
 // Operational cap, not a correctness constant. With the product's default
 // eight upload workers, five pushes bound one repository to 40 upload tasks.
 const PUSH_ADMISSION_SLOTS: usize = 5;
@@ -3004,9 +3007,13 @@ pub fn lock_ttl_remaining(expires_at_unix: Option<u64>) -> u64 {
 }
 
 fn push_lock_wait_delay(attempt: u32, remaining: Duration) -> Duration {
+    push_lock_wait_delay_with_cap(attempt, remaining, PUSH_LOCK_WAIT_BACKOFF_CAP)
+}
+
+fn push_lock_wait_delay_with_cap(attempt: u32, remaining: Duration, cap: Duration) -> Duration {
     let shift = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
     let exp = PUSH_LOCK_WAIT_BACKOFF_BASE.saturating_mul(shift);
-    let bound = exp.min(PUSH_LOCK_WAIT_BACKOFF_CAP).min(remaining);
+    let bound = exp.min(cap).min(remaining);
     let bound_nanos = u64::try_from(bound.as_nanos()).unwrap_or(u64::MAX);
     if bound_nanos == 0 {
         return Duration::ZERO;
@@ -3850,6 +3857,12 @@ pub struct PushPipeline {
     manifest_etag: tokio::sync::Mutex<Option<String>>,
     /// Generation and shard-index hash returned by a successful manifest CAS.
     committed_manifest_anchor: tokio::sync::Mutex<Option<CommittedManifestAnchor>>,
+    /// Exact pack inventory already materialized by this pipeline's journal compaction.
+    /// Publication reuses it instead of downloading the immutable segments again.
+    committed_pack_inventory: tokio::sync::Mutex<Option<Vec<PackManifestEntry>>>,
+    /// A same-ref successor owns the next mutation, so it also owns publishing
+    /// the next useful locator generation.
+    locator_publication_deferred: std::sync::atomic::AtomicBool,
     /// Whether this generation has the complete bounded visibility proof that
     /// protocol-v2 admission requires alongside exact locator coverage.
     git_visibility_published: std::sync::atomic::AtomicBool,
@@ -4800,6 +4813,7 @@ pub(crate) async fn acquire_push_lock_leases(
     let deadline = (!config.lock_wait.is_zero()).then(|| Instant::now() + config.lock_wait);
     let mut wait_attempt = 0;
     let mut checked_committed_holders = HashSet::new();
+    let mut announced_successor = false;
     let mut acquire_context = PushLockAcquireContext::new(Arc::clone(store.inner()));
 
     loop {
@@ -4837,6 +4851,26 @@ pub(crate) async fn acquire_push_lock_leases(
             {
                 let holder_key = (ref_name.to_owned(), holder.to_owned());
                 if checked_committed_holders.insert(holder_key) {
+                    if !holder.is_empty() {
+                        match PushLock::announce_ref_successor(
+                            store.inner(),
+                            prefix,
+                            ref_name,
+                            holder,
+                        )
+                        .await
+                        {
+                            Ok(()) => announced_successor = true,
+                            Err(error) => {
+                                warn!(
+                                    %ref_name,
+                                    %holder,
+                                    %error,
+                                    "could not announce queued ref-lock successor"
+                                );
+                            }
+                        }
+                    }
                     match release_lock_committed_by_visible_transaction(
                         store, prefix, ref_name, holder,
                     )
@@ -4909,7 +4943,12 @@ pub(crate) async fn acquire_push_lock_leases(
             return Err(err);
         }
 
-        let delay = push_lock_wait_delay(wait_attempt, deadline.saturating_duration_since(now));
+        let remaining = deadline.saturating_duration_since(now);
+        let delay = if announced_successor {
+            push_lock_wait_delay_with_cap(wait_attempt, remaining, PUSH_LOCK_SUCCESSOR_POLL_CAP)
+        } else {
+            push_lock_wait_delay(wait_attempt, remaining)
+        };
         wait_attempt = wait_attempt.saturating_add(1);
         debug!(
             attempt = wait_attempt,
@@ -5072,6 +5111,35 @@ async fn compact_ref_journal_until_idle(
         "ref journal compactor reached its bounded drain limit"
     );
     Ok(latest)
+}
+
+async fn ref_successor_is_claimed(
+    store: &Store,
+    prefix: &str,
+    ref_names: &[String],
+    predecessor_holders: &BTreeMap<String, String>,
+) -> Result<bool> {
+    use futures_util::StreamExt;
+
+    let mut claims = futures_util::stream::iter(ref_names.iter().map(|ref_name| async move {
+        if let Some(holder) = predecessor_holders.get(ref_name)
+            && PushLock::ref_successor_was_announced(store.inner(), prefix, ref_name, holder)
+                .await
+                .map_err(CrabError::from)?
+        {
+            return Ok(true);
+        }
+        PushLock::ref_lease_is_claimed(store.inner(), prefix, ref_name)
+            .await
+            .map_err(CrabError::from)
+    }))
+    .buffer_unordered(DEFAULT_HEAD_CHECK_CONCURRENCY);
+    while let Some(claimed) = claims.next().await {
+        if claimed? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 pub(crate) async fn release_push_lock_leases(mut leases: Vec<PushLockLease>) {
@@ -5329,6 +5397,7 @@ pub(crate) async fn publish_committed_pack_locators(
     router: &StoreLayout,
     packs: &[CommittedPackIndex<'_>],
     anchor: CommittedManifestAnchor,
+    pinned_inventory: Option<&[PackManifestEntry]>,
     lock_ttl: Duration,
     cancel: &CancellationToken,
 ) -> Result<crab_metadata::git_object_locator::LocatorWriteStats> {
@@ -5379,7 +5448,20 @@ pub(crate) async fn publish_committed_pack_locators(
         {
             return Ok(crab_metadata::git_object_locator::LocatorWriteStats::default());
         }
-        let current_packs = read_bulk_pack_list(store, router, &current.pack_index_hash).await?;
+        let loaded_inventory;
+        let current_packs = if let Some(pinned) = pinned_inventory {
+            let (pinned_hash, _, _) =
+                crate::metadata::manifest::compact_pack_index(anchor.generation, pinned)?;
+            if pinned_hash != current.pack_index_hash {
+                return Err(CrabError::Internal(
+                    "pinned locator inventory does not match its committed manifest".to_owned(),
+                ));
+            }
+            pinned
+        } else {
+            loaded_inventory = read_bulk_pack_list(store, router, &current.pack_index_hash).await?;
+            &loaded_inventory
+        };
 
         let planned_object_rows = current_packs
             .iter()
@@ -5392,18 +5474,8 @@ pub(crate) async fn publish_committed_pack_locators(
             )
             .await?;
         let operation = async {
-            let prior_coverage = writer.coverage();
-            let covered_packs = if let Some(coverage) = prior_coverage {
-                read_bulk_pack_list(store, router, &coverage.pack_index_hash.hex()).await?
-            } else {
-                Vec::new()
-            };
-            let covered = covered_packs
-                .iter()
-                .map(|pack| (pack.pack_id.as_str(), (pack.object_count, pack.size)))
-                .collect::<HashMap<_, _>>();
             let mut pack_records = Vec::with_capacity(current_packs.len());
-            for pack in &current_packs {
+            for pack in current_packs {
                 let pack_id = MerkleHash::from_hex(&pack.pack_id).map_err(|error| {
                     CrabError::Internal(format!(
                         "committed pack id is invalid for locator publication: {error}"
@@ -5418,6 +5490,11 @@ pub(crate) async fn publish_committed_pack_locators(
                 });
             }
             let bindings = writer.bind_packs(&pack_records).await?;
+            let covered = bindings
+                .iter()
+                .filter(|binding| writer.binding_has_covered_objects(**binding))
+                .map(|binding| binding.record.pack_id)
+                .collect::<HashSet<_>>();
             let retained_slots = bindings
                 .iter()
                 .map(|binding| binding.pack_slot)
@@ -5425,17 +5502,15 @@ pub(crate) async fn publish_committed_pack_locators(
             let sweep = writer.sweep_unreferenced(&retained_slots).await?;
             let rebuild_all = sweep.pack_rows_deleted != 0;
             let mut evidence = Vec::new();
-            for pack in &current_packs {
-                if !rebuild_all
-                    && covered.get(pack.pack_id.as_str()) == Some(&(pack.object_count, pack.size))
-                {
-                    continue;
-                }
+            for pack in current_packs {
                 let pack_id = MerkleHash::from_hex(&pack.pack_id).map_err(|error| {
                     CrabError::Internal(format!(
                         "committed pack id is invalid for locator publication: {error}"
                     ))
                 })?;
+                if !rebuild_all && covered.contains(&pack_id) {
+                    continue;
+                }
                 let pack_evidence = if let Some(local) = local_evidence.remove(&pack_id) {
                     validate_locator_pack_evidence(
                         pack,
@@ -5557,7 +5632,7 @@ pub(crate) async fn repair_git_object_locator_if_current(
         return Ok(false);
     };
     let stats =
-        publish_committed_pack_locators(store, router, &[], anchor, lock_ttl, cancel).await?;
+        publish_committed_pack_locators(store, router, &[], anchor, None, lock_ttl, cancel).await?;
     Ok(stats.coverage_updated)
 }
 
@@ -5853,6 +5928,7 @@ async fn publish_uploaded_pack_locators(
     router: &StoreLayout,
     packs: &[UploadedGitPack],
     anchor: CommittedManifestAnchor,
+    pinned_inventory: Option<&[PackManifestEntry]>,
     lock_ttl: Duration,
     cancel: &CancellationToken,
 ) -> Result<crab_metadata::git_object_locator::LocatorWriteStats> {
@@ -5865,7 +5941,16 @@ async fn publish_uploaded_pack_locators(
             git_sha1: &uploaded.git_sha1,
         })
         .collect::<Vec<_>>();
-    publish_committed_pack_locators(store, router, &committed, anchor, lock_ttl, cancel).await
+    publish_committed_pack_locators(
+        store,
+        router,
+        &committed,
+        anchor,
+        pinned_inventory,
+        lock_ttl,
+        cancel,
+    )
+    .await
 }
 
 /// Pre-computed pointer walk produced by the native push orchestrator.
@@ -5967,6 +6052,8 @@ impl PushPipeline {
             base_commit_graph_loaded: tokio::sync::Mutex::new(false),
             manifest_etag: tokio::sync::Mutex::new(None),
             committed_manifest_anchor: tokio::sync::Mutex::new(None),
+            committed_pack_inventory: tokio::sync::Mutex::new(None),
+            locator_publication_deferred: std::sync::atomic::AtomicBool::new(false),
             git_visibility_published: std::sync::atomic::AtomicBool::new(false),
             failure_stage: std::sync::OnceLock::new(),
             push_commit_receipt: tokio::sync::Mutex::new(None),
@@ -7757,6 +7844,27 @@ impl PushPipeline {
             compact_ref_journal_until_idle(store, &self.router, manifest.pusher.clone()),
         )
         .await;
+        let successor_claimed = if let Ok(Some(compaction)) = &compacted {
+            match ref_successor_is_claimed(
+                store,
+                &self.prefix,
+                &compaction.edited_refs,
+                &compaction.edited_ref_lock_holders,
+            )
+            .await
+            {
+                Ok(claimed) => claimed,
+                Err(error) => {
+                    warn!(
+                        %error,
+                        "could not inspect ref-lock handoff; publishing this locator generation"
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
         if let Err(error) = manifest_lock.release().await {
             warn!(%error, "ref journal committed; compaction lock release requires repair");
         }
@@ -7764,7 +7872,19 @@ impl PushPipeline {
             Ok(Some(compaction)) => {
                 let compacted_manifest = compaction.manifest;
                 match committed_manifest_anchor(&compacted_manifest) {
-                    Ok(anchor) => *self.committed_manifest_anchor.lock().await = anchor,
+                    Ok(anchor) => {
+                        *self.committed_manifest_anchor.lock().await = anchor;
+                        if successor_claimed {
+                            self.locator_publication_deferred
+                                .store(true, std::sync::atomic::Ordering::Relaxed);
+                            debug!(
+                                generation = compacted_manifest.generation,
+                                "same-ref successor will publish the next locator generation"
+                            );
+                        } else if anchor.is_some() {
+                            *self.committed_pack_inventory.lock().await = Some(compaction.packs);
+                        }
+                    }
                     Err(error) => {
                         warn!(%error, "ref journal committed; compacted anchor requires repair")
                     }
@@ -14771,6 +14891,10 @@ impl PushPipeline {
             let file_index_plan = self.pending_file_index_plan.lock().await.clone();
             let shard_hashes = self.uploaded_shard_hashes.lock().await.clone();
             let anchor = *self.committed_manifest_anchor.lock().await;
+            let pack_inventory = self.committed_pack_inventory.lock().await.clone();
+            let locator_deferred = self
+                .locator_publication_deferred
+                .load(std::sync::atomic::Ordering::Relaxed);
             let needs_metadb_write = !file_index_plan.is_empty()
                 || !self.pending_legacy_chunk_tombstones.lock().await.is_empty()
                 || !self
@@ -14821,12 +14945,15 @@ impl PushPipeline {
                     "Git visibility proof requires repair; publishing exact locators independently"
                 );
             }
-            if let (Some(anchor), Some(store)) = (anchor, self.store.as_ref()) {
+            if locator_deferred {
+                git_indexed = false;
+            } else if let (Some(anchor), Some(store)) = (anchor, self.store.as_ref()) {
                 match publish_uploaded_pack_locators(
                     store,
                     &self.router,
                     &uploaded_packs,
                     anchor,
+                    pack_inventory.as_deref(),
                     self.config.lock_ttl,
                     &self.cancel,
                 )
@@ -17986,6 +18113,17 @@ mod tests {
         assert!(bounded <= Duration::from_secs(1));
     }
 
+    #[test]
+    fn announced_successor_poll_stays_inside_handoff_window() {
+        let delay = push_lock_wait_delay_with_cap(
+            32,
+            Duration::from_secs(30),
+            PUSH_LOCK_SUCCESSOR_POLL_CAP,
+        );
+
+        assert!(delay <= PUSH_LOCK_SUCCESSOR_POLL_CAP);
+    }
+
     #[tokio::test]
     async fn prepopulated_walk_is_reusable_for_manifest_cas_replan() {
         let mut config = PushConfig::default();
@@ -18611,6 +18749,77 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn compactor_defers_locator_publication_to_claimed_same_ref_successor() {
+        let _guard = GitDirGuard::new();
+        let (store, router) = test_store_router("journal-locator-successor");
+        create_manifest_with_etag(
+            &store,
+            &router,
+            &Manifest::default_for_repo("refs/heads/main"),
+        )
+        .await
+        .expect("create initial manifest");
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            vec![make_spec("refs/heads/main")],
+            Some(store.clone()),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router.clone(),
+            None,
+            CancellationToken::new(),
+            None,
+        );
+        pipeline.read_base_manifest().await.expect("read base");
+        let sha_map = pipeline.resolve_src_ref_map().expect("resolve refs");
+        let decisions = pipeline
+            .evaluate_decisions_with_sha_map(&sha_map)
+            .await
+            .expect("evaluate refs");
+        *pipeline.planned_ref_decisions.lock().await = Some(decisions.clone());
+        pipeline.prepare_git_pack().await.expect("prepare pack");
+        pipeline.upload_packs().await.expect("upload pack");
+        let (candidate, bulk) = pipeline
+            .apply_decisions_with_sha_map(&decisions, false, &sha_map)
+            .await
+            .expect("build candidate");
+        let leases = acquire_push_lock_leases(
+            &store,
+            router.repo_prefix(),
+            &[make_spec("refs/heads/main")],
+            &PushConfig::default(),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("acquire predecessor ref lock");
+        let predecessor_holder = leases[0].lock.holder().to_owned();
+        PushLock::announce_ref_successor(
+            store.inner(),
+            router.repo_prefix(),
+            "refs/heads/main",
+            &predecessor_holder,
+        )
+        .await
+        .expect("announce queued successor");
+        pipeline.install_locks(leases).await;
+        let mut admission_commit = None;
+
+        pipeline
+            .commit_ref_journal(candidate, bulk, &sha_map, decisions, &mut admission_commit)
+            .await
+            .expect("commit and compact journal");
+
+        assert!(pipeline.committed_manifest_anchor.lock().await.is_some());
+        assert!(pipeline.committed_pack_inventory.lock().await.is_none());
+        assert!(
+            pipeline
+                .locator_publication_deferred
+                .load(std::sync::atomic::Ordering::Relaxed)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn cancellation_after_manifest_cas_reports_committed_success() {
         let _guard = GitDirGuard::new();
         let cancel = CancellationToken::new();
@@ -18880,6 +19089,38 @@ mod tests {
             Some(covered_generation)
         );
         stale.close().await.expect("close stale locator session");
+
+        let capability_store = store.as_storage().clone();
+        let capability_prefix = repo_prefix.to_owned();
+        let v2_ready = tokio::spawn(async move {
+            crate::git::upload_pack_wire::snapshot_available(
+                &capability_store,
+                &capability_prefix,
+                &CancellationToken::new(),
+            )
+            .await
+        })
+        .await
+        .expect("join capability discovery");
+        assert!(
+            !v2_ready,
+            "capability discovery must use complete-pack fetch while locator coverage lags"
+        );
+        let still_stale = crab_metadata::git_object_locator::GitObjectLocatorSession::open(
+            Arc::clone(store.inner()),
+            repo_prefix,
+        )
+        .await
+        .expect("reopen stale locator session");
+        assert_eq!(
+            still_stale.coverage().map(|coverage| coverage.generation),
+            Some(covered_generation),
+            "capability discovery must not rebuild the locator"
+        );
+        still_stale
+            .close()
+            .await
+            .expect("close unchanged locator session");
 
         let repository = crate::git::upload_pack_wire::open_repository(
             store.as_storage(),
@@ -19256,6 +19497,16 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(CrabError::PushLockHeld { .. })));
+        assert!(
+            PushLock::ref_successor_was_announced(
+                store.inner(),
+                router.repo_prefix(),
+                "refs/heads/main",
+                held[0].lock.holder(),
+            )
+            .await
+            .unwrap()
+        );
         release_push_lock_leases(held).await;
     }
 
@@ -20434,6 +20685,7 @@ mod tests {
                 git_sha1: &git_sha1,
             }],
             anchor,
+            None,
             Duration::from_secs(60),
             &CancellationToken::new(),
         )
@@ -20517,6 +20769,7 @@ mod tests {
             &router,
             &[],
             anchor,
+            None,
             Duration::from_secs(60),
             &CancellationToken::new(),
         )
@@ -20695,6 +20948,7 @@ mod tests {
                 git_sha1: &second_git_sha1,
             }],
             anchor,
+            Some(&current_packs),
             Duration::from_secs(60),
             &CancellationToken::new(),
         )

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -5038,6 +5038,17 @@ mod tests {
         assert!(!caps.contains("filter"));
     }
 
+    #[test]
+    fn protocol_v2_capability_preserves_complete_pack_fetch() {
+        let caps = format_capabilities_with_v2(false, true);
+
+        assert!(caps.lines().any(|capability| capability == "fetch"));
+        assert!(
+            caps.lines()
+                .any(|capability| capability == "stateless-connect")
+        );
+    }
+
     // --- validate_fetch_entries_with_manifest ---
 
     /// Build a minimal manifest carrying just the supplied refs. All

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -69,14 +69,17 @@ struct FetchRequest {
     filter: UploadPackFilter,
 }
 
-/// Ensure the repository has the complete proof required to advertise
-/// protocol-v2 upload-pack, repairing current derived locator lag when possible.
+/// Check whether the repository has the complete proof required to advertise
+/// protocol-v2 upload-pack without rebuilding lagging locator coverage.
 pub async fn snapshot_available(
     store: &crab_storage::Store,
     prefix: &str,
     cancellation: &CancellationToken,
 ) -> bool {
-    let Ok(repository) = open_repository(store, prefix, cancellation).await else {
+    // If exact locator coverage lags, omit v2 and let Git use the
+    // already-advertised complete-pack fetch path. Rebuilding it here makes
+    // every dependent hot-ref generation pay the full locator publication cost.
+    let Ok(repository) = open_repository_snapshot(store, prefix, cancellation).await else {
         return false;
     };
     match repository.visibility_index(cancellation).await {
@@ -95,7 +98,9 @@ pub async fn snapshot_available(
             .await
             {
                 Ok(Some(super::push::GitVisibilityPublication::Published)) => {
-                    let Ok(repository) = open_repository(store, prefix, cancellation).await else {
+                    let Ok(repository) =
+                        open_repository_snapshot(store, prefix, cancellation).await
+                    else {
                         return false;
                     };
                     repository.visibility_index(cancellation).await.is_ok()
@@ -302,20 +307,7 @@ pub(crate) async fn open_repository(
     prefix: &str,
     cancellation: &CancellationToken,
 ) -> Result<RemoteGitRepository> {
-    let bucket = store.bucket_identity();
-    let provider = format!("{:?}:{}:{}", bucket.cloud, bucket.host, bucket.container);
-    let identity = RepositoryIdentity::new(provider, prefix.to_owned(), 1).map_err(remote_error)?;
-    let layout = crab_storage::StoreLayout::new(store.clone(), prefix.to_owned());
-    let runtime = Arc::new(RemoteGitRuntime::default());
-    let open = RemoteGitRepository::open(
-        store.clone(),
-        layout.clone(),
-        identity.clone(),
-        Arc::clone(&runtime),
-        RepositoryOptions::default(),
-        cancellation,
-    )
-    .await;
+    let open = open_repository_snapshot(store, prefix, cancellation).await;
     let (observed_generation, required_generation) = match open {
         Ok(repository) => return Ok(repository),
         Err(RemoteGitError::RepositoryIndexing { observed, required }) => (observed, required),
@@ -325,8 +317,7 @@ pub(crate) async fn open_repository(
     // The manifest generation check distinguishes derived publication lag from
     // an active ref-journal transaction, which must remain unavailable.
     let repair_store = crate::storage::Store::from_storage(store.clone());
-    let repair_layout =
-        crate::storage::StoreLayout::new(repair_store.clone(), layout.repo_prefix().to_owned());
+    let repair_layout = crate::storage::StoreLayout::new(repair_store.clone(), prefix.to_owned());
     let repaired = super::push::repair_git_object_locator_if_current(
         &repair_store,
         &repair_layout,
@@ -347,6 +338,21 @@ pub(crate) async fn open_repository(
         "repaired current Git locator before upload-pack admission"
     );
 
+    open_repository_snapshot(store, prefix, cancellation)
+        .await
+        .map_err(remote_error)
+}
+
+async fn open_repository_snapshot(
+    store: &crab_storage::Store,
+    prefix: &str,
+    cancellation: &CancellationToken,
+) -> crab_remote_git::Result<RemoteGitRepository> {
+    let bucket = store.bucket_identity();
+    let provider = format!("{:?}:{}:{}", bucket.cloud, bucket.host, bucket.container);
+    let identity = RepositoryIdentity::new(provider, prefix.to_owned(), 1)?;
+    let layout = crab_storage::StoreLayout::new(store.clone(), prefix.to_owned());
+    let runtime = Arc::new(RemoteGitRuntime::default());
     RemoteGitRepository::open(
         store.clone(),
         layout,
@@ -356,7 +362,6 @@ pub(crate) async fn open_repository(
         cancellation,
     )
     .await
-    .map_err(remote_error)
 }
 
 pub(crate) fn visible_ref_names(

--- a/crates/crab-coordination/src/push_lock.rs
+++ b/crates/crab-coordination/src/push_lock.rs
@@ -398,6 +398,74 @@ impl PushLock {
         let path = push_lock_path(prefix, ref_name)?;
         release_if_holder_checked(store, &path, holder).await
     }
+
+    /// Return whether a ref lease currently carries a non-released claim.
+    ///
+    /// This is an immediate handoff signal, not an acquisition decision: it
+    /// deliberately avoids a backend-clock probe and may conservatively report
+    /// an expired claimant until the next acquirer reclaims it.
+    pub async fn ref_lease_is_claimed(
+        store: &Arc<dyn ObjectStore>,
+        prefix: &str,
+        ref_name: &str,
+    ) -> Result<bool> {
+        let path = push_lock_path(prefix, ref_name)?;
+        let object_path = Path::from(path.as_str());
+        let (body, _) = match get_with_version(store, &object_path).await {
+            Ok(lock) => lock,
+            Err(object_store::Error::NotFound { .. }) => return Ok(false),
+            Err(source) => return Err(store_error(&path, source)),
+        };
+        deserialize_payload(&path, &body).map(|payload| !payload.is_released())
+    }
+
+    /// Record that a contender observed `predecessor_holder` on a ref lease.
+    ///
+    /// One fixed object per ref is overwritten across handoffs. The marker is
+    /// advisory and carries the predecessor identity so stale handoffs cannot
+    /// suppress publication by a later owner.
+    pub async fn announce_ref_successor(
+        store: &Arc<dyn ObjectStore>,
+        prefix: &str,
+        ref_name: &str,
+        predecessor_holder: &str,
+    ) -> Result<()> {
+        if predecessor_holder.is_empty() {
+            return Err(CoordinationError::Configuration {
+                key: predecessor_holder.to_owned(),
+                origin: "push successor predecessor holder must not be empty".to_owned(),
+            });
+        }
+        let path = format!("{}.successor", push_lock_path(prefix, ref_name)?);
+        store
+            .put(
+                &Path::from(path.as_str()),
+                Bytes::copy_from_slice(predecessor_holder.as_bytes()).into(),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|source| store_error(&path, source))
+    }
+
+    /// Return whether a contender announced a handoff from this exact holder.
+    pub async fn ref_successor_was_announced(
+        store: &Arc<dyn ObjectStore>,
+        prefix: &str,
+        ref_name: &str,
+        predecessor_holder: &str,
+    ) -> Result<bool> {
+        let path = format!("{}.successor", push_lock_path(prefix, ref_name)?);
+        let result = match store.get(&Path::from(path.as_str())).await {
+            Ok(result) => result,
+            Err(object_store::Error::NotFound { .. }) => return Ok(false),
+            Err(source) => return Err(store_error(&path, source)),
+        };
+        result
+            .bytes()
+            .await
+            .map(|body| body.as_ref() == predecessor_holder.as_bytes())
+            .map_err(|source| store_error(&path, source))
+    }
 }
 
 impl Drop for PushLock {
@@ -968,6 +1036,61 @@ mod tests {
             PushLock::release_ref_if_holder(&store, "org/repo", "refs/heads/main", lock.holder(),)
                 .await
                 .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn ref_claim_probe_tracks_acquire_and_release_without_creating_a_lock() {
+        let store = memory_store();
+
+        assert!(
+            !PushLock::ref_lease_is_claimed(&store, "org/repo", "refs/heads/main")
+                .await
+                .unwrap()
+        );
+        let lock = PushLock::acquire_ref_default(&store, "org/repo", "refs/heads/main")
+            .await
+            .unwrap();
+        assert!(
+            PushLock::ref_lease_is_claimed(&store, "org/repo", "refs/heads/main")
+                .await
+                .unwrap()
+        );
+
+        lock.release().await.unwrap();
+        assert!(
+            !PushLock::ref_lease_is_claimed(&store, "org/repo", "refs/heads/main")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn ref_successor_marker_is_scoped_to_the_observed_predecessor() {
+        let store = memory_store();
+        PushLock::announce_ref_successor(&store, "org/repo", "refs/heads/main", "holder-a")
+            .await
+            .unwrap();
+
+        assert!(
+            PushLock::ref_successor_was_announced(
+                &store,
+                "org/repo",
+                "refs/heads/main",
+                "holder-a",
+            )
+            .await
+            .unwrap()
+        );
+        assert!(
+            !PushLock::ref_successor_was_announced(
+                &store,
+                "org/repo",
+                "refs/heads/main",
+                "holder-b",
+            )
+            .await
+            .unwrap()
         );
     }
 

--- a/crates/crab-metadata/src/git_object_locator/writer.rs
+++ b/crates/crab-metadata/src/git_object_locator/writer.rs
@@ -199,6 +199,18 @@ impl GitObjectLocatorWriter {
         self.metadata.coverage
     }
 
+    /// Return whether this binding's object rows belong to the initial exact coverage.
+    ///
+    /// Bindings created by an interrupted newer publication remain durable, but
+    /// their rows must be rebuilt until a later session advances coverage.
+    #[must_use]
+    pub fn binding_has_covered_objects(&self, binding: GitPackLocatorBinding) -> bool {
+        self.bindings.get(&binding.pack_slot) == Some(&binding.record)
+            && self
+                .initial_coverage
+                .is_some_and(|coverage| binding.record.committed_generation <= coverage.generation)
+    }
+
     /// Durably bind immutable packs to monotonic non-zero slots.
     pub async fn bind_packs(
         &mut self,
@@ -885,6 +897,49 @@ mod tests {
             .expect("reuse retained pack")[0];
 
         assert_eq!(retained_binding, original_binding);
+        reopened.close().await.expect("close reopened writer");
+    }
+
+    #[tokio::test]
+    async fn initial_coverage_distinguishes_retained_rows_from_interrupted_bindings() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut initial = GitObjectLocatorWriter::open(Arc::clone(&store), "org/repo")
+            .await
+            .expect("open initial writer");
+        let covered = initial.bind_packs(&[pack(1)]).await.expect("bind covered")[0];
+        initial
+            .write_locations(covered, &[entry(1)])
+            .await
+            .expect("write covered location");
+        initial
+            .set_coverage(GitLocatorCoverage {
+                generation: 1,
+                pack_index_hash: hash(100),
+            })
+            .await
+            .expect("set initial coverage");
+        initial.close().await.expect("close initial writer");
+
+        let mut interrupted = GitObjectLocatorWriter::open(Arc::clone(&store), "org/repo")
+            .await
+            .expect("open interrupted writer");
+        let retained = interrupted
+            .bind_packs(&[pack(1)])
+            .await
+            .expect("bind retained")[0];
+        let uncovered = interrupted
+            .bind_packs(&[pack(2)])
+            .await
+            .expect("bind uncovered")[0];
+        assert!(interrupted.binding_has_covered_objects(retained));
+        assert!(!interrupted.binding_has_covered_objects(uncovered));
+        interrupted.close().await.expect("close interrupted writer");
+
+        let reopened = GitObjectLocatorWriter::open(store, "org/repo")
+            .await
+            .expect("reopen writer");
+        assert!(reopened.binding_has_covered_objects(retained));
+        assert!(!reopened.binding_has_covered_objects(uncovered));
         reopened.close().await.expect("close reopened writer");
     }
 

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -1,5 +1,7 @@
 //! Storage-backed manifest pointer and segmented metadata helpers.
 
+use std::collections::BTreeMap;
+
 use bytes::Bytes;
 use crab_storage::{ETag, StorageError, Store, StoreLayout};
 use futures_util::{StreamExt, TryStreamExt};
@@ -49,6 +51,12 @@ pub struct RepositorySnapshot {
 pub struct RefJournalCompaction {
     /// Compacted manifest committed by compare-and-swap.
     pub manifest: Manifest,
+    /// Exact immutable pack inventory used to build the committed pack index.
+    pub packs: Vec<PackManifestEntry>,
+    /// Distinct refs changed by the transaction wave folded into this generation.
+    pub edited_refs: Vec<String>,
+    /// Last ref-lock holder folded for each edited ref, when journal evidence includes it.
+    pub edited_ref_lock_holders: BTreeMap<String, String>,
     /// Whether complete generation-bound Git visibility was published before the manifest.
     pub git_visibility_published: bool,
 }
@@ -340,6 +348,25 @@ pub async fn compact_ref_journal(
     // The old summary does not cover journal-only ref advances.
     manifest.commit_graph_hash = None;
     manifest.seal_git_validation();
+    let mut edited_refs = snapshot
+        .journal
+        .ordered_edits
+        .iter()
+        .map(|edit| edit.ref_name.clone())
+        .collect::<Vec<_>>();
+    edited_refs.sort_unstable();
+    edited_refs.dedup();
+    let mut edited_ref_lock_holders = BTreeMap::new();
+    for edit in &snapshot.journal.ordered_edits {
+        match &edit.lock_holder {
+            Some(holder) => {
+                edited_ref_lock_holders.insert(edit.ref_name.clone(), holder.clone());
+            }
+            None => {
+                edited_ref_lock_holders.remove(&edit.ref_name);
+            }
+        }
+    }
 
     // Complete evidence publishes authorization before the compacted manifest;
     // otherwise no proof is written and upload-pack withholds protocol v2.
@@ -368,6 +395,9 @@ pub async fn compact_ref_journal(
     cleanup_compacted_transactions(store, router, &compacted_transactions).await;
     Ok(Some(RefJournalCompaction {
         manifest,
+        packs: snapshot.journal.packs,
+        edited_refs,
+        edited_ref_lock_holders,
         git_visibility_published,
     }))
 }
@@ -1086,6 +1116,7 @@ mod tests {
 
         assert!(!compacted.git_visibility_published);
         assert_eq!(compacted.manifest.refs["refs/heads/main"], "b".repeat(40));
+        assert_eq!(compacted.edited_refs, ["refs/heads/main"]);
         assert!(snapshot.journal.transactions.is_empty());
         assert_eq!(snapshot.journal.refs["refs/heads/main"], "b".repeat(40));
         assert!(


### PR DESCRIPTION
## Summary

- publish an exact predecessor-scoped same-ref successor marker and keep announced contenders inside a bounded handoff polling window
- let the last useful journal generation own locator publication, reuse its verified pack inventory, and distinguish covered bindings from interrupted newer bindings without rereading prior segmented indexes
- make capability discovery avoid locator read-repair while preserving the complete-pack remote-helper fetch contract; terminal protocol-v2 opens still repair current derived lag

## Why this is the best fix

The repeated work originated at the ref-lock to locator-publication ownership boundary. This moves ownership there instead of adding retries around the global SlateDB rebuild or a data server. The signal is advisory and bounded to one reusable object per contended ref, stale signals are predecessor-scoped, and every correctness path still has complete-pack fetch plus terminal read-repair.

Sibling publishers are explicit: repack pins its already-verified replacement inventory; history recovery keeps the canonical stored-inventory read because it does not hold serialized local pack-index evidence.

## Proof

Focused tests pass for:

- successor marker scoping and ref-claim probing
- same-ref compactor deferral and committed-lock handoff
- current locator read-repair, including proof that capability discovery leaves lagging coverage unchanged
- interrupted locator binding coverage
- bounded journal compaction inventory
- CLI locator generation advance and concurrent sibling evidence recovery
- preservation of both legacy fetch and stateless-connect capabilities

RustFS end-to-end, four concurrent writers with crab/crab:

- latest main hot ref: 1,511 requests total, 377.75 per push, four locator receipts
- this branch hot ref, two consecutive runs: 812 and 894 total, 203.0 and 223.5 per push, one locator receipt and one WAL publication each
- reduction: 40.8% to 46.3% requests per hot-ref push
- independent refs: 606 total, 151.5 per push versus 605 and 151.25 on main
- all writers integrated, final protocol-v2 clone contained all commits, and fsck was clean

Formatting passes. Strict clippy passes for crab-coordination and crab-metadata. The broad crab lib clippy reaches an unrelated existing Rust 1.97 lint failure in crab-vfs (duration units and one trailing comma); no touched surface warning was emitted before that dependency failure.