### PR TITLE
docs(web): refresh diagnostic flow diagrams

### DIFF
--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -1,76 +1,85 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 560" width="620" height="560">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 748" width="960" height="748" role="img" aria-labelledby="restore-title restore-desc">
+  <title id="restore-title">Crab hydrate restore flow</title>
+  <desc id="restore-desc">Crab hydrate probes xorb storage-class metadata, hydrates warm objects immediately, and sends archived objects through restore policy, tiered restore requests, exponential polling, and timeout handling.</desc>
 
   <defs>
-    <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
   </defs>
 
-  <g id="background">
-    <rect x="0" y="0" width="620" height="560" fill="#FFFFFF"/>
+  <rect width="960" height="748" fill="#FFFFFF"/>
+
+  <g id="entry">
+    <rect x="365" y="24" width="230" height="54" rx="14" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="480" y="57" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="700" fill="#0F172A">crab hydrate --all</text>
+
+    <rect x="325" y="106" width="310" height="58" rx="14" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <text x="480" y="131" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">HEAD xorb</text>
+    <text x="480" y="150" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read storage-class metadata</text>
+
+    <polygon points="500,200 620,248 500,296 380,248" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="500" y="245" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">storage class?</text>
   </g>
 
-  <g id="containers">
+  <g id="warm-path">
+    <text x="296" y="273" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#10B981">Warm</text>
+    <rect x="50" y="345" width="300" height="86" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="200" y="375" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Warm classes</text>
+    <text x="200" y="397" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Standard · Standard-IA · Glacier Instant Retrieval</text>
+    <text x="200" y="416" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#10B981">hydrate immediately</text>
+
+    <rect x="105" y="470" width="190" height="62" rx="13" fill="#FFFFFF" stroke="#10B981" stroke-width="1.5"/>
+    <text x="200" y="507" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Hydrate xorb</text>
   </g>
 
-  <g id="nodes">
-    <!-- crab hydrate -->
-    <rect x="220" y="30" width="180" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <!-- HEAD request -->
-    <rect x="200" y="120" width="220" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
-    <!-- Storage class? diamond -->
-    <polygon points="310,210 410,255 310,300 210,255" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <!-- Read immediately (Warm) -->
-    <rect x="60" y="330" width="180" height="50" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <!-- auto_restore? diamond (Archive) -->
-    <polygon points="460,330 560,375 460,420 360,375" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <!-- Issue restore request (Yes) -->
-    <rect x="360" y="450" width="200" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <!-- Error (No) -->
-    <rect x="100" y="450" width="220" height="50" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <!-- Poll until ready -->
-    <rect x="360" y="530" width="200" height="50" rx="8" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+  <g id="archive-path">
+    <text x="800" y="273" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0284C7">Archive classes</text>
+    <text x="800" y="289" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Glacier Flexible · Deep Archive · Azure Archive</text>
+
+    <polygon points="800,307 900,352 800,397 700,352" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="800" y="349" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">restore enabled?</text>
+
+    <rect x="390" y="415" width="235" height="76" rx="13" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="507" y="445" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">ArchiveRestoreRequired</text>
+    <text x="507" y="467" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">[CRAB-E0210] · --no-restore</text>
+
+    <rect x="660" y="415" width="280" height="76" rx="13" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <text x="800" y="438" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">RestoreOrchestrator</text>
+    <text x="800" y="458" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">request a restore tier</text>
+    <text x="800" y="477" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600" fill="#06B6D4">expedited · standard · bulk</text>
+
+    <rect x="660" y="515" width="280" height="76" rx="13" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="800" y="539" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Poll until readable</text>
+    <text x="800" y="559" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">30s × 1.5 · 10-minute cap</text>
+    <text x="800" y="578" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">timeout: 6 hours by default</text>
+
+    <rect x="610" y="620" width="170" height="62" rx="13" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="695" y="657" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Hydrate xorb</text>
+
+    <rect x="800" y="620" width="140" height="62" rx="13" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="870" y="647" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0F172A">Restore timeout</text>
+    <text x="870" y="666" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">[CRAB-E0211] · retry</text>
   </g>
 
-  <g id="labels">
-    <text x="310" y="60" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab hydrate</text>
-    <text x="310" y="150" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">HEAD request for xorb</text>
-    <text x="310" y="252" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Storage class?</text>
-
-    <!-- Branch labels -->
-    <text x="155" y="310" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Warm</text>
-    <text x="430" y="310" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B">Archive</text>
-
-    <text x="150" y="360" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Read immediately</text>
-
-    <text x="460" y="372" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">auto_restore?</text>
-
-    <!-- auto_restore branches -->
-    <text x="500" y="430" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7">Yes</text>
-    <text x="330" y="430" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#F59E0B">No</text>
-
-    <text x="460" y="480" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Issue restore request</text>
-    <text x="210" y="480" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">ArchiveRestoreRequired error</text>
-    <text x="460" y="560" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="bold" fill="#0F172A">Poll until ready</text>
+  <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5">
+    <line x1="480" y1="78" x2="480" y2="106" marker-end="url(#arrowhead)"/>
+    <line x1="480" y1="164" x2="480" y2="200" marker-end="url(#arrowhead)"/>
+    <path d="M 380 248 H 200 V 345" marker-end="url(#arrowhead)"/>
+    <line x1="200" y1="431" x2="200" y2="470" marker-end="url(#arrowhead)"/>
+    <path d="M 620 248 H 800 V 307" marker-end="url(#arrowhead)"/>
+    <path d="M 700 352 H 625 V 415" marker-end="url(#arrowhead)"/>
+    <line x1="800" y1="397" x2="800" y2="415" marker-end="url(#arrowhead)"/>
+    <line x1="800" y1="491" x2="800" y2="515" marker-end="url(#arrowhead)"/>
+    <path d="M 800 591 V 607 H 695 V 620" marker-end="url(#arrowhead)"/>
+    <path d="M 800 607 H 870 V 620" marker-end="url(#arrowhead)"/>
   </g>
 
-  <g id="connections">
-    <!-- hydrate → HEAD -->
-    <line x1="310" y1="80" x2="310" y2="120" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- HEAD → Storage class? -->
-    <line x1="310" y1="170" x2="310" y2="210" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- Storage class → Read (Warm, left) -->
-    <path d="M 210 255 L 150 255 L 150 330" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- Storage class → auto_restore? (Archive, right) -->
-    <path d="M 410 255 L 460 255 L 460 330" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- auto_restore → Restore (Yes, down) -->
-    <line x1="460" y1="420" x2="460" y2="450" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- auto_restore → Error (No, left) -->
-    <path d="M 360 375 L 210 375 L 210 450" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- Restore → Poll -->
-    <line x1="460" y1="500" x2="460" y2="530" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- Poll → Read -->
-    <path d="M 360 555 L 150 555 L 150 380" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <g id="branch-labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">
+    <text x="670" y="408">No</text>
+    <text x="820" y="410" fill="#10B981">Yes</text>
   </g>
 
+  <rect x="60" y="705" width="840" height="30" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
+  <text x="480" y="725" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">Restore policy: --no-restore overrides --restore, then hydrate.auto_restore config</text>
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 760" width="960" height="760" role="img" aria-labelledby="restore-title restore-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 932" width="960" height="932" role="img" aria-labelledby="restore-title restore-desc">
   <title id="restore-title">Crab hydrate restore flow</title>
   <desc id="restore-desc">Crab hydrate probes xorb storage-class metadata, hydrates warm objects immediately, and sends archived objects through restore policy, tiered restore requests, exponential polling, and timeout handling.</desc>
 
