### PR TITLE
feat(web): improve SEO and brand metadata

### DIFF
--- a/packages/web/app/about-us/page.tsx
+++ b/packages/web/app/about-us/page.tsx
@@ -1,20 +1,16 @@
-import type { Metadata } from "next"
 import Link from "next/link"
 import { ArrowRight, Cloud, GitBranch, ShieldCheck } from "lucide-react"
 
 import { LegalPage, LegalSection } from "@/components/marketing/legal-page"
 import { Button } from "@/components/ui/button"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "About Us",
   description:
     "Learn about Beyondnote Technology Inc, the team building Crab: a serverless Git remote helper for large repositories in cloud object storage.",
-  openGraph: {
-    title: "About Us - Crab",
-    description:
-      "Crab is built for teams that need Git workflows for large files without a hosted LFS control plane.",
-  },
-}
+  path: "/about-us",
+})
 
 const sectionLinks = [
   { id: "who-we-are", label: "Who we are" },

--- a/packages/web/app/auth/page.tsx
+++ b/packages/web/app/auth/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import {
   ShieldCheck,
   KeyRound,
@@ -30,17 +29,14 @@ import { TypingCode } from "@/components/marketing/typing-code"
 import { Badge } from "@/components/ui/badge"
 import { AuthFlowSvg } from "@/app/diagrams/auth-flow-svg"
 import { AuthInternalsSvg } from "@/app/diagrams/auth-internals-svg"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Crab Auth — Enterprise Identity & Credential Vending",
   description:
     "Identity-based access control for Crab repositories. SSO via OIDC, RBAC policies, and short-lived scoped credentials for AWS, GCP, and Azure — no shared keys, no manual rotation.",
-  openGraph: {
-    title: "Crab Auth — Enterprise Identity & Credential Vending",
-    description:
-      "Identity-based access control for Crab repositories. SSO via OIDC, RBAC policies, and short-lived scoped credentials for AWS, GCP, and Azure — no shared keys, no manual rotation.",
-  },
-}
+  path: "/auth",
+})
 
 /* ─── Client-side auth methods ─── */
 

--- a/packages/web/app/blog/[slug]/page.tsx
+++ b/packages/web/app/blog/[slug]/page.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/blog"
 import { blogSource } from "@/lib/blog-source"
 import { getBlogPost, getBlogPosts } from "@/lib/blog-posts"
+import { createPageMetadata } from "@/lib/metadata"
 import { cn } from "@/lib/utils"
 import { getMDXComponents } from "@/mdx-components"
 
