### PR TITLE
perf(git): compact visibility proof storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,6 +2219,7 @@ name = "crab-metadata"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "blake3",
  "bytes",
  "crab-storage",

--- a/crab/docs/architecture/git-integration.md
+++ b/crab/docs/architecture/git-integration.md
@@ -237,10 +237,11 @@ generation proof before manifest or coordinator commit. Protected receive
 builds that proof from its existing verified materialization workspace, so the
 commit boundary does not download the candidate pack inventory a second time.
 
-Current proof keys use the manifest Git-validation digest. Crab 1.0.15's
-generation-and-pack-index key remains readable and GC-rooted only as a shipped
-data migration; the next write or explicit metadata repair backfills the
-digest-bound proof.
+Current proof keys use the manifest Git-validation digest, and current proof
+bodies store one sorted object-ID dictionary plus per-ref position closures.
+Crab 1.0.15's generation-and-pack-index key remains readable and GC-rooted only
+as a shipped data migration; the next write or explicit metadata repair
+backfills the digest-bound proof.
 
 Source: `crab/src/git/push.rs`, `crab/src/git/push_manifest.rs`,
 `crates/crab-git/src/push_state.rs`

--- a/crab/docs/architecture/git-integration.md
+++ b/crab/docs/architecture/git-integration.md
@@ -238,7 +238,8 @@ builds that proof from its existing verified materialization workspace, so the
 commit boundary does not download the candidate pack inventory a second time.
 
 Current proof keys use the manifest Git-validation digest, and current proof
-bodies store one sorted object-ID dictionary plus per-ref position closures.
+bodies store one sorted object-ID dictionary plus adaptive sparse-position or
+bitmap closures per ref.
 Crab 1.0.15's generation-and-pack-index key remains readable and GC-rooted only
 as a shipped data migration; the next write or explicit metadata repair
 backfills the digest-bound proof.

--- a/crab/docs/architecture/git-protocol-v2.md
+++ b/crab/docs/architecture/git-protocol-v2.md
@@ -77,11 +77,14 @@ keeps request rejections distinguishable from truncated pack generation.
 Every requested OID is admitted from the immutable visibility proof before the
 remote reader obtains object bytes. Current proofs are keyed by and carry the
 manifest Git-validation digest, which binds generation, pack inventory, HEAD,
-refs, and peeled refs. Invalid or missing proof suppresses v2 advertisement; it
-never triggers a silent complete filtered fetch. Crab 1.0.15 proofs keyed only
-by generation and pack-index hash remain an explicit read migration: write and
-repair owners backfill the digest-bound key, and GC retains both roots while
-that tagged-data migration is supported.
+refs, and peeled refs. Their storage codec writes each object ID once in a
+sorted dictionary and represents each ref closure as sorted dictionary
+positions, avoiding repeated 40-byte IDs for shared history. Invalid or missing
+proof suppresses v2 advertisement; it never triggers a silent complete
+filtered fetch. Crab 1.0.15 proofs keyed only by generation and pack-index hash
+remain an explicit read migration: write and repair owners backfill the
+digest-bound key, and GC retains both roots while that tagged-data migration is
+supported.
 
 Each direct ref update uploads content-addressed visibility evidence before its
 journal marker becomes visible. Fast-forward and ordinary updates encode only

--- a/crab/docs/architecture/git-protocol-v2.md
+++ b/crab/docs/architecture/git-protocol-v2.md
@@ -78,8 +78,9 @@ Every requested OID is admitted from the immutable visibility proof before the
 remote reader obtains object bytes. Current proofs are keyed by and carry the
 manifest Git-validation digest, which binds generation, pack inventory, HEAD,
 refs, and peeled refs. Their storage codec writes each object ID once in a
-sorted dictionary and represents each ref closure as sorted dictionary
-positions, avoiding repeated 40-byte IDs for shared history. Invalid or missing
+sorted dictionary and represents each ref closure as sparse dictionary
+positions or a dense bitmap, avoiding repeated 40-byte IDs and integer-heavy
+closures for shared history. Invalid or missing
 proof suppresses v2 advertisement; it never triggers a silent complete
 filtered fetch. Crab 1.0.15 proofs keyed only by generation and pack-index hash
 remain an explicit read migration: write and repair owners backfill the