@@ -8,78 +8,78 @@
     </marker>
   </defs>
 
-  <rect width="960" height="760" fill="#FFFFFF"/>
+  <rect width="960" height="932" fill="#FFFFFF"/>
 
   <g id="entry">
-    <rect x="365" y="24" width="230" height="54" rx="14" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <text x="480" y="57" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="700" fill="#0F172A">crab hydrate --all</text>
+    <rect x="350" y="24" width="260" height="62" rx="15" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="480" y="62" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="700" fill="#0F172A">crab hydrate --all</text>
 
-    <rect x="325" y="106" width="310" height="58" rx="14" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
-    <text x="480" y="131" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">HEAD xorb</text>
-    <text x="480" y="150" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read storage-class metadata</text>
+    <rect x="310" y="128" width="340" height="70" rx="15" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <text x="480" y="158" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">HEAD xorb</text>
+    <text x="480" y="181" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read storage-class metadata</text>
 
-    <polygon points="500,200 620,248 500,296 380,248" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="500" y="245" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">storage class?</text>
+    <polygon points="480,240 620,296 480,352 340,296" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="480" y="294" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">storage class?</text>
   </g>
 
   <g id="warm-path">
-    <text x="296" y="273" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#10B981">Warm</text>
-    <rect x="50" y="345" width="300" height="86" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text x="200" y="375" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Warm classes</text>
-    <text x="200" y="397" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Standard · Standard-IA · Glacier Instant Retrieval</text>
-    <text x="200" y="416" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#10B981">hydrate immediately</text>
+    <text x="225" y="377" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#10B981">Warm</text>
+    <rect x="50" y="404" width="350" height="100" rx="15" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="225" y="442" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Warm classes</text>
+    <text x="225" y="468" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Standard · Standard-IA · Glacier Instant Retrieval</text>
+    <text x="225" y="491" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#10B981">hydrate immediately</text>
 
-    <rect x="105" y="470" width="190" height="62" rx="13" fill="#FFFFFF" stroke="#10B981" stroke-width="1.5"/>
-    <text x="200" y="507" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Hydrate xorb</text>
+    <rect x="120" y="548" width="210" height="72" rx="14" fill="#FFFFFF" stroke="#10B981" stroke-width="1.5"/>
+    <text x="225" y="591" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Hydrate xorb</text>
   </g>
 
   <g id="archive-path">
-    <text x="800" y="273" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0284C7">Archive classes</text>
-    <text x="800" y="289" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Glacier Flexible · Deep Archive · Azure Archive</text>
+    <text x="790" y="377" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0284C7">Archive classes</text>
+    <text x="790" y="402" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Glacier Flexible · Deep Archive · Azure Archive</text>
 
-    <polygon points="800,307 900,352 800,397 700,352" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="800" y="349" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">restore enabled?</text>
+    <polygon points="790,430 900,480 790,530 680,480" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="790" y="484" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">restore enabled?</text>
 
-    <rect x="390" y="415" width="235" height="76" rx="13" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text x="507" y="445" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">ArchiveRestoreRequired</text>
-    <text x="507" y="467" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">[CRAB-E0210] · --no-restore</text>
+    <rect x="340" y="565" width="280" height="86" rx="14" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="480" y="599" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">ArchiveRestoreRequired</text>
+    <text x="480" y="624" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">[CRAB-E0210] · --no-restore</text>
 
-    <rect x="660" y="415" width="280" height="76" rx="13" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
-    <text x="800" y="438" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">RestoreOrchestrator</text>
-    <text x="800" y="458" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">request a restore tier</text>
-    <text x="800" y="477" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600" fill="#06B6D4">expedited · standard · bulk</text>
+    <rect x="640" y="565" width="300" height="86" rx="14" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <text x="790" y="598" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">RestoreOrchestrator</text>
+    <text x="790" y="621" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">request a restore tier</text>
+    <text x="790" y="646" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600" fill="#06B6D4">expedited · standard · bulk</text>
 
-    <rect x="660" y="515" width="280" height="76" rx="13" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="800" y="539" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Poll until readable</text>
-    <text x="800" y="559" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">30s × 1.5 · 10-minute cap</text>
-    <text x="800" y="578" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">timeout: 6 hours by default</text>
+    <rect x="640" y="690" width="300" height="90" rx="14" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="790" y="724" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Poll until readable</text>
+    <text x="790" y="748" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">30s × 1.5 · 10-minute cap</text>
+    <text x="790" y="772" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">timeout: 6 hours by default</text>
 
-    <rect x="610" y="620" width="170" height="62" rx="13" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text x="695" y="657" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Hydrate xorb</text>
+    <rect x="590" y="800" width="180" height="70" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="680" y="842" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Hydrate xorb</text>
 
-    <rect x="800" y="620" width="140" height="62" rx="13" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text x="870" y="647" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0F172A">Restore timeout</text>
-    <text x="870" y="666" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">[CRAB-E0211] · retry</text>
+    <rect x="790" y="800" width="150" height="70" rx="14" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="865" y="831" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0F172A">Restore timeout</text>
+    <text x="865" y="855" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">[CRAB-E0211] · retry</text>
   </g>
 
   <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-    <line x1="480" y1="78" x2="480" y2="102" marker-end="url(#arrowhead)"/>
-    <line x1="480" y1="164" x2="480" y2="196" marker-end="url(#arrowhead)"/>
-    <path d="M 380 248 H 200 V 341" marker-end="url(#arrowhead)"/>
-    <line x1="200" y1="431" x2="200" y2="466" marker-end="url(#arrowhead)"/>
-    <path d="M 620 248 H 680 V 303 H 800" marker-end="url(#arrowhead)"/>
-    <path d="M 700 352 H 650 V 400 H 507 V 411" marker-end="url(#arrowhead)"/>
-    <line x1="800" y1="397" x2="800" y2="411" marker-end="url(#arrowhead)"/>
-    <line x1="800" y1="491" x2="800" y2="511" marker-end="url(#arrowhead)"/>
-    <path d="M 800 591 V 600 H 695 V 616" marker-end="url(#arrowhead)"/>
-    <path d="M 800 600 H 870 V 616" marker-end="url(#arrowhead)"/>
+    <line x1="480" y1="86" x2="480" y2="120" marker-end="url(#arrowhead)"/>
+    <line x1="480" y1="198" x2="480" y2="232" marker-end="url(#arrowhead)"/>
+    <path d="M 340 296 H 180 V 388 H 225 V 396" marker-end="url(#arrowhead)"/>
+    <line x1="225" y1="504" x2="225" y2="540" marker-end="url(#arrowhead)"/>
+    <path d="M 620 296 H 640 V 414 H 790 V 422" marker-end="url(#arrowhead)"/>
+    <path d="M 680 480 H 620 V 540 H 480 V 557" marker-end="url(#arrowhead)"/>
+    <line x1="790" y1="530" x2="790" y2="557" marker-end="url(#arrowhead)"/>
+    <line x1="790" y1="651" x2="790" y2="682" marker-end="url(#arrowhead)"/>
+    <path d="M 790 780 V 789 H 680 V 792" marker-end="url(#arrowhead)"/>
+    <path d="M 790 789 H 865 V 792" marker-end="url(#arrowhead)"/>
   </g>
 
   <g id="branch-labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">
-    <text x="660" y="392">No</text>
-    <text x="820" y="407" fill="#10B981">Yes</text>
+    <text x="635" y="526">No</text>
+    <text x="820" y="551" fill="#10B981">Yes</text>
   </g>
 