@@ -64,15 +65,21 @@ export async function generateMetadata({
   if (!page) return {}
 
   const { title, description } = page.data
+  const post = getBlogPost(slug)
 
-  return {
+  return createPageMetadata({
     title: title ? `${title} — Crab Blog` : "Crab Blog",
-    description,
-    openGraph: {
-      title: title ?? undefined,
-      description: description ?? undefined,
-    },
-  }
+    description: description ?? "Technical guides from the Crab team.",
+    path: `/blog/${slug}`,
+    absoluteTitle: true,
+    article: post
+      ? {
+          publishedTime: new Date(post.date).toISOString(),
+          authors: [post.author.name],
+          tags: post.tags,
+        }
+      : undefined,
+  })
 }
 
 export default async function BlogPostPage({

--- a/packages/web/app/blog/page.tsx
+++ b/packages/web/app/blog/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import Link from "next/link"
 import { Suspense } from "react"
 import {
@@ -30,17 +29,14 @@ import {
 } from "@/lib/blog"
 import { getBlogPosts } from "@/lib/blog-posts"
 import { cn } from "@/lib/utils"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
-  title: "Blog — Crab",
+export const metadata = createPageMetadata({
+  title: "Blog",
   description:
     "Technical guides, diagrams, and architecture walkthroughs for learning Crab progressively.",
-  openGraph: {
-    title: "Blog — Crab",
-    description:
-      "Technical guides, diagrams, and architecture walkthroughs for learning Crab progressively.",
-  },
-}
+  path: "/blog",
+})
 
 const CATEGORIES: BlogPostMeta["category"][] = [
   "Product",

--- a/packages/web/app/cache/page.tsx
+++ b/packages/web/app/cache/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import {
   HardDrive,
   Database,
@@ -35,17 +34,14 @@ import { TypingCode } from "@/components/marketing/typing-code"
 import { Counter } from "@/components/marketing/counter"
 import { CacheHierarchySvg } from "@/app/diagrams/cache-hierarchy-svg"
 import { CacheServiceArchitectureSvg } from "@/app/diagrams/cache-service-architecture-svg"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Crab Cache — Cut Cloud Storage Bills",
   description:
     "Reduce object storage egress costs by serving repeated fetches from a shared cache. One clone populates the cache — every subsequent clone, fetch, and hydrate avoids hitting S3/GCS/Azure.",
-  openGraph: {
-    title: "Crab Cache — Cut Cloud Storage Bills",
-    description:
-      "Reduce object storage egress costs by serving repeated fetches from a shared cache. One clone populates the cache — every subsequent clone, fetch, and hydrate avoids hitting S3/GCS/Azure.",
-  },
-}
+  path: "/cache",
+})
 
 const cacheFeatures = [
   {

--- a/packages/web/app/changelog/page.tsx
+++ b/packages/web/app/changelog/page.tsx
@@ -1,21 +1,16 @@
-import type { Metadata } from "next"
-
 import { MarketingLayout } from "@/components/marketing-layout"
 import { HeroSection } from "@/components/marketing/hero-section"
 import { Reveal } from "@/components/marketing/reveal"
 import { ChangelogEntry } from "@/components/changelog/changelog-entry"
 import { sortChangelog, changelogData } from "@/lib/changelog"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
-  title: "Changelog — Crab",
+export const metadata = createPageMetadata({
+  title: "Changelog",
   description:
     "Track verified product updates, fixes, and release artifacts across Crab releases.",
-  openGraph: {
-    title: "Changelog — Crab",
-    description:
-      "Track verified product updates, fixes, and release artifacts across Crab releases.",
-  },
-}
+  path: "/changelog",
+})
 
 const ENTRIES_PER_PAGE = 10
 

--- a/packages/web/app/cli/page.tsx
+++ b/packages/web/app/cli/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import {
   Cpu,
   Layers,
@@ -34,17 +33,14 @@ import { CliPushPipelineSvg } from "@/app/diagrams/cli-push-pipeline-svg"
 import { cn } from "@/lib/utils"
 
 import { InteractiveCliSandbox } from "@/components/marketing/interactive-cli-sandbox"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Crab CLI",
   description:
     "A single Rust binary that acts as a Git remote helper and filter driver for cloud object storage. Push and pull large files to S3, GCS, or Azure with standard Git commands.",
-  openGraph: {
-    title: "Crab CLI",
-    description:
-      "A single Rust binary that acts as a Git remote helper and filter driver for cloud object storage. Push and pull large files to S3, GCS, or Azure with standard Git commands.",
-  },
-}
+  path: "/cli",
+})
 
 const features = [
   {

--- a/packages/web/app/docs/cli/[[...slug]]/page.tsx
+++ b/packages/web/app/docs/cli/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import { DocsPage, DocsBody } from 'fumadocs-ui/page';
 import { getMDXComponents } from '@/mdx-components';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
+import { createPageMetadata } from '@/lib/metadata';
 
 export default async function CliDocPage({
   params,
@@ -42,8 +43,9 @@ export async function generateMetadata({
   const page = cliSource.getPage(slug);
   if (!page) return {};
 
-  return {
-    title: page.data.title,
-    description: page.data.description,
-  };
+  return createPageMetadata({
+    title: page.data.title ?? 'Crab CLI Documentation',
+    description: page.data.description ?? 'Crab CLI documentation.',
+    path: `/docs/cli/${page.slugs.join('/')}`,
+  });
 }

--- a/packages/web/app/docs/page.tsx
+++ b/packages/web/app/docs/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import {
   ArrowRight,
   BookOpen,
@@ -15,12 +14,14 @@ import { MarketingLayout } from "@/components/marketing-layout"
 import { HeroSection } from "@/components/marketing/hero-section"
 import { Reveal } from "@/components/marketing/reveal"
 import { DocsCategoryCard } from "@/components/docs/docs-category-card"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Documentation",
   description:
     "Explore Crab documentation — CLI guides, workflows, architecture, and more.",
-}
+  path: "/docs",
+})
 
 /* ─── CLI doc categories ─── */
 

--- a/packages/web/app/integrations/page.tsx
+++ b/packages/web/app/integrations/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import { MailIcon } from "lucide-react"
 
 import { MarketingLayout } from "@/components/marketing-layout"
@@ -7,17 +6,14 @@ import { Reveal } from "@/components/marketing/reveal"
 import { CTASection } from "@/components/marketing/cta-section"
 import { IntegrationGrid } from "@/components/integrations/integration-grid"
 import { integrations } from "@/lib/integrations"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
-  title: "Integrations — Crab",
+export const metadata = createPageMetadata({
+  title: "Integrations",
   description:
     "Explore tools and platforms that integrate with Crab — cloud providers, CI/CD, ML frameworks, and more.",
-  openGraph: {
-    title: "Integrations — Crab",
-    description:
-      "Explore tools and platforms that integrate with Crab — cloud providers, CI/CD, ML frameworks, and more.",
-  },
-}
+  path: "/integrations",
+})
 
 export default function IntegrationsPage() {
   return (

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,31 +1,103 @@
 import type { Metadata } from "next"
-import { Geist, Geist_Mono, Inter } from "next/font/google"
+import { Geist_Mono, Inter } from "next/font/google"
 
 import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { RootProvider } from "fumadocs-ui/provider/next"
 import { SkipNavLink } from "@/components/navigation/skip-nav-link"
-import { cn } from "@/lib/utils";
+import {
+  CRAB_LOGO_PATH,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+  createPageMetadata,
+} from "@/lib/metadata"
+import { cn } from "@/lib/utils"
+
+const rootPageMetadata = createPageMetadata({
+  title: "Crab — Serverless Git Remote",
+  description: SITE_DESCRIPTION,
+  path: "/",
+  absoluteTitle: true,
+})
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://crab.build'),
+  ...rootPageMetadata,
+  metadataBase: new URL(SITE_URL),
+  applicationName: SITE_NAME,
   title: {
-    default: 'Crab — Serverless Git Remote',
-    template: '%s | Crab',
+    default: "Crab — Serverless Git Remote",
+    template: `%s | ${SITE_NAME}`,
   },
-  description: 'Git remote helper for cloud object storage. No servers, no LFS endpoints.',
+  keywords: [
+    "serverless Git",
+    "Git remote helper",
+    "large file version control",
+    "cloud object storage",
+    "S3 Git storage",
+    "GCS Git storage",
+    "Azure Blob Git storage",
+    "Git LFS alternative",
+    "Xet deduplication",
+  ],
+  authors: [{ name: "Beyondnote Technology Inc", url: "/about-us" }],
+  creator: "Beyondnote Technology Inc",
+  publisher: "Beyondnote Technology Inc",
+  category: "technology",
+  referrer: "origin-when-cross-origin",
+  formatDetection: {
+    address: false,
+    email: false,
+    telephone: false,
+  },
   icons: {
-    icon: { url: '/crab.optimized.svg', type: 'image/svg+xml' },
-    apple: '/apple-icon.png',
+    icon: [{ url: CRAB_LOGO_PATH, type: "image/svg+xml", sizes: "any" }],
+    shortcut: [{ url: CRAB_LOGO_PATH, type: "image/svg+xml" }],
+    apple: [{ url: "/apple-icon.png", sizes: "180x180", type: "image/png" }],
   },
-  openGraph: {
-    type: 'website',
-    siteName: 'Crab',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'Crab — Serverless Git Remote' }],
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
   },
 }
 
-const inter = Inter({subsets:['latin'],variable:'--font-sans'})
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": `${SITE_URL}/#organization`,
+      name: SITE_NAME,
+      legalName: "Beyondnote Technology Inc",
+      url: SITE_URL,
+      logo: {
+        "@type": "ImageObject",
+        url: `${SITE_URL}${CRAB_LOGO_PATH}`,
+        width: 400,
+        height: 400,
+      },
+      sameAs: ["https://github.com/crabbuild/crab-oss"],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#website`,
+      url: SITE_URL,
+      name: SITE_NAME,
+      description: SITE_DESCRIPTION,
+      inLanguage: "en",
+      publisher: { "@id": `${SITE_URL}/#organization` },
+    },
+  ],
+}
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" })
 
 const fontMono = Geist_Mono({
   subsets: ["latin"],
@@ -41,9 +113,18 @@ export default function RootLayout({
     <html
       lang="en"
       suppressHydrationWarning
-      className={cn("antialiased", fontMono.variable, "font-sans", inter.variable)}
+      className={cn(
+        "antialiased",
+        fontMono.variable,
+        "font-sans",
+        inter.variable
+      )}
     >
       <body>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
         <SkipNavLink />
         <RootProvider>
           <ThemeProvider>{children}</ThemeProvider>

--- a/packages/web/app/manifest.ts
+++ b/packages/web/app/manifest.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next"
+
+import { CRAB_LOGO_PATH, SITE_DESCRIPTION, SITE_NAME } from "@/lib/metadata"
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: `${SITE_NAME} — Serverless Git Remote`,
+    short_name: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#000000",
+    icons: [
+      {
+        src: CRAB_LOGO_PATH,
+        sizes: "any",
+        type: "image/svg+xml",
+      },
+      {
+        src: "/apple-icon.png",
+        sizes: "180x180",
+        type: "image/png",
+      },
+    ],
+  }
+}

--- a/packages/web/app/opengraph-image.tsx
+++ b/packages/web/app/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { createSocialImage } from "./social-image"
+
+export const alt =
+  "Crab — serverless Git for large files in cloud object storage"
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+
+export default function OpenGraphImage() {
+  return createSocialImage()
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import {
   ArrowRight,
   Cloud,
@@ -26,17 +25,15 @@ import { ChunkingDiagramSvg } from "./landing-svgs"
 import { TestimonialsCarousel } from "@/components/marketing/testimonials-carousel"
 import { FAQSection } from "@/components/marketing/faq-section"
 import { InstallTabs, InstallTabIcons } from "@/components/marketing/install-tabs"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Crab — Git for any file at any scale",
   description:
     "Crab is a serverless Git remote storage solution powered by the Xet protocol for chunk-level deduplication. Version any file, any size, any number — straight into your S3, GCS, or Azure bucket.",
-  openGraph: {
-    title: "Crab — Git for any file at any scale",
-    description:
-      "Serverless Git remote powered by the Xet protocol for chunk-level deduplication. Any file, any size, any number — straight into your cloud bucket.",
-  },
-}
+  path: "/",
+  absoluteTitle: true,
+})
 
 const heroStats: ReadonlyArray<{
   end: number

--- a/packages/web/app/pricing/page.tsx
+++ b/packages/web/app/pricing/page.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from "react"
-import type { Metadata } from "next"
 import { Download, Check, Minus, ArrowRight, MailIcon } from "lucide-react"
 
 import { MarketingLayout } from "@/components/marketing-layout"
@@ -19,17 +18,14 @@ import {
   TableCell,
 } from "@/components/ui/table"
 import { pricingData } from "@/lib/pricing-data"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
-  title: "Pricing — Crab",
+export const metadata = createPageMetadata({
+  title: "Pricing",
   description:
     "Crab is free for developers. Enterprise teams get SSO, managed caching, audit logs, and priority support starting at $39/seat/month.",
-  openGraph: {
-    title: "Pricing — Crab",
-    description:
-      "Crab is free for developers. Enterprise teams get SSO, managed caching, audit logs, and priority support starting at $39/seat/month.",
-  },
-}
+  path: "/pricing",
+})
 
 /* ─── Tier card data ─── */
 

--- a/packages/web/app/privacy/page.tsx
+++ b/packages/web/app/privacy/page.tsx
@@ -1,21 +1,17 @@
-import type { Metadata } from "next"
 import Link from "next/link"
 import { Database, KeyRound, ShieldCheck } from "lucide-react"
 
 import { LegalPage, LegalSection } from "@/components/marketing/legal-page"
+import { createPageMetadata } from "@/lib/metadata"
 
 const LAST_UPDATED = "July 6, 2026"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Privacy Policy",
   description:
     "Privacy Policy for Crab, including crab.build, the Crab CLI, downloads, support, and optional Crab services.",
-  openGraph: {
-    title: "Privacy Policy - Crab",
-    description:
-      "How Beyondnote Technology Inc handles information for Crab's website, CLI, support, downloads, and optional services.",
-  },
-}
+  path: "/privacy",
+})
 
 const sectionLinks = [
   { id: "introduction", label: "Introduction" },

--- a/packages/web/app/remote-services/page.tsx
+++ b/packages/web/app/remote-services/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import {
   Cloud,
   Globe,
@@ -22,17 +21,14 @@ import { StepFlow } from "@/components/marketing/step-flow"
 import { CTASection } from "@/components/marketing/cta-section"
 import { Reveal } from "@/components/marketing/reveal"
 import { RemoteHelperFlowSvg } from "@/app/diagrams/remote-helper-flow-svg"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Remote Services",
   description:
     "Crab's remote helper protocol connects Git to cloud object storage. Push and pull repositories to S3, GCS, or Azure with zero infrastructure.",
-  openGraph: {
-    title: "Remote Services — Crab",
-    description:
-      "Crab's remote helper protocol connects Git to cloud object storage. Push and pull repositories to S3, GCS, or Azure with zero infrastructure.",
-  },
-}
+  path: "/remote-services",
+})
 
 const providerFeatures = [
   {

--- a/packages/web/app/robots.ts
+++ b/packages/web/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next"
+
+import { SITE_URL } from "@/lib/metadata"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  }
+}

