### PR TITLE
docs(web): add worked blog visuals and examples

### DIFF
--- a/packages/web/components/blog/blog-detail-diagrams.tsx
+++ b/packages/web/components/blog/blog-detail-diagrams.tsx
@@ -1,0 +1,312 @@
+import { DiagramFrame } from "@/components/blog/blog-diagrams"
+
+const REUSED = {
+  fill: "color-mix(in srgb, #10b981 12%, var(--card))",
+  stroke: "#10b981",
+}
+
+const CHANGED = {
+  fill: "color-mix(in srgb, #f59e0b 12%, var(--card))",
+  stroke: "#f59e0b",
+}
+
+const VERSION_A = ["header", "weights 1", "weights 2", "optimizer", "footer"]
+const VERSION_B = ["header", "weights 1", "new weights", "optimizer", "footer"]
+
+export function ChunkReuseDiagram() {
+  const startX = 126
+  const segmentWidth = 112
+  const gap = 6
+
+  return (
+    <DiagramFrame
+      title="One local edit preserves distant chunks"
+      caption="The edited region receives a new hash. Once content-defined boundaries resynchronize, the optimizer and footer chunks retain their earlier identities."
+    >
+      <svg
+        viewBox="0 0 760 238"
+        className="h-auto w-full min-w-[40rem]"
+        role="img"
+        aria-label="Two file versions with four reused regions and one changed region"
+      >
+        {[VERSION_A, VERSION_B].map((segments, rowIndex) => {
+          const y = 38 + rowIndex * 76
+          return (
+            <g key={rowIndex}>
+              <text
+                x="26"
+                y={y + 30}
+                fill="var(--foreground)"
+                fontFamily="Inter, ui-sans-serif, system-ui"
+                fontSize="13"
+                fontWeight="650"
+              >
+                Version {rowIndex === 0 ? "A" : "B"}
+              </text>
+              {segments.map((segment, index) => {
+                const changed = index === 2
+                const colors = changed ? CHANGED : REUSED
+                const x = startX + index * (segmentWidth + gap)
+                return (
+                  <g key={segment}>
+                    <rect
+                      x={x}
+                      y={y}
+                      width={segmentWidth}
+                      height="52"
+                      rx="8"
+                      fill={colors.fill}
+                      stroke={colors.stroke}
+                      strokeWidth="1.5"
+                    />
+                    <text
+                      x={x + segmentWidth / 2}
+                      y={y + 23}
+                      textAnchor="middle"
+                      fill="var(--foreground)"
+                      fontFamily="Inter, ui-sans-serif, system-ui"
+                      fontSize="11"
+                      fontWeight="600"
+                    >
+                      {segment}
+                    </text>
+                    <text
+                      x={x + segmentWidth / 2}
+                      y={y + 39}
+                      textAnchor="middle"
+                      fill="var(--muted-foreground)"
+                      fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+                      fontSize="9"
+                    >
+                      {changed
+                        ? rowIndex === 0
+                          ? "old hash"
+                          : "new hash"
+                        : "same hash"}
+                    </text>
+                  </g>
+                )
+              })}
+            </g>
+          )
+        })}
+        <g transform="translate(126 208)">
+          <rect
+            width="11"
+            height="11"
+            rx="2"
+            fill={REUSED.fill}
+            stroke={REUSED.stroke}
+          />
+          <text x="18" y="9" fill="var(--muted-foreground)" fontSize="10">
+            reused without upload
+          </text>
+          <rect
+            x="178"
+            width="11"
+            height="11"
+            rx="2"
+            fill={CHANGED.fill}
+            stroke={CHANGED.stroke}
+          />
+          <text x="196" y="9" fill="var(--muted-foreground)" fontSize="10">
+            new chunk data
+          </text>
+        </g>
+      </svg>
+    </DiagramFrame>
+  )
+}
+
+function ReachabilityMarker() {
+  return (
+    <marker
+      id="gc-reachability-arrow"
+      viewBox="0 0 10 10"
+      refX="9"
+      refY="5"
+      markerWidth="8"
+      markerHeight="8"
+      orient="auto"
+    >
+      <path d="M1 1 9 5 1 9 3.5 5Z" fill="#64748b" />
+    </marker>
+  )
+}
+
+export function GarbageCollectionReachabilityDiagram() {
+  const connector = {
+    fill: "none",
+    stroke: "#64748b",
+    strokeWidth: 1.5,
+    markerEnd: "url(#gc-reachability-arrow)",
+  } as const
+
+  return (
+    <DiagramFrame
+      title="Reachability and age decide each object outcome"
+      caption="The collector retains every marked object. An unmarked object must also outlive the grace window before it becomes a deletion candidate."
+    >
+      <svg
+        viewBox="0 0 760 334"
+        className="h-auto w-full min-w-[40rem]"
+        role="img"
+        aria-label="Garbage collection combines retained roots and an object inventory before classifying objects"
+      >
+        <defs>
+          <ReachabilityMarker />
+        </defs>
+
+        <path d="M175 104 C175 130 330 120 330 145" {...connector} />
+        <path d="M585 104 C585 130 430 120 430 145" {...connector} />
+        <path d="M330 217 C330 241 114 234 114 260" {...connector} />
+        <path d="M380 217 V260" {...connector} />
+        <path d="M430 217 C430 241 646 234 646 260" {...connector} />
+
+        <g>
+          <rect
+            x="40"
+            y="34"
+            width="270"
+            height="70"
+            rx="10"
+            fill="color-mix(in srgb, #8b5cf6 10%, var(--card))"
+            stroke="#8b5cf6"
+            strokeWidth="1.5"
+          />
+          <text
+            x="175"
+            y="63"
+            textAnchor="middle"
+            fill="var(--foreground)"
+            fontSize="13"
+            fontWeight="650"
+          >
+            Retained roots
+          </text>
+          <text
+            x="175"
+            y="83"
+            textAnchor="middle"
+            fill="var(--muted-foreground)"
+            fontSize="10"
+          >
+            refs · recovery · workflows · holds
+          </text>
+        </g>
+
+        <g>
+          <rect
+            x="450"
+            y="34"
+            width="270"
+            height="70"
+            rx="10"
+            fill="color-mix(in srgb, #0284c7 10%, var(--card))"
+            stroke="#0284c7"
+            strokeWidth="1.5"
+          />
+          <text
+            x="585"
+            y="63"
+            textAnchor="middle"
+            fill="var(--foreground)"
+            fontSize="13"
+            fontWeight="650"
+          >
+            Object inventory snapshot
+          </text>
+          <text
+            x="585"
+            y="83"
+            textAnchor="middle"
+            fill="var(--muted-foreground)"
+            fontSize="10"
+          >
+            packs · shards · xorbs
+          </text>
+        </g>
+
+        <g>
+          <rect
+            x="250"
+            y="145"
+            width="260"
+            height="72"
+            rx="10"
+            fill="color-mix(in srgb, #06b6d4 10%, var(--card))"
+            stroke="#06b6d4"
+            strokeWidth="1.5"
+          />
+          <text
+            x="380"
+            y="175"
+            textAnchor="middle"
+            fill="var(--foreground)"
+            fontSize="13"
+            fontWeight="650"
+          >
+            Mark dependencies and classify
+          </text>
+          <text
+            x="380"
+            y="196"
+            textAnchor="middle"
+            fill="var(--muted-foreground)"
+            fontSize="10"
+          >
+            union roots · subtract live set · apply age
+          </text>
+        </g>
+
+        {[
+          { x: 24, title: "Reachable", detail: "retain", stroke: "#10b981" },
+          {
+            x: 290,
+            title: "Recent orphan",
+            detail: "wait for grace",
+            stroke: "#f59e0b",
+          },
+          {
+            x: 556,
+            title: "Old orphan",
+            detail: "eligible to delete",
+            stroke: "#fb7185",
+          },
+        ].map((outcome) => (
+          <g key={outcome.title}>
+            <rect
+              x={outcome.x}
+              y="260"
+              width="180"
+              height="54"
+              rx="9"
+              fill={`color-mix(in srgb, ${outcome.stroke} 10%, var(--card))`}
+              stroke={outcome.stroke}
+              strokeWidth="1.5"
+            />
+            <text
+              x={outcome.x + 90}
+              y="283"
+              textAnchor="middle"
+              fill="var(--foreground)"
+              fontSize="12"
+              fontWeight="650"
+            >
+              {outcome.title}
+            </text>
+            <text
+              x={outcome.x + 90}
+              y="300"
+              textAnchor="middle"
+              fill="var(--muted-foreground)"
+              fontSize="10"
+            >
+              {outcome.detail}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </DiagramFrame>
+  )
+}

--- a/packages/web/components/blog/blog-diagrams.tsx
+++ b/packages/web/components/blog/blog-diagrams.tsx
@@ -34,7 +34,7 @@ type FlowItem = {
   tone: Tone
 }
 
-function DiagramFrame({
+export function DiagramFrame({
   title,
   caption,
   children,

--- a/packages/web/content/blog/cost-optimization-s3-storage.mdx
+++ b/packages/web/content/blog/cost-optimization-s3-storage.mdx
@@ -50,7 +50,7 @@ Separate hot, warm, and archival xorbs instead of averaging the complete reposit
 | Required latency | Interactive | Batch-compatible | Restore-compatible |
 | Minimum retention | Provider class rule | Provider class rule | Provider class rule |
 
-Multiply each set by its current regional prices, then add request and transfer terms. This model makes a cold-tail policy visible instead of hiding it inside one storage total.
+Multiply each set by its current regional prices, then add request and transfer terms. Separate rows expose a cold-tail policy that one storage total would hide.
 
 Run a sensitivity check as well. Double the archive read frequency, increase the hot set by one release cycle, and model an early-delete event. The policy should remain acceptable under plausible workload changes.
 
@@ -70,6 +70,21 @@ Populate the table from logs and Crab counters rather than estimates where possi
 
 Keep cache-served and origin-served bytes separate. Provider billing sees the origin path, while application latency sees both. A shared cache may trade object-store transfer for cache-service compute and network cost.
 
+## Work one tiering decision with concrete numbers
+
+Use a small calculation to test whether a lower storage rate pays for retrieval and transition work. The rates below illustrate the method; replace them with the current rates and minimum-retention rules for your provider.
+
+Assume access logs identify 6,000 GB of reachable xorbs that workflows read once per quarter. The proposed class lowers storage by `$0.014` per GB-month, charges `$0.02` per retrieved GB, and requires `$18` of one-time transition requests.
+
+| Term | Calculation | Effect |
+| --- | ---: | ---: |
+| Monthly storage reduction | `6,000 GB × $0.014` | `$84` saved |
+| Expected monthly retrieval | `200 GB × $0.02` | `$4` added |
+| Steady monthly savings | `$84 - $4` | `$80` saved |
+| Transition payback | `$18 ÷ $80` | `0.225 months` |
+
+The arithmetic supports the transition, but it does not prove the policy is safe. Confirm that quarterly restores meet the recovery-time objective and that early-deletion charges cannot erase the `$80` estimate.
+
 ## Measure local and remote bytes
 
 Use Crab's inventory before changing policy:
@@ -88,7 +103,7 @@ Keep the observation window long enough to include releases, training cycles, an
 
 Measure growth by cause. New unique chunks, retained historical roots, abandoned uploads inside the grace period, repacking overlap, and delayed provider deletion all add remote bytes for different reasons.
 
-One inventory total cannot identify the right control. Deduplication affects new unique data. Retention policy and GC affect unreachable data.
+One inventory total cannot identify the failing cost term. Deduplication affects new unique data. Retention policy and GC affect unreachable data.
 
 Repacking affects object layout. Provider lifecycle affects the rate charged for reachable xorb bytes.
 

--- a/packages/web/content/blog/crab-vs-git-lfs.mdx
+++ b/packages/web/content/blog/crab-vs-git-lfs.mdx
@@ -58,7 +58,7 @@ With hosted Git LFS, the forge usually supplies the endpoint, authorization flow
 
 Crab removes the endpoint from the data path. Clients need direct access to the repository prefix, and operators use object-store inventory, lifecycle, access logs, and retention policy. Crab also adds native operations for hydration, dehydration, mounts, integrity checking, optimization, and garbage collection.
 
-The right comparison includes the people who will operate the repository. A workflow that saves transfer but has no sustainable credential path is not a successful migration.
+Include repository operators in the comparison. A workflow that saves transfer but has no sustainable credential path is not a successful migration.
 
 ## Changed-file behavior can dominate the comparison
 
@@ -104,7 +104,7 @@ The recovery question differs between the systems. Ask where large bytes live, w
 
 ## Compare cost with version churn included
 
-A useful cost model includes stored bytes, requests, network transfer, retrieval, service charges, and operator time. Whole-file storage grows with each distinct file object. Native Crab storage grows with chunks that lack durable proof, plus recipe and shard metadata.
+Model stored bytes, requests, network transfer, retrieval, service charges, and operator time. Whole-file storage grows with each distinct file object. Native Crab storage grows with chunks that lack durable proof, plus recipe and shard metadata.
 
 The difference is workload-dependent. Two compressed or encrypted versions may share little physical content, so chunking cannot create savings from semantic similarity. Two checkpoints with stable byte regions may reuse most chunks even though the full-file hashes differ.
 
@@ -120,7 +120,7 @@ A full native conversion is a different operation. `crab lfs migrate export --to
 
 ## Run a two-version pilot
 
-A useful comparison needs more than one initial upload. Choose a repository slice with ordinary source, one frequently changed binary, and one stable large asset.
+Test more than one initial upload. Choose a repository slice with ordinary source, one frequently changed binary, and one stable large asset.
 
 Evaluate both systems with the same sequence:
 

--- a/packages/web/content/blog/first-crab-push.mdx
+++ b/packages/web/content/blog/first-crab-push.mdx
@@ -144,7 +144,7 @@ The reader needs only the published repository state and authorized object acces
 
 Run one controlled negative check as well. Remove access from the isolated reader or point it at an unauthorized prefix, then confirm hydration fails without replacing the pointer with partial bytes. Restore the correct credentials and rerun the same hydration successfully.
 
-This check proves that errors stay visible at the data boundary. It also confirms that the test environment is actually reading the configured origin instead of an unintended local copy.
+This check proves that errors stay visible at the data boundary. It also confirms that the test environment reads the configured origin instead of an unintended local copy.
 
 ## Verify a changed version as well
 

--- a/packages/web/content/blog/garbage-collection-serverless.mdx
+++ b/packages/web/content/blog/garbage-collection-serverless.mdx
@@ -47,6 +47,8 @@ The walk follows both data lanes. Git roots reach commits, trees, packs, and poi
 
 Shared chunks complicate intuition but not the rule. An xorb remains live when any retained recipe needs one of its chunks. The branch or file that first uploaded it does not own the complete object.
 
+<GarbageCollectionReachabilityDiagram />
+
 ## Retained roots express recovery policy
 
 Current branches and tags describe active Git history. The ref journal records committed transitions. Recovery history preserves earlier states that operators may restore after an accidental ref change.

--- a/packages/web/content/blog/git-remote-helpers-filter-processes.mdx
+++ b/packages/web/content/blog/git-remote-helpers-filter-processes.mdx
@@ -107,7 +107,7 @@ Clean completes before Git writes the pointer into the index. At that moment, Cr
 
 The recipe records every chunk identity and its logical order. New chunk bytes remain in staging until a push flushes them into immutable xorbs. Known chunks can reference existing durable locations after canonical proof.
 
-This separation allows offline staging. A contributor can add and commit managed files without immediate object-store access when the required local state is available. Push becomes the network and durability boundary.
+Because staging owns the bytes before push, a contributor can add and commit managed files without immediate object-store access when the required local state is available. Push becomes the network and durability boundary.
 
 Offline preparation also creates responsibility. Deleting staging before first publication can remove the only recipe or new bytes behind a committed pointer. The committed Git blob remains, but the client can no longer prove its Crab closure.
 
@@ -206,7 +206,7 @@ The helper downloads the required pack data and imports it through Git's object 
 
 Remote-tracking refs update only after Git receives the requested object closure. Managed files remain pointer blobs at this stage. Fetch therefore proves history transport, while later smudge or hydration proves large-file reconstruction.
 
-This distinction explains a valid partial workflow: a code-review job can fetch and inspect a mixed commit without obtaining any xorb ranges. The repository history is present even though managed working-tree bytes remain deferred.
+A code-review job can therefore fetch and inspect a mixed commit without obtaining any xorb ranges. The repository history is present even though managed working-tree bytes remain deferred.
 
 ## Fetch and push cross both storage paths
 

--- a/packages/web/content/blog/multi-layer-caching.mdx
+++ b/packages/web/content/blog/multi-layer-caching.mdx
@@ -79,7 +79,7 @@ Mutable caches need invalidation when the value behind a key changes. A content-
 
 Crab still needs eviction, corruption handling, and metadata generation checks. Eviction controls disk capacity. Hash verification detects wrong bytes. Generation-aware metadata prevents a stale index view from hiding newer canonical state.
 
-This model reduces invalidation complexity, but it does not eliminate authority checks. A locally known chunk cannot prove that the remote repository published the same dependency.
+Immutable keys reduce invalidation complexity, but they do not eliminate authority checks. A locally known chunk cannot prove that the remote repository published the same dependency.
 
 Concurrent readers can share immutable cache entries without coordinating version replacement. If two hydrations request the same absent xorb range, request coalescing can prevent duplicate origin reads while both consumers wait for one verified result.
 
@@ -93,7 +93,7 @@ Crab groups required chunks by xorb and coalesces compatible byte ranges. It can
 
 Coalescing has an economic threshold. One wider range may cost fewer requests but transfer bytes that the file does not need. Several narrow ranges reduce unused transfer but add latency and request charges.
 
-The right balance depends on xorb layout and workload locality. Sequential model reads favor wider adjacent ranges. Sparse access through a mount may favor narrow reads, especially when object-store transfer costs exceed request costs.
+Choose range width from xorb layout and workload locality. Sequential model reads favor wider adjacent ranges. Sparse access through a mount may favor narrow reads, especially when object-store transfer costs exceed request costs.
 
 Cache measurements should retain both figures. A lower request count is not automatically an improvement if origin bytes increase enough to erase the benefit.
 

--- a/packages/web/content/blog/what-is-crab.mdx
+++ b/packages/web/content/blog/what-is-crab.mdx
@@ -38,7 +38,7 @@ During a clone, Git can check out the small pointers first. You can then hydrate
 
 The pointer remains part of the commit, so a branch or tag still identifies one exact large-file version. Renaming a managed file changes the Git tree. Replacing its content changes the pointer identity. Reverting the commit restores the earlier pointer, which Crab can resolve through the same immutable data store.
 
-This arrangement keeps ordinary Git operations useful. You can inspect history, compare pointer changes, review path selection, and merge source changes without downloading every managed byte. A tool that needs the real model, archive, or dataset hydrates that path before reading it.
+Because Git stores the pointer as a blob, ordinary Git operations remain useful. You can inspect history, compare pointer changes, review path selection, and merge source changes without downloading every managed byte. A tool that needs the real model, archive, or dataset hydrates that path before reading it.
 
 ## The pointer is a contract, not a placeholder
 
@@ -81,11 +81,11 @@ One repository does not require one checkout shape. A source developer can keep 
 
 These clients still share the same commits and refs. Materialization is local policy, not a separate version of history. A pointer-only checkout and a hydrated checkout agree about which file belongs at a path, even though only one has the full bytes on disk.
 
-This matters when repository content exceeds a laptop or runner. Teams do not need to split history merely because different jobs have different storage capacity. They can make the required working set explicit for each workflow instead.
+When repository content exceeds a laptop or runner, each workflow can declare the working set it needs. Teams keep one history even when jobs have different storage capacity.
 
 ## Each storage layer has one responsibility
 
-Crab becomes easier to operate when you separate repository identity from file materialization. Git answers which version belongs to a commit. Crab metadata answers how to reconstruct that version. Object storage supplies the immutable bytes.
+Operate Crab by separating repository identity from file materialization. Git answers which version belongs to a commit. Crab metadata answers how to reconstruct that version. Object storage supplies the immutable bytes.
 
 | Layer | Stores | Does not decide |
 | --- | --- | --- |
@@ -95,7 +95,7 @@ Crab becomes easier to operate when you separate repository identity from file m
 | Xorbs | Packed, compressed large-file chunks | Git history or path selection |
 | Ref journal | The visible branch and tag state | Working-tree hydration state |
 
-This separation keeps failure boundaries narrow. A missing local cache entry causes an origin read, not a history change. A failed upload blocks the ref update, not an existing reader. A dehydrate operation changes local materialization, not the committed file identity.
+Separate ownership narrows each failure boundary. A missing local cache entry causes an origin read, not a history change. A failed upload blocks the ref update, not an existing reader. A dehydrate operation changes local materialization, not the committed file identity.
 
 ## One edit shows why the model matters
 
@@ -111,7 +111,7 @@ Crab owns Git transport and the managed large-file data path. It does not become
 
 The serverless claim is therefore narrow and useful: no Crab data server sits between the client and object storage. Removing that service reduces one availability and scaling boundary. It also makes bucket policy, client installation, and provider observability part of repository operations.
 
-This boundary is worth stating during adoption. A team that expects Crab to replace every forge feature will evaluate the wrong system. A team that needs Git-compatible storage for large files can evaluate the exact path Crab owns.
+State that boundary during adoption. A team that expects Crab to replace every forge feature will evaluate the wrong system. A team that needs Git-compatible storage for large files can evaluate the exact path Crab owns.
 
 ## Evaluate the operating contract before adoption
 

--- a/packages/web/content/blog/why-we-built-crab.mdx
+++ b/packages/web/content/blog/why-we-built-crab.mdx
@@ -29,9 +29,9 @@ A binary file can be perfectly valid in Git. The scaling problem appears when th
 
 Suppose a model checkpoint is 8 GB and a training run changes a small region. The new version is still another large Git object. Repeat that cycle across branches and releases, and the repository becomes expensive to clone, cache, back up, and operate.
 
-The result is not only slower commands. Teams move related data outside the repository or share bucket paths in documents. Naming conventions then reconnect a model with the source commit that produced it.
+Slow commands change team behavior. Teams move related data outside the repository or share bucket paths in documents. Naming conventions then reconnect a model with the source commit that produced it.
 
-Git's strengths explain this behavior. A commit closes over its trees and blobs, and a clone can obtain the complete reachable object graph. That self-contained model is valuable for source code because the graph remains compact and Git can compress related objects effectively.
+The pressure follows from Git's strongest guarantee. A commit closes over its trees and blobs, and a clone can obtain the complete reachable object graph. That self-contained model is valuable for source code because the graph remains compact and Git can compress related objects effectively.
 
 Large binary history changes the economics of the same guarantee. Every clone, mirror, scan, and backup must account for the reachable objects. A shallow clone can narrow history for one client, but it does not change what the repository retains or what other workflows may need.
 
@@ -57,7 +57,7 @@ Teams may respond by separating code and data informally. A commit message names
 
 The missing contract is identity. A source commit should identify the exact data it consumes or produces. That relationship must survive renames, branch changes, storage lifecycle rules, and work on another machine.
 
-## A useful design must preserve four properties
+## A large-file path must preserve four properties
 
 Moving bytes out of Git solves only the first constraint. A practical large-file path also needs to preserve these properties:
 

--- a/packages/web/content/blog/xet-protocol-deduplication.mdx
+++ b/packages/web/content/blog/xet-protocol-deduplication.mdx
@@ -29,13 +29,9 @@ Fixed-size chunking divides a file every _n_ bytes. Insert one byte near the beg
 
 Content-defined chunking chooses boundaries from the byte stream itself. A local edit disturbs nearby boundaries, but stable regions later in the file tend to produce the same chunks as before.
 
-```text
-version A: [header][weights 1][weights 2][optimizer][footer]
-version B: [header][weights 1][new weights][optimizer][footer]
-reused:     header    weights 1               optimizer  footer
-```
+<ChunkReuseDiagram />
 
-This behavior matters for model checkpoints, database snapshots, archives, and media containers where a new version may share large regions with an earlier one.
+Boundary recovery creates reuse in model checkpoints, database snapshots, archives, and media containers that preserve large byte regions between versions.
 
 ## Boundary stability is local, not absolute
 
@@ -51,7 +47,7 @@ Smaller target chunks can isolate local edits and increase potential reuse. They
 
 Content-defined chunking therefore uses bounded sizes around a target rather than accepting an arbitrary boundary at every matching byte pattern. Minimum and maximum limits prevent pathological tiny chunks or unbounded regions.
 
-The right target is a repository-level engineering choice because file producers and access patterns differ. A checkpoint workload and a media archive may preserve byte regions at different scales.
+Choose the target size from the repository's file producers and access patterns. A checkpoint workload and a media archive may preserve byte regions at different scales.
 
 Crab's file identity does not depend on the chosen storage packing. Changing chunking policy for new files can affect reuse with earlier chunks, so policy changes need measurement and a migration rationale.
 
@@ -69,7 +65,7 @@ Hash identity is independent of compression. Crab can compress chunks inside xor
 
 A chunk hash answers whether two byte sequences are equal. It does not answer where the bytes are stored. Shard and chunk-index metadata connect the identity to an xorb and byte range.
 
-This distinction allows storage layout to change without changing file identity. A repack operation can place a chunk in a better xorb while the file recipe continues to name the same content hash.
+Separating identity from location lets storage layout change without changing file identity. A repack operation can place a chunk in a better xorb while the file recipe continues to name the same content hash.
 
 It also protects deletion. Garbage collection cannot treat an unknown location as proof that a chunk is unused. The collector must walk retained recipes and shard terms before classifying an object as unreachable.
 
@@ -91,7 +87,7 @@ The cheapest useful evidence should answer first, but each layer has a different
 
 A local hit can remove repeated CPU or disk work. It cannot authorize publication when canonical storage has no corresponding location. Push resolves that distinction before it omits a chunk upload.
 
-Negative lookup results also deserve care. A stale local metadata view may not know about a chunk published by another writer. Crab can refresh canonical state before classifying the chunk as new, which trades a lookup for an avoided duplicate upload.
+Treat a negative lookup as provisional. A stale local metadata view may not know about a chunk published by another writer. Crab can refresh canonical state before classifying the chunk as new, which trades one lookup for an avoided duplicate upload.
 
 ## Estimate the byte outcome before compression
 
@@ -115,7 +111,7 @@ Crab uses bounded xorb targets and can optimize layout later. The file contract 
 
 Packing happens after chunk classification. Reused chunks keep their proven locations, while new chunks accumulate into one or more xorb builders. Each completed xorb receives an immutable content identity before upload.
 
-The xorb boundary is an operational unit, not a file boundary. One xorb can contain chunks from several files, and one file can reference chunks across several xorbs created at different times. This arrangement improves reuse but means object deletion must follow reachability metadata rather than path naming.
+The xorb boundary is an operational unit, not a file boundary. One xorb can contain chunks from several files, and one file can reference chunks across several xorbs created at different times. Cross-file packing improves reuse, so object deletion must follow reachability metadata rather than path naming.
 
 Compression and packing also affect retry size. A bounded xorb limits how much work a failed upload repeats. The target must remain large enough to avoid turning every chunk into its own object-store request.
 
@@ -143,7 +139,7 @@ Recipes also preserve zero-length and boundary conditions explicitly through the
 
 Because content determines identity, reuse is not limited to adjacent commits. It can occur across renamed paths, copied assets, branches, and file versions, provided the repository metadata can prove that the chunk is already stored.
 
-The practical savings depend on the data. Encrypted or recompressed files may change most bytes even when their logical content changes little. Append-heavy snapshots and iterative checkpoints can preserve physical overlap across versions.
+Savings follow the encoded bytes, not the logical edit. Encrypted or recompressed files may change most bytes even when their logical content changes little. Append-heavy snapshots and iterative checkpoints can preserve physical overlap across versions.
 
 Consider three representative overlap patterns:
 

--- a/packages/web/mdx-components.tsx
+++ b/packages/web/mdx-components.tsx
@@ -17,6 +17,10 @@ import {
 import { GitArchitecturePlayer } from '@/components/blog/git-architecture-player';
 import { BlogProcessPlayer } from '@/components/blog/blog-process-player';
 import {
+  ChunkReuseDiagram,
+  GarbageCollectionReachabilityDiagram,
+} from '@/components/blog/blog-detail-diagrams';
+import {
   CacheHierarchyDiagram,
   CrabMentalModelDiagram,
   DedupPipelineDiagram,
@@ -113,6 +117,8 @@ export function getMDXComponents(components?: MDXComponents) {
     TakeawayBox,
     GitArchitecturePlayer,
     BlogProcessPlayer,
+    ChunkReuseDiagram,
+    GarbageCollectionReachabilityDiagram,
     CacheHierarchyDiagram,
     CrabMentalModelDiagram,
     DedupPipelineDiagram,


### PR DESCRIPTION
## Summary

Follow-up to #61's final content and diagram audit.

- replace the Xet ASCII sketch with a responsive SVG that distinguishes reused and changed chunk identities
- add a garbage-collection reachability SVG covering retained roots, inventory, grace-period protection, and deletion eligibility
- add a worked 6,000 GB storage-tier calculation with retrieval cost and transition payback
- tighten synthetic phrasing across the conceptual guides while preserving technical contracts

## Audit evidence

- all 16 posts retain at least one visual
- publication dates span May 1 through August 14, 2026
- affected pages rendered at 1440 px and 390 px
- all five new garbage-collection marker references resolve
- connector endpoints meet destination borders; no dangling arrowheads or line crossings
- SVGs remain inside horizontally scrollable mobile frames with visible guidance
- the worked cost table remains readable at mobile width
- corpus scan found no targeted filler terms, em dashes, or ellipses

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors; 17 existing warnings outside this change)
- `npm run test` (4 tests passed)
- `npm run check:links` (192 pages and 1,991 fragments)
- `npm run build` (230 static pages generated)
- `git diff --check`