-  <rect x="60" y="705" width="840" height="30" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
-  <text x="480" y="725" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">Restore policy: --no-restore overrides --restore, then hydrate.auto_restore config</text>
+  <rect x="30" y="892" width="900" height="30" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
+  <text x="480" y="912" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">Restore policy: --no-restore overrides --restore, then hydrate.auto_restore config</text>
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 932" width="960" height="932" role="img" aria-labelledby="restore-title restore-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 1060" width="960" height="1060" role="img" aria-labelledby="restore-title restore-desc">
   <title id="restore-title">Crab hydrate restore flow</title>
   <desc id="restore-desc">Crab hydrate probes xorb storage-class metadata, hydrates warm objects immediately, and sends archived objects through restore policy, tiered restore requests, exponential polling, and timeout handling.</desc>
 
@@ -8,7 +8,7 @@
     </marker>
   </defs>
 
-  <rect width="960" height="932" fill="#FFFFFF"/>
+  <rect width="960" height="1060" fill="#FFFFFF"/>
 
   <g id="entry">
     <rect x="350" y="24" width="260" height="62" rx="15" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
@@ -49,17 +49,17 @@
     <text x="790" y="621" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">request a restore tier</text>
     <text x="790" y="646" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600" fill="#06B6D4">expedited · standard · bulk</text>
 
-    <rect x="640" y="690" width="300" height="90" rx="14" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="790" y="724" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Poll until readable</text>
-    <text x="790" y="748" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">30s × 1.5 · 10-minute cap</text>
-    <text x="790" y="772" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">timeout: 6 hours by default</text>
+    <rect x="640" y="700" width="300" height="112" rx="14" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="790" y="742" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Poll until readable</text>
+    <text x="790" y="771" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">30s × 1.5 · 10-minute cap</text>
+    <text x="790" y="796" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">timeout: 6 hours by default</text>
 
-    <rect x="590" y="800" width="180" height="70" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text x="680" y="842" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Hydrate xorb</text>
+    <rect x="590" y="900" width="180" height="82" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="680" y="949" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Hydrate xorb</text>
 
-    <rect x="790" y="800" width="150" height="70" rx="14" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text x="865" y="831" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0F172A">Restore timeout</text>
-    <text x="865" y="855" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">[CRAB-E0211] · retry</text>
+    <rect x="790" y="900" width="150" height="82" rx="14" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="865" y="937" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0F172A">Restore timeout</text>
+    <text x="865" y="963" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">[CRAB-E0211] · retry</text>
   </g>
 
   <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -70,9 +70,9 @@
     <path d="M 620 296 H 640 V 414 H 790 V 422" marker-end="url(#arrowhead)"/>
     <path d="M 680 480 H 620 V 540 H 480 V 557" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="530" x2="790" y2="557" marker-end="url(#arrowhead)"/>
-    <line x1="790" y1="651" x2="790" y2="682" marker-end="url(#arrowhead)"/>
-    <path d="M 790 780 V 789 H 680 V 792" marker-end="url(#arrowhead)"/>
-    <path d="M 790 789 H 865 V 792" marker-end="url(#arrowhead)"/>
+    <line x1="790" y1="651" x2="790" y2="692" marker-end="url(#arrowhead)"/>
+    <path d="M 790 812 V 858 H 680 V 892" marker-end="url(#arrowhead)"/>
+    <path d="M 790 858 H 865 V 892" marker-end="url(#arrowhead)"/>
   </g>
 
   <g id="branch-labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">
@@ -80,6 +80,6 @@
     <text x="820" y="551" fill="#10B981">Yes</text>
   </g>
 
-  <rect x="30" y="892" width="900" height="30" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
-  <text x="480" y="912" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">Restore policy: --no-restore overrides --restore, then hydrate.auto_restore config</text>
+  <rect x="30" y="1018" width="900" height="32" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
+  <text x="480" y="1039" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">Restore policy: --no-restore overrides --restore, then hydrate.auto_restore config</text>
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 748" width="960" height="748" role="img" aria-labelledby="restore-title restore-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 760" width="960" height="760" role="img" aria-labelledby="restore-title restore-desc">
   <title id="restore-title">Crab hydrate restore flow</title>
   <desc id="restore-desc">Crab hydrate probes xorb storage-class metadata, hydrates warm objects immediately, and sends archived objects through restore policy, tiered restore requests, exponential polling, and timeout handling.</desc>
 
@@ -67,8 +67,8 @@
     <line x1="480" y1="164" x2="480" y2="200" marker-end="url(#arrowhead)"/>
     <path d="M 380 248 H 200 V 345" marker-end="url(#arrowhead)"/>
     <line x1="200" y1="431" x2="200" y2="470" marker-end="url(#arrowhead)"/>
-    <path d="M 620 248 H 800 V 307" marker-end="url(#arrowhead)"/>
-    <path d="M 700 352 H 625 V 415" marker-end="url(#arrowhead)"/>
+    <path d="M 620 248 H 680 V 307 H 800" marker-end="url(#arrowhead)"/>
+    <path d="M 700 352 H 650 V 400 H 507 V 415" marker-end="url(#arrowhead)"/>
     <line x1="800" y1="397" x2="800" y2="415" marker-end="url(#arrowhead)"/>
     <line x1="800" y1="491" x2="800" y2="515" marker-end="url(#arrowhead)"/>
     <path d="M 800 591 V 607 H 695 V 620" marker-end="url(#arrowhead)"/>
@@ -76,7 +76,7 @@
   </g>
 
   <g id="branch-labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">
-    <text x="670" y="408">No</text>
+    <text x="660" y="392">No</text>
     <text x="820" y="410" fill="#10B981">Yes</text>
   </g>
 

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -8,7 +8,7 @@
     </marker>
   </defs>
 
-  <rect width="960" height="748" fill="#FFFFFF"/>
+  <rect width="960" height="760" fill="#FFFFFF"/>
 
   <g id="entry">
     <rect x="365" y="24" width="230" height="54" rx="14" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
@@ -63,16 +63,16 @@
   </g>
 
   <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5">
-    <line x1="480" y1="78" x2="480" y2="106" marker-end="url(#arrowhead)"/>
-    <line x1="480" y1="164" x2="480" y2="200" marker-end="url(#arrowhead)"/>
-    <path d="M 380 248 H 200 V 345" marker-end="url(#arrowhead)"/>
-    <line x1="200" y1="431" x2="200" y2="470" marker-end="url(#arrowhead)"/>
-    <path d="M 620 248 H 680 V 307 H 800" marker-end="url(#arrowhead)"/>
-    <path d="M 700 352 H 650 V 400 H 507 V 415" marker-end="url(#arrowhead)"/>
-    <line x1="800" y1="397" x2="800" y2="415" marker-end="url(#arrowhead)"/>
-    <line x1="800" y1="491" x2="800" y2="515" marker-end="url(#arrowhead)"/>
-    <path d="M 800 591 V 607 H 695 V 620" marker-end="url(#arrowhead)"/>
-    <path d="M 800 607 H 870 V 620" marker-end="url(#arrowhead)"/>
+    <line x1="480" y1="78" x2="480" y2="96" marker-end="url(#arrowhead)"/>
+    <line x1="480" y1="164" x2="480" y2="190" marker-end="url(#arrowhead)"/>
+    <path d="M 380 248 H 200 V 335" marker-end="url(#arrowhead)"/>
+    <line x1="200" y1="431" x2="200" y2="460" marker-end="url(#arrowhead)"/>
+    <path d="M 620 248 H 680 V 297 H 800" marker-end="url(#arrowhead)"/>
+    <path d="M 700 352 H 650 V 400 H 507 V 405" marker-end="url(#arrowhead)"/>
+    <line x1="800" y1="397" x2="800" y2="405" marker-end="url(#arrowhead)"/>
+    <line x1="800" y1="491" x2="800" y2="505" marker-end="url(#arrowhead)"/>
+    <path d="M 800 591 V 600 H 695 V 610" marker-end="url(#arrowhead)"/>
+    <path d="M 800 600 H 870 V 610" marker-end="url(#arrowhead)"/>
   </g>
 
   <g id="branch-labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -67,7 +67,7 @@
     <line x1="480" y1="198" x2="480" y2="232" marker-end="url(#arrowhead)"/>
     <path d="M 340 296 H 225 V 396" marker-end="url(#arrowhead)"/>
     <line x1="225" y1="504" x2="225" y2="540" marker-end="url(#arrowhead)"/>