--- a/packages/web/app/sitemap.ts
+++ b/packages/web/app/sitemap.ts
@@ -1,39 +1,42 @@
 import type { MetadataRoute } from "next"
 import { blogSource } from "@/lib/blog-source"
+import { SITE_URL } from "@/lib/metadata"
 import { cliSource } from "@/lib/source"
-
-const BASE_URL = "https://crab.build"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes: MetadataRoute.Sitemap = [
-    { url: `${BASE_URL}/` },
-    { url: `${BASE_URL}/about-us` },
-    { url: `${BASE_URL}/cli` },
-    { url: `${BASE_URL}/use-cases` },
-    { url: `${BASE_URL}/pricing` },
-    { url: `${BASE_URL}/blog` },
-    { url: `${BASE_URL}/changelog` },
-    { url: `${BASE_URL}/integrations` },
-    { url: `${BASE_URL}/privacy` },
-    { url: `${BASE_URL}/terms-of-service` },
+    { url: `${SITE_URL}/`, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/about-us` },
+    { url: `${SITE_URL}/auth` },
+    { url: `${SITE_URL}/blog`, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${SITE_URL}/cache` },
+    { url: `${SITE_URL}/changelog`, changeFrequency: "weekly" },
+    { url: `${SITE_URL}/cli`, priority: 0.9 },
+    { url: `${SITE_URL}/docs`, priority: 0.9 },
+    { url: `${SITE_URL}/integrations` },
+    { url: `${SITE_URL}/pricing` },
+    { url: `${SITE_URL}/privacy` },
+    { url: `${SITE_URL}/remote-services` },
+    { url: `${SITE_URL}/terms-of-service` },
+    { url: `${SITE_URL}/use-cases` },
   ]
 
   const blogEntries: MetadataRoute.Sitemap = blogSource
     .getPages()
     .map((post) => ({
-      url: `${BASE_URL}/blog/${post.slugs[0]}`,
+      url: `${SITE_URL}/blog/${post.slugs[0]}`,
       lastModified: post.data.date ? new Date(post.data.date) : new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
     }))
 
   const cliDocEntries: MetadataRoute.Sitemap = cliSource
     .getPages()
     .map((page) => ({
-      url: `${BASE_URL}/docs/cli/${page.slugs.join("/")}`,
+      url: `${SITE_URL}/docs/cli/${page.slugs.join("/")}`,
+      changeFrequency: "weekly",
+      priority: 0.8,
     }))
 
