### PR TITLE
docs(web): restyle CLI SVG diagrams

### DIFF
--- a/packages/web/content/docs/cli/cache-service/cache-topology.svg
+++ b/packages/web/content/docs/cli/cache-service/cache-topology.svg
@@ -2,7 +2,7 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#475569"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
   </defs>
 
@@ -15,51 +15,51 @@
   </g>
 
   <g id="nodes">
-    <rect x="80"  y="110" width="180" height="70" rx="8" fill="#0EA5E9" stroke="#0369A1" stroke-width="2"/>
-    <rect x="310" y="110" width="180" height="70" rx="8" fill="#0EA5E9" stroke="#0369A1" stroke-width="2"/>
-    <rect x="540" y="110" width="180" height="70" rx="8" fill="#0EA5E9" stroke="#0369A1" stroke-width="2"/>
+    <rect x="80"  y="110" width="180" height="70" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="2"/>
+    <rect x="310" y="110" width="180" height="70" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="2"/>
+    <rect x="540" y="110" width="180" height="70" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="2"/>
 
-    <rect x="180" y="260" width="440" height="180" rx="10" fill="#1E293B" stroke="#0F172A" stroke-width="2"/>
+    <rect x="180" y="260" width="440" height="180" rx="10" fill="#F0F9FF" stroke="#0284C7" stroke-width="2"/>
 
-    <rect x="270" y="500" width="260" height="70" rx="8" fill="#475569" stroke="#1E293B" stroke-width="2"/>
+    <rect x="270" y="500" width="260" height="70" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="2"/>
   </g>
 
   <g id="labels">
-    <text x="400" y="36" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="bold" fill="#0F172A">Cache Service Topology</text>
+    <text x="400" y="36" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="bold" fill="#0F172A">Cache Service Topology</text>
 
-    <text x="55" y="92" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#0369A1">Crab clients</text>
+    <text x="55" y="92" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0284C7">Crab clients</text>
 
-    <text x="170" y="138" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">Developer</text>
-    <text x="170" y="160" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">workstation</text>
+    <text x="170" y="138" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Developer</text>
+    <text x="170" y="160" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">workstation</text>
 
-    <text x="400" y="138" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">CI</text>
-    <text x="400" y="160" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">runner</text>
+    <text x="400" y="138" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">CI</text>
+    <text x="400" y="160" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">runner</text>
 
-    <text x="630" y="138" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">CLI / clients</text>
-    <text x="630" y="160" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">client</text>
+    <text x="630" y="138" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">CLI / clients</text>
+    <text x="630" y="160" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">client</text>
 
-    <text x="400" y="294" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="bold" fill="#FFFFFF">crab-cache-server</text>
-    <text x="400" y="316" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" fill="#94A3B8">NVMe local disk · 1 TiB cache</text>
-    <text x="220" y="356" font-family="Arial, Helvetica, sans-serif" font-size="13" fill="#E0F2FE">• Caches xorbs, shards, packs</text>
-    <text x="220" y="382" font-family="Arial, Helvetica, sans-serif" font-size="13" fill="#E0F2FE">• Serves cross-repo dedup queries</text>
-    <text x="220" y="408" font-family="Arial, Helvetica, sans-serif" font-size="13" fill="#E0F2FE">• Push warming for new uploads</text>
+    <text x="400" y="294" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="bold" fill="#0F172A">crab-cache-server</text>
+    <text x="400" y="316" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#64748B">NVMe local disk · 1 TiB cache</text>
+    <text x="220" y="356" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#64748B">• Caches xorbs, shards, packs</text>
+    <text x="220" y="382" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#64748B">• Serves cross-repo dedup queries</text>
+    <text x="220" y="408" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#64748B">• Push warming for new uploads</text>
 
-    <text x="400" y="528" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">Origin object store</text>
-    <text x="400" y="550" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" fill="#CBD5E1">S3 · GCS · Azure Blob</text>
+    <text x="400" y="528" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Origin object store</text>
+    <text x="400" y="550" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#64748B">S3 · GCS · Azure Blob</text>
 
-    <text x="278" y="220" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">HTTPS</text>
-    <text x="400" y="220" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">HTTPS</text>
-    <text x="522" y="220" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">HTTPS</text>
+    <text x="278" y="220" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">HTTPS</text>
+    <text x="400" y="220" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">HTTPS</text>
+    <text x="522" y="220" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">HTTPS</text>
 
-    <text x="412" y="474" font-family="Arial, Helvetica, sans-serif" font-size="11" font-style="italic" fill="#475569">cache miss / origin probe</text>
+    <text x="412" y="474" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-style="italic" fill="#64748B">cache miss / origin probe</text>
   </g>
 
   <g id="connections">
-    <path d="M 170 182 L 170 230 L 278 230 L 278 258" fill="none" stroke="#475569" stroke-width="2" marker-end="url(#arrowhead)"/>
-    <line x1="400" y1="182" x2="400" y2="258" stroke="#475569" stroke-width="2" marker-end="url(#arrowhead)"/>
-    <path d="M 630 182 L 630 230 L 522 230 L 522 258" fill="none" stroke="#475569" stroke-width="2" marker-end="url(#arrowhead)"/>
+    <path d="M 170 182 L 170 230 L 278 230 L 278 258" fill="none" stroke="#64748B" stroke-width="2" marker-end="url(#arrowhead)"/>
+    <line x1="400" y1="182" x2="400" y2="258" stroke="#64748B" stroke-width="2" marker-end="url(#arrowhead)"/>
+    <path d="M 630 182 L 630 230 L 522 230 L 522 258" fill="none" stroke="#64748B" stroke-width="2" marker-end="url(#arrowhead)"/>
 
-    <line x1="400" y1="442" x2="400" y2="498" stroke="#475569" stroke-width="2" marker-end="url(#arrowhead)"/>
+    <line x1="400" y1="442" x2="400" y2="498" stroke="#64748B" stroke-width="2" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -2,28 +2,8 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="processGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="resultGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
-    <linearGradient id="errorGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#EF4444"/>
-      <stop offset="100%" stop-color="#DC2626"/>
-    </linearGradient>
-    <linearGradient id="decisionGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#CBD5E1"/>
-      <stop offset="100%" stop-color="#94A3B8"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -35,62 +15,62 @@
 
   <g id="nodes">
     <!-- crab hydrate -->
-    <rect x="220" y="30" width="180" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="220" y="30" width="180" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
     <!-- HEAD request -->
-    <rect x="200" y="120" width="220" height="50" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="200" y="120" width="220" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
     <!-- Storage class? diamond -->
-    <polygon points="310,210 410,255 310,300 210,255" fill="url(#decisionGrad)" stroke="#64748B" stroke-width="1.5"/>
+    <polygon points="310,210 410,255 310,300 210,255" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
     <!-- Read immediately (Warm) -->
-    <rect x="60" y="330" width="180" height="50" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="60" y="330" width="180" height="50" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <!-- auto_restore? diamond (Archive) -->
-    <polygon points="460,330 560,375 460,420 360,375" fill="url(#decisionGrad)" stroke="#64748B" stroke-width="1.5"/>
+    <polygon points="460,330 560,375 460,420 360,375" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
     <!-- Issue restore request (Yes) -->
-    <rect x="360" y="450" width="200" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="360" y="450" width="200" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
     <!-- Error (No) -->
-    <rect x="100" y="450" width="220" height="50" rx="8" fill="url(#errorGrad)" stroke="#DC2626" stroke-width="1.5"/>
+    <rect x="100" y="450" width="220" height="50" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
     <!-- Poll until ready -->
-    <rect x="360" y="530" width="200" height="50" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="360" y="530" width="200" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
-    <text x="310" y="60" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">crab hydrate</text>
-    <text x="310" y="150" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">HEAD request for xorb</text>
-    <text x="310" y="252" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#1E293B">Storage class?</text>
+    <text x="310" y="60" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab hydrate</text>
+    <text x="310" y="150" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">HEAD request for xorb</text>
+    <text x="310" y="252" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Storage class?</text>
 
     <!-- Branch labels -->
-    <text x="155" y="310" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Warm</text>
-    <text x="430" y="310" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#64748B">Archive</text>
+    <text x="155" y="310" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Warm</text>
+    <text x="430" y="310" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B">Archive</text>
 
-    <text x="150" y="360" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#F1F5F9">Read immediately</text>
+    <text x="150" y="360" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Read immediately</text>
 
-    <text x="460" y="372" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#1E293B">auto_restore?</text>
+    <text x="460" y="372" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">auto_restore?</text>
 
     <!-- auto_restore branches -->
-    <text x="500" y="430" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Yes</text>
-    <text x="330" y="430" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#DC2626">No</text>
+    <text x="500" y="430" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Yes</text>
+    <text x="330" y="430" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#F59E0B">No</text>
 
-    <text x="460" y="480" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Issue restore request</text>
-    <text x="210" y="480" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">ArchiveRestoreRequired error</text>
-    <text x="460" y="560" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">Poll until ready</text>
+    <text x="460" y="480" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Issue restore request</text>
+    <text x="210" y="480" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">ArchiveRestoreRequired error</text>
+    <text x="460" y="560" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Poll until ready</text>
   </g>
 
   <g id="connections">
     <!-- hydrate → HEAD -->
-    <line x1="310" y1="80" x2="310" y2="120" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="310" y1="80" x2="310" y2="120" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- HEAD → Storage class? -->
-    <line x1="310" y1="170" x2="310" y2="210" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="310" y1="170" x2="310" y2="210" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Storage class → Read (Warm, left) -->
-    <path d="M 210 255 L 150 255 L 150 330" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 210 255 L 150 255 L 150 330" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Storage class → auto_restore? (Archive, right) -->
-    <path d="M 410 255 L 460 255 L 460 330" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 410 255 L 460 255 L 460 330" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- auto_restore → Restore (Yes, down) -->
-    <line x1="460" y1="420" x2="460" y2="450" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="460" y1="420" x2="460" y2="450" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- auto_restore → Error (No, left) -->
-    <path d="M 360 375 L 210 375 L 210 450" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 360 375 L 210 375 L 210 450" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Restore → Poll -->
-    <line x1="460" y1="500" x2="460" y2="530" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="460" y1="500" x2="460" y2="530" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Poll → Read -->
-    <path d="M 360 555 L 150 555 L 150 380" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 360 555 L 150 555 L 150 380" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/integrity-check-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/integrity-check-flow.svg
@@ -2,20 +2,8 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="checkGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="chainGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -29,58 +17,58 @@
 
   <g id="nodes">
     <!-- crab fsck -->
-    <rect x="280" y="30" width="160" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="280" y="30" width="160" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
 
     <!-- Check items (row) -->