-    <path d="M 620 296 H 640 V 414 H 790 V 422" marker-end="url(#arrowhead)"/>
+    <path d="M 620 296 H 640 V 414 H 790 V 428" marker-end="url(#arrowhead)"/>
     <path d="M 680 480 H 620 V 565 H 480 V 582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="530" x2="790" y2="582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="680" x2="790" y2="722" marker-end="url(#arrowhead)"/>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -67,7 +67,7 @@
     <line x1="480" y1="198" x2="480" y2="232" marker-end="url(#arrowhead)"/>
     <path d="M 340 296 H 225 V 396" marker-end="url(#arrowhead)"/>
     <line x1="225" y1="504" x2="225" y2="540" marker-end="url(#arrowhead)"/>
-    <path d="M 620 296 H 640 V 414 H 790 V 418" marker-end="url(#arrowhead)"/>
+    <path d="M 620 296 H 640 V 414 H 790 V 430" marker-end="url(#arrowhead)"/>
     <path d="M 680 480 H 620 V 565 H 480 V 582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="530" x2="790" y2="582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="680" x2="790" y2="722" marker-end="url(#arrowhead)"/>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -67,7 +67,7 @@
     <line x1="480" y1="198" x2="480" y2="232" marker-end="url(#arrowhead)"/>
     <path d="M 340 296 H 225 V 396" marker-end="url(#arrowhead)"/>
     <line x1="225" y1="504" x2="225" y2="540" marker-end="url(#arrowhead)"/>
-    <path d="M 620 296 H 640 V 404 H 790 V 410" marker-end="url(#arrowhead)"/>
+    <path d="M 620 296 H 640 V 404 H 790 V 426" marker-end="url(#arrowhead)"/>
     <path d="M 680 480 H 620 V 565 H 480 V 582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="530" x2="790" y2="582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="680" x2="790" y2="722" marker-end="url(#arrowhead)"/>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -67,7 +67,7 @@
     <line x1="480" y1="198" x2="480" y2="232" marker-end="url(#arrowhead)"/>
     <path d="M 340 296 H 225 V 396" marker-end="url(#arrowhead)"/>
     <line x1="225" y1="504" x2="225" y2="540" marker-end="url(#arrowhead)"/>
-    <path d="M 620 296 H 640 V 414 H 790 V 428" marker-end="url(#arrowhead)"/>
+    <path d="M 620 296 H 640 V 414 H 790 V 418" marker-end="url(#arrowhead)"/>
     <path d="M 680 480 H 620 V 565 H 480 V 582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="530" x2="790" y2="582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="680" x2="790" y2="722" marker-end="url(#arrowhead)"/>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -3,8 +3,8 @@
   <desc id="restore-desc">Crab hydrate probes xorb storage-class metadata, hydrates warm objects immediately, and sends archived objects through restore policy, tiered restore requests, exponential polling, and timeout handling.</desc>
 
   <defs>
-    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
+    <marker id="arrowhead" markerWidth="9" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#64748B"/>
     </marker>
   </defs>
 
@@ -62,22 +62,22 @@
     <text x="870" y="666" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">[CRAB-E0211] · retry</text>
   </g>
 
-  <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5">
-    <line x1="480" y1="78" x2="480" y2="96" marker-end="url(#arrowhead)"/>
-    <line x1="480" y1="164" x2="480" y2="190" marker-end="url(#arrowhead)"/>
-    <path d="M 380 248 H 200 V 335" marker-end="url(#arrowhead)"/>
-    <line x1="200" y1="431" x2="200" y2="460" marker-end="url(#arrowhead)"/>
-    <path d="M 620 248 H 680 V 297 H 800" marker-end="url(#arrowhead)"/>
-    <path d="M 700 352 H 650 V 400 H 507 V 405" marker-end="url(#arrowhead)"/>
-    <line x1="800" y1="397" x2="800" y2="405" marker-end="url(#arrowhead)"/>
-    <line x1="800" y1="491" x2="800" y2="505" marker-end="url(#arrowhead)"/>
-    <path d="M 800 591 V 600 H 695 V 610" marker-end="url(#arrowhead)"/>
-    <path d="M 800 600 H 870 V 610" marker-end="url(#arrowhead)"/>
+  <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="480" y1="78" x2="480" y2="102" marker-end="url(#arrowhead)"/>
+    <line x1="480" y1="164" x2="480" y2="196" marker-end="url(#arrowhead)"/>
+    <path d="M 380 248 H 200 V 341" marker-end="url(#arrowhead)"/>
+    <line x1="200" y1="431" x2="200" y2="466" marker-end="url(#arrowhead)"/>
+    <path d="M 620 248 H 680 V 303 H 800" marker-end="url(#arrowhead)"/>
+    <path d="M 700 352 H 650 V 400 H 507 V 411" marker-end="url(#arrowhead)"/>
+    <line x1="800" y1="397" x2="800" y2="411" marker-end="url(#arrowhead)"/>
+    <line x1="800" y1="491" x2="800" y2="511" marker-end="url(#arrowhead)"/>
+    <path d="M 800 591 V 600 H 695 V 616" marker-end="url(#arrowhead)"/>
+    <path d="M 800 600 H 870 V 616" marker-end="url(#arrowhead)"/>
   </g>
 
   <g id="branch-labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">
     <text x="660" y="392">No</text>
-    <text x="820" y="410" fill="#10B981">Yes</text>
+    <text x="820" y="407" fill="#10B981">Yes</text>
   </g>
 
   <rect x="60" y="705" width="840" height="30" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 1060" width="960" height="1060" role="img" aria-labelledby="restore-title restore-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 1100" width="960" height="1100" role="img" aria-labelledby="restore-title restore-desc">
   <title id="restore-title">Crab hydrate restore flow</title>
   <desc id="restore-desc">Crab hydrate probes xorb storage-class metadata, hydrates warm objects immediately, and sends archived objects through restore policy, tiered restore requests, exponential polling, and timeout handling.</desc>
 
@@ -8,7 +8,7 @@
     </marker>
   </defs>
 
-  <rect width="960" height="1060" fill="#FFFFFF"/>
+  <rect width="960" height="1100" fill="#FFFFFF"/>
 
   <g id="entry">
     <rect x="350" y="24" width="260" height="62" rx="15" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
@@ -23,7 +23,7 @@
   </g>
 
   <g id="warm-path">
-    <text x="225" y="377" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#10B981">Warm</text>
+    <text x="205" y="367" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#10B981">Warm</text>
     <rect x="50" y="404" width="350" height="100" rx="15" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
     <text x="225" y="442" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Warm classes</text>
     <text x="225" y="468" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Standard · Standard-IA · Glacier Instant Retrieval</text>