--- a/crab/scripts/check-architecture-gates.py
+++ b/crab/scripts/check-architecture-gates.py
@@ -3139,11 +3139,24 @@ def check_metadata_feature_budget(root: Path, cargo: str, metadata: dict) -> boo
             ],
             "local-index": ["dep:rusqlite"],
             "remote-index": ["dep:futures-util", "dep:object_store", "dep:slatedb"],
-            "storage": ["dep:crab-storage", "dep:futures-util", "dep:object_store"],
+            "storage": [
+                "dep:base64",
+                "dep:crab-storage",
+                "dep:futures-util",
+                "dep:object_store",
+            ],
         },
     )
 
-    for name in ("crab-storage", "futures-util", "object_store", "rusqlite", "slatedb", "tokio"):
+    for name in (
+        "base64",
+        "crab-storage",
+        "futures-util",
+        "object_store",
+        "rusqlite",
+        "slatedb",
+        "tokio",
+    ):
         dependency = normal_dependency(package, name)
         if dependency is None or not dependency["optional"]:
             violations.append(f"crab-metadata: {name} must stay optional")

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -19268,19 +19268,21 @@ mod tests {
         create_manifest_with_etag(&store, &router, &initial)
             .await
             .expect("create initial manifest");
-        let pushed = PushPipeline::new(
-            PushConfig::default(),
-            vec![make_spec("refs/heads/main")],
-            Some(store.clone()),
-            None,
-            None,
-            router.repo_prefix().to_owned(),
-            router.clone(),
-            None,
-            CancellationToken::new(),
-            None,
+        let pushed = Box::pin(
+            PushPipeline::new(
+                PushConfig::default(),
+                vec![make_spec("refs/heads/main")],
+                Some(store.clone()),
+                None,
+                None,
+                router.repo_prefix().to_owned(),
+                router.clone(),
+                None,
+                CancellationToken::new(),
+                None,
+            )
+            .execute(),
         )
-        .execute()
         .await;
         assert_eq!(
             pushed.outcomes.get("refs/heads/main"),
@@ -19403,19 +19405,21 @@ mod tests {
         create_manifest_with_etag(&store, &router, &initial)
             .await
             .expect("create initial manifest");
-        let pushed = PushPipeline::new(
-            PushConfig::default(),
-            vec![make_spec("refs/heads/main")],
-            Some(store.clone()),
-            None,
-            None,
-            router.repo_prefix().to_owned(),
-            router.clone(),
-            None,
-            CancellationToken::new(),
-            None,
+        let pushed = Box::pin(
+            PushPipeline::new(
+                PushConfig::default(),
+                vec![make_spec("refs/heads/main")],
+                Some(store.clone()),
+                None,
+                None,
+                router.repo_prefix().to_owned(),
+                router.clone(),
+                None,
+                CancellationToken::new(),
+                None,
+            )
+            .execute(),
         )
-        .execute()
         .await;
         assert_eq!(
             pushed.outcomes.get("refs/heads/main"),

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -17804,7 +17804,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             current.format,
-            crab_metadata::git_visibility::GitVisibilityFormat::V2
+            crab_metadata::git_visibility::GitVisibilityFormat::V3
         );
     }
 

--- a/crates/crab-metadata/Cargo.toml
+++ b/crates/crab-metadata/Cargo.toml
@@ -15,9 +15,10 @@ default = []
 file-index-reader = ["storage", "dep:futures-util", "dep:object_store", "dep:slatedb", "dep:tokio"]
 local-index = ["dep:rusqlite"]
 remote-index = ["dep:futures-util", "dep:object_store", "dep:slatedb"]
-storage = ["dep:crab-storage", "dep:futures-util", "dep:object_store"]
+storage = ["dep:base64", "dep:crab-storage", "dep:futures-util", "dep:object_store"]
 
 [dependencies]
+base64 = { version = "0.22", optional = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }
 crab-storage = { workspace = true, optional = true }

--- a/crates/crab-metadata/src/git_visibility.rs
+++ b/crates/crab-metadata/src/git_visibility.rs
@@ -390,6 +390,8 @@ fn corrupt(reason: impl Into<String>) -> MetadataError {
 mod storage {
     use std::collections::{BTreeMap, BTreeSet};
 
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD_NO_PAD;
     use bytes::Bytes;
     use crab_storage::{StorageError, Store, StoreLayout};
     use object_store::path::Path as ObjectPath;
@@ -443,7 +445,14 @@ mod storage {
         pack_index_hash: String,
         git_validation_digest: String,
         objects: Vec<String>,
-        refs: BTreeMap<String, Vec<u32>>,
+        refs: BTreeMap<String, GitVisibilityClosureV3>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    enum GitVisibilityClosureV3 {
+        Sparse(Vec<u32>),
+        Bitmap(String),
     }
 
     impl GitVisibilityIndexV3 {
@@ -470,7 +479,7 @@ mod storage {
                 .refs
                 .iter()
                 .map(|(name, closure)| {
-                    let closure = closure
+                    let positions = closure
                         .iter()
                         .map(|oid| {
                             positions.get(oid.as_str()).copied().ok_or_else(|| {
@@ -480,7 +489,10 @@ mod storage {
                             })
                         })
                         .collect::<Result<Vec<_>>>()?;
-                    Ok((name.clone(), closure))
+                    Ok((
+                        name.clone(),
+                        GitVisibilityClosureV3::from_positions(positions, objects.len())?,
+                    ))
                 })
                 .collect::<Result<BTreeMap<_, _>>>()?;
             Ok(Self {
@@ -532,8 +544,9 @@ mod storage {
                             "visibility index contains an invalid ref name",
                         ));
                     }
+                    let positions = closure.into_positions(self.objects.len())?;
                     membership_count = membership_count
-                        .checked_add(u64::try_from(closure.len()).map_err(|_| {
+                        .checked_add(u64::try_from(positions.len()).map_err(|_| {
                             super::corrupt("visibility index object count cannot be represented")
                         })?)
                         .ok_or_else(|| super::corrupt("visibility index object count overflows"))?;
@@ -541,7 +554,7 @@ mod storage {
                         return Err(super::corrupt("visibility index contains too many objects"));
                     }
                     let mut prior_position = None;
-                    let objects = closure
+                    let objects = positions
                         .into_iter()
                         .map(|position| {
                             if prior_position.is_some_and(|prior| prior >= position) {
@@ -580,6 +593,111 @@ mod storage {
             index.validate()?;
             Ok(index)
         }
+    }
+
+    impl GitVisibilityClosureV3 {
+        fn from_positions(positions: Vec<u32>, object_count: usize) -> Result<Self> {
+            let bitmap_len = object_count.div_ceil(8);
+            let bitmap_encoded_len = bitmap_len
+                .checked_div(3)
+                .and_then(|groups| groups.checked_mul(4))
+                .and_then(|size| {
+                    size.checked_add(match bitmap_len % 3 {
+                        0 => 0,
+                        1 => 2,
+                        _ => 3,
+                    })
+                })
+                .ok_or_else(|| super::corrupt("visibility closure bitmap size overflows"))?;
+            let sparse_encoded_len = positions
+                .iter()
+                .try_fold(positions.len().saturating_sub(1), |size, position| {
+                    size.checked_add(decimal_digits(*position))
+                });
+            let sparse_encoded_len = sparse_encoded_len
+                .ok_or_else(|| super::corrupt("visibility sparse closure size overflows"))?;
+            if bitmap_encoded_len >= sparse_encoded_len {
+                return Ok(Self::Sparse(positions));
+            }
+
+            let mut bitmap = vec![0_u8; bitmap_len];
+            for position in positions {
+                let position = usize::try_from(position).map_err(|_| {
+                    super::corrupt("visibility closure position cannot be represented")
+                })?;
+                let byte = bitmap.get_mut(position / 8).ok_or_else(|| {
+                    super::corrupt("visibility closure position is outside its dictionary")
+                })?;
+                *byte |= 1 << (position % 8);
+            }
+            Ok(Self::Bitmap(STANDARD_NO_PAD.encode(bitmap)))
+        }
+
+        fn into_positions(self, object_count: usize) -> Result<Vec<u32>> {
+            match self {
+                Self::Sparse(positions) => Ok(positions),
+                Self::Bitmap(encoded) => {
+                    let bitmap = STANDARD_NO_PAD.decode(&encoded).map_err(|_| {
+                        super::corrupt("visibility closure bitmap is not valid base64")
+                    })?;
+                    if STANDARD_NO_PAD.encode(&bitmap) != encoded {
+                        return Err(super::corrupt(
+                            "visibility closure bitmap is not canonical base64",
+                        ));
+                    }
+                    let expected_len = object_count.div_ceil(8);
+                    if bitmap.len() != expected_len {
+                        return Err(super::corrupt(
+                            "visibility closure bitmap length does not match its dictionary",
+                        ));
+                    }
+                    if let Some(last) = bitmap.last()
+                        && !object_count.is_multiple_of(8)
+                        && last >> (object_count % 8) != 0
+                    {
+                        return Err(super::corrupt(
+                            "visibility closure bitmap sets a position outside its dictionary",
+                        ));
+                    }
+                    let position_count = bitmap.iter().try_fold(0_u64, |count, byte| {
+                        count.checked_add(u64::from(byte.count_ones()))
+                    });
+                    let position_count = position_count
+                        .and_then(|count| usize::try_from(count).ok())
+                        .ok_or_else(|| {
+                            super::corrupt("visibility closure object count cannot be represented")
+                        })?;
+                    let mut positions = Vec::with_capacity(position_count);
+                    for (byte_index, byte) in bitmap.iter().enumerate() {
+                        for bit_index in 0..8 {
+                            if byte & (1 << bit_index) == 0 {
+                                continue;
+                            }
+                            let position = byte_index
+                                .checked_mul(8)
+                                .and_then(|position| position.checked_add(bit_index))
+                                .and_then(|position| u32::try_from(position).ok())
+                                .ok_or_else(|| {
+                                    super::corrupt(
+                                        "visibility closure position cannot be represented",
+                                    )
+                                })?;
+                            positions.push(position);
+                        }
+                    }
+                    Ok(positions)
+                }
+            }
+        }
+    }
+
+    fn decimal_digits(mut value: u32) -> usize {
+        let mut digits = 1;
+        while value >= 10 {
+            value /= 10;
+            digits += 1;
+        }
+        digits
     }
 
     impl GitVisibilityIndexV1 {
@@ -1151,9 +1269,10 @@ mod tests {
         let objects = (0..256)
             .map(|position| format!("{position:040x}"))
             .collect::<Vec<_>>();
-        let refs = (0..8)
+        let mut refs = (0..8)
             .map(|position| (format!("refs/heads/branch-{position}"), objects.clone()))
-            .collect();
+            .collect::<BTreeMap<_, _>>();
+        refs.insert("refs/heads/sparse".to_owned(), vec![objects[0].clone()]);
         let index = GitVisibilityIndex::new(7, "a".repeat(64), "b".repeat(64), refs);
         let expanded = serde_json::to_vec(&serde_json::json!({
             "version": index.version,
@@ -1172,7 +1291,9 @@ mod tests {
             .unwrap();
         let stored: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(stored["objects"].as_array().unwrap().len(), 256);
-        assert!(body.len() < expanded.len() / 2);
+        assert!(stored["refs"]["refs/heads/branch-0"]["bitmap"].is_string());
+        assert!(stored["refs"]["refs/heads/sparse"]["sparse"].is_array());
+        assert!(body.len() < expanded.len() / 4);
         assert_eq!(
             read(
                 &store,
@@ -1206,7 +1327,39 @@ mod tests {
             "pack_index_hash": pack_hash.clone(),
             "git_validation_digest": digest.clone(),
             "objects": ["1".repeat(40)],
-            "refs": {"refs/heads/main": [1]},
+            "refs": {"refs/heads/main": {"sparse": [1]}},
+        });
+        store
+            .put(
+                &router.git_visibility_path(&digest),
+                Bytes::from(serde_json::to_vec(&malformed).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert!(read(&store, &router, 7, &pack_hash, &digest).await.is_err());
+    }
+
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn v3_storage_rejects_bitmap_bits_outside_dictionary() {
+        use std::sync::Arc;
+
+        use bytes::Bytes;
+        use crab_storage::{Store, StoreLayout};
+        use object_store::memory::InMemory;
+
+        let store = Store::new(Arc::new(InMemory::new()));
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        let pack_hash = "a".repeat(64);
+        let digest = "b".repeat(64);
+        let malformed = serde_json::json!({
+            "version": 3,
+            "generation": 7,
+            "pack_index_hash": pack_hash.clone(),
+            "git_validation_digest": digest.clone(),
+            "objects": ["1".repeat(40)],
+            "refs": {"refs/heads/main": {"bitmap": "gA"}},
         });
         store
             .put(

--- a/crates/crab-metadata/src/git_visibility.rs
+++ b/crates/crab-metadata/src/git_visibility.rs
@@ -14,7 +14,7 @@ use crate::error::{MetadataError, Result};
 use crate::manifests::Manifest;
 
 /// Current serialized visibility-index format.
-pub const GIT_VISIBILITY_INDEX_VERSION: u32 = 2;
+pub const GIT_VISIBILITY_INDEX_VERSION: u32 = 3;
 
 /// Maximum serialized proof accepted from object storage.
 pub const MAX_GIT_VISIBILITY_INDEX_BYTES: u64 = 128 * 1024 * 1024;
@@ -175,8 +175,7 @@ fn validate_sorted_oids(objects: &[String], field: &str) -> Result<()> {
 }
 
 /// Complete ref-rooted Git object visibility proof for one repository snapshot.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitVisibilityIndex {
     /// Schema version of this object.
     pub version: u32,
@@ -389,16 +388,17 @@ fn corrupt(reason: impl Into<String>) -> MetadataError {
 
 #[cfg(feature = "storage")]
 mod storage {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use bytes::Bytes;
     use crab_storage::{StorageError, Store, StoreLayout};
     use object_store::path::Path as ObjectPath;
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     use super::{
-        GitVisibilityEdit, GitVisibilityIndex, MAX_GIT_VISIBILITY_INDEX_BYTES, validate_hash,
-        validate_ref_closures,
+        GIT_VISIBILITY_INDEX_VERSION, GitVisibilityEdit, GitVisibilityIndex,
+        MAX_GIT_VISIBILITY_INDEX_BYTES, MAX_GIT_VISIBILITY_OBJECTS, MAX_GIT_VISIBILITY_REFS,
+        validate_hash, validate_oid, validate_ref_closures,
     };
     use crate::error::Result;
     use crate::manifests::Manifest;
@@ -409,8 +409,8 @@ mod storage {
     /// Stored format used to satisfy a visibility read.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum GitVisibilityFormat {
-        /// Digest-bound proof written by current Crab versions.
-        V2,
+        /// Dictionary-compressed, digest-bound proof written by current Crab versions.
+        V3,
         /// Generation-and-pack-bound proof shipped by Crab 1.0.15.
         V1,
     }
@@ -431,6 +431,155 @@ mod storage {
         generation: u64,
         pack_index_hash: String,
         refs: BTreeMap<String, Vec<String>>,
+    }
+
+    // Runtime authorization uses per-ref OID slices. Persistence keeps that API
+    // out of the storage contract by deduplicating shared OIDs here.
+    #[derive(Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct GitVisibilityIndexV3 {
+        version: u32,
+        generation: u64,
+        pack_index_hash: String,
+        git_validation_digest: String,
+        objects: Vec<String>,
+        refs: BTreeMap<String, Vec<u32>>,
+    }
+
+    impl GitVisibilityIndexV3 {
+        fn from_index(index: &GitVisibilityIndex) -> Result<Self> {
+            index.validate()?;
+            let objects = index
+                .refs
+                .values()
+                .flatten()
+                .cloned()
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let positions = objects
+                .iter()
+                .enumerate()
+                .map(|(position, oid)| {
+                    u32::try_from(position)
+                        .map(|position| (oid.as_str(), position))
+                        .map_err(|_| super::corrupt("visibility object dictionary is too large"))
+                })
+                .collect::<Result<BTreeMap<_, _>>>()?;
+            let refs = index
+                .refs
+                .iter()
+                .map(|(name, closure)| {
+                    let closure = closure
+                        .iter()
+                        .map(|oid| {
+                            positions.get(oid.as_str()).copied().ok_or_else(|| {
+                                super::corrupt(
+                                    "visibility closure object is absent from its dictionary",
+                                )
+                            })
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok((name.clone(), closure))
+                })
+                .collect::<Result<BTreeMap<_, _>>>()?;
+            Ok(Self {
+                version: GIT_VISIBILITY_INDEX_VERSION,
+                generation: index.generation,
+                pack_index_hash: index.pack_index_hash.clone(),
+                git_validation_digest: index.git_validation_digest.clone(),
+                objects,
+                refs,
+            })
+        }
+
+        fn into_index(self) -> Result<GitVisibilityIndex> {
+            if self.version != GIT_VISIBILITY_INDEX_VERSION {
+                return Err(super::corrupt(
+                    "visibility index storage version is unsupported",
+                ));
+            }
+            if !(self.pack_index_hash.is_empty() && self.refs.is_empty()) {
+                validate_hash(&self.pack_index_hash, "pack index hash")?;
+            }
+            validate_hash(&self.git_validation_digest, "Git validation digest")?;
+            if self.objects.len() as u64 > MAX_GIT_VISIBILITY_OBJECTS {
+                return Err(super::corrupt(
+                    "visibility object dictionary contains too many objects",
+                ));
+            }
+            let mut previous: Option<&str> = None;
+            for oid in &self.objects {
+                validate_oid(oid)?;
+                if previous.is_some_and(|value| value >= oid.as_str()) {
+                    return Err(super::corrupt(
+                        "visibility object dictionary must be sorted and deduplicated",
+                    ));
+                }
+                previous = Some(oid.as_str());
+            }
+            if self.refs.len() > MAX_GIT_VISIBILITY_REFS {
+                return Err(super::corrupt("visibility index contains too many refs"));
+            }
+            let mut membership_count = 0u64;
+            let mut covered = vec![false; self.objects.len()];
+            let refs = self
+                .refs
+                .into_iter()
+                .map(|(name, closure)| {
+                    if name.is_empty() || name.bytes().any(|byte| byte.is_ascii_control()) {
+                        return Err(super::corrupt(
+                            "visibility index contains an invalid ref name",
+                        ));
+                    }
+                    membership_count = membership_count
+                        .checked_add(u64::try_from(closure.len()).map_err(|_| {
+                            super::corrupt("visibility index object count cannot be represented")
+                        })?)
+                        .ok_or_else(|| super::corrupt("visibility index object count overflows"))?;
+                    if membership_count > MAX_GIT_VISIBILITY_OBJECTS {
+                        return Err(super::corrupt("visibility index contains too many objects"));
+                    }
+                    let mut prior_position = None;
+                    let objects = closure
+                        .into_iter()
+                        .map(|position| {
+                            if prior_position.is_some_and(|prior| prior >= position) {
+                                return Err(super::corrupt(
+                                    "visibility closure positions must be sorted and deduplicated",
+                                ));
+                            }
+                            prior_position = Some(position);
+                            let position = usize::try_from(position).map_err(|_| {
+                                super::corrupt("visibility closure position cannot be represented")
+                            })?;
+                            let oid = self.objects.get(position).ok_or_else(|| {
+                                super::corrupt(
+                                    "visibility closure position is outside its dictionary",
+                                )
+                            })?;
+                            covered[position] = true;
+                            Ok(oid.clone())
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok((name, objects))
+                })
+                .collect::<Result<BTreeMap<_, _>>>()?;
+            if covered.iter().any(|covered| !covered) {
+                return Err(super::corrupt(
+                    "visibility object dictionary contains an unreferenced object",
+                ));
+            }
+            let index = GitVisibilityIndex {
+                version: self.version,
+                generation: self.generation,
+                pack_index_hash: self.pack_index_hash,
+                git_validation_digest: self.git_validation_digest,
+                refs,
+            };
+            index.validate()?;
+            Ok(index)
+        }
     }
 
     impl GitVisibilityIndexV1 {
@@ -471,7 +620,7 @@ mod storage {
         Ok(body)
     }
 
-    async fn read_v2(
+    async fn read_v3(
         store: &Store,
         router: &StoreLayout<Store>,
         generation: u64,
@@ -480,13 +629,13 @@ mod storage {
     ) -> Result<GitVisibilityIndex> {
         let path = router.git_visibility_path(git_validation_digest);
         let body = read_bounded(store, &path).await?;
-        let index: GitVisibilityIndex = serde_json::from_slice(&body).map_err(|error| {
+        let index: GitVisibilityIndexV3 = serde_json::from_slice(&body).map_err(|error| {
             crate::error::MetadataError::CorruptObject {
                 path: path.as_ref().to_owned(),
                 reason: format!("invalid visibility index JSON: {error}"),
             }
         })?;
-        index.validate()?;
+        let index = index.into_index()?;
         index.validate_identity(generation, pack_index_hash, git_validation_digest)?;
         Ok(index)
     }
@@ -532,7 +681,7 @@ mod storage {
         git_validation_digest: &str,
     ) -> Result<GitVisibilityRead> {
         validate_hash(git_validation_digest, "Git validation digest")?;
-        match read_v2(
+        match read_v3(
             store,
             router,
             generation,
@@ -543,7 +692,7 @@ mod storage {
         {
             Ok(index) => Ok(GitVisibilityRead {
                 index,
-                format: GitVisibilityFormat::V2,
+                format: GitVisibilityFormat::V3,
             }),
             Err(crate::error::MetadataError::Storage {
                 source: StorageError::NotFound { .. },
@@ -589,7 +738,8 @@ mod storage {
         index: &GitVisibilityIndex,
     ) -> Result<()> {
         index.validate()?;
-        let body = serde_json::to_vec(index).map_err(|error| {
+        let stored = GitVisibilityIndexV3::from_index(index)?;
+        let body = serde_json::to_vec(&stored).map_err(|error| {
             crate::error::MetadataError::Internal(format!("visibility index serialize: {error}"))
         })?;
         if body.len() as u64 > MAX_GIT_VISIBILITY_INDEX_BYTES {
@@ -628,14 +778,14 @@ mod storage {
                         ),
                     });
                 }
-                let existing: GitVisibilityIndex =
+                let existing: GitVisibilityIndexV3 =
                     serde_json::from_slice(&existing).map_err(|error| {
                         crate::error::MetadataError::CorruptObject {
                             path: path.as_ref().to_owned(),
                             reason: format!("invalid existing visibility index JSON: {error}"),
                         }
                     })?;
-                existing.validate()?;
+                let existing = existing.into_index()?;
                 existing.validate_identity(
                     index.generation,
                     &index.pack_index_hash,
@@ -946,7 +1096,7 @@ mod tests {
 
     #[cfg(feature = "storage")]
     #[tokio::test]
-    async fn shipped_v1_proof_is_read_and_can_be_backfilled_to_v2() {
+    async fn shipped_v1_proof_is_read_and_can_be_backfilled_to_v3() {
         use std::sync::Arc;
 
         use bytes::Bytes;
@@ -984,8 +1134,89 @@ mod tests {
         let current = read_with_format(&store, &router, generation, &pack_hash, &digest)
             .await
             .unwrap();
-        assert_eq!(current.format, GitVisibilityFormat::V2);
+        assert_eq!(current.format, GitVisibilityFormat::V3);
         assert_eq!(current.index, migrated.index);
+    }
+
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn v3_storage_deduplicates_shared_ref_history() {
+        use std::sync::Arc;
+
+        use crab_storage::{Store, StoreLayout};
+        use object_store::memory::InMemory;
+
+        let store = Store::new(Arc::new(InMemory::new()));
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        let objects = (0..256)
+            .map(|position| format!("{position:040x}"))
+            .collect::<Vec<_>>();
+        let refs = (0..8)
+            .map(|position| (format!("refs/heads/branch-{position}"), objects.clone()))
+            .collect();
+        let index = GitVisibilityIndex::new(7, "a".repeat(64), "b".repeat(64), refs);
+        let expanded = serde_json::to_vec(&serde_json::json!({
+            "version": index.version,
+            "generation": index.generation,
+            "pack_index_hash": &index.pack_index_hash,
+            "git_validation_digest": &index.git_validation_digest,
+            "refs": &index.refs,
+        }))
+        .unwrap();
+
+        upload_if_absent(&store, &router, &index).await.unwrap();
+
+        let (body, _) = store
+            .get_with_etag(&router.git_visibility_path(&index.git_validation_digest))
+            .await
+            .unwrap();
+        let stored: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(stored["objects"].as_array().unwrap().len(), 256);
+        assert!(body.len() < expanded.len() / 2);
+        assert_eq!(
+            read(
+                &store,
+                &router,
+                index.generation,
+                &index.pack_index_hash,
+                &index.git_validation_digest,
+            )
+            .await
+            .unwrap(),
+            index
+        );
+    }
+
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn v3_storage_rejects_closure_positions_outside_dictionary() {
+        use std::sync::Arc;
+
+        use bytes::Bytes;
+        use crab_storage::{Store, StoreLayout};
+        use object_store::memory::InMemory;
+
+        let store = Store::new(Arc::new(InMemory::new()));
+        let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        let pack_hash = "a".repeat(64);
+        let digest = "b".repeat(64);
+        let malformed = serde_json::json!({
+            "version": 3,
+            "generation": 7,
+            "pack_index_hash": pack_hash.clone(),
+            "git_validation_digest": digest.clone(),
+            "objects": ["1".repeat(40)],
+            "refs": {"refs/heads/main": [1]},
+        });
+        store
+            .put(
+                &router.git_visibility_path(&digest),
+                Bytes::from(serde_json::to_vec(&malformed).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert!(read(&store, &router, 7, &pack_hash, &digest).await.is_err());
     }
 
     #[cfg(feature = "storage")]


### PR DESCRIPTION
## Summary

- encode current Git visibility proofs with one sorted object-ID dictionary
- choose sparse positions or a dense bitmap independently for each ref closure
- keep the runtime authorization API and digest-bound v2 object key unchanged
- retain the shipped Crab 1.0.15 v1 reader, GC root, and write/repair backfill path
- reject malformed dictionaries, non-canonical bitmaps, unsorted or duplicate positions, out-of-range positions, unused dictionary entries, and proofs over existing limits
- document the compact proof contract

## Why this shape

Shared Git history previously repeated each 40-byte object ID once per ref. The v3 body codec stores each ID once, then chooses the smaller canonical closure representation per ref: sparse integer positions for small closures and a base64 bitset for dense shared history. This preserves the existing logical per-ref closure API while avoiding both repeated OIDs and integer-heavy dense closures.

The codec is the only serialized current-proof representation; the logical type no longer derives Serde, preventing an expanded v3 format from becoming a second storage contract. The proof key remains v2 because its digest-bound identity contract does not change. `base64` is optional and enabled only by the existing metadata storage feature.

The 9-ref/256-object fixture includes both dense and sparse refs, verifies the representation choice and exact round trip, and stores below one quarter of the expanded JSON size. Repositories with disjoint sparse histories retain sparse closures instead of paying full bitmap width.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p crab-metadata --no-default-features`
- `cargo test -p crab-metadata --no-fail-fast` — 128 passed
- `cargo test -p crab-metadata --features storage --no-fail-fast` — 170 passed
- `cargo clippy -p crab-metadata --features storage --lib -- -D warnings`
- `cargo check -p crab-remote-git`
- `cargo test -p crab-remote-git --no-fail-fast` — 74 unit + 44 integration passed
- `cargo check -p crab-auth-server`
- focused `crab` visibility, v1 migration, protected upload-pack repair, and GC tests passed

`cargo clippy -p crab-metadata --all-targets --features storage -- -D warnings` remains blocked by two pre-existing current-main test lints in `manifests.rs` and `ref_registry.rs`; the library lint is clean.