-  return [
-    ...staticRoutes,
-    ...blogEntries,
-    ...cliDocEntries,
-  ]
+  return [...staticRoutes, ...blogEntries, ...cliDocEntries]
 }

--- a/packages/web/app/social-image.tsx
+++ b/packages/web/app/social-image.tsx
@@ -1,0 +1,65 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { ImageResponse } from "next/og"
+
+const SOCIAL_IMAGE_SIZE = { width: 1200, height: 630 }
+
+const logoDataUrl = readFile(
+  join(process.cwd(), "public", "crab.optimized.svg"),
+  "base64"
+).then((logo) => `data:image/svg+xml;base64,${logo}`)
+
+export async function createSocialImage() {
+  const logo = await logoDataUrl
+
+  return new ImageResponse(
+    <div
+      style={{
+        alignItems: "center",
+        background: "#09090b",
+        color: "#fafafa",
+        display: "flex",
+        height: "100%",
+        justifyContent: "center",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          alignItems: "center",
+          display: "flex",
+          gap: 56,
+          padding: "72px 88px",
+        }}
+      >
+        <div
+          style={{
+            alignItems: "center",
+            background: "#ffffff",
+            borderRadius: 48,
+            display: "flex",
+            height: 240,
+            justifyContent: "center",
+            width: 240,
+          }}
+        >
+          {/* ImageResponse requires a plain image element for embedded data URLs. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img alt="" height="190" src={logo} width="190" />
+        </div>
+        <div
+          style={{ display: "flex", flexDirection: "column", maxWidth: 650 }}
+        >
+          <div style={{ fontSize: 76, fontWeight: 700, letterSpacing: -3 }}>
+            Crab
+          </div>
+          <div style={{ color: "#d4d4d8", fontSize: 38, lineHeight: 1.25 }}>
+            Serverless Git for large files in your cloud storage
+          </div>
+        </div>
+      </div>
+    </div>,
+    SOCIAL_IMAGE_SIZE
+  )
+}

--- a/packages/web/app/terms-of-service/page.tsx
+++ b/packages/web/app/terms-of-service/page.tsx
@@ -1,21 +1,17 @@
-import type { Metadata } from "next"
 import Link from "next/link"
 import { Cloud, FileText, Scale } from "lucide-react"
 
 import { LegalPage, LegalSection } from "@/components/marketing/legal-page"
+import { createPageMetadata } from "@/lib/metadata"
 
 const LAST_UPDATED = "July 6, 2026"
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Terms of Service",
   description:
     "Terms of Service for crab.build, Crab documentation, downloads, the Crab CLI, and optional Crab services.",
-  openGraph: {
-    title: "Terms of Service - Crab",
-    description:
-      "Legal terms for Crab's website, software downloads, documentation, support, and optional services.",
-  },
-}
+  path: "/terms-of-service",
+})
 
 const sectionLinks = [
   { id: "acceptance", label: "Acceptance" },

--- a/packages/web/app/twitter-image.tsx
+++ b/packages/web/app/twitter-image.tsx
@@ -1,0 +1,10 @@
+import { createSocialImage } from "./social-image"
+
+export const alt =
+  "Crab — serverless Git for large files in cloud object storage"
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+
+export default function TwitterImage() {
+  return createSocialImage()
+}

--- a/packages/web/app/use-cases/page.tsx
+++ b/packages/web/app/use-cases/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next"
 import {
   Brain,
   Database,
@@ -34,17 +33,14 @@ import { LazyHydrateSvg } from "@/app/diagrams/lazy-hydrate-svg"
 import { EnterpriseArchitectureSvg } from "@/app/diagrams/enterprise-architecture-svg"
 import { CiTimelineSvg } from "@/app/diagrams/ci-timeline-svg"
 import { cn } from "@/lib/utils"
+import { createPageMetadata } from "@/lib/metadata"
 
-export const metadata: Metadata = {
-  title: "Use Cases — Crab",
+export const metadata = createPageMetadata({
+  title: "Use Cases",
   description:
     "How teams use Crab for ML/AI, data science, game development, large binary assets, enterprise, and DevOps/CI-CD workflows.",
-  openGraph: {
-    title: "Use Cases — Crab",
-    description:
-      "How teams use Crab for ML/AI, data science, game development, large binary assets, enterprise, and DevOps/CI-CD workflows.",
-  },
-}
+  path: "/use-cases",
+})
 
 // ---------- Local helpers --------------------------------------------------
 

--- a/packages/web/lib/metadata.ts
+++ b/packages/web/lib/metadata.ts
@@ -1,0 +1,69 @@
+import type { Metadata } from "next"
+
+export const SITE_URL = "https://crab.build"
+export const SITE_NAME = "Crab"
+export const SITE_DESCRIPTION =
+  "Git remote helper for cloud object storage. No servers, no LFS endpoints."
+export const CRAB_LOGO_PATH = "/crab.optimized.svg"
+
+interface PageMetadataOptions {
+  title: string
+  description: string
+  path: string
+  absoluteTitle?: boolean
+  article?: {
+    publishedTime: string
+    authors: string[]
+    tags?: string[]
+  }
+}
+
+export function createPageMetadata({
+  title,
+  description,
+  path,
+  absoluteTitle = false,
+  article,
+}: PageMetadataOptions): Metadata {
+  const sharedOpenGraph = {
+    title,
+    description,
+    url: path,
+    siteName: SITE_NAME,
+    locale: "en_US",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Crab — serverless Git for large files in cloud object storage",
+      },
+    ],
+  }
+
+  return {
+    title: absoluteTitle ? { absolute: title } : title,
+    description,
+    alternates: { canonical: path },
+    openGraph: article
+      ? {
+          ...sharedOpenGraph,
+          type: "article",
+          publishedTime: article.publishedTime,
+          authors: article.authors,
+          tags: article.tags,
+        }
+      : { ...sharedOpenGraph, type: "website" },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [
+        {
+          url: "/twitter-image",
+          alt: "Crab — serverless Git for large files in cloud object storage",
+        },
+      ],
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- use `crab.optimized.svg` for favicon, shortcut icon, manifest branding, structured organization data, and generated social cards
- centralize canonical, Open Graph, Twitter, and article metadata across marketing, blog, and docs routes
- add crawler directives, a web manifest, and complete missing routes in the sitemap
- replace the missing `/og-image.png` reference with generated PNG Open Graph and Twitter endpoints sourced from the optimized SVG

## Verification

- `npm run typecheck`
- `npm run lint` (passes with 17 pre-existing warnings)
- `npm run test` (2 tests passed)
- `npm run build` (229 pages generated)
- `npm run check:links` (190 pages, 1970 fragments)
- runtime smoke: SVG, Open Graph image, Twitter image, manifest, robots, and sitemap endpoints returned HTTP 200