@@ -34,45 +34,45 @@
   </g>
 
   <g id="archive-path">
-    <text x="790" y="377" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0284C7">Archive classes</text>
-    <text x="790" y="402" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Glacier Flexible · Deep Archive · Azure Archive</text>
+    <text x="790" y="365" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0284C7">Archive classes</text>
+    <text x="790" y="390" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">Glacier Flexible · Deep Archive · Azure Archive</text>
 
     <polygon points="790,430 900,480 790,530 680,480" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
     <text x="790" y="484" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">restore enabled?</text>
 
-    <rect x="340" y="565" width="280" height="86" rx="14" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text x="480" y="599" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">ArchiveRestoreRequired</text>
-    <text x="480" y="624" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">[CRAB-E0210] · --no-restore</text>
+    <rect x="340" y="590" width="280" height="90" rx="14" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="480" y="625" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">ArchiveRestoreRequired</text>
+    <text x="480" y="651" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">[CRAB-E0210] · --no-restore</text>
 
-    <rect x="640" y="565" width="300" height="86" rx="14" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
-    <text x="790" y="598" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">RestoreOrchestrator</text>
-    <text x="790" y="621" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">request a restore tier</text>
-    <text x="790" y="646" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600" fill="#06B6D4">expedited · standard · bulk</text>
+    <rect x="640" y="590" width="300" height="90" rx="14" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <text x="790" y="623" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">RestoreOrchestrator</text>
+    <text x="790" y="647" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">request a restore tier</text>
+    <text x="790" y="672" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600" fill="#06B6D4">expedited · standard · bulk</text>
 
-    <rect x="640" y="700" width="300" height="112" rx="14" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="790" y="742" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Poll until readable</text>
-    <text x="790" y="771" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">30s × 1.5 · 10-minute cap</text>
-    <text x="790" y="796" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">timeout: 6 hours by default</text>
+    <rect x="640" y="730" width="300" height="112" rx="14" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="790" y="772" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Poll until readable</text>
+    <text x="790" y="801" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">30s × 1.5 · 10-minute cap</text>
+    <text x="790" y="826" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">timeout: 6 hours by default</text>
 
-    <rect x="590" y="900" width="180" height="82" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text x="680" y="949" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Hydrate xorb</text>
+    <rect x="590" y="930" width="180" height="82" rx="14" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="680" y="979" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Hydrate xorb</text>
 
-    <rect x="790" y="900" width="150" height="82" rx="14" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text x="865" y="937" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0F172A">Restore timeout</text>
-    <text x="865" y="963" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">[CRAB-E0211] · retry</text>
+    <rect x="790" y="930" width="150" height="82" rx="14" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="865" y="967" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#0F172A">Restore timeout</text>
+    <text x="865" y="993" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">[CRAB-E0211] · retry</text>
   </g>
 
   <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
     <line x1="480" y1="86" x2="480" y2="120" marker-end="url(#arrowhead)"/>
     <line x1="480" y1="198" x2="480" y2="232" marker-end="url(#arrowhead)"/>
-    <path d="M 340 296 H 180 V 388 H 225 V 396" marker-end="url(#arrowhead)"/>
+    <path d="M 340 296 H 225 V 396" marker-end="url(#arrowhead)"/>
     <line x1="225" y1="504" x2="225" y2="540" marker-end="url(#arrowhead)"/>
     <path d="M 620 296 H 640 V 414 H 790 V 422" marker-end="url(#arrowhead)"/>
-    <path d="M 680 480 H 620 V 540 H 480 V 557" marker-end="url(#arrowhead)"/>
-    <line x1="790" y1="530" x2="790" y2="557" marker-end="url(#arrowhead)"/>
-    <line x1="790" y1="651" x2="790" y2="692" marker-end="url(#arrowhead)"/>
-    <path d="M 790 812 V 858 H 680 V 892" marker-end="url(#arrowhead)"/>
-    <path d="M 790 858 H 865 V 892" marker-end="url(#arrowhead)"/>
+    <path d="M 680 480 H 620 V 565 H 480 V 582" marker-end="url(#arrowhead)"/>
+    <line x1="790" y1="530" x2="790" y2="582" marker-end="url(#arrowhead)"/>
+    <line x1="790" y1="680" x2="790" y2="722" marker-end="url(#arrowhead)"/>
+    <path d="M 790 842 V 890 H 680 V 922" marker-end="url(#arrowhead)"/>
+    <path d="M 790 890 H 865 V 922" marker-end="url(#arrowhead)"/>
   </g>
 
   <g id="branch-labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">
@@ -80,6 +80,6 @@
     <text x="820" y="551" fill="#10B981">Yes</text>
   </g>
 
-  <rect x="30" y="1018" width="900" height="32" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
-  <text x="480" y="1039" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">Restore policy: --no-restore overrides --restore, then hydrate.auto_restore config</text>
+  <rect x="30" y="1050" width="900" height="32" rx="10" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
+  <text x="480" y="1071" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">Restore policy: --no-restore overrides --restore, then hydrate.auto_restore config</text>
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore-flow.svg
@@ -67,7 +67,7 @@
     <line x1="480" y1="198" x2="480" y2="232" marker-end="url(#arrowhead)"/>
     <path d="M 340 296 H 225 V 396" marker-end="url(#arrowhead)"/>
     <line x1="225" y1="504" x2="225" y2="540" marker-end="url(#arrowhead)"/>