-    <rect x="40" y="130" width="150" height="46" rx="8" fill="url(#checkGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="210" y="130" width="150" height="46" rx="8" fill="url(#checkGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="380" y="130" width="150" height="46" rx="8" fill="url(#checkGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="550" y="130" width="150" height="46" rx="8" fill="url(#checkGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="40" y="130" width="150" height="46" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <rect x="210" y="130" width="150" height="46" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <rect x="380" y="130" width="150" height="46" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <rect x="550" y="130" width="150" height="46" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
 
     <!-- Data chain (inside container) -->
-    <rect x="60" y="300" width="180" height="50" rx="8" fill="url(#chainGrad)" stroke="#0F172A" stroke-width="1.5"/>
-    <rect x="280" y="300" width="180" height="50" rx="8" fill="url(#chainGrad)" stroke="#0F172A" stroke-width="1.5"/>
-    <rect x="500" y="300" width="160" height="50" rx="8" fill="url(#chainGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="60" y="300" width="180" height="50" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="280" y="300" width="180" height="50" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="500" y="300" width="160" height="50" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- crab fsck -->
-    <text x="360" y="60" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">crab fsck</text>
+    <text x="360" y="60" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab fsck</text>
 
     <!-- Check items -->
-    <text x="115" y="158" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Check git refs</text>
-    <text x="285" y="158" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Verify pack list</text>
-    <text x="455" y="158" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Check push locks</text>
-    <text x="625" y="152" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Find abandoned</text>
-    <text x="625" y="168" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">uploads</text>
+    <text x="115" y="158" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Check git refs</text>
+    <text x="285" y="158" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Verify pack list</text>
+    <text x="455" y="158" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Check push locks</text>
+    <text x="625" y="152" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Find abandoned</text>
+    <text x="625" y="168" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">uploads</text>
 
     <!-- Container label -->
-    <text x="50" y="283" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#0284C7" letter-spacing="0.5">WALK DATA CHAIN</text>
+    <text x="50" y="283" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7" letter-spacing="0.5">WALK DATA CHAIN</text>
 
     <!-- Chain items -->
-    <text x="150" y="320" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">Pointer →</text>
-    <text x="150" y="338" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">File Index</text>
+    <text x="150" y="320" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Pointer →</text>
+    <text x="150" y="338" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">File Index</text>
 
-    <text x="370" y="320" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">File Index →</text>
-    <text x="370" y="338" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">Shard</text>
+    <text x="370" y="320" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">File Index →</text>
+    <text x="370" y="338" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">Shard</text>
 
-    <text x="580" y="320" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">Shard →</text>
-    <text x="580" y="338" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">Xorb</text>
+    <text x="580" y="320" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Shard →</text>
+    <text x="580" y="338" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">Xorb</text>
   </g>
 
   <g id="connections">
     <!-- fsck → checks (fan out) -->
-    <path d="M 310 80 L 310 100 L 115 100 L 115 130" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <path d="M 340 80 L 340 100 L 285 100 L 285 130" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <path d="M 380 80 L 380 100 L 455 100 L 455 130" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <path d="M 410 80 L 410 100 L 625 100 L 625 130" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 310 80 L 310 100 L 115 100 L 115 130" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 340 80 L 340 100 L 285 100 L 285 130" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 380 80 L 380 100 L 455 100 L 455 130" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 410 80 L 410 100 L 625 100 L 625 130" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- fsck → data chain container -->
-    <path d="M 360 80 L 360 100 L 360 200 L 150 200 L 150 300" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 360 80 L 360 100 L 360 200 L 150 200 L 150 300" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- Chain connections -->
-    <line x1="240" y1="325" x2="280" y2="325" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="460" y1="325" x2="500" y2="325" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="240" y1="325" x2="280" y2="325" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="460" y1="325" x2="500" y2="325" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/metadata-database-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/metadata-database-flow.svg
@@ -2,23 +2,11 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
     <marker id="arrowhead-dashed" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
       <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="dbGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="storeGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -27,63 +15,63 @@
 
   <g id="containers">
     <!-- Local Cache container -->
-    <rect x="380" y="300" width="280" height="170" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+    <rect x="380" y="300" width="280" height="170" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
   </g>
 
   <g id="nodes">
     <!-- Commands -->
-    <rect x="40" y="40" width="150" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="40" y="140" width="150" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="40" y="40" width="150" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="40" y="140" width="150" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
 
     <!-- Databases -->
-    <rect x="260" y="40" width="220" height="56" rx="8" fill="url(#dbGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="260" y="140" width="220" height="56" rx="8" fill="url(#dbGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="260" y="40" width="220" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="260" y="140" width="220" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
 
     <!-- Storage -->
-    <rect x="540" y="40" width="130" height="56" rx="8" fill="url(#storeGrad)" stroke="#0F172A" stroke-width="1.5"/>
-    <rect x="540" y="140" width="130" height="56" rx="8" fill="url(#storeGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="540" y="40" width="130" height="56" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="540" y="140" width="130" height="56" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
 
     <!-- Local Cache items -->
-    <rect x="405" y="335" width="180" height="44" rx="8" fill="url(#dbGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="405" y="410" width="180" height="44" rx="8" fill="url(#storeGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="405" y="335" width="180" height="44" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="405" y="410" width="180" height="44" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- Commands -->
-    <text x="115" y="70" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">crab push</text>
-    <text x="115" y="170" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">crab hydrate</text>
+    <text x="115" y="70" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab push</text>
+    <text x="115" y="170" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab hydrate</text>
 
     <!-- Databases -->
-    <text x="370" y="62" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">File Index DB</text>
-    <text x="370" y="80" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">(file_hash → shard_hash)</text>
+    <text x="370" y="62" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">File Index DB</text>
+    <text x="370" y="80" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(file_hash → shard_hash)</text>
 
-    <text x="370" y="162" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Chunk Index DB</text>
-    <text x="370" y="180" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">(chunk_hash → xorb_ref)</text>
+    <text x="370" y="162" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Chunk Index DB</text>
+    <text x="370" y="180" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(chunk_hash → xorb_ref)</text>
 
     <!-- Storage -->
-    <text x="605" y="62" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#F1F5F9">Shards</text>
-    <text x="605" y="78" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" fill="#94A3B8">.crab/shards/</text>
+    <text x="605" y="62" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">Shards</text>
+    <text x="605" y="78" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">.crab/shards/</text>
 
-    <text x="605" y="162" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#F1F5F9">Xorbs</text>
-    <text x="605" y="178" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" fill="#94A3B8">.crab/xorbs/</text>
+    <text x="605" y="162" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">Xorbs</text>
+    <text x="605" y="178" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">.crab/xorbs/</text>
 
     <!-- Local Cache -->
-    <text x="400" y="318" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#64748B" letter-spacing="0.5">LOCAL CACHE</text>
-    <text x="495" y="362" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">In-memory LRU</text>
-    <text x="495" y="437" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">SQLite file</text>
+    <text x="400" y="318" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B" letter-spacing="0.5">LOCAL CACHE</text>
+    <text x="495" y="362" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">In-memory LRU</text>
+    <text x="495" y="437" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">SQLite file</text>
   </g>
 
   <g id="connections">
     <!-- crab push → File Index -->
-    <line x1="190" y1="55" x2="260" y2="60" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="190" y1="55" x2="260" y2="60" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- crab push → Chunk Index -->
-    <path d="M 190 75 L 225 75 L 225 165 L 260 165" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 190 75 L 225 75 L 225 165 L 260 165" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- crab hydrate → File Index -->
-    <path d="M 190 155 L 225 155 L 225 75 L 260 75" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 190 155 L 225 155 L 225 75 L 260 75" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- File Index → Shards -->
-    <line x1="480" y1="68" x2="540" y2="68" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="480" y1="68" x2="540" y2="68" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Chunk Index → Xorbs -->
-    <line x1="480" y1="168" x2="540" y2="168" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="480" y1="168" x2="540" y2="168" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Chunk Index → Memory (dashed) -->
     <path d="M 370 196 L 370 250 L 495 250 L 495 330" fill="none" stroke="#64748B" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowhead-dashed)"/>
     <!-- Memory → SQLite (dashed) -->

--- a/packages/web/content/docs/cli/diagnostics/recovery-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/recovery-flow.svg
@@ -2,24 +2,8 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="processGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="resultGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
-    <linearGradient id="decisionGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#CBD5E1"/>
-      <stop offset="100%" stop-color="#94A3B8"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -31,55 +15,55 @@
 
   <g id="nodes">
     <!-- Crash -->
-    <rect x="240" y="30" width="200" height="50" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="240" y="30" width="200" height="50" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <!-- Markers -->
-    <rect x="210" y="120" width="260" height="50" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="210" y="120" width="260" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
     <!-- Next push -->
-    <rect x="240" y="210" width="200" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="240" y="210" width="200" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
     <!-- Recovery scan -->
-    <rect x="240" y="300" width="200" height="50" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="240" y="300" width="200" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
     <!-- Marker state? diamond -->
-    <polygon points="340,390 460,435 340,480 220,435" fill="url(#decisionGrad)" stroke="#64748B" stroke-width="1.5"/>
+    <polygon points="340,390 460,435 340,480 220,435" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
     <!-- Clean marker -->
-    <rect x="60" y="510" width="160" height="50" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="60" y="510" width="160" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
     <!-- Clean stale -->
-    <rect x="260" y="510" width="160" height="50" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="260" y="510" width="160" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
     <!-- Retry upload -->
-    <rect x="460" y="510" width="160" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="460" y="510" width="160" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
-    <text x="340" y="60" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#F1F5F9">Push interrupted</text>
-    <text x="340" y="150" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">Inflight markers left in store</text>
-    <text x="340" y="240" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">Next push starts</text>
-    <text x="340" y="330" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">Recovery scan</text>
-    <text x="340" y="432" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#1E293B">Marker state?</text>
+    <text x="340" y="60" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Push interrupted</text>
+    <text x="340" y="150" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Inflight markers left in store</text>
+    <text x="340" y="240" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Next push starts</text>
+    <text x="340" y="330" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Recovery scan</text>
+    <text x="340" y="432" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Marker state?</text>
 
     <!-- Branch labels -->
-    <text x="140" y="488" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#64748B">Committed</text>
-    <text x="340" y="488" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#64748B">Stale</text>
-    <text x="540" y="488" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Live</text>
+    <text x="140" y="488" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B">Committed</text>
+    <text x="340" y="488" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B">Stale</text>
+    <text x="540" y="488" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Live</text>
 
-    <text x="140" y="540" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Clean marker</text>
-    <text x="340" y="540" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Clean stale marker</text>
-    <text x="540" y="540" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Retry upload</text>
+    <text x="140" y="540" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Clean marker</text>
+    <text x="340" y="540" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Clean stale marker</text>
+    <text x="540" y="540" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Retry upload</text>
   </g>
 
   <g id="connections">
     <!-- Crash → Markers -->
-    <line x1="340" y1="80" x2="340" y2="120" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="340" y1="80" x2="340" y2="120" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Markers → Next push -->
-    <line x1="340" y1="170" x2="340" y2="210" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="340" y1="170" x2="340" y2="210" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Next push → Recovery scan -->
-    <line x1="340" y1="260" x2="340" y2="300" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="340" y1="260" x2="340" y2="300" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Recovery scan → Diamond -->
-    <line x1="340" y1="350" x2="340" y2="390" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="340" y1="350" x2="340" y2="390" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Diamond → Clean (Committed, left) -->
-    <path d="M 220 435 L 140 435 L 140 510" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 220 435 L 140 435 L 140 510" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Diamond → Clean stale (Stale, down) -->
-    <line x1="340" y1="480" x2="340" y2="510" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="340" y1="480" x2="340" y2="510" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
     <!-- Diamond → Retry (Live, right) -->
-    <path d="M 460 435 L 540 435 L 540 510" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 460 435 L 540 435 L 540 510" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/file-inspection/disk-usage-flow.svg
+++ b/packages/web/content/docs/cli/file-inspection/disk-usage-flow.svg
@@ -2,23 +2,11 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
     <marker id="arrowhead-dashed" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
       <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="localGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="remoteGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="resultGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -27,54 +15,54 @@
 
   <g id="containers">
     <!-- Local Disk container -->
-    <rect x="30" y="40" width="280" height="300" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+    <rect x="30" y="40" width="280" height="300" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- Cloud Storage container -->
-    <rect x="30" y="40" width="280" height="300" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+    <rect x="30" y="40" width="280" height="300" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
     <rect x="430" y="40" width="280" height="120" rx="12" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
   </g>
 
   <g id="nodes">
     <!-- Local items -->
-    <rect x="55" y="85" width="230" height="56" rx="8" fill="url(#localGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="55" y="165" width="230" height="56" rx="8" fill="url(#localGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="55" y="245" width="230" height="56" rx="8" fill="url(#localGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="55" y="85" width="230" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="55" y="165" width="230" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="55" y="245" width="230" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
 
     <!-- Remote item -->
-    <rect x="455" y="85" width="230" height="56" rx="8" fill="url(#remoteGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="455" y="85" width="230" height="56" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
 
     <!-- Result boxes -->
-    <rect x="455" y="220" width="180" height="50" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
-    <rect x="455" y="300" width="180" height="50" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="455" y="220" width="180" height="50" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <rect x="455" y="300" width="180" height="50" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- Container titles -->
-    <text x="50" y="65" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">LOCAL DISK</text>
-    <text x="450" y="65" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#0284C7" letter-spacing="0.5">CLOUD STORAGE</text>
+    <text x="50" y="65" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">LOCAL DISK</text>
+    <text x="450" y="65" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0284C7" letter-spacing="0.5">CLOUD STORAGE</text>
 
     <!-- Local items -->
-    <text x="170" y="108" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">Working Tree</text>
-    <text x="170" y="126" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">(hydrated files)</text>
+    <text x="170" y="108" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Working Tree</text>
+    <text x="170" y="126" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(hydrated files)</text>
 
-    <text x="170" y="188" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">Staging Area</text>
-    <text x="170" y="206" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">(.crab/staging/)</text>
+    <text x="170" y="188" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Staging Area</text>
+    <text x="170" y="206" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(.crab/staging/)</text>
 
-    <text x="170" y="268" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">Local Cache</text>
-    <text x="170" y="286" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">(~/.cache/crab/)</text>
+    <text x="170" y="268" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Local Cache</text>
+    <text x="170" y="286" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(~/.cache/crab/)</text>
 
     <!-- Remote item -->
-    <text x="570" y="108" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">Xorbs + Shards</text>
-    <text x="570" y="126" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#E0F2FE">(permanent)</text>
+    <text x="570" y="108" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Xorbs + Shards</text>
+    <text x="570" y="126" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(permanent)</text>
 
     <!-- Result labels -->
-    <text x="545" y="250" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#F1F5F9">Free space</text>
-    <text x="545" y="330" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#F1F5F9">Reduce cloud costs</text>
+    <text x="545" y="250" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Free space</text>
+    <text x="545" y="330" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Reduce cloud costs</text>
 
     <!-- Arrow labels -->
-    <text x="370" y="100" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" fill="#475569">crab dehydrate</text>
-    <text x="370" y="185" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" fill="#475569">crab staging clean</text>
-    <text x="370" y="265" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" fill="#475569">crab prune</text>
-    <text x="570" y="168" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" fill="#475569">crab gc</text>
+    <text x="370" y="100" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">crab dehydrate</text>
+    <text x="370" y="185" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">crab staging clean</text>
+    <text x="370" y="265" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">crab prune</text>
+    <text x="570" y="168" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">crab gc</text>
   </g>
 
   <g id="connections">

--- a/packages/web/content/docs/cli/file-inspection/file-status-flow.svg
+++ b/packages/web/content/docs/cli/file-inspection/file-status-flow.svg
@@ -2,23 +2,11 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
     <marker id="arrowhead-dashed" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#94A3B8"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="pointerGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="hydratedGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="modifiedGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -30,51 +18,51 @@
 
   <g id="nodes">
     <!-- Pointer state (left) -->
-    <rect x="40" y="110" width="170" height="70" rx="8" fill="url(#pointerGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="40" y="110" width="170" height="70" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
     <!-- Hydrated state (center) -->
-    <rect x="290" y="110" width="170" height="70" rx="8" fill="url(#hydratedGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="290" y="110" width="170" height="70" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <!-- Modified state (right) -->
-    <rect x="540" y="110" width="170" height="70" rx="8" fill="url(#modifiedGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="540" y="110" width="170" height="70" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- Pointer label -->
-    <text x="125" y="140" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">Pointer</text>
-    <text x="125" y="160" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">(128 bytes)</text>
+    <text x="125" y="140" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Pointer</text>
+    <text x="125" y="160" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(128 bytes)</text>
 
     <!-- Hydrated label -->
-    <text x="375" y="140" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">Hydrated</text>
-    <text x="375" y="160" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#E0F2FE">(full content)</text>
+    <text x="375" y="140" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Hydrated</text>
+    <text x="375" y="160" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(full content)</text>
 
     <!-- Modified label -->
-    <text x="625" y="140" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#F1F5F9">Modified</text>
-    <text x="625" y="160" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">(uncommitted changes)</text>
+    <text x="625" y="140" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Modified</text>
+    <text x="625" y="160" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(uncommitted changes)</text>
 
     <!-- Arrow labels -->
-    <text x="245" y="108" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">crab hydrate</text>
-    <text x="245" y="200" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#64748B">crab dehydrate</text>
-    <text x="490" y="108" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#475569">edit file</text>
-    <text x="490" y="200" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">crab add + commit</text>
+    <text x="245" y="108" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">crab hydrate</text>
+    <text x="245" y="200" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B">crab dehydrate</text>
+    <text x="490" y="108" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B">edit file</text>
+    <text x="490" y="200" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">crab add + commit</text>
 
     <!-- Self-loop label -->
-    <text x="625" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">dehydrate blocked</text>
+    <text x="625" y="260" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">dehydrate blocked</text>
   </g>
 
   <g id="connections">
     <!-- Pointer → Hydrated (top arrow, right) -->
-    <line x1="210" y1="125" x2="290" y2="125" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="210" y1="125" x2="290" y2="125" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- Hydrated → Pointer (bottom arrow, left) -->
-    <line x1="290" y1="165" x2="210" y2="165" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="290" y1="165" x2="210" y2="165" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- Hydrated → Modified (top arrow, right) -->
-    <line x1="460" y1="125" x2="540" y2="125" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="460" y1="125" x2="540" y2="125" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- Modified → Hydrated (bottom arrow, left) -->
-    <line x1="540" y1="165" x2="460" y2="165" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="540" y1="165" x2="460" y2="165" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- Modified → Modified (self-loop, dashed) -->
-    <path d="M 660 180 L 660 235 L 590 235 L 590 180" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowhead-dashed)"/>
+    <path d="M 660 180 L 660 235 L 590 235 L 590 180" fill="none" stroke="#64748B" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowhead-dashed)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/getting-started/clone-hydrate-flow.svg
+++ b/packages/web/content/docs/cli/getting-started/clone-hydrate-flow.svg
@@ -2,20 +2,8 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="processGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="resultGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -24,60 +12,60 @@
 
   <g id="containers">
     <!-- Clone phase background -->
-    <rect x="30" y="50" width="760" height="110" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1"/>
+    <rect x="30" y="50" width="760" height="110" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
     <!-- Hydrate phase background -->
     <rect x="30" y="190" width="760" height="110" rx="12" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1"/>
   </g>
 
   <g id="nodes">
     <!-- Row 1: Clone phase -->
-    <rect x="50" y="72" width="210" height="56" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="310" y="72" width="210" height="56" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="570" y="72" width="200" height="56" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="50" y="72" width="210" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="310" y="72" width="210" height="56" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <rect x="570" y="72" width="200" height="56" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
 
     <!-- Row 2: Hydrate phase -->
-    <rect x="50" y="212" width="210" height="56" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="310" y="212" width="210" height="56" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="570" y="212" width="200" height="56" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="50" y="212" width="210" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="310" y="212" width="210" height="56" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <rect x="570" y="212" width="200" height="56" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- Phase labels -->
-    <text x="50" y="42" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">CLONE</text>
-    <text x="50" y="182" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#0284C7" letter-spacing="0.5">HYDRATE</text>
+    <text x="50" y="42" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">CLONE</text>
+    <text x="50" y="182" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0284C7" letter-spacing="0.5">HYDRATE</text>
 
     <!-- Row 1 labels -->
-    <text x="155" y="95" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">crab clone</text>
-    <text x="155" y="112" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#E0F2FE">crab://bucket/repo</text>
+    <text x="155" y="95" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">crab clone</text>
+    <text x="155" y="112" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">crab://bucket/repo</text>
 
-    <text x="415" y="95" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Download git objects</text>
-    <text x="415" y="112" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">commits, trees, pointers</text>
+    <text x="415" y="95" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Download git objects</text>
+    <text x="415" y="112" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">commits, trees, pointers</text>
 
-    <text x="670" y="95" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">Working tree has</text>
-    <text x="670" y="112" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">pointer blobs only</text>
+    <text x="670" y="95" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Working tree has</text>
+    <text x="670" y="112" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">pointer blobs only</text>
 
     <!-- Row 2 labels -->
-    <text x="155" y="235" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">crab hydrate</text>
-    <text x="155" y="252" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#E0F2FE">'*.bin'</text>
+    <text x="155" y="235" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">crab hydrate</text>
+    <text x="155" y="252" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">'*.bin'</text>
 
-    <text x="415" y="235" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Download chunks</text>
-    <text x="415" y="252" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">from cloud storage</text>
+    <text x="415" y="235" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Download chunks</text>
+    <text x="415" y="252" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">from cloud storage</text>
 
-    <text x="670" y="235" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">Reconstruct</text>
-    <text x="670" y="252" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">full files</text>
+    <text x="670" y="235" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Reconstruct</text>
+    <text x="670" y="252" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">full files</text>
   </g>
 
   <g id="connections">
     <!-- Row 1 arrows -->
-    <line x1="260" y1="100" x2="310" y2="100" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="520" y1="100" x2="570" y2="100" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="260" y1="100" x2="310" y2="100" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="520" y1="100" x2="570" y2="100" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- Vertical connector from row 1 result to row 2 start -->
-    <path d="M 670 128 L 670 165 L 155 165 L 155 212" fill="none" stroke="#334155" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#arrowhead)"/>
+    <path d="M 670 128 L 670 165 L 155 165 L 155 212" fill="none" stroke="#64748B" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#arrowhead)"/>
 
     <!-- Row 2 arrows -->
-    <line x1="260" y1="240" x2="310" y2="240" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="520" y1="240" x2="570" y2="240" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="260" y1="240" x2="310" y2="240" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="520" y1="240" x2="570" y2="240" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/getting-started/git-crab-integration.svg
+++ b/packages/web/content/docs/cli/getting-started/git-crab-integration.svg
@@ -1,25 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 520" width="920" height="520">
 
   <defs>
-    <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+    <marker id="arrowhead" viewBox="0 0 10 10" markerWidth="8" markerHeight="8" refX="9" refY="5" orient="auto">
+      <path d="M1 1 9 5 1 9 3.5 5Z" fill="#64748B"/>
     </marker>
-    <linearGradient id="gitGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="filterGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#CBD5E1"/>
-      <stop offset="100%" stop-color="#94A3B8"/>
-    </linearGradient>
-    <linearGradient id="crabGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="outputGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -27,59 +11,59 @@
   </g>
 
   <g id="containers">
-    <rect x="40" y="90" width="380" height="390" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
-    <rect x="460" y="170" width="240" height="310" rx="12" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
+    <rect x="40" y="90" width="380" height="390" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
+    <rect x="460" y="170" width="240" height="310" rx="12" fill="#FFFFFF" stroke="#BAE6FD" stroke-width="1.5"/>
   </g>
 
   <g id="nodes">
-    <rect x="70"  y="160" width="160" height="50" rx="8" fill="url(#gitGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="70"  y="270" width="160" height="50" rx="8" fill="url(#gitGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="70"  y="380" width="160" height="50" rx="8" fill="url(#gitGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="70"  y="160" width="160" height="50" rx="10" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="70"  y="270" width="160" height="50" rx="10" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="70"  y="380" width="160" height="50" rx="10" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
 
-    <rect x="280" y="160" width="120" height="50" rx="8" fill="url(#filterGrad)" stroke="#64748B" stroke-width="1.5"/>
-    <rect x="280" y="270" width="120" height="50" rx="8" fill="url(#filterGrad)" stroke="#64748B" stroke-width="1.5"/>
-    <rect x="280" y="380" width="120" height="50" rx="8" fill="url(#filterGrad)" stroke="#64748B" stroke-width="1.5"/>
+    <rect x="280" y="160" width="120" height="50" rx="10" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <rect x="280" y="270" width="120" height="50" rx="10" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <rect x="280" y="380" width="120" height="50" rx="10" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
 
-    <rect x="480" y="270" width="200" height="50" rx="8" fill="url(#crabGrad)" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="480" y="380" width="200" height="50" rx="8" fill="url(#crabGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="480" y="270" width="200" height="50" rx="10" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="480" y="380" width="200" height="50" rx="10" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
 
-    <rect x="740" y="270" width="140" height="50" rx="8" fill="url(#outputGrad)" stroke="#0F172A" stroke-width="1.5"/>
-    <rect x="740" y="380" width="140" height="50" rx="8" fill="url(#outputGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="740" y="270" width="140" height="50" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <rect x="740" y="380" width="140" height="50" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
-    <text x="460" y="50" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="bold" fill="#0F172A">How Crab Integrates with Git</text>
+    <text x="460" y="50" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="650" fill="#0F172A">How Crab Integrates with Git</text>
 
-    <text x="60" y="130" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">GIT OPERATIONS</text>
-    <text x="480" y="210" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#0284C7" letter-spacing="0.5">CRAB BINARY</text>
+    <text x="60" y="130" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="650" fill="#64748B" letter-spacing="0.5">GIT OPERATIONS</text>
+    <text x="480" y="210" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="650" fill="#0284C7" letter-spacing="0.5">CRAB BINARY</text>
 
-    <text x="150" y="190" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">git add / commit</text>
-    <text x="150" y="300" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">git checkout</text>
-    <text x="150" y="410" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">git push / fetch</text>
+    <text x="150" y="190" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="650" fill="#0F172A">git add / commit</text>
+    <text x="150" y="300" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="650" fill="#0F172A">git checkout</text>
+    <text x="150" y="410" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="650" fill="#0F172A">git push / fetch</text>
 
-    <text x="340" y="190" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#1E293B">Clean</text>
-    <text x="340" y="300" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#1E293B">Smudge</text>
-    <text x="340" y="410" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#1E293B">Remote</text>
+    <text x="340" y="190" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="650" fill="#0F172A">Clean</text>
+    <text x="340" y="300" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="650" fill="#0F172A">Smudge</text>
+    <text x="340" y="410" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="650" fill="#0F172A">Remote</text>
 
-    <text x="580" y="300" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">crab filter-process</text>
-    <text x="580" y="410" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">git-remote-crab</text>
+    <text x="580" y="300" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="650" fill="#0F172A">crab filter-process</text>
+    <text x="580" y="410" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="650" fill="#0F172A">git-remote-crab</text>
 
-    <text x="810" y="290" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">Chunks +</text>
-    <text x="810" y="306" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">Pointers</text>
-    <text x="810" y="410" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">Cloud Storage</text>
+    <text x="810" y="290" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="650" fill="#0F172A">Chunks +</text>
+    <text x="810" y="306" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="650" fill="#0F172A">Pointers</text>
+    <text x="810" y="410" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="650" fill="#0F172A">Cloud Storage</text>
   </g>
 
   <g id="connections">
-    <line x1="230" y1="185" x2="280" y2="185" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="230" y1="295" x2="280" y2="295" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="230" y1="405" x2="280" y2="405" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="230" y1="185" x2="280" y2="185" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="230" y1="295" x2="280" y2="295" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="230" y1="405" x2="280" y2="405" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
-    <path d="M 340 210 L 340 235 L 580 235 L 580 270" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="400" y1="295" x2="480" y2="295" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="400" y1="405" x2="480" y2="405" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 340 210 L 340 235 L 580 235 L 580 270" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="400" y1="295" x2="480" y2="295" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="400" y1="405" x2="480" y2="405" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
-    <line x1="680" y1="295" x2="740" y2="295" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="680" y1="405" x2="740" y2="405" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="680" y1="295" x2="740" y2="295" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="680" y1="405" x2="740" y2="405" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/getting-started/import-flow.svg
+++ b/packages/web/content/docs/cli/getting-started/import-flow.svg
@@ -2,16 +2,8 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="sourceGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="targetGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -20,41 +12,41 @@
 
   <g id="containers">
     <!-- Source bucket container -->
-    <rect x="30" y="40" width="280" height="170" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+    <rect x="30" y="40" width="280" height="170" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- Target repo container -->
     <rect x="430" y="40" width="280" height="170" rx="12" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
   </g>
 
   <g id="nodes">
     <!-- Source file listing box -->
-    <rect x="55" y="90" width="230" height="100" rx="8" fill="url(#sourceGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="55" y="90" width="230" height="100" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
     <!-- Target description box -->
-    <rect x="455" y="90" width="230" height="100" rx="8" fill="url(#targetGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="455" y="90" width="230" height="100" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- Container titles -->
-    <text x="50" y="68" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">EXISTING BUCKET</text>
-    <text x="450" y="68" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#0284C7" letter-spacing="0.5">CRAB REPOSITORY</text>
+    <text x="50" y="68" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">EXISTING BUCKET</text>
+    <text x="450" y="68" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0284C7" letter-spacing="0.5">CRAB REPOSITORY</text>
 
     <!-- Source content (left-aligned file tree) -->
-    <text x="75" y="118" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#F1F5F9">s3://data-lake/models/</text>
-    <text x="75" y="140" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">├── weights.bin</text>
-    <text x="75" y="158" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">├── embeddings.bin</text>
-    <text x="75" y="176" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">└── config.json</text>
+    <text x="75" y="118" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">s3://data-lake/models/</text>
+    <text x="75" y="140" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">├── weights.bin</text>
+    <text x="75" y="158" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">├── embeddings.bin</text>
+    <text x="75" y="176" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">└── config.json</text>
 
     <!-- Target content -->
-    <text x="570" y="125" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#FFFFFF">Git repo with pointers</text>
-    <text x="570" y="148" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#E0F2FE">+ .crab/ metadata</text>
-    <text x="570" y="168" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#E0F2FE">+ xorbs in cloud</text>
+    <text x="570" y="125" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Git repo with pointers</text>
+    <text x="570" y="148" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">+ .crab/ metadata</text>
+    <text x="570" y="168" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">+ xorbs in cloud</text>
 
     <!-- Arrow label -->
-    <text x="380" y="128" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">crab import</text>
+    <text x="380" y="128" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">crab import</text>
   </g>
 
   <g id="connections">
     <!-- Source → Target -->
-    <line x1="285" y1="140" x2="455" y2="140" stroke="#334155" stroke-width="2" marker-end="url(#arrowhead)"/>
+    <line x1="285" y1="140" x2="455" y2="140" stroke="#64748B" stroke-width="2" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/getting-started/mirror-mode-flow.svg
+++ b/packages/web/content/docs/cli/getting-started/mirror-mode-flow.svg
@@ -2,20 +2,8 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="storageGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
-    <linearGradient id="gitGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -24,7 +12,7 @@
 
   <g id="containers">
     <!-- Developer Workstation container -->
-    <rect x="40" y="40" width="600" height="440" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+    <rect x="40" y="40" width="600" height="440" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
   </g>
 
   <g id="nodes">
@@ -32,57 +20,57 @@
     <rect x="80" y="80" width="280" height="44" rx="22" fill="#E0F2FE" stroke="#BAE6FD" stroke-width="1"/>
 
     <!-- crab push box -->
-    <rect x="120" y="230" width="160" height="56" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="120" y="230" width="160" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
 
     <!-- S3 Bucket box -->
-    <rect x="420" y="230" width="160" height="56" rx="8" fill="url(#storageGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="420" y="230" width="160" height="56" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
 
     <!-- GitHub box -->
-    <rect x="120" y="380" width="160" height="56" rx="8" fill="url(#gitGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="120" y="380" width="160" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- Container title -->
-    <text x="60" y="62" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">DEVELOPER WORKSTATION</text>
+    <text x="60" y="62" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#64748B" letter-spacing="0.5">DEVELOPER WORKSTATION</text>
 
     <!-- Working Tree label -->
-    <text x="220" y="107" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#0369A1">Working Tree: real files (hydrated)</text>
+    <text x="220" y="107" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0284C7">Working Tree: real files (hydrated)</text>
 
     <!-- Flow annotation: git push origin -->
-    <text x="112" y="155" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">git push origin</text>
-    <text x="112" y="170" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">(pre-push hook fires first)</text>
+    <text x="112" y="155" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">git push origin</text>
+    <text x="112" y="170" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(pre-push hook fires first)</text>
 
     <!-- crab push label -->
-    <text x="200" y="254" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">crab push</text>
-    <text x="200" y="272" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#E0F2FE">(hook)</text>
+    <text x="200" y="254" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">crab push</text>
+    <text x="200" y="272" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(hook)</text>
 
     <!-- S3 Bucket label -->
-    <text x="500" y="254" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#F1F5F9">S3 Bucket</text>
-    <text x="500" y="272" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">(Crab)</text>
+    <text x="500" y="254" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">S3 Bucket</text>
+    <text x="500" y="272" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(Crab)</text>
 
     <!-- S3 annotation -->
-    <text x="500" y="304" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#64748B">large file xorbs</text>
+    <text x="500" y="304" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">large file xorbs</text>
 
     <!-- Flow annotation: then git push proceeds -->
-    <text x="112" y="330" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">then git push proceeds</text>
+    <text x="112" y="330" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">then git push proceeds</text>
 
     <!-- GitHub label -->
-    <text x="200" y="404" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">GitHub</text>
-    <text x="200" y="422" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#CBD5E1">(origin)</text>
+    <text x="200" y="404" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">GitHub</text>
+    <text x="200" y="422" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(origin)</text>
 
     <!-- GitHub annotation -->
-    <text x="310" y="412" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#64748B">pointer blobs only (~128 bytes each)</text>
+    <text x="310" y="412" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">pointer blobs only (~128 bytes each)</text>
   </g>
 
   <g id="connections">
     <!-- Working Tree → crab push -->
-    <line x1="200" y1="124" x2="200" y2="230" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="200" y1="124" x2="200" y2="230" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- crab push → S3 Bucket (horizontal) -->
-    <line x1="280" y1="258" x2="420" y2="258" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="280" y1="258" x2="420" y2="258" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- crab push → GitHub (vertical) -->
-    <line x1="200" y1="286" x2="200" y2="380" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="200" y1="286" x2="200" y2="380" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/getting-started/tracking-flow.svg
+++ b/packages/web/content/docs/cli/getting-started/tracking-flow.svg
@@ -2,24 +2,8 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="processGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="resultGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
-    <linearGradient id="decisionGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#CBD5E1"/>
-      <stop offset="100%" stop-color="#94A3B8"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -31,74 +15,74 @@
 
   <g id="nodes">
     <!-- Row 1: Command -->
-    <rect x="240" y="30" width="200" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="240" y="30" width="200" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
 
     <!-- Row 2: Process -->
-    <rect x="225" y="130" width="230" height="50" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="225" y="130" width="230" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
 
     <!-- Row 3: Code output (wider) -->
-    <rect x="120" y="230" width="440" height="50" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="120" y="230" width="440" height="50" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
 
     <!-- Row 4: Decision diamond -->
-    <polygon points="340,320 460,370 340,420 220,370" fill="url(#decisionGrad)" stroke="#64748B" stroke-width="1.5"/>
+    <polygon points="340,320 460,370 340,420 220,370" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
 
     <!-- Row 5: Yes/No branches -->
-    <rect x="60" y="470" width="220" height="50" rx="8" fill="url(#cmdGrad)" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="400" y="470" width="220" height="50" rx="8" fill="url(#processGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="60" y="470" width="220" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="400" y="470" width="220" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
 
     <!-- Row 6: Final results -->
-    <rect x="60" y="560" width="220" height="50" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
-    <rect x="400" y="560" width="220" height="50" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="60" y="560" width="220" height="50" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <rect x="400" y="560" width="220" height="50" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- Row 1 -->
-    <text x="340" y="60" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">crab track '*.bin'</text>
+    <text x="340" y="60" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab track '*.bin'</text>
 
     <!-- Row 2 -->
-    <text x="340" y="160" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">Writes to .gitattributes</text>
+    <text x="340" y="160" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">Writes to .gitattributes</text>
 
     <!-- Row 3 -->
-    <text x="340" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#94A3B8">*.bin filter=crab diff=crab merge=crab -text</text>
+    <text x="340" y="260" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#64748B">*.bin filter=crab diff=crab merge=crab -text</text>
 
     <!-- Row 4: Diamond -->
-    <text x="340" y="366" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#1E293B">File matches</text>
-    <text x="340" y="382" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#1E293B">pattern?</text>
+    <text x="340" y="366" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">File matches</text>
+    <text x="340" y="382" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">pattern?</text>
 
     <!-- Branch labels -->
-    <text x="205" y="438" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Yes</text>
-    <text x="475" y="438" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#64748B">No</text>
+    <text x="205" y="438" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Yes</text>
+    <text x="475" y="438" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B">No</text>
 
     <!-- Row 5 -->
-    <text x="170" y="500" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">Routed through Crab filter</text>
-    <text x="510" y="500" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">Handled by git normally</text>
+    <text x="170" y="500" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Routed through Crab filter</text>
+    <text x="510" y="500" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Handled by git normally</text>
 
     <!-- Row 6 -->
-    <text x="170" y="590" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#F1F5F9">Chunked + stored as pointer</text>
-    <text x="510" y="590" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#F1F5F9">Stored in git objects</text>
+    <text x="170" y="590" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Chunked + stored as pointer</text>
+    <text x="510" y="590" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Stored in git objects</text>
   </g>
 
   <g id="connections">
     <!-- A → B -->
-    <line x1="340" y1="80" x2="340" y2="130" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="340" y1="80" x2="340" y2="130" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- B → C -->
-    <line x1="340" y1="180" x2="340" y2="230" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="340" y1="180" x2="340" y2="230" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- C → D (diamond top) -->
-    <line x1="340" y1="280" x2="340" y2="320" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="340" y1="280" x2="340" y2="320" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- D → E (Yes, left branch) -->
-    <path d="M 220 370 L 170 370 L 170 470" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 220 370 L 170 370 L 170 470" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- D → F (No, right branch) -->
-    <path d="M 460 370 L 510 370 L 510 470" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <path d="M 460 370 L 510 370 L 510 470" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- E → G -->
-    <line x1="170" y1="520" x2="170" y2="560" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="170" y1="520" x2="170" y2="560" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- F → H -->
-    <line x1="510" y1="520" x2="510" y2="560" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="510" y1="520" x2="510" y2="560" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/guides/daily-workflow-flow.svg
+++ b/packages/web/content/docs/cli/guides/daily-workflow-flow.svg
@@ -2,20 +2,8 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
-    <linearGradient id="crabGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#38BDF8"/>
-      <stop offset="100%" stop-color="#0EA5E9"/>
-    </linearGradient>
-    <linearGradient id="gitGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#64748B"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="resultGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1E293B"/>
-      <stop offset="100%" stop-color="#0F172A"/>
-    </linearGradient>
   </defs>
 
   <g id="background">
@@ -24,59 +12,59 @@
 
   <g id="containers">
     <!-- Push phase background -->
-    <rect x="30" y="30" width="620" height="100" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1"/>
+    <rect x="30" y="30" width="620" height="100" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
     <!-- Pull phase background -->
     <rect x="30" y="200" width="620" height="220" rx="12" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1"/>
   </g>
 
   <g id="nodes">
     <!-- Row 1: Push flow (horizontal) -->
-    <rect x="60" y="55" width="150" height="50" rx="8" fill="url(#crabGrad)" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="270" y="55" width="150" height="50" rx="8" fill="url(#gitGrad)" stroke="#334155" stroke-width="1.5"/>
-    <rect x="480" y="55" width="150" height="50" rx="8" fill="url(#gitGrad)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="60" y="55" width="150" height="50" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="270" y="55" width="150" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="480" y="55" width="150" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
 
     <!-- Row 2: Clone -->
-    <rect x="430" y="250" width="190" height="56" rx="8" fill="url(#crabGrad)" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="430" y="250" width="190" height="56" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
 
     <!-- Row 3: Hydrate -->
-    <rect x="430" y="340" width="190" height="56" rx="8" fill="url(#resultGrad)" stroke="#0F172A" stroke-width="1.5"/>
+    <rect x="430" y="340" width="190" height="56" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
   </g>
 
   <g id="labels">
     <!-- Phase labels -->
-    <text x="50" y="48" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#64748B" letter-spacing="0.5">PUSH</text>
-    <text x="50" y="218" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#0284C7" letter-spacing="0.5">PULL (NEW MACHINE)</text>
+    <text x="50" y="48" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B" letter-spacing="0.5">PUSH</text>
+    <text x="50" y="218" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7" letter-spacing="0.5">PULL (NEW MACHINE)</text>
 
     <!-- Row 1 labels -->
-    <text x="135" y="85" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">crab add</text>
-    <text x="345" y="85" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">git commit</text>
-    <text x="555" y="85" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#FFFFFF">git push</text>
+    <text x="135" y="85" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab add</text>
+    <text x="345" y="85" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">git commit</text>
+    <text x="555" y="85" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">git push</text>
 
     <!-- Annotation between push and clone -->
-    <text x="525" y="160" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">uploads xorbs to</text>
-    <text x="525" y="175" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">S3 / GCS / Azure</text>
+    <text x="525" y="160" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">uploads xorbs to</text>
+    <text x="525" y="175" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">S3 / GCS / Azure</text>
 
     <!-- Row 2 label -->
-    <text x="525" y="273" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#FFFFFF">crab clone</text>
-    <text x="525" y="291" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#E0F2FE">(new machine)</text>
+    <text x="525" y="273" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">crab clone</text>
+    <text x="525" y="291" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(new machine)</text>
 
     <!-- Row 3 label -->
-    <text x="525" y="363" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="bold" fill="#F1F5F9">crab hydrate</text>
-    <text x="525" y="381" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#94A3B8">(restore files)</text>
+    <text x="525" y="363" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">crab hydrate</text>
+    <text x="525" y="381" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(restore files)</text>
   </g>
 
   <g id="connections">
     <!-- crab add → git commit -->
-    <line x1="210" y1="80" x2="270" y2="80" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="210" y1="80" x2="270" y2="80" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- git commit → git push -->
-    <line x1="420" y1="80" x2="480" y2="80" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="420" y1="80" x2="480" y2="80" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- git push → crab clone (vertical with offset) -->
-    <line x1="555" y1="105" x2="555" y2="250" stroke="#334155" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#arrowhead)"/>
+    <line x1="555" y1="105" x2="555" y2="250" stroke="#64748B" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#arrowhead)"/>
 
     <!-- crab clone → crab hydrate -->
-    <line x1="525" y1="306" x2="525" y2="340" stroke="#334155" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="525" y1="306" x2="525" y2="340" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/virtual-filesystem/fuse-read-flow.svg
+++ b/packages/web/content/docs/cli/virtual-filesystem/fuse-read-flow.svg
@@ -2,16 +2,16 @@
 
   <defs>
     <marker id="arrow-solid" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
     <marker id="arrow-teal" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#0D9488"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
   </defs>
 
   <!-- Background -->
   <g id="background">
-    <rect x="0" y="0" width="720" height="780" fill="#F9FAFB"/>
+    <rect x="0" y="0" width="720" height="780" fill="#FFFFFF"/>
   </g>
 
   <!-- Containers -->
@@ -21,80 +21,80 @@
   <!-- Nodes -->
   <g id="nodes">
     <!-- A: Application reads -->
-    <rect x="220" y="60" width="280" height="56" rx="12" fill="#EFF6FF" stroke="#2563EB" stroke-width="1.5"/>
+    <rect x="220" y="60" width="280" height="56" rx="12" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
     <!-- B: Kernel FUSE driver -->
     <rect x="230" y="170" width="260" height="50" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- C: Crab VFS engine -->
     <rect x="230" y="274" width="260" height="50" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- D: Decision diamond -->
-    <polygon points="360,374 470,424 360,474 250,424" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+    <polygon points="360,374 470,424 360,474 250,424" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- E: Serve from local cache (left) -->
-    <rect x="80" y="530" width="210" height="56" rx="12" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+    <rect x="80" y="530" width="210" height="56" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <!-- F: Download chunks (right) -->
     <rect x="430" y="530" width="220" height="56" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- G: Cache chunks -->
     <rect x="430" y="636" width="220" height="56" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- H: Return data -->
-    <rect x="80" y="636" width="210" height="56" rx="12" fill="#EFF6FF" stroke="#2563EB" stroke-width="1.5"/>
+    <rect x="80" y="636" width="210" height="56" rx="12" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
   </g>
 
   <!-- Labels -->
   <g id="labels">
     <!-- Title -->
-    <text x="360" y="36" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="18" font-weight="700" fill="#0F172A">FUSE Read Flow</text>
+    <text x="360" y="36" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="700" fill="#0F172A">FUSE Read Flow</text>
 
     <!-- A -->
-    <text x="360" y="84" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#0F172A">Application reads</text>
-    <text x="360" y="103" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="11" fill="#64748B">/mnt/models/weights.bin</text>
+    <text x="360" y="84" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600" fill="#0F172A">Application reads</text>
+    <text x="360" y="103" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">/mnt/models/weights.bin</text>
     <!-- B -->
-    <text x="360" y="200" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Kernel FUSE driver</text>
+    <text x="360" y="200" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Kernel FUSE driver</text>
     <!-- C -->
-    <text x="360" y="304" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Crab VFS engine</text>
+    <text x="360" y="304" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Crab VFS engine</text>
     <!-- D -->
-    <text x="360" y="428" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">File in cache?</text>
+    <text x="360" y="428" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">File in cache?</text>
     <!-- Branch labels -->
-    <text x="200" y="498" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0D9488">Yes</text>
-    <text x="520" y="498" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#64748B">No</text>
+    <text x="200" y="498" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#10B981">Yes</text>
+    <text x="520" y="498" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#64748B">No</text>
     <!-- E -->
-    <text x="185" y="554" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Serve from cache</text>
-    <text x="185" y="572" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="11" fill="#64748B">instant response</text>
+    <text x="185" y="554" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Serve from cache</text>
+    <text x="185" y="572" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">instant response</text>
     <!-- F -->
-    <text x="540" y="554" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Download chunks</text>
-    <text x="540" y="572" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="11" fill="#64748B">from cloud storage</text>
+    <text x="540" y="554" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Download chunks</text>
+    <text x="540" y="572" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">from cloud storage</text>
     <!-- G -->
-    <text x="540" y="660" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Cache chunks</text>
-    <text x="540" y="678" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="11" fill="#64748B">for next access</text>
+    <text x="540" y="660" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Cache chunks</text>
+    <text x="540" y="678" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">for next access</text>
     <!-- H -->
-    <text x="185" y="660" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Return data</text>
-    <text x="185" y="678" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="11" fill="#64748B">to application</text>
+    <text x="185" y="660" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Return data</text>
+    <text x="185" y="678" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">to application</text>
   </g>
 
   <!-- Connections -->
   <g id="connections">
     <!-- A → B -->
-    <line x1="360" y1="116" x2="360" y2="170" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <line x1="360" y1="116" x2="360" y2="170" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- B → C -->
-    <line x1="360" y1="220" x2="360" y2="274" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <line x1="360" y1="220" x2="360" y2="274" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- C → D -->
-    <line x1="360" y1="324" x2="360" y2="374" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <line x1="360" y1="324" x2="360" y2="374" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- D → E (Yes, left branch) -->
-    <path d="M 250,424 L 185,424 L 185,530" fill="none" stroke="#0D9488" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
+    <path d="M 250,424 L 185,424 L 185,530" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
     <!-- D → F (No, right branch) -->
-    <path d="M 470,424 L 540,424 L 540,530" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <path d="M 470,424 L 540,424 L 540,530" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- F → G -->
-    <line x1="540" y1="586" x2="540" y2="636" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <line x1="540" y1="586" x2="540" y2="636" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- G → H (cache then return) -->
-    <path d="M 430,664 L 290,664" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <path d="M 430,664 L 290,664" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- E → H -->
-    <line x1="185" y1="586" x2="185" y2="636" stroke="#0D9488" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
+    <line x1="185" y1="586" x2="185" y2="636" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
   </g>
 
   <!-- Info callout -->
   <g id="callout">
-    <rect x="60" y="730" width="600" height="36" rx="10" fill="#F1F5F9" stroke="#E2E8F0" stroke-width="1"/>
-    <circle cx="84" cy="748" r="10" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1"/>
-    <text x="84" y="752" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="10" fill="#2563EB">i</text>
-    <text x="106" y="752" font-family="Inter, -apple-system, sans-serif" font-size="11" fill="#334155">Cache hits are served instantly. Misses download chunks on demand and cache them for subsequent reads.</text>
+    <rect x="60" y="730" width="600" height="36" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
+    <circle cx="84" cy="748" r="10" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1"/>
+    <text x="84" y="752" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#0284C7">i</text>
+    <text x="106" y="752" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#0F172A">Cache hits are served instantly. Misses download chunks on demand and cache them for subsequent reads.</text>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/virtual-filesystem/local-mount-flow.svg
+++ b/packages/web/content/docs/cli/virtual-filesystem/local-mount-flow.svg
@@ -2,19 +2,19 @@
 
   <defs>
     <marker id="arrow-solid" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#334155"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
     <marker id="arrow-teal" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#0D9488"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
     <marker id="arrow-blue" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#2563EB"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
   </defs>
 
   <!-- Background -->
   <g id="background">
-    <rect x="0" y="0" width="720" height="700" fill="#F9FAFB"/>
+    <rect x="0" y="0" width="720" height="700" fill="#FFFFFF"/>
   </g>
 
   <!-- Containers -->
@@ -24,19 +24,19 @@
   <!-- Nodes -->
   <g id="nodes">
     <!-- A: read file -->
-    <rect x="240" y="60" width="240" height="50" rx="12" fill="#EFF6FF" stroke="#2563EB" stroke-width="1.5"/>
+    <rect x="240" y="60" width="240" height="50" rx="12" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
     <!-- B: Pointer file? diamond -->
-    <polygon points="360,150 460,195 360,240 260,195" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+    <polygon points="360,150 460,195 360,240 260,195" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- C: Read from .git/objects (No path, right) -->
     <rect x="500" y="270" width="170" height="50" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- D: Return content instantly (right) -->
-    <rect x="500" y="360" width="170" height="50" rx="12" fill="#EFF6FF" stroke="#2563EB" stroke-width="1.5"/>
+    <rect x="500" y="360" width="170" height="50" rx="12" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
     <!-- E: Parse pointer (Yes path, left) -->
     <rect x="60" y="270" width="240" height="50" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- F: Chunk in cache? diamond -->
-    <polygon points="180,360 280,405 180,450 80,405" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+    <polygon points="180,360 280,405 180,450 80,405" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- G: Return cached content (left) -->
-    <rect x="50" y="500" width="210" height="50" rx="12" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+    <rect x="50" y="500" width="210" height="50" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <!-- H: Download from object storage (right) -->
     <rect x="360" y="490" width="250" height="50" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <!-- I: Cache chunk locally -->
@@ -46,62 +46,62 @@
   <!-- Labels -->
   <g id="labels">
     <!-- Title -->
-    <text x="360" y="36" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="18" font-weight="700" fill="#0F172A">Local Mount Read Flow</text>
+    <text x="360" y="36" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="700" fill="#0F172A">Local Mount Read Flow</text>
 
     <!-- A -->
-    <text x="360" y="90" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">read /tmp/view/model.bin</text>
+    <text x="360" y="90" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">read /tmp/view/model.bin</text>
     <!-- B -->
-    <text x="360" y="199" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Pointer file?</text>
+    <text x="360" y="199" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Pointer file?</text>
     <!-- Branch labels for B -->
-    <text x="480" y="225" font-family="Inter, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#64748B">No</text>
-    <text x="220" y="255" font-family="Inter, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#0D9488">Yes</text>
+    <text x="480" y="225" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">No</text>
+    <text x="220" y="255" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#10B981">Yes</text>
     <!-- C -->
-    <text x="585" y="300" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Read .git/objects</text>
+    <text x="585" y="300" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Read .git/objects</text>
     <!-- D -->
-    <text x="585" y="390" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Return content instantly</text>
+    <text x="585" y="390" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Return content instantly</text>
     <!-- E -->
-    <text x="180" y="300" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Parse pointer → file_hash</text>
+    <text x="180" y="300" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Parse pointer → file_hash</text>
     <!-- F -->
-    <text x="180" y="409" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Chunk in cache?</text>
+    <text x="180" y="409" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Chunk in cache?</text>
     <!-- Branch labels for F -->
-    <text x="90" y="460" font-family="Inter, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#0D9488">Yes</text>
-    <text x="310" y="430" font-family="Inter, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#64748B">No</text>
+    <text x="90" y="460" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#10B981">Yes</text>
+    <text x="310" y="430" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">No</text>
     <!-- G -->
-    <text x="155" y="530" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Return cached content</text>
+    <text x="155" y="530" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Return cached content</text>
     <!-- H -->
-    <text x="485" y="520" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Download from object storage</text>
+    <text x="485" y="520" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Download from object storage</text>
     <!-- I -->
-    <text x="485" y="610" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Cache chunk locally</text>
+    <text x="485" y="610" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="600" fill="#0F172A">Cache chunk locally</text>
   </g>
 
   <!-- Connections -->
   <g id="connections">
     <!-- A → B -->
-    <line x1="360" y1="110" x2="360" y2="150" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <line x1="360" y1="110" x2="360" y2="150" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- B → C (No, right) -->
-    <path d="M 460,195 L 585,195 L 585,270" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <path d="M 460,195 L 585,195 L 585,270" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- C → D -->
-    <line x1="585" y1="320" x2="585" y2="360" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <line x1="585" y1="320" x2="585" y2="360" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- B → E (Yes, left) -->
-    <path d="M 260,195 L 180,195 L 180,270" fill="none" stroke="#0D9488" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
+    <path d="M 260,195 L 180,195 L 180,270" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
     <!-- E → F -->
-    <line x1="180" y1="320" x2="180" y2="360" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <line x1="180" y1="320" x2="180" y2="360" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- F → G (Yes, down) -->
-    <path d="M 80,405 L 60,405 L 60,520 L 50,520" fill="none" stroke="#0D9488" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
+    <path d="M 80,405 L 60,405 L 60,520 L 50,520" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
     <!-- F → H (No, right) -->
-    <path d="M 280,405 L 485,405 L 485,490" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <path d="M 280,405 L 485,405 L 485,490" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- H → I -->
-    <line x1="485" y1="540" x2="485" y2="580" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <line x1="485" y1="540" x2="485" y2="580" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
     <!-- I → G (cache then return) -->
-    <path d="M 360,605 L 155,605 L 155,550" fill="none" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
+    <path d="M 360,605 L 155,605 L 155,550" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrow-solid)"/>
   </g>
 
   <!-- Info callout -->
   <g id="callout">
-    <rect x="60" y="650" width="600" height="36" rx="10" fill="#F1F5F9" stroke="#E2E8F0" stroke-width="1"/>
-    <circle cx="84" cy="668" r="10" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1"/>
-    <text x="84" y="672" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="10" fill="#2563EB">i</text>
-    <text x="106" y="672" font-family="Inter, -apple-system, sans-serif" font-size="11" fill="#334155">Non-pointer files are served directly from git objects. Pointer files trigger on-demand chunk resolution.</text>
+    <rect x="60" y="650" width="600" height="36" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
+    <circle cx="84" cy="668" r="10" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1"/>
+    <text x="84" y="672" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#0284C7">i</text>
+    <text x="106" y="672" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#0F172A">Non-pointer files are served directly from git objects. Pointer files trigger on-demand chunk resolution.</text>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/virtual-filesystem/mount-pipeline.svg
+++ b/packages/web/content/docs/cli/virtual-filesystem/mount-pipeline.svg
@@ -2,76 +2,76 @@
 
   <defs>
     <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#475569"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
     <marker id="arrowhead-sky" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#0ea5e9"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
     </marker>
   </defs>
 
   <g id="background">
-    <rect x="0" y="0" width="760" height="310" fill="#ffffff"/>
+    <rect x="0" y="0" width="760" height="310" fill="#FFFFFF"/>
   </g>
 
   <g id="containers">
     <!-- Phase groups -->
-    <rect x="30" y="50" width="230" height="160" rx="8" fill="#f0f9ff" stroke="#bae6fd" stroke-width="1"/>
-    <rect x="275" y="50" width="210" height="160" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-    <rect x="500" y="50" width="230" height="160" rx="8" fill="#fef9c3" stroke="#fde047" stroke-width="1"/>
+    <rect x="30" y="50" width="230" height="160" rx="8" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1"/>
+    <rect x="275" y="50" width="210" height="160" rx="8" fill="#ECFDF5" stroke="#A7F3D0" stroke-width="1"/>
+    <rect x="500" y="50" width="230" height="160" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1"/>
   </g>
 
   <g id="nodes">
     <!-- Phase 1: Setup -->
-    <rect x="50" y="85" width="190" height="30" rx="5" fill="#0ea5e9" stroke="#0284c7" stroke-width="1"/>
-    <rect x="50" y="125" width="190" height="30" rx="5" fill="#0ea5e9" stroke="#0284c7" stroke-width="1"/>
-    <rect x="50" y="165" width="190" height="30" rx="5" fill="#0ea5e9" stroke="#0284c7" stroke-width="1"/>
+    <rect x="50" y="85" width="190" height="30" rx="5" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1"/>
+    <rect x="50" y="125" width="190" height="30" rx="5" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1"/>
+    <rect x="50" y="165" width="190" height="30" rx="5" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1"/>
 
     <!-- Phase 2: Build -->
-    <rect x="295" y="85" width="170" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1"/>
-    <rect x="295" y="125" width="170" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1"/>
-    <rect x="295" y="165" width="170" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1"/>
+    <rect x="295" y="85" width="170" height="30" rx="5" fill="#ECFDF5" stroke="#10B981" stroke-width="1"/>
+    <rect x="295" y="125" width="170" height="30" rx="5" fill="#ECFDF5" stroke="#10B981" stroke-width="1"/>
+    <rect x="295" y="165" width="170" height="30" rx="5" fill="#ECFDF5" stroke="#10B981" stroke-width="1"/>
 
     <!-- Phase 3: Run -->
-    <rect x="520" y="85" width="190" height="30" rx="5" fill="#eab308" stroke="#ca8a04" stroke-width="1"/>
-    <rect x="520" y="125" width="190" height="30" rx="5" fill="#eab308" stroke="#ca8a04" stroke-width="1"/>
-    <rect x="520" y="165" width="190" height="30" rx="5" fill="#eab308" stroke="#ca8a04" stroke-width="1"/>
+    <rect x="520" y="85" width="190" height="30" rx="5" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1"/>
+    <rect x="520" y="125" width="190" height="30" rx="5" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1"/>
+    <rect x="520" y="165" width="190" height="30" rx="5" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1"/>
   </g>
 
   <g id="labels">
     <!-- Title -->
-    <text x="380" y="28" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="bold" fill="#0f172a">Mount Pipeline (11 Steps)</text>
+    <text x="380" y="28" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="15" font-weight="bold" fill="#0F172A">Mount Pipeline (11 Steps)</text>
 
     <!-- Phase labels -->
-    <text x="145" y="68" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="bold" fill="#0369a1">SETUP</text>
-    <text x="380" y="68" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="bold" fill="#047857">BUILD</text>
-    <text x="615" y="68" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="bold" fill="#854d0e">RUN</text>
+    <text x="145" y="68" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="bold" fill="#0284C7">SETUP</text>
+    <text x="380" y="68" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="bold" fill="#10B981">BUILD</text>
+    <text x="615" y="68" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="bold" fill="#F59E0B">RUN</text>
 
     <!-- Phase 1 steps -->
-    <text x="145" y="105" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#ffffff">1. Resolve Source</text>
-    <text x="145" y="145" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#ffffff">2. Blobless Clone</text>
-    <text x="145" y="185" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#ffffff">3. Resolve HEAD</text>
+    <text x="145" y="105" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">1. Resolve Source</text>
+    <text x="145" y="145" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">2. Blobless Clone</text>
+    <text x="145" y="185" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">3. Resolve HEAD</text>
 
     <!-- Phase 2 steps -->
-    <text x="380" y="105" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#ffffff">4. Build Snapshot</text>
-    <text x="380" y="145" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#ffffff">5. Open Overlay</text>
-    <text x="380" y="185" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#ffffff">6. Reconcile</text>
+    <text x="380" y="105" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">4. Build Snapshot</text>
+    <text x="380" y="145" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">5. Open Overlay</text>
+    <text x="380" y="185" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">6. Reconcile</text>
 
     <!-- Phase 3 steps -->
-    <text x="615" y="105" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#422006">7. Start Hydration</text>
-    <text x="615" y="145" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#422006">8. Create Resolver</text>
-    <text x="615" y="185" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#422006">9. Create Engine</text>
+    <text x="615" y="105" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">7. Start Hydration</text>
+    <text x="615" y="145" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">8. Create Resolver</text>
+    <text x="615" y="185" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">9. Create Engine</text>
 
     <!-- Bottom row -->
-    <text x="380" y="240" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" fill="#475569">→ 10. FUSE Mount → 11. Refresh Loop (periodic ref poll)</text>
+    <text x="380" y="240" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">→ 10. FUSE Mount → 11. Refresh Loop (periodic ref poll)</text>
 
     <!-- Note -->
-    <text x="380" y="275" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" fill="#64748b">For local sources, step 2 (blobless clone) is skipped — reads directly from .git/</text>
+    <text x="380" y="275" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">For local sources, step 2 (blobless clone) is skipped — reads directly from .git/</text>
   </g>
 
   <g id="connections">
     <!-- Phase flow arrows -->
-    <line x1="260" y1="130" x2="295" y2="130" stroke="#475569" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="485" y1="130" x2="520" y2="130" stroke="#475569" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="260" y1="130" x2="295" y2="130" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="485" y1="130" x2="520" y2="130" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
   </g>
 
 </svg>

--- a/packages/web/content/docs/cli/workflow/experiment-worktree-flow.svg
+++ b/packages/web/content/docs/cli/workflow/experiment-worktree-flow.svg
@@ -1,29 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 500" width="980" height="500" role="img" aria-label="Experiment worktree flow">
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#2563EB"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
     <marker id="arrow-teal" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#0D9488"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
   </defs>
-  <rect width="980" height="500" fill="#F9FAFB"/>
-  <text x="490" y="46" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#0F172A">Experiment Run Lifecycle</text>
+  <rect width="980" height="500" fill="#FFFFFF"/>
+  <text x="490" y="46" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" fill="#0F172A">Experiment Run Lifecycle</text>
 
-  <g font-family="Inter, -apple-system, sans-serif">
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
     <rect x="45" y="145" width="150" height="74" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="120" y="176" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">HEAD</text>
     <text x="120" y="197" text-anchor="middle" font-size="12" fill="#64748B">committed baseline</text>
 
-    <rect x="250" y="110" width="180" height="145" rx="14" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1.5"/>
+    <rect x="250" y="110" width="180" height="145" rx="14" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
     <text x="340" y="145" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">temp worktree</text>
     <text x="340" y="168" text-anchor="middle" font-size="12" fill="#64748B">isolated checkout</text>
-    <rect x="280" y="190" width="120" height="34" rx="8" fill="#FFFFFF" stroke="#CBD5E1"/>
-    <text x="340" y="212" text-anchor="middle" font-size="12" fill="#334155">apply -S values</text>
+    <rect x="280" y="190" width="120" height="34" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
+    <text x="340" y="212" text-anchor="middle" font-size="12" fill="#0F172A">apply -S values</text>
 
-    <rect x="500" y="145" width="150" height="74" rx="12" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+    <rect x="500" y="145" width="150" height="74" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <text x="575" y="176" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">run DAG</text>
-    <text x="575" y="197" text-anchor="middle" font-size="12" fill="#0D9488">cache aware</text>
+    <text x="575" y="197" text-anchor="middle" font-size="12" fill="#10B981">cache aware</text>
 
     <rect x="720" y="88" width="190" height="70" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="815" y="116" text-anchor="middle" font-size="14" font-weight="700" fill="#0F172A">metadata</text>
@@ -37,13 +37,13 @@
     <text x="815" y="350" text-anchor="middle" font-size="14" font-weight="700" fill="#0F172A">push or promote</text>
     <text x="815" y="371" text-anchor="middle" font-size="12" fill="#64748B">share or branch</text>
 
-    <path d="M 195 182 L 250 182" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 430 182 L 500 182" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 650 182 L 685 182 L 685 123 L 720 123" fill="none" stroke="#0D9488" stroke-width="1.8" marker-end="url(#arrow-teal)"/>
-    <path d="M 650 182 L 685 182 L 685 240 L 720 240" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 650 182 L 685 182 L 685 357 L 720 357" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 195 182 L 250 182" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 430 182 L 500 182" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 650 182 L 685 182 L 685 123 L 720 123" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow-teal)"/>
+    <path d="M 650 182 L 685 182 L 685 240 L 720 240" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 650 182 L 685 182 L 685 357 L 720 357" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
 
