### PR TITLE
fix(ci): restore cache and Git compatibility

### DIFF
--- a/crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py
@@ -197,6 +197,25 @@ class ProtocolV2PartialCloneSmoke:
             raise SmokeError(f"Git executable is not executable: {candidate}")
         return candidate
 
+    def git_supports_filter(self, filter_spec: str) -> tuple[bool, str]:
+        probe = subprocess.run(
+            [
+                str(self.git_bin),
+                "-C",
+                str(self.source),
+                "rev-list",
+                "--objects",
+                f"--filter={filter_spec}",
+                "--all",
+            ],
+            env=self.env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        return probe.returncode == 0, probe.stderr.strip()
+
     def build_env(self) -> dict[str, str]:
         env = os.environ.copy()
         env.update(
@@ -1017,13 +1036,25 @@ class ProtocolV2PartialCloneSmoke:
             ("blob-none", "blob:none", "blob:none", False, None),
             ("blob-limit", "blob:limit=1k", "blob:limit=1024", False, None),
             ("tree-depth", "tree:1", "tree:1", False, None),
-            ("object-type-tag", "object:type=tag", "object:type=tag", False, tag_oid),
-            ("object-type-commit", "object:type=commit", "object:type=commit", False, commit_oid),
-            ("object-type-tree", "object:type=tree", "object:type=tree", False, tree_oid),
-            ("object-type-blob", "object:type=blob", "object:type=blob", True, small_oid),
             ("sparse", f"sparse:oid={sparse_oid}", "sparse:oid=<oid>", False, None),
             ("combine", "combine:blob:none+tree:1", "combine:blob:none+tree:1", False, None),
         ]
+        object_type_supported, object_type_probe_error = self.git_supports_filter(
+            "object:type=tag"
+        )
+        if object_type_supported:
+            filters[3:3] = [
+                ("object-type-tag", "object:type=tag", "object:type=tag", False, tag_oid),
+                (
+                    "object-type-commit",
+                    "object:type=commit",
+                    "object:type=commit",
+                    False,
+                    commit_oid,
+                ),
+                ("object-type-tree", "object:type=tree", "object:type=tree", False, tree_oid),
+                ("object-type-blob", "object:type=blob", "object:type=blob", True, small_oid),
+            ]
         before = self.store_snapshot("before-filter-matrix")
         nested_oid = self.git_value(
             self.source,
@@ -1222,6 +1253,10 @@ class ProtocolV2PartialCloneSmoke:
         after = self.store_snapshot("after-filter-matrix")
         self.report["performance"]["filter-matrix"] = {
             "filters": rows,
+            "client_capabilities": {
+                "object_type_filter": object_type_supported,
+                "object_type_probe_error": object_type_probe_error or None,
+            },
             "remote_unchanged": after["objects"] == before["objects"]
             and after["bytes"] == before["bytes"],
             "before": before,

--- a/crab/src/git/incremental_walk.rs
+++ b/crab/src/git/incremental_walk.rs
@@ -86,12 +86,17 @@ pub fn walk_incremental_with_hidden(
     hidden_shas: &[&str],
     new_sha: &str,
 ) -> Result<(Vec<PointerBlob>, Vec<CommitEntry>)> {
+    // Linked worktrees keep their object database in the common Git
+    // directory; walking the private worktree directory fails before any
+    // ref-specific logic can run.
+    let git_dir = crate::git::discover::resolve_common_dir(git_dir);
+
     // No boundary — fall back to full walk.
     if hidden_shas.is_empty() {
         debug!("no hidden shas, falling back to full walk");
         let refs = vec![("(push)".to_owned(), new_sha.to_owned())];
-        let reachable = super::walk::walk_reachable(git_dir, &refs)?;
-        let entries = collect_entries_from_walk(git_dir, new_sha)?;
+        let reachable = super::walk::walk_reachable(&git_dir, &refs)?;
+        let entries = collect_entries_from_walk(&git_dir, new_sha)?;
         return Ok((reachable.pointers, entries));
     }
 

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -30149,7 +30149,8 @@ mod tests {
         // The visibility proof is built from the shared test repository's
         // object database, so the candidate tip must be a real reachable
         // commit rather than a placeholder object ID.
-        let new_sha = TEST_GIT_REPO.commit_sha.as_str();
+        let git_dir = crate::test::git_repo::TEST_GIT_REPO.git_dir.clone();
+        let new_sha = crate::test::git_repo::TEST_GIT_REPO.commit_sha.as_str();
 
         let mut base = Manifest::default_for_repo("refs/heads/main");
         base.refs.insert("refs/heads/main".into(), old_sha.into());
@@ -30159,6 +30160,7 @@ mod tests {
         let config = PushConfig {
             active_active_replication: Some(active_active_replication()),
             active_active_coordinator: Some(ActiveActiveWriteCoordinator::new(coordinator)),
+            git_dir: Some(git_dir),
             ..PushConfig::default()
         };
         let spec = PushSpec {


### PR DESCRIPTION
## Summary

- Require canonical origin payload proofs when publishing cached xorbs, shards, and metadata.
- Restore strict active-active Git visibility validation.
- Resolve linked-worktree Git object reads through the common Git directory.
- Skip object:type filter cases when the client Git version does not support them, preserving Git 2.30 compatibility.

## Validation

- cargo fmt --all -- --check
- CI-equivalent cargo clippy for package crab passed with the workflow lint policy.
- Focused cache, replication, and linked-worktree tests passed.
- Full workspace run passed 3,642 library tests; linked-worktree integration passed 6 tests.

The workspace run also exposed an unrelated existing no_direct_stdout inventory failure in crab/src/cmd/metadb.rs.