-    <path d="M 620 296 H 640 V 414 H 790 V 430" marker-end="url(#arrowhead)"/>
+    <path d="M 620 296 H 640 V 404 H 790 V 410" marker-end="url(#arrowhead)"/>
     <path d="M 680 480 H 620 V 565 H 480 V 582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="530" x2="790" y2="582" marker-end="url(#arrowhead)"/>
     <line x1="790" y1="680" x2="790" y2="722" marker-end="url(#arrowhead)"/>

--- a/packages/web/content/docs/cli/diagnostics/hydrate-restore.mdx
+++ b/packages/web/content/docs/cli/diagnostics/hydrate-restore.mdx
@@ -11,7 +11,7 @@ meta:
 
 When files are stored in archive storage classes (S3 Glacier, Deep Archive, Azure Archive), they can't be read immediately. Crab's hydrate-restore subsystem detects archived xorbs during hydration and either automatically initiates a restore or fails with a clear error explaining what needs to happen.
 
-![Hydrate restore flow — probes storage class, reads warm files immediately, restores archived files with polling.](./hydrate-restore-flow.svg)
+![Hydrate restore flow — probes storage-class metadata, hydrates warm xorbs immediately, and routes archived xorbs through restore policy, tier selection, exponential polling, and timeout handling.](./hydrate-restore-flow.svg)
 
 ## How It Works
 

--- a/packages/web/content/docs/cli/diagnostics/integrity-check-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/integrity-check-flow.svg
@@ -11,9 +11,9 @@
   <rect width="920" height="620" fill="#FFFFFF"/>
 
   <g id="command">
-    <rect x="350" y="28" width="220" height="58" rx="14" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <text x="460" y="63" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="700" fill="#0F172A">crab fsck</text>
-    <text x="460" y="108" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read-only integrity check</text>
+    <rect x="350" y="24" width="220" height="72" rx="14" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="460" y="56" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="700" fill="#0F172A">crab fsck</text>
+    <text x="460" y="78" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read-only integrity check</text>
   </g>
 
   <g id="checks">
@@ -55,29 +55,29 @@
     <rect x="32" y="408" width="856" height="140" rx="16" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
     <text x="56" y="436" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0284C7" letter-spacing="0.6">WALK DATA CHAIN</text>
 
-    <rect x="56" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="146" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Pointer</text>
-    <text x="146" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">file hash</text>
+    <rect x="70" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="160" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Pointer</text>
+    <text x="160" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">file hash</text>
 
-    <rect x="256" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="346" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">File Index</text>
-    <text x="346" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">shard hash</text>
+    <rect x="270" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="360" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">File Index</text>
+    <text x="360" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">shard hash</text>
 
-    <rect x="456" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="546" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Shard</text>
-    <text x="546" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">xorb refs</text>
+    <rect x="470" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="560" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Shard</text>
+    <text x="560" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">xorb refs</text>
 
-    <rect x="656" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="746" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Xorb</text>
-    <text x="746" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">object bytes</text>
+    <rect x="670" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="760" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Xorb</text>
+    <text x="760" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">object bytes</text>
   </g>
 
   <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5">
-    <path d="M 460 86 V 128" marker-end="url(#arrowhead)"/>
+    <path d="M 460 96 V 148" marker-end="url(#arrowhead)"/>
     <path d="M 460 370 V 408" marker-end="url(#arrowhead)"/>
-    <line x1="236" y1="491" x2="256" y2="491" marker-end="url(#arrowhead)"/>
-    <line x1="436" y1="491" x2="456" y2="491" marker-end="url(#arrowhead)"/>
-    <line x1="636" y1="491" x2="656" y2="491" marker-end="url(#arrowhead)"/>
+    <line x1="250" y1="491" x2="270" y2="491" marker-end="url(#arrowhead)"/>
+    <line x1="450" y1="491" x2="470" y2="491" marker-end="url(#arrowhead)"/>
+    <line x1="650" y1="491" x2="670" y2="491" marker-end="url(#arrowhead)"/>
   </g>
 
   <rect x="48" y="570" width="824" height="32" rx="10" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1"/>

--- a/packages/web/content/docs/cli/diagnostics/integrity-check-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/integrity-check-flow.svg
@@ -1,74 +1,85 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 420" width="720" height="420">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 620" width="920" height="620" role="img" aria-labelledby="integrity-title integrity-desc">
+  <title id="integrity-title">Crab repository integrity checks</title>
+  <desc id="integrity-desc">Crab fsck checks Git objects, the data chain, pack and index manifests, push locks, multipart uploads, and shard lists before walking from a pointer through the file index and shard to the xorb.</desc>
 
   <defs>
-    <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
   </defs>
 
-  <g id="background">
-    <rect x="0" y="0" width="720" height="420" fill="#FFFFFF"/>
+  <rect width="920" height="620" fill="#FFFFFF"/>
+
+  <g id="command">
+    <rect x="350" y="28" width="220" height="58" rx="14" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="460" y="63" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="16" font-weight="700" fill="#0F172A">crab fsck</text>
+    <text x="460" y="108" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read-only integrity check</text>
   </g>
 
-  <g id="containers">
-    <!-- Data chain verification container -->
-    <rect x="30" y="260" width="660" height="130" rx="12" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1"/>
+  <g id="checks">
+    <rect x="32" y="148" width="856" height="222" rx="16" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+    <text x="56" y="177" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#64748B" letter-spacing="0.6">CROSS-CHECK REPOSITORY STATE</text>
+
+    <rect x="48" y="198" width="250" height="66" rx="12" fill="#FFFFFF" stroke="#10B981" stroke-width="1.5"/>
+    <circle cx="70" cy="222" r="5" fill="#10B981"/>
+    <text x="84" y="222" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Git objects</text>
+    <text x="84" y="243" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">all refs resolve</text>
+
+    <rect x="335" y="198" width="250" height="66" rx="12" fill="#FFFFFF" stroke="#10B981" stroke-width="1.5"/>
+    <circle cx="357" cy="222" r="5" fill="#10B981"/>
+    <text x="371" y="222" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Data chain</text>
+    <text x="371" y="243" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">file indices + xorbs</text>
+
+    <rect x="622" y="198" width="250" height="66" rx="12" fill="#FFFFFF" stroke="#10B981" stroke-width="1.5"/>
+    <circle cx="644" cy="222" r="5" fill="#10B981"/>
+    <text x="658" y="222" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Pack / index</text>
+    <text x="658" y="243" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">manifests consistent</text>
+
+    <rect x="48" y="286" width="250" height="66" rx="12" fill="#FFFFFF" stroke="#F59E0B" stroke-width="1.5"/>
+    <circle cx="70" cy="310" r="5" fill="#F59E0B"/>
+    <text x="84" y="310" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Push locks</text>
+    <text x="84" y="331" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">expired locks are repairable</text>
+
+    <rect x="335" y="286" width="250" height="66" rx="12" fill="#FFFFFF" stroke="#F59E0B" stroke-width="1.5"/>
+    <circle cx="357" cy="310" r="5" fill="#F59E0B"/>
+    <text x="371" y="310" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Multipart uploads</text>
+    <text x="371" y="331" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">none abandoned</text>
+
+    <rect x="622" y="286" width="250" height="66" rx="12" fill="#FFFFFF" stroke="#10B981" stroke-width="1.5"/>
+    <circle cx="644" cy="310" r="5" fill="#10B981"/>
+    <text x="658" y="310" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Shard list</text>
+    <text x="658" y="331" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">consistent with manifests</text>
   </g>
 
-  <g id="nodes">
-    <!-- crab fsck -->
-    <rect x="280" y="30" width="160" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+  <g id="data-chain">
+    <rect x="32" y="408" width="856" height="140" rx="16" fill="#F0F9FF" stroke="#BAE6FD" stroke-width="1.5"/>
+    <text x="56" y="436" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0284C7" letter-spacing="0.6">WALK DATA CHAIN</text>
 
-    <!-- Check items (row) -->
-    <rect x="40" y="130" width="150" height="46" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <rect x="210" y="130" width="150" height="46" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <rect x="380" y="130" width="150" height="46" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <rect x="550" y="130" width="150" height="46" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <rect x="56" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="146" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Pointer</text>
+    <text x="146" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">file hash</text>
 
-    <!-- Data chain (inside container) -->
-    <rect x="60" y="300" width="180" height="50" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="280" y="300" width="180" height="50" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="500" y="300" width="160" height="50" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="256" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="346" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">File Index</text>
+    <text x="346" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">shard hash</text>
+
+    <rect x="456" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="546" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Shard</text>
+    <text x="546" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">xorb refs</text>
+
+    <rect x="656" y="462" width="180" height="58" rx="12" fill="#FFFFFF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="746" y="486" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Xorb</text>
+    <text x="746" y="505" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">object bytes</text>
   </g>
 
-  <g id="labels">
-    <!-- crab fsck -->
-    <text x="360" y="60" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab fsck</text>
-
-    <!-- Check items -->
-    <text x="115" y="158" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Check git refs</text>
-    <text x="285" y="158" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Verify pack list</text>
-    <text x="455" y="158" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Check push locks</text>
-    <text x="625" y="152" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Find abandoned</text>
-    <text x="625" y="168" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">uploads</text>
-
-    <!-- Container label -->
-    <text x="50" y="283" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0284C7" letter-spacing="0.5">WALK DATA CHAIN</text>
-
-    <!-- Chain items -->
-    <text x="150" y="320" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Pointer →</text>
-    <text x="150" y="338" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">File Index</text>
-
-    <text x="370" y="320" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">File Index →</text>
-    <text x="370" y="338" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">Shard</text>
-
-    <text x="580" y="320" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Shard →</text>
-    <text x="580" y="338" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">Xorb</text>
+  <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5">
+    <path d="M 460 86 V 128" marker-end="url(#arrowhead)"/>
+    <path d="M 460 370 V 408" marker-end="url(#arrowhead)"/>
+    <line x1="236" y1="491" x2="256" y2="491" marker-end="url(#arrowhead)"/>
+    <line x1="436" y1="491" x2="456" y2="491" marker-end="url(#arrowhead)"/>
+    <line x1="636" y1="491" x2="656" y2="491" marker-end="url(#arrowhead)"/>
   </g>
 
-  <g id="connections">
-    <!-- fsck → checks (fan out) -->
-    <path d="M 310 80 L 310 100 L 115 100 L 115 130" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <path d="M 340 80 L 340 100 L 285 100 L 285 130" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <path d="M 380 80 L 380 100 L 455 100 L 455 130" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <path d="M 410 80 L 410 100 L 625 100 L 625 130" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-
-    <!-- fsck → data chain container -->
-    <path d="M 360 80 L 360 100 L 360 200 L 150 200 L 150 300" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-
-    <!-- Chain connections -->
-    <line x1="240" y1="325" x2="280" y2="325" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="460" y1="325" x2="500" y2="325" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-  </g>
-
+  <rect x="48" y="570" width="824" height="32" rx="10" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1"/>
+  <text x="460" y="591" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">Repairable warning: expired push locks can be removed with crab fsck --repair</text>
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/integrity-check.mdx
+++ b/packages/web/content/docs/cli/diagnostics/integrity-check.mdx
@@ -15,7 +15,7 @@ full reconstruction and Git-connectivity check of current head.
 
 Think of it as `git fsck` extended to cover Crab's object store layer.
 
-![Integrity check — crab fsck verifies refs, packs, locks, uploads, and walks the full data chain from pointer to xorb.](./integrity-check-flow.svg)
+![Integrity check — crab fsck cross-checks Git objects, the data chain, pack and index manifests, push locks, multipart uploads, and shard lists before walking from a pointer through the file index and shard to the xorb.](./integrity-check-flow.svg)
 
 ## Running an Integrity Check
 

--- a/packages/web/content/docs/cli/diagnostics/metadata-database-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/metadata-database-flow.svg
@@ -1,81 +1,88 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 490" width="700" height="490">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640" width="960" height="640" role="img" aria-labelledby="metadata-title metadata-desc">
+  <title id="metadata-title">Crab metadata databases and local cache</title>
+  <desc id="metadata-desc">Crab push and hydrate use a per-repository file index and a bucket-shared chunk index. Chunk lookups are served through an in-memory LRU and persistent SQLite cache before reaching object storage.</desc>
 
   <defs>
-    <marker id="arrowhead" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
-    <marker id="arrowhead-dashed" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#64748B"/>
+    <marker id="arrowhead-dashed" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#64748B"/>
     </marker>
   </defs>
 
-  <g id="background">
-    <rect x="0" y="0" width="700" height="490" fill="#FFFFFF"/>
+  <rect width="960" height="640" fill="#FFFFFF"/>
+
+  <g id="source-panel">
+    <rect x="32" y="52" width="208" height="290" rx="16" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+    <text x="56" y="82" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#64748B" letter-spacing="0.6">PUSH &amp; HYDRATE</text>
+
+    <rect x="56" y="112" width="160" height="64" rx="13" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="136" y="141" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#0F172A">crab push</text>
+    <text x="136" y="161" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">write metadata</text>
+
+    <rect x="56" y="218" width="160" height="64" rx="13" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="136" y="247" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#0F172A">crab hydrate</text>
+    <text x="136" y="267" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read metadata</text>
   </g>
 
-  <g id="containers">
-    <!-- Local Cache container -->
-    <rect x="380" y="300" width="280" height="170" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+  <g id="database-panel">
+    <rect x="270" y="52" width="370" height="290" rx="16" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+    <text x="294" y="82" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#64748B" letter-spacing="0.6">SLATEDB METADATA</text>
+
+    <rect x="300" y="108" width="310" height="86" rx="13" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="455" y="135" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">File Index DB</text>
+    <text x="455" y="155" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">file_hash → shard_hash</text>
+    <text x="455" y="176" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600" fill="#0284C7">per repository · {repo_prefix}/file_index_db/</text>
+
+    <rect x="300" y="220" width="310" height="86" rx="13" fill="#ECFEFF" stroke="#06B6D4" stroke-width="1.5"/>
+    <text x="455" y="247" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Chunk Index DB</text>
+    <text x="455" y="267" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">chunk_hash → xorb_ref</text>
+    <text x="455" y="288" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" font-weight="600" fill="#06B6D4">shared across repos · .crab/chunk_index_db/</text>
   </g>
 
-  <g id="nodes">
-    <!-- Commands -->
-    <rect x="40" y="40" width="150" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <rect x="40" y="140" width="150" height="50" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+  <g id="storage-panel">
+    <rect x="670" y="52" width="258" height="290" rx="16" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+    <text x="694" y="82" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#64748B" letter-spacing="0.6">REMOTE OBJECTS</text>
 
-    <!-- Databases -->
-    <rect x="260" y="40" width="220" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <rect x="260" y="140" width="220" height="56" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <rect x="700" y="112" width="198" height="76" rx="13" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="799" y="141" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Shards</text>
+    <text x="799" y="161" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">file metadata + refs</text>
+    <text x="799" y="178" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#0284C7">.crab/shards/</text>
 
-    <!-- Storage -->
-    <rect x="540" y="40" width="130" height="56" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <rect x="540" y="140" width="130" height="56" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-
-    <!-- Local Cache items -->
-    <rect x="405" y="335" width="180" height="44" rx="8" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <rect x="405" y="410" width="180" height="44" rx="8" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <rect x="700" y="224" width="198" height="76" rx="13" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="799" y="253" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Xorbs</text>
+    <text x="799" y="273" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">deduplicated chunks</text>
+    <text x="799" y="290" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#10B981">.crab/xorbs/</text>
   </g>
 
-  <g id="labels">
-    <!-- Commands -->
-    <text x="115" y="70" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab push</text>
-    <text x="115" y="170" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="bold" fill="#0F172A">crab hydrate</text>
+  <g id="cache-panel">
+    <rect x="270" y="382" width="370" height="164" rx="16" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+    <text x="294" y="412" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#64748B" letter-spacing="0.6">LOCAL CHUNK-INDEX CACHE</text>
 
-    <!-- Databases -->
-    <text x="370" y="62" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">File Index DB</text>
-    <text x="370" y="80" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(file_hash → shard_hash)</text>
+    <rect x="300" y="430" width="310" height="48" rx="12" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="455" y="459" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">In-memory LRU · hot chunk lookups</text>
 
-    <text x="370" y="162" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">Chunk Index DB</text>
-    <text x="370" y="180" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">(chunk_hash → xorb_ref)</text>
-
-    <!-- Storage -->
-    <text x="605" y="62" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">Shards</text>
-    <text x="605" y="78" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">.crab/shards/</text>
-
-    <text x="605" y="162" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#0F172A">Xorbs</text>
-    <text x="605" y="178" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#64748B">.crab/xorbs/</text>
-
-    <!-- Local Cache -->
-    <text x="400" y="318" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="bold" fill="#64748B" letter-spacing="0.5">LOCAL CACHE</text>
-    <text x="495" y="362" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">In-memory LRU</text>
-    <text x="495" y="437" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="bold" fill="#0F172A">SQLite file</text>
+    <rect x="300" y="490" width="310" height="44" rx="12" fill="#FFFFFF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="455" y="517" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#0F172A">SQLite file · persistent cache</text>
   </g>
 
-  <g id="connections">
-    <!-- crab push → File Index -->
-    <line x1="190" y1="55" x2="260" y2="60" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- crab push → Chunk Index -->
-    <path d="M 190 75 L 225 75 L 225 165 L 260 165" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- crab hydrate → File Index -->
-    <path d="M 190 155 L 225 155 L 225 75 L 260 75" fill="none" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- File Index → Shards -->
-    <line x1="480" y1="68" x2="540" y2="68" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- Chunk Index → Xorbs -->
-    <line x1="480" y1="168" x2="540" y2="168" stroke="#64748B" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <!-- Chunk Index → Memory (dashed) -->
-    <path d="M 370 196 L 370 250 L 495 250 L 495 330" fill="none" stroke="#64748B" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowhead-dashed)"/>
-    <!-- Memory → SQLite (dashed) -->
-    <line x1="495" y1="379" x2="495" y2="410" stroke="#64748B" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowhead-dashed)"/>
+  <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5">
+    <line x1="216" y1="144" x2="300" y2="144" marker-end="url(#arrowhead)"/>
+    <path d="M 216 152 H 252 V 263 H 300" marker-end="url(#arrowhead)"/>
+    <path d="M 216 250 H 252 V 152 H 300" marker-end="url(#arrowhead)"/>
+    <path d="M 216 258 H 300" marker-end="url(#arrowhead)"/>
+    <line x1="610" y1="151" x2="700" y2="151" marker-end="url(#arrowhead)"/>
+    <line x1="610" y1="263" x2="700" y2="263" marker-end="url(#arrowhead)"/>
+    <path d="M 455 306 V 350 H 455 V 430" stroke-dasharray="5,4" marker-end="url(#arrowhead-dashed)"/>
+    <line x1="455" y1="478" x2="455" y2="490" stroke-dasharray="5,4" marker-end="url(#arrowhead-dashed)"/>
   </g>
 