-    <rect x="260" y="330" width="360" height="52" rx="10" fill="#F1F5F9" stroke="#CBD5E1"/>
-    <text x="440" y="361" text-anchor="middle" font-size="13" font-weight="600" fill="#334155">The workspace stays clean until you explicitly apply an experiment</text>
+    <rect x="260" y="330" width="360" height="52" rx="10" fill="#F8FAFC" stroke="#E2E8F0"/>
+    <text x="440" y="361" text-anchor="middle" font-size="13" font-weight="600" fill="#0F172A">The workspace stays clean until you explicitly apply an experiment</text>
   </g>
 </svg>

--- a/packages/web/content/docs/cli/workflow/hydra-composition-flow.svg
+++ b/packages/web/content/docs/cli/workflow/hydra-composition-flow.svg
@@ -1,42 +1,42 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 500" width="960" height="500" role="img" aria-label="Hydra composition flow">
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#2563EB"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
   </defs>
-  <rect width="960" height="500" fill="#F9FAFB"/>
-  <text x="480" y="46" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#0F172A">Hydra Composition for Experiments</text>
+  <rect width="960" height="500" fill="#FFFFFF"/>
+  <text x="480" y="46" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" fill="#0F172A">Hydra Composition for Experiments</text>
 
-  <g font-family="Inter, -apple-system, sans-serif">
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
     <rect x="60" y="105" width="210" height="250" rx="14" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="165" y="138" text-anchor="middle" font-size="16" font-weight="700" fill="#0F172A">conf/</text>