+  <rect x="32" y="580" width="896" height="38" rx="11" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1"/>
+  <text x="58" y="604" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700" fill="#64748B">OPERATIONS</text>
+  <text x="218" y="604" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">crab metadb diagnose</text>
+  <circle cx="402" cy="600" r="2.5" fill="#CBD5E1"/>
+  <text x="426" y="604" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">cache stats</text>
+  <circle cx="512" cy="600" r="2.5" fill="#CBD5E1"/>
+  <text x="536" y="604" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#0F172A">rebuild --db both</text>
 </svg>

--- a/packages/web/content/docs/cli/diagnostics/metadata-database-flow.svg
+++ b/packages/web/content/docs/cli/diagnostics/metadata-database-flow.svg
@@ -17,13 +17,13 @@
     <rect x="32" y="52" width="208" height="290" rx="16" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="56" y="82" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#64748B" letter-spacing="0.6">PUSH &amp; HYDRATE</text>
 
-    <rect x="56" y="112" width="160" height="64" rx="13" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <text x="136" y="141" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#0F172A">crab push</text>
-    <text x="136" y="161" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">write metadata</text>
+    <rect x="56" y="119" width="160" height="64" rx="13" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="136" y="148" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#0F172A">crab push</text>
+    <text x="136" y="168" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">write metadata</text>
 
-    <rect x="56" y="218" width="160" height="64" rx="13" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
-    <text x="136" y="247" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#0F172A">crab hydrate</text>
-    <text x="136" y="267" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read metadata</text>
+    <rect x="56" y="231" width="160" height="64" rx="13" fill="#F5F3FF" stroke="#8B5CF6" stroke-width="1.5"/>
+    <text x="136" y="260" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#0F172A">crab hydrate</text>
+    <text x="136" y="280" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">read metadata</text>
   </g>
 
   <g id="database-panel">
@@ -45,15 +45,15 @@
     <rect x="670" y="52" width="258" height="290" rx="16" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
     <text x="694" y="82" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700" fill="#64748B" letter-spacing="0.6">REMOTE OBJECTS</text>
 
-    <rect x="700" y="112" width="198" height="76" rx="13" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
-    <text x="799" y="141" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Shards</text>
-    <text x="799" y="161" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">file metadata + refs</text>
-    <text x="799" y="178" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#0284C7">.crab/shards/</text>
+    <rect x="700" y="113" width="198" height="76" rx="13" fill="#F0F9FF" stroke="#0284C7" stroke-width="1.5"/>
+    <text x="799" y="142" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Shards</text>
+    <text x="799" y="162" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">file metadata + refs</text>
+    <text x="799" y="179" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#0284C7">.crab/shards/</text>
 
-    <rect x="700" y="224" width="198" height="76" rx="13" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text x="799" y="253" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Xorbs</text>
-    <text x="799" y="273" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">deduplicated chunks</text>
-    <text x="799" y="290" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#10B981">.crab/xorbs/</text>
+    <rect x="700" y="225" width="198" height="76" rx="13" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text x="799" y="254" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Xorbs</text>
+    <text x="799" y="274" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748B">deduplicated chunks</text>
+    <text x="799" y="291" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#10B981">.crab/xorbs/</text>
   </g>
 
   <g id="cache-panel">
@@ -68,10 +68,10 @@
   </g>
 
   <g id="connections" fill="none" stroke="#64748B" stroke-width="1.5">
-    <line x1="216" y1="144" x2="300" y2="144" marker-end="url(#arrowhead)"/>
-    <path d="M 216 152 H 252 V 263 H 300" marker-end="url(#arrowhead)"/>
-    <path d="M 216 250 H 252 V 152 H 300" marker-end="url(#arrowhead)"/>
-    <path d="M 216 258 H 300" marker-end="url(#arrowhead)"/>
+    <path d="M 216 151 H 244 V 263"/>
+    <path d="M 216 263 H 260 V 151"/>
+    <line x1="216" y1="151" x2="300" y2="151" marker-end="url(#arrowhead)"/>
+    <line x1="216" y1="263" x2="300" y2="263" marker-end="url(#arrowhead)"/>
     <line x1="610" y1="151" x2="700" y2="151" marker-end="url(#arrowhead)"/>
     <line x1="610" y1="263" x2="700" y2="263" marker-end="url(#arrowhead)"/>
     <path d="M 455 306 V 350 H 455 V 430" stroke-dasharray="5,4" marker-end="url(#arrowhead-dashed)"/>

--- a/packages/web/content/docs/cli/diagnostics/metadata-database.mdx
+++ b/packages/web/content/docs/cli/diagnostics/metadata-database.mdx
@@ -11,7 +11,7 @@ meta:
 
 Crab maintains two SlateDB databases that map content to storage locations. These databases are what make deduplication and hydration fast — without them, every operation would need to scan all shards.
 
-![Metadata subsystem — push and hydrate use File Index and Chunk Index databases, with a local LRU cache backed by SQLite.](./metadata-database-flow.svg)
+![Metadata subsystem — push and hydrate use a per-repository File Index and bucket-shared Chunk Index, with local in-memory and SQLite caches in front of chunk lookups.](./metadata-database-flow.svg)
 
 ## Two Databases
 


### PR DESCRIPTION
## Summary
- update integrity-check, hydrate-restore, and metadata-database diagrams to match current documented behavior
- improve flow layout, labels, decision paths, restore tiers, cache ownership, and repair operations
- refresh image alt text for the new diagram content

## Validation
- npm run typecheck
- npm run test
- npm run lint (0 errors; existing warnings only)
- npm run check:links
- npm run build
- xmllint --noout on all three SVGs