-    <rect x="88" y="170" width="154" height="36" rx="8" fill="#EFF6FF" stroke="#BFDBFE"/>
-    <text x="165" y="193" text-anchor="middle" font-size="12" font-weight="600" fill="#1E3A5F">config.yaml</text>
-    <rect x="88" y="222" width="154" height="36" rx="8" fill="#F8FAFC" stroke="#CBD5E1"/>
-    <text x="165" y="245" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">train/model/*</text>
-    <rect x="88" y="274" width="154" height="36" rx="8" fill="#F8FAFC" stroke="#CBD5E1"/>
-    <text x="165" y="297" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">train/optimizer/*</text>
+    <rect x="88" y="170" width="154" height="36" rx="8" fill="#F0F9FF" stroke="#BAE6FD"/>
+    <text x="165" y="193" text-anchor="middle" font-size="12" font-weight="600" fill="#0F172A">config.yaml</text>
+    <rect x="88" y="222" width="154" height="36" rx="8" fill="#F8FAFC" stroke="#E2E8F0"/>
+    <text x="165" y="245" text-anchor="middle" font-size="12" font-weight="600" fill="#0F172A">train/model/*</text>
+    <rect x="88" y="274" width="154" height="36" rx="8" fill="#F8FAFC" stroke="#E2E8F0"/>
+    <text x="165" y="297" text-anchor="middle" font-size="12" font-weight="600" fill="#0F172A">train/optimizer/*</text>
 
-    <rect x="360" y="128" width="220" height="85" rx="12" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+    <rect x="360" y="128" width="220" height="85" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <text x="470" y="162" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">defaults</text>
-    <text x="470" y="184" text-anchor="middle" font-size="12" fill="#0D9488">base group choices</text>
+    <text x="470" y="184" text-anchor="middle" font-size="12" fill="#10B981">base group choices</text>
 
-    <rect x="360" y="268" width="220" height="85" rx="12" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1.5"/>
+    <rect x="360" y="268" width="220" height="85" rx="12" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
     <text x="470" y="302" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">-S overrides</text>
-    <text x="470" y="324" text-anchor="middle" font-size="12" fill="#2563EB">groups and dotted values</text>
+    <text x="470" y="324" text-anchor="middle" font-size="12" fill="#0284C7">groups and dotted values</text>
 
     <rect x="690" y="145" width="210" height="180" rx="14" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="795" y="181" text-anchor="middle" font-size="16" font-weight="700" fill="#0F172A">composed params</text>
     <text x="795" y="206" text-anchor="middle" font-size="12" fill="#64748B">written into experiment</text>
-    <rect x="725" y="238" width="140" height="42" rx="8" fill="#F0FDFA" stroke="#99F6E4"/>
-    <text x="795" y="264" text-anchor="middle" font-size="12" font-weight="600" fill="#0D9488">crab exp run</text>
+    <rect x="725" y="238" width="140" height="42" rx="8" fill="#ECFDF5" stroke="#A7F3D0"/>
+    <text x="795" y="264" text-anchor="middle" font-size="12" font-weight="600" fill="#10B981">crab exp run</text>
 
-    <path d="M 270 188 L 360 170" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 270 292 L 360 310" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 580 170 L 690 210" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 580 310 L 690 260" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 270 188 L 360 170" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 270 292 L 360 310" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 580 170 L 690 210" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 580 310 L 690 260" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
 
-    <rect x="250" y="405" width="460" height="44" rx="10" fill="#F1F5F9" stroke="#CBD5E1"/>
-    <text x="480" y="432" text-anchor="middle" font-size="13" font-weight="600" fill="#334155">Later overrides win: root config, defaults, group selections, then scalar values</text>
+    <rect x="250" y="405" width="460" height="44" rx="10" fill="#F8FAFC" stroke="#E2E8F0"/>
+    <text x="480" y="432" text-anchor="middle" font-size="13" font-weight="600" fill="#0F172A">Later overrides win: root config, defaults, group selections, then scalar values</text>
   </g>
 </svg>

--- a/packages/web/content/docs/cli/workflow/pipeline-dag-flow.svg
+++ b/packages/web/content/docs/cli/workflow/pipeline-dag-flow.svg
@@ -1,20 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" width="960" height="520" role="img" aria-label="Pipeline DAG flow">
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#2563EB"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
   </defs>
-  <rect width="960" height="520" fill="#F9FAFB"/>
-  <text x="480" y="48" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#0F172A">DAG Execution and Cache Decisions</text>
+  <rect width="960" height="520" fill="#FFFFFF"/>
+  <text x="480" y="48" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" fill="#0F172A">DAG Execution and Cache Decisions</text>
 
-  <g font-family="Inter, -apple-system, sans-serif">
-    <rect x="385" y="95" width="190" height="60" rx="12" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+    <rect x="385" y="95" width="190" height="60" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <text x="480" y="121" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">ingest</text>
-    <text x="480" y="141" text-anchor="middle" font-size="12" fill="#0D9488">cache hit</text>
+    <text x="480" y="141" text-anchor="middle" font-size="12" fill="#10B981">cache hit</text>
 
-    <rect x="175" y="225" width="190" height="60" rx="12" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+    <rect x="175" y="225" width="190" height="60" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <text x="270" y="251" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">features</text>
-    <text x="270" y="271" text-anchor="middle" font-size="12" fill="#0D9488">cache hit</text>
+    <text x="270" y="271" text-anchor="middle" font-size="12" fill="#10B981">cache hit</text>
 
     <rect x="595" y="225" width="190" height="60" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="690" y="251" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">report</text>
@@ -24,17 +24,17 @@
     <text x="375" y="381" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">train</text>
     <text x="375" y="401" text-anchor="middle" font-size="12" fill="#64748B">stale</text>
 
-    <rect x="490" y="355" width="190" height="60" rx="12" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1.5"/>
+    <rect x="490" y="355" width="190" height="60" rx="12" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
     <text x="585" y="381" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">evaluate</text>
-    <text x="585" y="401" text-anchor="middle" font-size="12" fill="#2563EB">waits for train</text>
+    <text x="585" y="401" text-anchor="middle" font-size="12" fill="#0284C7">waits for train</text>
 
-    <path d="M 440 155 L 315 225" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 520 155 L 645 225" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 300 285 L 355 355" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 690 285 L 610 355" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
-    <path d="M 470 385 L 490 385" fill="none" stroke="#2563EB" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 440 155 L 315 225" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 520 155 L 645 225" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 300 285 L 355 355" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 690 285 L 610 355" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <path d="M 470 385 L 490 385" fill="none" stroke="#64748B" stroke-width="1.8" marker-end="url(#arrow)"/>
 
-    <rect x="75" y="440" width="810" height="44" rx="10" fill="#F1F5F9" stroke="#CBD5E1"/>
-    <text x="480" y="467" text-anchor="middle" font-size="13" font-weight="600" fill="#334155">Crab runs stale nodes in topological order and replays cached nodes without executing their commands</text>
+    <rect x="75" y="440" width="810" height="44" rx="10" fill="#F8FAFC" stroke="#E2E8F0"/>
+    <text x="480" y="467" text-anchor="middle" font-size="13" font-weight="600" fill="#0F172A">Crab runs stale nodes in topological order and replays cached nodes without executing their commands</text>
   </g>
 </svg>

--- a/packages/web/content/docs/cli/workflow/remote-cache-ci-flow.svg
+++ b/packages/web/content/docs/cli/workflow/remote-cache-ci-flow.svg
@@ -1,46 +1,46 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 520" width="980" height="520" role="img" aria-label="Remote cache and CI flow">
   <defs>
     <marker id="arrow-blue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#2563EB"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
     <marker id="arrow-teal" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#0D9488"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
   </defs>
-  <rect width="980" height="520" fill="#F9FAFB"/>
-  <text x="490" y="46" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#0F172A">Remote Stage Cache for Teams and CI</text>
+  <rect width="980" height="520" fill="#FFFFFF"/>
+  <text x="490" y="46" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" fill="#0F172A">Remote Stage Cache for Teams and CI</text>
 
-  <g font-family="Inter, -apple-system, sans-serif">
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
     <rect x="55" y="145" width="205" height="105" rx="14" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="158" y="182" text-anchor="middle" font-size="16" font-weight="700" fill="#0F172A">developer</text>
     <text x="158" y="206" text-anchor="middle" font-size="12" fill="#64748B">crab run --cache-push</text>
 
-    <rect x="390" y="105" width="210" height="190" rx="14" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1.5"/>
+    <rect x="390" y="105" width="210" height="190" rx="14" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
     <text x="495" y="140" text-anchor="middle" font-size="16" font-weight="700" fill="#0F172A">Crab remote</text>
-    <ellipse cx="495" cy="195" rx="76" ry="24" fill="#DBEAFE" stroke="#93C5FD"/>
-    <rect x="419" y="195" width="152" height="62" fill="#DBEAFE" stroke="#93C5FD"/>
-    <ellipse cx="495" cy="257" rx="76" ry="24" fill="#BFDBFE" stroke="#93C5FD"/>
-    <text x="495" y="229" text-anchor="middle" font-size="13" font-weight="700" fill="#1E3A5F">stage cache</text>
+    <ellipse cx="495" cy="195" rx="76" ry="24" fill="#E0F2FE" stroke="#7DD3FC"/>
+    <rect x="419" y="195" width="152" height="62" fill="#E0F2FE" stroke="#7DD3FC"/>
+    <ellipse cx="495" cy="257" rx="76" ry="24" fill="#BAE6FD" stroke="#7DD3FC"/>
+    <text x="495" y="229" text-anchor="middle" font-size="13" font-weight="700" fill="#0F172A">stage cache</text>
     <text x="495" y="249" text-anchor="middle" font-size="12" fill="#64748B">manifests and outs</text>
 
-    <rect x="725" y="105" width="205" height="92" rx="14" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+    <rect x="725" y="105" width="205" height="92" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <text x="828" y="140" text-anchor="middle" font-size="16" font-weight="700" fill="#0F172A">strict CI</text>
-    <text x="828" y="164" text-anchor="middle" font-size="12" fill="#0D9488">crab run --cache-only</text>
+    <text x="828" y="164" text-anchor="middle" font-size="12" fill="#10B981">crab run --cache-only</text>
 
     <rect x="725" y="285" width="205" height="105" rx="14" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="828" y="323" text-anchor="middle" font-size="16" font-weight="700" fill="#0F172A">build CI</text>
     <text x="828" y="347" text-anchor="middle" font-size="12" fill="#64748B">pull, run, push misses</text>
 
-    <path d="M 260 197 L 390 197" fill="none" stroke="#0D9488" stroke-width="2" marker-end="url(#arrow-teal)"/>
-    <text x="325" y="181" text-anchor="middle" font-size="12" fill="#0D9488">publish</text>
-    <path d="M 600 185 L 725 151" fill="none" stroke="#2563EB" stroke-width="2" marker-end="url(#arrow-blue)"/>
-    <text x="662" y="151" text-anchor="middle" font-size="12" fill="#334155">restore only</text>
-    <path d="M 600 245 L 725 337" fill="none" stroke="#2563EB" stroke-width="2" marker-end="url(#arrow-blue)"/>
-    <text x="665" y="310" text-anchor="middle" font-size="12" fill="#334155">pull deps</text>
-    <path d="M 725 365 L 600 275" fill="none" stroke="#0D9488" stroke-width="2" marker-end="url(#arrow-teal)"/>
-    <text x="660" y="385" text-anchor="middle" font-size="12" fill="#0D9488">push fresh</text>
+    <path d="M 260 197 L 390 197" fill="none" stroke="#64748B" stroke-width="2" marker-end="url(#arrow-teal)"/>
+    <text x="325" y="181" text-anchor="middle" font-size="12" fill="#10B981">publish</text>
+    <path d="M 600 185 L 725 151" fill="none" stroke="#64748B" stroke-width="2" marker-end="url(#arrow-blue)"/>
+    <text x="662" y="151" text-anchor="middle" font-size="12" fill="#0F172A">restore only</text>
+    <path d="M 600 245 L 725 337" fill="none" stroke="#64748B" stroke-width="2" marker-end="url(#arrow-blue)"/>
+    <text x="665" y="310" text-anchor="middle" font-size="12" fill="#0F172A">pull deps</text>
+    <path d="M 725 365 L 600 275" fill="none" stroke="#64748B" stroke-width="2" marker-end="url(#arrow-teal)"/>
+    <text x="660" y="385" text-anchor="middle" font-size="12" fill="#10B981">push fresh</text>
 
-    <rect x="235" y="430" width="510" height="44" rx="10" fill="#F1F5F9" stroke="#CBD5E1"/>
-    <text x="490" y="457" text-anchor="middle" font-size="13" font-weight="600" fill="#334155">Use read-only cache for untrusted jobs and publish cache only from trusted branches</text>
+    <rect x="235" y="430" width="510" height="44" rx="10" fill="#F8FAFC" stroke="#E2E8F0"/>
+    <text x="490" y="457" text-anchor="middle" font-size="13" font-weight="600" fill="#0F172A">Use read-only cache for untrusted jobs and publish cache only from trusted branches</text>
   </g>
 </svg>

--- a/packages/web/content/docs/cli/workflow/stage-cache-flow.svg
+++ b/packages/web/content/docs/cli/workflow/stage-cache-flow.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 500" width="960" height="500" role="img" aria-label="Stage cache flow">
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#2563EB"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
   </defs>
-  <rect width="960" height="500" fill="#F9FAFB"/>
-  <text x="480" y="46" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#0F172A">How a Stage Becomes Reusable</text>
+  <rect width="960" height="500" fill="#FFFFFF"/>
+  <text x="480" y="46" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" fill="#0F172A">How a Stage Becomes Reusable</text>
 
-  <g font-family="Inter, -apple-system, sans-serif">
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
     <rect x="48" y="105" width="145" height="58" rx="12" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="120" y="130" text-anchor="middle" font-size="14" font-weight="700" fill="#0F172A">deps</text>
     <text x="120" y="149" text-anchor="middle" font-size="12" fill="#64748B">files and URLs</text>
@@ -24,15 +24,15 @@
     <text x="120" y="355" text-anchor="middle" font-size="14" font-weight="700" fill="#0F172A">cmd</text>
     <text x="120" y="374" text-anchor="middle" font-size="12" fill="#64748B">argv or shell</text>
 
-    <rect x="285" y="195" width="170" height="105" rx="14" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+    <rect x="285" y="195" width="170" height="105" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <text x="370" y="238" text-anchor="middle" font-size="16" font-weight="700" fill="#0F172A">stage hash</text>
     <text x="370" y="262" text-anchor="middle" font-size="12" fill="#64748B">content-addressed key</text>
 
-    <polygon points="600,170 735,250 600,330 465,250" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1.5"/>
+    <polygon points="600,170 735,250 600,330 465,250" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
     <text x="600" y="244" text-anchor="middle" font-size="15" font-weight="700" fill="#0F172A">cache entry</text>
     <text x="600" y="266" text-anchor="middle" font-size="12" fill="#64748B">exists?</text>
 
-    <rect x="760" y="115" width="150" height="72" rx="12" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+    <rect x="760" y="115" width="150" height="72" rx="12" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <text x="835" y="145" text-anchor="middle" font-size="14" font-weight="700" fill="#0F172A">replay outs</text>
     <text x="835" y="164" text-anchor="middle" font-size="12" fill="#64748B">skip command</text>
 
@@ -40,14 +40,14 @@
     <text x="835" y="345" text-anchor="middle" font-size="14" font-weight="700" fill="#0F172A">execute cmd</text>
     <text x="835" y="364" text-anchor="middle" font-size="12" fill="#64748B">commit outputs</text>
 
-    <path d="M 193 134 L 285 225" fill="none" stroke="#2563EB" stroke-width="1.7" marker-end="url(#arrow)"/>
-    <path d="M 193 209 L 285 240" fill="none" stroke="#2563EB" stroke-width="1.7" marker-end="url(#arrow)"/>
-    <path d="M 193 284 L 285 260" fill="none" stroke="#2563EB" stroke-width="1.7" marker-end="url(#arrow)"/>
-    <path d="M 193 359 L 285 275" fill="none" stroke="#2563EB" stroke-width="1.7" marker-end="url(#arrow)"/>
-    <line x1="455" y1="250" x2="465" y2="250" stroke="#2563EB" stroke-width="1.7" marker-end="url(#arrow)"/>
-    <path d="M 735 250 L 748 250 L 748 151 L 760 151" fill="none" stroke="#0D9488" stroke-width="1.7" marker-end="url(#arrow)"/>
-    <text x="724" y="133" font-size="12" fill="#0D9488">hit</text>
-    <path d="M 735 250 L 748 250 L 748 351 L 760 351" fill="none" stroke="#2563EB" stroke-width="1.7" marker-end="url(#arrow)"/>
-    <text x="718" y="374" font-size="12" fill="#2563EB">miss</text>
+    <path d="M 193 134 L 285 225" fill="none" stroke="#64748B" stroke-width="1.7" marker-end="url(#arrow)"/>
+    <path d="M 193 209 L 285 240" fill="none" stroke="#64748B" stroke-width="1.7" marker-end="url(#arrow)"/>
+    <path d="M 193 284 L 285 260" fill="none" stroke="#64748B" stroke-width="1.7" marker-end="url(#arrow)"/>
+    <path d="M 193 359 L 285 275" fill="none" stroke="#64748B" stroke-width="1.7" marker-end="url(#arrow)"/>
+    <line x1="455" y1="250" x2="465" y2="250" stroke="#64748B" stroke-width="1.7" marker-end="url(#arrow)"/>
+    <path d="M 735 250 L 748 250 L 748 151 L 760 151" fill="none" stroke="#64748B" stroke-width="1.7" marker-end="url(#arrow)"/>
+    <text x="724" y="133" font-size="12" fill="#10B981">hit</text>
+    <path d="M 735 250 L 748 250 L 748 351 L 760 351" fill="none" stroke="#64748B" stroke-width="1.7" marker-end="url(#arrow)"/>
+    <text x="718" y="374" font-size="12" fill="#0284C7">miss</text>
   </g>
 </svg>

--- a/packages/web/content/docs/cli/workflow/workflow-overview.svg
+++ b/packages/web/content/docs/cli/workflow/workflow-overview.svg
@@ -1,58 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" width="960" height="520" role="img" aria-label="Crab workflow overview">
   <defs>
     <marker id="arrow-blue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#2563EB"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
     <marker id="arrow-teal" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#0D9488"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
     <filter id="soft-shadow" x="-10%" y="-10%" width="120%" height="120%">
-      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.08"/>
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#0F172A" flood-opacity="0.08"/>
     </filter>
   </defs>
-  <rect width="960" height="520" fill="#F9FAFB"/>
-  <text x="480" y="48" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#0F172A">Crab Workflow in a Production Repo</text>
+  <rect width="960" height="520" fill="#FFFFFF"/>
+  <text x="480" y="48" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" fill="#0F172A">Crab Workflow in a Production Repo</text>
 
   <rect x="50" y="95" width="250" height="330" rx="14" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5" filter="url(#soft-shadow)"/>
-  <text x="75" y="130" font-family="Inter, -apple-system, sans-serif" font-size="16" font-weight="700" fill="#0F172A">Git repository</text>
-  <text x="75" y="154" font-family="Inter, -apple-system, sans-serif" font-size="13" fill="#64748B">Committed, reviewed state</text>
-  <rect x="78" y="188" width="190" height="42" rx="8" fill="#EFF6FF" stroke="#BFDBFE"/>
-  <text x="173" y="214" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#1E3A5F">crab.yaml</text>
-  <rect x="78" y="246" width="190" height="42" rx="8" fill="#EFF6FF" stroke="#BFDBFE"/>
-  <text x="173" y="272" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#1E3A5F">crab.lock</text>
-  <rect x="78" y="304" width="190" height="42" rx="8" fill="#F8FAFC" stroke="#CBD5E1"/>
-  <text x="173" y="330" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#334155">params and metrics</text>
-  <rect x="78" y="362" width="190" height="42" rx="8" fill="#F8FAFC" stroke="#CBD5E1"/>
-  <text x="173" y="388" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#334155">pointer files</text>
+  <text x="75" y="130" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="700" fill="#0F172A">Git repository</text>
+  <text x="75" y="154" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#64748B">Committed, reviewed state</text>
+  <rect x="78" y="188" width="190" height="42" rx="8" fill="#F0F9FF" stroke="#BAE6FD"/>
+  <text x="173" y="214" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">crab.yaml</text>
+  <rect x="78" y="246" width="190" height="42" rx="8" fill="#F0F9FF" stroke="#BAE6FD"/>
+  <text x="173" y="272" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">crab.lock</text>
+  <rect x="78" y="304" width="190" height="42" rx="8" fill="#F8FAFC" stroke="#E2E8F0"/>
+  <text x="173" y="330" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">params and metrics</text>
+  <rect x="78" y="362" width="190" height="42" rx="8" fill="#F8FAFC" stroke="#E2E8F0"/>
+  <text x="173" y="388" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">pointer files</text>
 
-  <rect x="360" y="120" width="240" height="275" rx="14" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5" filter="url(#soft-shadow)"/>
-  <text x="480" y="155" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="17" font-weight="700" fill="#0F172A">Workflow engine</text>
-  <text x="480" y="178" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" fill="#64748B">Run, cache, compare, experiment</text>
-  <rect x="390" y="215" width="180" height="42" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
-  <text x="480" y="241" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0D9488">stage hash</text>
-  <rect x="390" y="273" width="180" height="42" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
-  <text x="480" y="299" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0D9488">local stage cache</text>
-  <rect x="390" y="331" width="180" height="42" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
-  <text x="480" y="357" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0D9488">run journal</text>
+  <rect x="360" y="120" width="240" height="275" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" filter="url(#soft-shadow)"/>
+  <text x="480" y="155" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="17" font-weight="700" fill="#0F172A">Workflow engine</text>
+  <text x="480" y="178" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#64748B">Run, cache, compare, experiment</text>
+  <rect x="390" y="215" width="180" height="42" rx="8" fill="#FFFFFF" stroke="#A7F3D0"/>
+  <text x="480" y="241" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#10B981">stage hash</text>
+  <rect x="390" y="273" width="180" height="42" rx="8" fill="#FFFFFF" stroke="#A7F3D0"/>
+  <text x="480" y="299" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#10B981">local stage cache</text>
+  <rect x="390" y="331" width="180" height="42" rx="8" fill="#FFFFFF" stroke="#A7F3D0"/>
+  <text x="480" y="357" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#10B981">run journal</text>
 
   <rect x="675" y="95" width="235" height="330" rx="14" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1.5" filter="url(#soft-shadow)"/>
-  <text x="793" y="130" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="16" font-weight="700" fill="#0F172A">Crab remote</text>
-  <text x="793" y="154" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" fill="#64748B">Object storage and refs</text>
-  <ellipse cx="793" cy="225" rx="88" ry="28" fill="#EFF6FF" stroke="#BFDBFE"/>
-  <rect x="705" y="225" width="176" height="76" fill="#EFF6FF" stroke="#BFDBFE"/>
-  <ellipse cx="793" cy="301" rx="88" ry="28" fill="#DBEAFE" stroke="#93C5FD"/>
-  <text x="793" y="267" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#1E3A5F">stage cache</text>
-  <text x="793" y="288" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" fill="#64748B">outputs and manifests</text>
-  <rect x="708" y="348" width="170" height="42" rx="8" fill="#F8FAFC" stroke="#CBD5E1"/>
-  <text x="793" y="374" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#334155">experiments</text>
+  <text x="793" y="130" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="700" fill="#0F172A">Crab remote</text>
+  <text x="793" y="154" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#64748B">Object storage and refs</text>
+  <ellipse cx="793" cy="225" rx="88" ry="28" fill="#F0F9FF" stroke="#BAE6FD"/>
+  <rect x="705" y="225" width="176" height="76" fill="#F0F9FF" stroke="#BAE6FD"/>
+  <ellipse cx="793" cy="301" rx="88" ry="28" fill="#E0F2FE" stroke="#7DD3FC"/>
+  <text x="793" y="267" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">stage cache</text>
+  <text x="793" y="288" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#64748B">outputs and manifests</text>
+  <rect x="708" y="348" width="170" height="42" rx="8" fill="#F8FAFC" stroke="#E2E8F0"/>
+  <text x="793" y="374" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">experiments</text>
 
-  <path d="M 300 235 L 360 235" stroke="#2563EB" stroke-width="2" marker-end="url(#arrow-blue)"/>
-  <text x="330" y="220" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" fill="#334155">parse</text>
-  <path d="M 600 250 L 675 250" stroke="#0D9488" stroke-width="2" marker-end="url(#arrow-teal)"/>
-  <text x="638" y="235" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" fill="#0D9488">push cache</text>
-  <path d="M 675 315 L 600 315" stroke="#2563EB" stroke-width="2" marker-end="url(#arrow-blue)"/>
-  <text x="638" y="337" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="12" fill="#334155">replay</text>
+  <path d="M 300 235 L 360 235" stroke="#64748B" stroke-width="2" marker-end="url(#arrow-blue)"/>
+  <text x="330" y="220" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#0F172A">parse</text>
+  <path d="M 600 250 L 675 250" stroke="#64748B" stroke-width="2" marker-end="url(#arrow-teal)"/>
+  <text x="638" y="235" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#10B981">push cache</text>
+  <path d="M 675 315 L 600 315" stroke="#64748B" stroke-width="2" marker-end="url(#arrow-blue)"/>
+  <text x="638" y="337" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#0F172A">replay</text>
 
-  <rect x="350" y="438" width="260" height="46" rx="10" fill="#F1F5F9" stroke="#CBD5E1"/>
-  <text x="480" y="466" text-anchor="middle" font-family="Inter, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#334155">Collaborators and CI reuse the same committed DAG and remote cache</text>
+  <rect x="350" y="438" width="260" height="46" rx="10" fill="#F8FAFC" stroke="#E2E8F0"/>
+  <text x="480" y="466" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Collaborators and CI reuse the same committed DAG and remote cache</text>
 </svg>


### PR DESCRIPTION
## Summary
- apply the shared Crab palette to all 22 SVG diagrams under packages/web/content/docs/cli
- remove legacy gradients and dark blocks while preserving diagram geometry and flow semantics
- normalize typography, pastel fills, and slate connectors across the diagrams

## Validation
- npm run build
- npm run typecheck
- npm run test
- npm run lint (passes with existing warnings)
- npm run check:links
- xmllint validation for all SVGs