### PR TITLE
feat: harden optimize workflows for large repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,10 +2053,12 @@ name = "crab-cache"
 version = "0.1.0"
 dependencies = [
  "axum 0.8.9",
+ "base64 0.22.1",
  "blake3",
  "bytes",
  "crab-types",
  "crab-xet",
+ "crc32fast",
  "filetime",
  "globset",
  "reqwest 0.12.28",
@@ -2066,6 +2068,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "xet-client",
@@ -2343,6 +2346,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "xet-core-structures",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,7 +2346,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "xet-core-structures",
 ]
 
 [[package]]

--- a/crab/docs/design/lfs.md
+++ b/crab/docs/design/lfs.md
@@ -624,7 +624,10 @@ All LFS commands live under `crab lfs <subcommand>`:
 | `lfs.transfer.maxretries` | 8 | Max retries per object on transient failure |
 | `lfs.transfer.maxretrydelay` | 10s | Max delay between retries |
 | `lfs.skipdownloaderrors` | false | Continue on download errors instead of aborting |
-| `lfs.lfsdir` | `.git/lfs` | Override local LFS storage directory |
+| `lfs.storage` | `.git/lfs` | Override local LFS storage; relative paths resolve inside the common Git directory |
+| `lfs.lfsdir` | `.git/lfs` | Legacy Crab alias for `lfs.storage` |
+| `lfs.pruneverifyremotealways` | false | Verify prune candidates remotely unless the CLI overrides it |
+| `lfs.pruneverifyunreachablealways` | false | Also verify unreachable prune candidates unless the CLI overrides it |
 
 ### Configuration Precedence
 
@@ -638,7 +641,9 @@ Lowest priority
 ```
 
 When a key is set in both `.lfsconfig` and `.gitconfig`, the `.lfsconfig`
-value wins. This matches official `git-lfs` behavior.
+value wins, except tracked `.lfsconfig` files cannot set `lfs.storage` or
+`lfs.lfsdir`. Repository-controlled configuration must not redirect local
+writes or prune deletion outside the repository's Git directory.
 
 ### Transfer Agent Config (set by `crab lfs install`)
 

--- a/crab/docs/design/technical-design.md
+++ b/crab/docs/design/technical-design.md
@@ -2025,7 +2025,7 @@ Format upgrades that require all clients to upgrade are rare and announced. The 
 
 - **Storage DoS**: malicious writer fills bucket with bogus data. Mitigation: S3 bucket-level size limits or cost alarms; user responsibility.
 - **Request-rate DoS**: many clients hammering S3. Mitigation: S3 auto-scales; costs money but doesn’t crash.
-- **Client resource DoS**: malicious repo contents designed to exhaust client memory (e.g., a shard referencing 10 million xorbs). Mitigation: crab enforces sanity limits on shard/xorb counts per operation, fails closed on exceeding them.
+- **Client resource DoS**: malicious repo contents designed to exhaust client memory (e.g., a shard referencing 10 million xorbs). Mitigation: `optimize` enforces caps of 1,000,000 canonical shards, 10,000,000 distinct source xorbs, 1,000,000 xorb references per source shard, and 512 MiB per source shard; the inventory and planner remain disk-backed/batched and fail closed before exceeding those limits.
 
 ### 20.5 Out of Scope
 

--- a/crab/docs/guides/cache.md
+++ b/crab/docs/guides/cache.md
@@ -6,6 +6,7 @@ Manage the local Crab cache.
 
 ```
 crab cache stats
+crab cache verify
 crab cache clean
 ```
 
@@ -34,6 +35,8 @@ service cache data after a successful push cannot affect clone or hydrate.
 ### crab cache stats
 
 Print cache statistics: total size, number of objects, and cache directory path.
+The xet-core range-cache walk streams filesystem entries on one blocking worker
+instead of retaining the complete inventory or blocking the async runtime.
 
 ```bash
 crab cache stats
@@ -47,6 +50,20 @@ re-fetched from the remote store as needed.
 ```bash
 crab cache clean
 ```
+
+Cleanup covers both the Crab object-cache root and a separately configured
+xet-core range-cache directory. Crab refuses recursive cleanup when either path
+resolves to a filesystem root, the home directory, or an ancestor of the
+current checkout. `crab optimize cache clean --dry-run` reports the exact file
+and byte totals without deleting them.
+
+### crab cache verify
+
+Hash-check chunks and shards, validate xorb metadata and compressed chunks, and
+validate xet-core range filenames, lengths, offset headers, and CRCs while
+streaming the inventory. Corrupt entries are evicted; Xorb index rows are
+removed with corrupt xorb bodies. Filesystem read or removal failures fail the
+command rather than producing a false clean report.
 
 ## Cache Location
 
@@ -95,8 +112,8 @@ crab fetch  # re-populate on the fast disk
 - When the cache may be corrupted.
 - When switching to a different remote and the old cache is no longer relevant.
 
-Note: `crab prune` is usually preferred over `cache clean` because it only
-removes unreferenced objects, keeping useful cached data intact.
+Note: `crab prune` is usually preferred over `cache clean` because it evicts
+the least-recently-used objects only until configured byte budgets are met.
 
 ## Related Commands
 

--- a/crab/docs/guides/cost.md
+++ b/crab/docs/guides/cost.md
@@ -72,6 +72,9 @@ This uses a deterministic `blake3(key)` hash to include ~25% of
 objects. The report records that totals are scaled estimates when sampling
 is enabled; it does not currently emit a statistical confidence interval.
 
+The optional `--top-k` cold-object report is bounded to 10,000 entries so a
+large archive inventory cannot turn the report into unbounded memory use.
+
 ## Pricing Model
 
 ### Embedded prices
@@ -159,19 +162,20 @@ operator checklist:
 - `crab doctor --cost` for cost inventory and recommendations.
 - active-active maintenance admission before any mutating apply step.
 - lifecycle tiering through `crab tier plan --apply --merge` when
-  `[tier] enabled = true`.
-- xorb optimization is exposed as a planned step, but apply is currently
-  blocked until destination xorbs can be committed with their file-index and
-  shard metadata atomically. Use `crab optimize xorbs --dry-run` for estimates.
+  `[tier] enabled = true`; provider conditional-write and read-back checks
+  remain in force.
+- xorb optimization through the reconciled xorb, shard, and file-index
+  transaction path. Use `crab optimize xorbs --dry-run` for estimates.
 - local cache pruning through `crab prune`.
 - replica policy checks through `crab replica doctor --fix-plan` when
   replication is configured.
 
 `crab optimize apply` executes the same plan in order. It preserves each
-underlying command's safety checks and stops on the first failed step. Xorb
-rewrites are opt-in because they can be long-running and may restore archived
-objects before rewriting content-addressed xorbs; requesting that step
-currently fails closed until metadata reconciliation is implemented.
+underlying command's safety checks, holds a repository-wide apply lock, and
+stops on the first failed step. Child output is drained with a fixed memory
+bound, and invalid sampling or unavailable report-inventory requests fail
+before apply. Xorb rewrites are opt-in because they can be long-running and
+may restore archived objects before rewriting content-addressed xorbs.
 
 ### 5. Heaviest Cold Objects
 

--- a/crab/docs/guides/fetch.md
+++ b/crab/docs/guides/fetch.md
@@ -10,10 +10,10 @@ crab fetch [OPTIONS]
 
 ## Description
 
-`crab fetch` downloads xorbs and shards from the remote store into the local
-cache without hydrating any files. This warms the cache so that subsequent
-`crab hydrate` or `git checkout` operations are fast, even on slow or
-unreliable networks.
+`crab fetch` resolves Crab pointer blobs from Git, reconstructs each selected
+file into a discard sink, and retains the verified xet ranges and metadata in
+the canonical local caches. It never materializes the selected files in the
+working tree.
 
 Think of it as "download now, use later" — you can fetch objects while on a fast
 connection, then hydrate files later when offline or on a slower link.
@@ -30,12 +30,15 @@ connection, then hydrate files later when offline or on a slower link.
 ## How It Works
 
 1. Reads the remote URL from `.crab/remote`.
-2. Builds an S3 client for the configured bucket.
-3. Lists objects under the repository prefix (shards first, then xorbs).
-4. For each object:
-   - Checks if it already exists in the local cache.
-   - If not cached, downloads it and writes it to the cache directory.
-5. Reports the total number of objects and bytes fetched.
+2. Resolves pointer blobs from the index/HEAD, or every local ref with `--all`.
+3. Applies `--include` and `--exclude` to repository paths before reading blob
+   bodies. Git blob sizes are batch-checked so large non-pointer blobs are not
+   loaded into memory.
+4. Selects the configured primary or replica through the normal read policy.
+5. Reconstructs each unique file through the canonical file-index, shard, and
+   xet-core range-cache path. Output is discarded after its hash and size are
+   verified, so memory use is independent of logical file size.
+6. Synchronizes the local chunk index unless `--no-sync-chunk-index` is set.
 
 Objects are stored in the local cache at `~/.cache/crab/` (or the path
 specified by `$CRAB_CACHE_DIR`).
@@ -66,12 +69,9 @@ crab fetch --all
 crab fetch --dry-run
 ```
 
-```
-fetch (dry run): would fetch objects from crab://my-bucket/my-repo
-  prefix: my-repo
-  include: []
-  exclude: []
-```
+Dry-run resolves the exact local Git selection and reports its file count and
+logical bytes. It does not resolve credentials, contact a replica, or mutate a
+cache.
 
 ### Fetch everything except training data
 
@@ -82,7 +82,7 @@ crab fetch --exclude 'data/train/*'
 ## Output
 
 ```
-fetch complete: 42 objects, 1288490188 bytes downloaded
+fetch complete: 42 file(s), 1288490188 logical bytes verified
 ```
 
 ## Use Cases
@@ -117,7 +117,7 @@ crab fetch
 Supports `--json` and `--jsonl`.
 
 - `--json` runs to completion and emits a single result envelope.
-- `--jsonl` streams per-xorb progress followed by a terminal `result` event.
+- `--jsonl` emits phase progress followed by a terminal `result` event.
 
 ### crab fetch --json
 
@@ -128,7 +128,8 @@ Supports `--json` and `--jsonl`.
   "timestamp": "2026-04-24T18:32:30.200Z",
   "data": {
     "objects_fetched": 42,
-    "bytes_fetched": 1288490188,
+    "bytes_downloaded": 1288490188,
+    "objects_skipped": 0,
     "duration_ms": 8500
   }
 }
@@ -137,9 +138,8 @@ Supports `--json` and `--jsonl`.
 ### crab fetch --jsonl
 
 ```
-{"schema":"fetch.event","version":"1.0","timestamp":"2026-04-24T18:32:22.100Z","type":"progress","data":{"operation":"fetching","current":10,"total":42,"bytes":314572800,"total_bytes":1288490188,"rate_bytes_per_sec":52000000.0}}
-{"schema":"fetch.event","version":"1.0","timestamp":"2026-04-24T18:32:25.300Z","type":"xorb_done","data":{"hash":"a1b2c3d4e5f6","bytes":31457280,"compressed_bytes":28311552,"status":"ok"}}
-{"schema":"fetch.event","version":"1.0","timestamp":"2026-04-24T18:32:30.200Z","type":"result","data":{"objects_fetched":42,"bytes_fetched":1288490188,"duration_ms":8500}}
+{"schema":"perf.phase","version":"1.0","timestamp":"2026-04-24T18:32:30.100Z","type":"event","data":{"command":"fetch","phase":"hydration_prefetch","duration_ms":8400,"bytes":1288490188,"items":42}}
+{"schema":"fetch.event","version":"1.0","timestamp":"2026-04-24T18:32:30.200Z","type":"result","data":{"objects_fetched":42,"bytes_downloaded":1288490188,"objects_skipped":0,"duration_ms":8500}}
 ```
 
 See [Structured Output](structured-output.md) for envelope details, event types,

--- a/crab/docs/guides/lfs.md
+++ b/crab/docs/guides/lfs.md
@@ -465,12 +465,12 @@ crab lfs prune [OPTIONS]
 | `--verbose`, `-v` | Print full object IDs in prune output |
 
 Prune protects objects referenced by the current checkout, stashes, other
-worktree checkouts, recent refs, recent commits, and commits not pushed to the
-configured prune remote. The recent window follows `lfs.fetchrecentrefsdays`,
-`lfs.fetchrecentremoterefs`, `lfs.fetchrecentcommitsdays`, and
-`lfs.pruneoffsetdays`. `--recent` disables recent protection. With `--force`,
-Crab follows Git LFS by also disabling recent protection while still preserving
-unpushed objects.
+worktree checkouts, the staged Git index, recent refs, recent commits, and
+commits not pushed to the configured prune remote. The recent window follows
+`lfs.fetchrecentrefsdays`, `lfs.fetchrecentremoterefs`,
+`lfs.fetchrecentcommitsdays`, and `lfs.pruneoffsetdays`. `--recent` disables
+only recent protection. `--force` skips the deletion confirmation; it does not
+change which objects are protected.
 
 With `--verify-remote`, prune HEAD-checks candidates in the configured LFS
 object store before deleting them locally. Reachable candidates are always
@@ -480,7 +480,19 @@ flag, prune only reasons about the local cache.
 
 With `--verify-remote`, Crab matches Git LFS and defaults
 `--when-unverified` to `halt`. Without remote verification, the option defaults
-to `continue` because no remote check can fail.
+to `continue` because no remote check can fail. When neither CLI override is
+present, `lfs.pruneverifyremotealways` and
+`lfs.pruneverifyunreachablealways` supply the verification defaults. Remote
+checks are bounded by `lfs.concurrenttransfers` and processed in bounded
+batches. Git revision and index discovery streams fixed-size object batches,
+and `cat-file --batch-check` excludes non-blob and oversized objects before
+their contents are read.
+
+Prune honors `lfs.storage`; a relative value is resolved inside the common Git
+directory, matching Git LFS. Do not prune when multiple repositories share one
+custom storage directory. Crab locks concurrent prune runs, rejects malformed
+or incomplete Git scans, validates each content-addressed object immediately
+before unlinking it, and exits nonzero if any deletion fails.
 
 ---
 
@@ -494,16 +506,25 @@ crab lfs convert --from xet --to lfs <PATH>
 crab lfs convert --rollback
 ```
 
-Direct conversion updates the index, working tree, and `.gitattributes` for
-matching paths. LFS-to-Crab conversion resolves the LFS object bytes, writes
-them into the working tree, and runs the native Crab add path so chunk data and
-metadata are staged together. Crab-to-LFS conversion verifies hydrated bytes,
-writes the local LFS object, uploads it to the configured LFS store, and stages
-the LFS pointer.
+Direct conversion requires a clean worktree and updates only indexed paths that
+match both the pattern and source pointer format. It preserves executable index
+modes. LFS-to-Crab conversion streams and verifies the LFS object bytes, writes
+them atomically into the working tree, and runs the native Crab add path so
+chunk data and metadata are staged together. Crab-to-LFS conversion streams and
+verifies hydrated bytes, atomically installs the local LFS object, uploads it to
+the configured LFS store, and stages the LFS pointer without collecting a large
+file in memory.
 
-Before changing files, Crab writes `.git/crab-lfs-convert-state.json`.
-`crab lfs convert --rollback` restores the previous index blobs and
-`.gitattributes` from that manifest.
+Conversion and rollback share an exclusive repository lock. Before changing
+files, Crab atomically writes `.git/crab-lfs-convert-state.json`; a new
+conversion replaces the prior completed conversion manifest. A failed
+conversion automatically rolls back. `crab lfs convert --rollback` preflights
+all affected files, refuses to overwrite post-conversion user edits, then
+restores exact `.gitattributes` bytes, index blobs, executable modes, and source
+pointer checkouts from the latest manifest. Candidate discovery streams the
+Git index in fixed-size batches and prefilters non-pointer-sized blobs before
+reading content; memory still scales with the matching files retained in the
+rollback manifest, not with every indexed file.
 
 ---
 
@@ -743,13 +764,18 @@ crab lfs dedup --crab-cache [--dry-run]
 Default dedup follows Git LFS semantics: it requires a clean working tree, no
 configured LFS extensions, and filesystem support for copy-on-write file
 cloning. It re-creates checked-out LFS files as copy-on-write clones of their
-objects under `.git/lfs/objects`.
+objects under the configured LFS storage directory. Before any replacement,
+Crab verifies every cache object and checkout against the indexed SHA-256 and
+size and rejects symlinks and non-regular files. `--dry-run` performs the same
+preflight without modifying files or requiring a copy-on-write probe.
 
 With `--crab-cache`, Crab runs its older cache cleanup mode. That mode removes
 only local LFS cache objects whose path SHA-256 matches their contents, whose
 size and Blake3 hash match a Crab pointer reachable from the index or local
 refs, and whose bytes are reconstructed identically from the local Crab staging
 area. Unverified objects are skipped and remain in the local LFS cache.
+Deletion failures make the command fail instead of reporting a partial cleanup
+as successful.
 
 ---
 

--- a/crab/docs/guides/metadb.md
+++ b/crab/docs/guides/metadb.md
@@ -21,7 +21,7 @@ Architecture detail lives in
 ## Synopsis
 
 ```
-crab metadb diagnose [--db file_index|chunk_index|both] [--json]
+crab metadb diagnose [--db file_index|chunk_index|both] [--deep] [--json]
 crab metadb rebuild  --db  file_index|chunk_index|both  [--json]
 crab metadb owner    [--once] [--interval SECONDS] [--jsonl]
 crab metadb compact  [--db file_index|chunk_index|both]
@@ -50,6 +50,13 @@ Safe to run concurrently with a push: `diagnose` opens each SlateDB
 in read-only mode, so it does not fence an in-flight writer.
 `--json` emits a `DiagnosePayload` structure suitable for scripting.
 
+Pass `--deep` to scan every key/value row and enumerate the backing object
+store. The deep verdict also flags malformed compacted-SST names (SlateDB
+requires 26-character ULIDs), so an orphaned or legacy object is reported as
+a warning instead of being mistaken for a clean database. Diagnosis never
+deletes remote objects; use the provider's retention/GC procedure after
+reviewing the reported path.
+
 Use `diagnose` when you want to confirm a database opens cleanly,
 check its epoch against the manifest, or verify the remote
 `gc_generation` the local cache is being compared against.
@@ -70,6 +77,14 @@ crab metadb rebuild --db both
 Rebuild is idempotent: repeated runs produce the same receipt history and
 point-readable heads, and an
 interrupted run can be restarted without any special cleanup.
+It validates every manifest-named shard, xorb placement, and Git pack before
+publishing generation evidence. Any validation failure or cancellation exits
+non-zero, retains legacy rows, and leaves the generation receipt unpublished.
+
+Shard validation is disk-backed. Rebuild downloads one manifest-named shard at
+a time into the maintenance cache, verifies its Xet hash, and parses its
+file/chunk sections from the temporary file. `--db file_index` and
+`--db chunk_index` avoid decoding the other index's entries.
 
 Rebuild is also the repair path after a crash between manifest CAS and
 post-CAS acceleration indexing. It never scans or advertises orphan shards
@@ -125,12 +140,13 @@ crab metadb compact
 crab metadb compact --db chunk_index
 ```
 
-Currently a **no-op**. SlateDB drives compaction in the background
-on its own schedule, and the public `slatedb` crate does not expose
-an imperative trigger. The command is kept so operator runbooks can
-call it without "unknown subcommand" errors, and so it becomes
-real work the moment SlateDB exposes the API. The command logs a
-warning explaining this and exits successfully.
+The command acquires a renewable repository maintenance lease, starts
+SlateDB's size-tiered compactor immediately, and waits until the currently
+eligible work has drained. When `--db both` is selected, it compacts the
+per-repository file index first and the bucket-shared chunk index second. It
+rejects an already-active compaction and exits non-zero on cancellation or a
+new compaction failure. An already policy-satisfied database is reported as a
+truthful no-op.
 
 ### `crab metadb cache stats`
 
@@ -140,14 +156,17 @@ Report on the local chunk-index cache.
 crab metadb cache stats
 ```
 
-Prints the SQLite cache path, on-disk size, entry count, installed
-shard count, and the `cache_gc_generation` cursor. Useful before
+Prints the SQLite cache path, combined database/WAL/shared-memory size, entry
+count, installed shard count, and the `cache_gc_generation` cursor. Inspection
+uses a read-only connection: it does not create, migrate, repair, or load all
+cache rows into memory. A configured `metadb.chunk_index.local_path` is honored.
+Useful before
 running `cache clear` (to know what you're wiping) and for
 troubleshooting "push is slow / no dedup" reports.
 
 ### `crab metadb cache clear`
 
-Wipe the local chunk-index SQLite file at
+Clear chunk and shard rows in the local chunk-index SQLite database at
 `~/.cache/crab/buckets/{bucket-hash}/chunk-index.sqlite`.
 
 ```bash
@@ -158,8 +177,8 @@ Forces a cold re-warm on the next operation: the next push falls
 through to `chunk_index_db` on every classification miss until the
 cache refills. Useful when the cache is suspected of drift or
 corruption, or when you want to force a clean starting point for
-a benchmark. The remote state is untouched — only the local file
-is removed.
+a benchmark. The remote state is untouched. The SQLite file, schema, and GC
+generation cursor are preserved so live process-shared handles remain valid.
 
 ## When to use `rebuild`
 
@@ -185,7 +204,7 @@ outside this migration and are ignored.
 | `hydrate` reports `FileNotFoundInFileIndexDb` | Either the file was never pushed, or `file_index_db` is missing entries | First verify the file was pushed: look for a shard entry naming that `file_hash` under `.crab/shards/`. If the shard exists but the entry is missing, `crab metadb rebuild --db file_index` repopulates from the shards. |
 | Push is slow and xet says nothing deduped | Local cache is empty or was wiped | Run `crab pull` (or `crab fetch`) to warm the cache via shard sync, then retry. Verify with `crab metadb cache stats` — after a pull, the entry count and installed shard count should both be non-zero. |
 | `crab metadb cache stats` shows the cache was wiped unexpectedly | Remote `sys:gc_generation` drifted beyond `cache_gc_grace` after `crab gc` ran | Expected behavior. GC bumps the remote generation so stale clients know to re-validate; when the drift exceeds the grace window the cache is wiped. The cache refills on the next `crab pull` / `crab push`. Increase `metadb.chunk_index.cache_gc_grace` if you want more headroom. |
-| `compact` appears to do nothing | It is a no-op at present | See the subcommand description above. SlateDB runs background compaction; there is no imperative trigger today. |
+| `compact` reports that policy is already satisfied | SlateDB has no currently eligible size-tiered work | No action is needed. The command only starts a foreground worker when the scheduler proposes work. |
 
 For anything not covered here, `crab doctor --metadb` gives a
 per-database tabular report (path, open state, epoch, SSTable count,
@@ -217,6 +236,10 @@ cache_gc_grace          = 3
 ```
 
 Leave a field unset to use the derived default shown in comments.
+The shipped `wal_flush_size` key controls SlateDB's L0 SST target size; Crab
+performs WAL durability flushes explicitly at commit boundaries. File-index and
+chunk-index tuning is applied independently, including to foreground
+`metadb compact` workers. Values must be non-zero.
 
 ### Environment variables
 

--- a/crab/docs/guides/operational-playbooks.md
+++ b/crab/docs/guides/operational-playbooks.md
@@ -4,13 +4,19 @@ Runbooks for common storage economy operations on production Crab
 buckets. Each playbook includes prerequisites, step-by-step commands,
 verification, and rollback procedures.
 
+Lifecycle apply steps below require a provider adapter with conditional
+lifecycle writes. The current S3, GCS, and Azure adapters render and verify
+plans but fail closed before mutation; do not treat the apply examples as a
+provider qualification result.
+
 ## Playbook 1: Enable lifecycle tiering on a production bucket
 
 **When to use:** First-time tiering setup on a bucket that has been
 running without lifecycle rules.
 
 **Prerequisites:**
-- Write credentials for the bucket (see [IAM requirements](crab-tier.md#iam-requirements))
+- A provider qualification row with conditional lifecycle-write support (see
+  [IAM requirements](crab-tier.md#iam-requirements))
 - Backup of any existing lifecycle rules (IaC or manual export)
 
 **Steps:**
@@ -152,8 +158,8 @@ crab doctor --cost --sample 0.25
 
 | Recommendation | Action | Risk |
 |---------------|--------|------|
-| Apply IA tiering | `crab tier plan --apply` | Low |
-| Apply Glacier tiering | `crab tier plan --apply` (adjust `to_deep_days`) | Medium |
+| Apply IA tiering | `crab tier plan --apply` after provider qualification | Low |
+| Apply Glacier tiering | `crab tier plan --apply` after provider qualification (adjust `to_deep_days`) | Medium |
 | Optimize xorbs | `crab optimize xorbs --apply` | Medium |
 | GC orphans | `crab gc` | Low |
 
@@ -185,7 +191,7 @@ crab gc --force-early-delete --yes-really
 
 | Operation A | Operation B | Allowed? |
 |------------|------------|----------|
-| `tier plan --apply` | `tier plan --apply` | One wins via CAS; other gets `TierLifecycleConflict` |
+| `tier plan --apply` | `tier plan --apply` | Providers with conditional CAS serialize; unsupported providers fail closed |
 | `optimize xorbs --apply` | `push` | Yes — reconciliation handles it |
 | `optimize xorbs --apply` | `gc` | No — `ConcurrentMaintenance` error |
 | `optimize xorbs --apply` | `optimize xorbs --apply` | No — `CRAB-E0332` error |

--- a/crab/docs/guides/optimize-xorbs.md
+++ b/crab/docs/guides/optimize-xorbs.md
@@ -8,12 +8,12 @@ and grouping profile for cost and performance optimization. This is not
 
 | Profile | Target xorb | Max xorbs/file | Group by | Compression |
 |---------|-------------|----------------|----------|-------------|
-| `ml` | 256 MiB | 4 | File | Zstd(3) |
-| `dataset` | 64 MiB | unlimited | Directory | Zstd(5) |
-| `code` | 16 MiB | unlimited | Hash | Zstd(9) |
+| `ml` | 256 MiB | — | — | LZ4 |
+| `dataset` | 64 MiB | — | — | LZ4 |
+| `code` | 16 MiB | — | — | LZ4 |
 
-When `--profile` is omitted, Crab scans the file index and selects a
-profile from median file size:
+When `--profile` is omitted, Crab scans the live xorb inventory and selects a
+profile from median source-object size:
 
 - p50 > 100 MiB: `ml`
 - p50 >= 1 MiB: `dataset`
@@ -26,9 +26,7 @@ Custom profiles live in `.crab/config.toml`:
 ```toml
 [optimize.xorbs.profiles.my-profile]
 target_xorb_bytes = 134217728   # 128 MiB
-max_xorbs_per_file = 8
-group_by = "file"
-compression = "zstd:5"
+compression = "lz4"
 ```
 
 Custom profiles live under the same command namespace as `crab optimize xorbs`.
@@ -42,9 +40,10 @@ crab optimize xorbs --profile ml --dry-run
 crab optimize xorbs --profile ml --dry-run --json
 ```
 
-`--dry-run` is the supported optimization path today. It lists the live
-source xorbs, obtains their sizes and storage classes, and produces an
-estimate without writing remote objects.
+`--dry-run` lists the live source xorbs, obtains their sizes and storage
+classes, and produces an estimate without writing remote objects. The
+inventory is disk-backed and bounded; malformed manifests fail closed before
+unbounded download or HEAD fan-out.
 
 Apply the rewrite:
 
@@ -52,9 +51,10 @@ Apply the rewrite:
 crab optimize xorbs --profile ml --apply
 ```
 
-Apply currently fails closed after configuration validation. The executor can
-write destination xorbs, but the file-index/shard manifest reconciliation
-needed for readers to resolve those destinations is not implemented yet.
+Apply writes immutable destination xorbs, records progress in a WAL journal,
+and reconciles file-index and shard metadata through a manifest CAS. If the
+process is interrupted, rerun with `--resume`; uploaded immutable objects are
+safe to reuse and old objects remain eligible for normal garbage collection.
 
 Resume an interrupted run:
 
@@ -81,7 +81,6 @@ Archive-class source xorbs are restored before processing when included:
 
 - `--include-cold=false`: skip archive xorbs.
 - `--restore-tier=<tier>`: restore tier for archive sources.
-- `--output-class=<class>`: storage class for destination xorbs.
 
 ## Structured Output
 

--- a/crab/docs/guides/optimize-xorbs.md
+++ b/crab/docs/guides/optimize-xorbs.md
@@ -52,9 +52,12 @@ crab optimize xorbs --profile ml --apply
 ```
 
 Apply writes immutable destination xorbs, records progress in a WAL journal,
-and reconciles file-index and shard metadata through a manifest CAS. If the
-process is interrupted, rerun with `--resume`; uploaded immutable objects are
-safe to reuse and old objects remain eligible for normal garbage collection.
+verifies source and destination size/hash, and reconciles file-index and shard
+metadata through a manifest CAS. Candidate indexes are published before the
+manifest becomes visible, and old roots remain protected until reconciliation
+completes. If the process is interrupted, rerun with `--resume`; uploaded
+immutable objects are safe to reuse and old objects remain eligible for normal
+garbage collection.
 
 Resume an interrupted run:
 

--- a/crab/docs/guides/repack.md
+++ b/crab/docs/guides/repack.md
@@ -29,10 +29,10 @@ replacing the segmented pack inventory selected by the unified manifest.
 
 1. Pins the unified manifest and its exact segmented pack inventory.
 2. Downloads every selected `.pack` and canonical `.idx` to a temporary bare
-   Git repository with bounded concurrency.
-3. Verifies each source pair, then runs `git repack --geometric=2 -d` in the
-   temporary repository. Git selects the smallest roll-up that restores the
-   geometric progression.
+   Git repository with bounded concurrency and a free-space preflight.
+3. Verifies each source pair and the complete pinned ref graph, then runs
+   `git repack --geometric=2 -d` in the temporary repository. Git selects the
+   smallest roll-up that restores the geometric progression.
 4. Builds or preserves the resulting `.idx` and `.rev` files, then runs
    `git fsck` against a validation repository containing every resulting pack.
 5. Uploads immutable pack/index/reverse-index files only for newly generated
@@ -40,8 +40,14 @@ replacing the segmented pack inventory selected by the unified manifest.
    segment.
 6. Performs one CAS of a new manifest generation with unchanged refs, HEAD,
    shard index, commit graph, and ref registry.
-7. Publishes exact SlateDB object locators. Locator failure is repairable and
-   does not invalidate an already committed manifest.
+7. Publishes exact SlateDB object locators and a generation receipt. Locator
+   or receipt failure is repairable and does not invalidate an already
+   committed manifest.
+
+Apply mode holds the repository-wide maintenance lease. The temporary
+workspace lives under Crab's cache root and is removed automatically. Dry-run
+reads only the canonical inventory and reports current bytes; replacement
+size is unknown until Git performs the repack.
 
 ### Atomicity
 
@@ -49,7 +55,8 @@ The unified manifest is updated using one CAS (compare-and-swap). If any other
 writer advances it after repack pins the input inventory, repack returns a
 conflict instead of retrying against different repository state. Uploaded
 immutable files remain unreferenced and are collected later under the normal GC
-grace period.
+grace period. A rerun repairs missing post-CAS evidence without advancing an
+already consolidated generation.
 
 ### Metadata Preservation
 
@@ -96,8 +103,8 @@ The following settings in `.crab/config.toml` affect repack behavior:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `repack_auto_threshold` | | Number of packs that triggers an advisory warning |
-| `download_concurrency` | | Maximum concurrent `.pack`/`.idx` downloads |
+| `repack_auto_threshold` | `50` | Pack count that triggers an advisory warning |
+| `download_concurrency` | `8` (capped at 16) | Maximum concurrent `.pack`/`.idx` downloads |
 
 ## Prerequisites
 

--- a/crab/docs/guides/tier.md
+++ b/crab/docs/guides/tier.md
@@ -43,9 +43,13 @@ Crab would apply. No credentials beyond read-only are needed.
 crab tier plan --apply
 ```
 
-Crab writes a backup of the current lifecycle configuration to
-`.crab/tier/backups/<RFC3339-ts>-pre-apply.json`, then submits the new rules
-via the provider's management API with a CAS guard to prevent races.
+Crab requires a provider conditional-write guard before lifecycle mutation,
+writes a backup of the current configuration to
+`.crab/tier/backups/<RFC3339-ts>-pre-apply.json`, submits the new rules, and
+requires an equivalent provider read-back before reporting success. The backup
+uses the repository's shared Crab directory, even when invoked from a
+subdirectory, and is synced before the provider write begins. Providers that
+cannot supply a conditional guard fail closed.
 
 ### Roll back
 
@@ -97,7 +101,8 @@ former.
 
 All tiering settings live under the `[tier]` section in `.crab/config.toml`.
 Every field has a sensible default; an absent `[tier]` block means defaults
-apply.
+apply. An unreadable or invalid Crab configuration is an error; maintenance
+does not silently substitute defaults.
 
 ```toml
 [tier]
@@ -337,7 +342,7 @@ user-managed rules that conflict, the error is raised regardless of `--merge`.
 | `--apply` | `plan` | `false` | Submit the plan to the provider (requires write credentials) |
 | `--merge` | `plan --apply` | `false` | Preserve non-`crab-` rules; replace only Crab-managed rules |
 | `--dry-run` | `plan --apply` | `false` | Show what would be written without submitting |
-| `--output` | `plan` | provider native | Output format: `xml`, `json`, or `yaml` |
+| `--output` | `plan` | provider native | Output format: `xml`, `json`, or `yaml`; JSON uses the standard `tier.plan` envelope |
 | `--json` | all | `false` | Emit structured JSON via `Envelope` (`"tier.plan"` v `"1.0"`) |
 | `--jsonl` | all | `false` | Stream JSONL events via `JsonlStream` (`"tier.event"` v `"1.0"`) |
 

--- a/crab/schemas/optimize.xorbs.event.json
+++ b/crab/schemas/optimize.xorbs.event.json
@@ -159,6 +159,12 @@
           },
           "type": "array"
         },
+        "corrupt_list_omitted": {
+          "description": "Number of corrupt source hashes omitted from the bounded report.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
         "counts": {
           "allOf": [
             {
@@ -186,6 +192,7 @@
         "bytes_read",
         "bytes_written",
         "corrupt_list",
+        "corrupt_list_omitted",
         "counts",
         "elapsed_ms",
         "profile",

--- a/crab/scripts/check-architecture-gates.py
+++ b/crab/scripts/check-architecture-gates.py
@@ -2876,11 +2876,27 @@ def check_cache_feature_budget(root: Path, cargo: str, metadata: dict) -> bool:
             "active-probe": ["dep:reqwest"],
             "local-cache": ["dep:filetime", "dep:rusqlite", "dep:tokio"],
             "remote-client": ["active-probe", "dep:tokio"],
-            "xet-chunk-cache": ["dep:tokio", "dep:xet-client", "dep:xet-runtime"],
+            "xet-chunk-cache": [
+                "dep:base64",
+                "dep:crc32fast",
+                "dep:tokio",
+                "dep:tokio-util",
+                "dep:xet-client",
+                "dep:xet-runtime",
+            ],
         },
     )
 
-    for name in ("filetime", "reqwest", "rusqlite", "tokio", "xet-client"):
+    for name in (
+        "base64",
+        "crc32fast",
+        "filetime",
+        "reqwest",
+        "rusqlite",
+        "tokio",
+        "tokio-util",
+        "xet-client",
+    ):
         dependency = normal_dependency(package, name)
         if dependency is None or not dependency["optional"]:
             violations.append(f"crab-cache: {name} must stay optional")
@@ -2961,7 +2977,14 @@ def check_cache_feature_budget(root: Path, cargo: str, metadata: dict) -> bool:
                 "--depth",
                 "2",
             ],
-            required={"tokio", "xet-client", "xet-runtime"},
+            required={
+                "base64",
+                "crc32fast",
+                "tokio",
+                "tokio-util",
+                "xet-client",
+                "xet-runtime",
+            },
             forbidden={"crab-cache-server", "crab-storage", "filetime", "object_store", "rusqlite"},
         ),
     ]

--- a/crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py
@@ -958,14 +958,19 @@ class ProtocolV2PartialCloneSmoke:
             ["switch", "-c", "fixture/lfs-pointers"],
             name="create LFS pointer fixture",
         )
+        lfs_content = deterministic_bytes(8 * 1024 * 1024, f"{self.run_id}:lfs-object")
+        lfs_oid_hex = hashlib.sha256(lfs_content).hexdigest()
         lfs_pointer = (
             "version https://git-lfs.github.com/spec/v1\n"
-            f"oid sha256:{hashlib.sha256(f'{self.run_id}:lfs'.encode()).hexdigest()}\n"
-            "size 8388608\n"
+            f"oid sha256:{lfs_oid_hex}\n"
+            f"size {len(lfs_content)}\n"
         ).encode()
         lfs_path = self.source / "lfs-pointer.bin"
         lfs_path.write_bytes(lfs_pointer)
         self.lfs_pointer_bytes = lfs_pointer
+        lfs_object = self.source / ".git" / "lfs" / "objects" / lfs_oid_hex[:2] / lfs_oid_hex[2:4] / lfs_oid_hex
+        lfs_object.parent.mkdir(parents=True, exist_ok=True)
+        lfs_object.write_bytes(lfs_content)
         self.run_git(self.source, ["add", lfs_path.name])
         self.run_git(self.source, ["commit", "-m", "LFS pointer fixture"])
         lfs_oid = self.git_value(

--- a/crab/src/cache/mod.rs
+++ b/crab/src/cache/mod.rs
@@ -37,7 +37,12 @@ pub use crab_cache::{
 };
 pub use crab_vfs::ChunkCache;
 pub use hydrated_pointer::{HydratedEntry, HydratedPointerCache};
-pub use xet_chunk_cache::{XetChunkCacheHandle, XetChunkCacheStats, xet_chunk_cache_from_config};
+pub use xet_chunk_cache::{
+    XetChunkCacheHandle, XetChunkCachePruneStats, XetChunkCacheStats, XetChunkCacheVerifyStats,
+    prune_xet_chunk_cache, prune_xet_chunk_cache_with_cancel, verify_xet_chunk_cache,
+    verify_xet_chunk_cache_with_cancel, xet_chunk_cache_from_config, xet_chunk_cache_stats,
+    xet_chunk_cache_stats_with_cancel,
+};
 
 /// Return the bucket-global persistent chunk-index cache path.
 pub(crate) fn chunk_index_cache_path(cache_root: &Path, identity: &BucketIdentity) -> PathBuf {

--- a/crab/src/cache/xet_chunk_cache.rs
+++ b/crab/src/cache/xet_chunk_cache.rs
@@ -3,7 +3,11 @@
 use crate::core::config::Config;
 use crate::core::error::Result;
 
-pub use crab_cache::{XetChunkCacheHandle, XetChunkCacheStats};
+pub use crab_cache::{
+    XetChunkCacheHandle, XetChunkCachePruneStats, XetChunkCacheStats, XetChunkCacheVerifyStats,
+    prune_xet_chunk_cache, prune_xet_chunk_cache_with_cancel, verify_xet_chunk_cache,
+    verify_xet_chunk_cache_with_cancel, xet_chunk_cache_stats, xet_chunk_cache_stats_with_cancel,
+};
 
 /// Opens the shared xet-core chunk cache from CLI configuration.
 ///

--- a/crab/src/cmd/artifacts.rs
+++ b/crab/src/cmd/artifacts.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 use clap::{Args, Subcommand};
 use fs4::fs_std::FileExt as LockFileExt;
 use serde::Serialize;
+use tokio_util::sync::CancellationToken;
 
 use crate::core::error::{CrabError, Result};
 use crate::core::output::{JsonlStream, OutputMode, emit_json};
@@ -555,8 +556,9 @@ fn remote_context(root: &Path) -> Result<Option<(crate::workflow::WorkflowStore,
         Err(error) => return Err(error),
     }
     let config = crate::core::config::Config::resolve_for_repo(root)?;
+    let cancel = CancellationToken::new();
     let (store, prefix) = crate::cmd::lfs::block_on_runtime(
-        crate::cmd::workflow::build_remote_store_for(root, &config, None),
+        crate::cmd::workflow::build_remote_store_for(root, &config, None, &cancel),
     )?;
     Ok(Some((store, prefix)))
 }

--- a/crab/src/cmd/cache.rs
+++ b/crab/src/cmd/cache.rs
@@ -5,10 +5,12 @@
 //! stage entries, and bloom filters.
 //! This command removes all cached data.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use crate::core::error::Result;
+use crate::core::config::Config;
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::OutputMode;
+use tokio_util::sync::CancellationToken;
 
 /// Summary of a cache clean operation.
 #[derive(Debug, Default, serde::Serialize)]
@@ -30,11 +32,24 @@ pub struct CacheVerifySummary {
 ///
 /// When `dry_run` is true, reports what would be removed without deleting.
 pub fn run_cache_clean(dry_run: bool, mode: OutputMode) -> Result<CacheCleanSummary> {
-    let cache_root = crate::cache::default_cache_root();
+    run_cache_clean_with_cancel(dry_run, mode, &CancellationToken::new())
+}
 
-    if !cache_root.exists() {
+/// Remove cache contents while honoring the caller's cancellation token.
+pub fn run_cache_clean_with_cancel(
+    dry_run: bool,
+    mode: OutputMode,
+    cancel: &CancellationToken,
+) -> Result<CacheCleanSummary> {
+    check_cancelled(cancel)?;
+    let config = Config::resolve_local()?;
+    let targets = clean_targets(
+        crate::cache::default_cache_root(),
+        config.effective_chunk_cache_dir(),
+    )?;
+    if targets.is_empty() {
         if !mode.is_machine() {
-            println!("Cache directory does not exist: {}", cache_root.display());
+            println!("Cache directories do not exist.");
         }
         return Ok(CacheCleanSummary {
             dry_run,
@@ -42,7 +57,14 @@ pub fn run_cache_clean(dry_run: bool, mode: OutputMode) -> Result<CacheCleanSumm
         });
     }
 
-    let (files, bytes) = walk_dir_size(&cache_root)?;
+    let mut files = 0u64;
+    let mut bytes = 0u64;
+    for target in &targets {
+        check_cancelled(cancel)?;
+        let (target_files, target_bytes) = walk_dir_size_with_cancel(target, cancel)?;
+        files = files.saturating_add(target_files);
+        bytes = bytes.saturating_add(target_bytes);
+    }
 
     if dry_run {
         if !mode.is_machine() {
@@ -59,8 +81,10 @@ pub fn run_cache_clean(dry_run: bool, mode: OutputMode) -> Result<CacheCleanSumm
         });
     }
 
-    // Remove all contents but keep the root directory itself.
-    remove_dir_contents(&cache_root)?;
+    for target in &targets {
+        check_cancelled(cancel)?;
+        remove_dir_contents_with_cancel(target, cancel)?;
+    }
 
     if !mode.is_machine() {
         println!(
@@ -77,14 +101,75 @@ pub fn run_cache_clean(dry_run: bool, mode: OutputMode) -> Result<CacheCleanSumm
     })
 }
 
+fn clean_targets(object_root: PathBuf, chunk_root: PathBuf) -> Result<Vec<PathBuf>> {
+    let mut targets = Vec::new();
+    for path in [object_root, chunk_root] {
+        if !path.exists() {
+            continue;
+        }
+        let canonical = std::fs::canonicalize(&path)?;
+        validate_destructive_cache_root(&canonical)?;
+        if targets
+            .iter()
+            .any(|root: &PathBuf| canonical.starts_with(root))
+        {
+            continue;
+        }
+        targets.retain(|root| !root.starts_with(&canonical));
+        targets.push(canonical);
+    }
+    Ok(targets)
+}
+
+fn validate_destructive_cache_root(path: &Path) -> Result<()> {
+    let cwd = std::fs::canonicalize(std::env::current_dir()?)?;
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|home| home.exists())
+        .map(std::fs::canonicalize)
+        .transpose()?;
+    let unsafe_path = path.parent().is_none()
+        || home.as_ref().is_some_and(|home| path == home)
+        || cwd.starts_with(path);
+    if unsafe_path {
+        return Err(CrabError::Configuration {
+            key: "cache directory is unsafe for recursive cleanup".to_owned(),
+            origin: path.display().to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Verify content-addressed local cache objects and evict corrupt entries.
 pub async fn run_cache_verify(mode: OutputMode) -> Result<CacheVerifySummary> {
+    run_cache_verify_with_cancel(mode, &CancellationToken::new()).await
+}
+
+/// Verify content-addressed cache objects while honoring cancellation.
+pub async fn run_cache_verify_with_cancel(
+    mode: OutputMode,
+    cancel: &CancellationToken,
+) -> Result<CacheVerifySummary> {
+    check_cancelled(cancel)?;
+    let config = Config::resolve_local()?;
     let cache = crate::cache::LocalCache::new(crate::cache::default_cache_root());
-    let report = cache.verify().await?;
+    let local_verify = cache.verify();
+    tokio::pin!(local_verify);
+    let report = tokio::select! {
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        result = &mut local_verify => result?,
+    };
+    check_cancelled(cancel)?;
+    let xet = crate::cache::verify_xet_chunk_cache_with_cancel(
+        &config.effective_chunk_cache_dir(),
+        cancel,
+    )
+    .await?;
+    check_cancelled(cancel)?;
     let summary = CacheVerifySummary {
-        objects_checked: report.total,
-        objects_valid: report.valid,
-        objects_corrupt: report.corrupt,
+        objects_checked: report.total.saturating_add(xet.total),
+        objects_valid: report.valid.saturating_add(xet.valid),
+        objects_corrupt: report.corrupt.saturating_add(xet.corrupt),
     };
 
     if mode.is_machine() {
@@ -105,14 +190,25 @@ pub async fn run_cache_verify(mode: OutputMode) -> Result<CacheVerifySummary> {
 }
 
 /// Walk a directory tree and return (file_count, total_bytes).
+#[cfg(test)]
 fn walk_dir_size(dir: &Path) -> Result<(u64, u64)> {
+    walk_dir_size_with_cancel(dir, &CancellationToken::new())
+}
+
+fn walk_dir_size_with_cancel(dir: &Path, cancel: &CancellationToken) -> Result<(u64, u64)> {
     let mut files = 0u64;
     let mut bytes = 0u64;
-    walk_dir_size_inner(dir, &mut files, &mut bytes)?;
+    walk_dir_size_inner(dir, &mut files, &mut bytes, cancel)?;
     Ok((files, bytes))
 }
 
-fn walk_dir_size_inner(dir: &Path, files: &mut u64, bytes: &mut u64) -> Result<()> {
+fn walk_dir_size_inner(
+    dir: &Path,
+    files: &mut u64,
+    bytes: &mut u64,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
     let entries = std::fs::read_dir(dir).map_err(|e| {
         crate::core::error::CrabError::Internal(format!(
             "failed to read directory {}: {e}",
@@ -121,15 +217,17 @@ fn walk_dir_size_inner(dir: &Path, files: &mut u64, bytes: &mut u64) -> Result<(
     })?;
 
     for entry in entries {
+        check_cancelled(cancel)?;
         let entry = entry.map_err(|e| {
             crate::core::error::CrabError::Internal(format!("dir entry error: {e}"))
         })?;
         let path = entry.path();
-        if path.is_dir() {
-            walk_dir_size_inner(&path, files, bytes)?;
-        } else if path.is_file() {
+        let file_type = entry.file_type().map_err(CrabError::Io)?;
+        if file_type.is_dir() {
+            walk_dir_size_inner(&path, files, bytes, cancel)?;
+        } else {
             *files += 1;
-            *bytes += std::fs::metadata(&path).map_or(0, |m| m.len());
+            *bytes = bytes.saturating_add(entry.metadata().map_or(0, |meta| meta.len()));
         }
     }
 
@@ -137,12 +235,21 @@ fn walk_dir_size_inner(dir: &Path, files: &mut u64, bytes: &mut u64) -> Result<(
 }
 
 /// Remove all files and subdirectories inside `dir`, but keep `dir` itself.
+#[cfg(test)]
 fn remove_dir_contents(dir: &Path) -> Result<()> {
+    remove_dir_contents_with_cancel(dir, &CancellationToken::new())
+}
+
+fn remove_dir_contents_with_cancel(dir: &Path, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
     for entry in std::fs::read_dir(dir)? {
+        check_cancelled(cancel)?;
         let entry = entry?;
         let path = entry.path();
-        if path.is_dir() {
-            std::fs::remove_dir_all(&path)?;
+        if entry.file_type()?.is_dir() {
+            remove_dir_contents_with_cancel(&path, cancel)?;
+            check_cancelled(cancel)?;
+            std::fs::remove_dir(&path)?;
         } else {
             std::fs::remove_file(&path)?;
         }
@@ -201,8 +308,68 @@ mod tests {
     }
 
     #[test]
+    fn cache_clean_walk_honors_cancellation() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"hello").unwrap();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let error = walk_dir_size_with_cancel(dir.path(), &cancel).unwrap_err();
+        assert!(matches!(error, CrabError::Cancelled));
+        assert!(dir.path().join("a.txt").exists());
+    }
+
+    #[test]
+    fn cache_clean_delete_honors_cancellation() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"hello").unwrap();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let error = remove_dir_contents_with_cancel(dir.path(), &cancel).unwrap_err();
+        assert!(matches!(error, CrabError::Cancelled));
+        assert!(dir.path().join("a.txt").exists());
+    }
+
+    #[test]
     fn format_bytes_units() {
         assert_eq!(format_bytes(500), "500 B");
         assert_eq!(format_bytes(1_048_576), "1.0 MB");
+    }
+
+    #[test]
+    fn clean_targets_deduplicates_nested_chunk_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("cache");
+        let chunks = root.join("chunks");
+        std::fs::create_dir_all(&chunks).unwrap();
+
+        let targets = clean_targets(root.clone(), chunks).unwrap();
+
+        assert_eq!(targets, vec![std::fs::canonicalize(root).unwrap()]);
+    }
+
+    #[test]
+    fn clean_rejects_current_working_directory() {
+        let cwd = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
+
+        let error = validate_destructive_cache_root(&cwd).unwrap_err();
+
+        assert!(matches!(error, CrabError::Configuration { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_dir_contents_does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("keep"), b"data").unwrap();
+        symlink(outside.path(), root.path().join("link")).unwrap();
+
+        remove_dir_contents(root.path()).unwrap();
+
+        assert!(outside.path().join("keep").exists());
     }
 }

--- a/crab/src/cmd/clone.rs
+++ b/crab/src/cmd/clone.rs
@@ -509,6 +509,9 @@ where
         emit_progress,
     )
     .await?;
+    // The sync updates the persistent chunk index and local shard cache;
+    // let that derived-state mutation settle before honoring cancellation.
+    check_cancelled(cancel)?;
 
     Ok(())
 }

--- a/crab/src/cmd/compact.rs
+++ b/crab/src/cmd/compact.rs
@@ -19,7 +19,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
 use crate::coordination::cas::cas_update_default;
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::storage::store::Store;
 use crab_metadata::manifests::ShardList;
 use crab_storage::canonical_global_content_path;
@@ -86,18 +86,31 @@ impl CompactOutcome {
 /// xet-core's `merge_shards()`, uploads the results, and CAS-updates
 /// the shard-list and ref-registry.
 pub async fn run_compact(args: &CompactArgs, store: &Store) -> Result<CompactOutcome> {
+    run_compact_with_cancel(args, store, &CancellationToken::new()).await
+}
+
+/// Run compaction with the caller's cancellation boundary.
+pub async fn run_compact_with_cancel(
+    args: &CompactArgs,
+    store: &Store,
+    cancel: &CancellationToken,
+) -> Result<CompactOutcome> {
     validate_max_shard_size(args.max_shard_size)?;
+    check_cancelled(cancel)?;
     if args.dry_run {
-        return run_compact_inner(args, store).await;
+        return run_compact_inner(args, store, cancel).await;
     }
-    let cancel = CancellationToken::new();
-    let writer =
-        crate::maintenance::GcWriterLeases::acquire(store, GLOBAL_PREFIX, &args.repo, &cancel)
-            .await?;
+    let writer = crate::maintenance::RepositoryMaintenanceLease::acquire(
+        store,
+        GLOBAL_PREFIX,
+        &args.repo,
+        cancel,
+    )
+    .await?;
     let operation = tokio::select! {
         biased;
         () = cancel.cancelled() => Err(CrabError::Cancelled),
-        result = run_compact_inner(args, store) => result,
+        result = run_compact_inner(args, store, cancel) => result,
     };
     let release = writer.release().await;
     match (operation, release) {
@@ -106,7 +119,12 @@ pub async fn run_compact(args: &CompactArgs, store: &Store) -> Result<CompactOut
     }
 }
 
-async fn run_compact_inner(args: &CompactArgs, store: &Store) -> Result<CompactOutcome> {
+async fn run_compact_inner(
+    args: &CompactArgs,
+    store: &Store,
+    cancel: &CancellationToken,
+) -> Result<CompactOutcome> {
+    check_cancelled(cancel)?;
     let shard_list_path = format!("{}/manifests/shard-list", args.repo);
 
     // Step 1: Read the per-repo shard-list.
@@ -156,7 +174,7 @@ async fn run_compact_inner(args: &CompactArgs, store: &Store) -> Result<CompactO
         ))
     })?;
 
-    download_shards(store, &source_hashes, source_dir.path()).await?;
+    download_shards(store, &source_hashes, source_dir.path(), cancel).await?;
 
     // Step 3: Merge shards via xet-core.
     let xet_context = XetContext::default().map_err(|error| {
@@ -218,6 +236,7 @@ async fn run_compact_inner(args: &CompactArgs, store: &Store) -> Result<CompactO
     // Step 4: Upload merged shards to the canonical global shard namespace.
     let mut new_hashes: Vec<String> = Vec::with_capacity(filtered.len());
     for shard_file in &filtered {
+        check_cancelled(cancel)?;
         let hash_hex = shard_file.shard_hash.hex();
         let shard_path = canonical_global_content_path("shards", &hash_hex);
 
@@ -241,11 +260,25 @@ async fn run_compact_inner(args: &CompactArgs, store: &Store) -> Result<CompactO
 
         debug!(hash = %hash_hex, size = buf.len(), "uploading compacted shard");
         let body = Bytes::from(buf);
-        store.put(&shard_path, body.clone()).await?;
         let hash = MerkleHash::from_hex(&hash_hex).map_err(|error| CrabError::CorruptObject {
             path: shard_path.to_string(),
             reason: format!("invalid compacted shard hash: {error}"),
         })?;
+        let local_path = target_dir.path().join(format!("upload-{}.shard", hash_hex));
+        tokio::fs::write(&local_path, &body)
+            .await
+            .map_err(CrabError::Io)?;
+        store
+            .put_multipart_file_retry_with_xet_hash(
+                &shard_path,
+                &local_path,
+                body.len() as u64,
+                hash.into(),
+                8 * 1024 * 1024,
+                cancel,
+                None,
+            )
+            .await?;
         crate::cmd::gc::closure::publish(store, GLOBAL_PREFIX, &hash, body, shard_path.as_ref())
             .await?;
         new_hashes.push(hash_hex);
@@ -325,9 +358,11 @@ async fn download_shards(
     store: &Store,
     shard_hashes: &[String],
     target_dir: &std::path::Path,
+    cancel: &CancellationToken,
 ) -> Result<()> {
     let shard_file_cache = new_shard_file_cache();
     for hash_hex in shard_hashes {
+        check_cancelled(cancel)?;
         let shard_path = canonical_global_content_path("shards", hash_hex);
         let (data, _) = store
             .get_with_etag_bounded(&shard_path, MAX_SOURCE_SHARD_BYTES)

--- a/crab/src/cmd/compact.rs
+++ b/crab/src/cmd/compact.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use object_store::path::Path as ObjectPath;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::coordination::cas::cas_update_default;
 use crate::core::error::{CrabError, Result};
@@ -31,6 +31,9 @@ use xet_runtime::core::XetContext;
 
 /// Default maximum compacted shard size (100 MiB).
 pub const DEFAULT_MAX_SHARD_SIZE: u64 = 100 * 1024 * 1024;
+const MAX_SOURCE_SHARD_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_SHARD_LIST_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_SHARD_LIST_ENTRIES: usize = 1_000_000;
 
 /// Global prefix for content-addressed objects.
 const GLOBAL_PREFIX: &str = ".crab";
@@ -83,6 +86,7 @@ impl CompactOutcome {
 /// xet-core's `merge_shards()`, uploads the results, and CAS-updates
 /// the shard-list and ref-registry.
 pub async fn run_compact(args: &CompactArgs, store: &Store) -> Result<CompactOutcome> {
+    validate_max_shard_size(args.max_shard_size)?;
     if args.dry_run {
         return run_compact_inner(args, store).await;
     }
@@ -290,13 +294,25 @@ async fn run_compact_inner(args: &CompactArgs, store: &Store) -> Result<CompactO
 /// Returns a default (empty) list if the manifest does not exist yet.
 async fn read_shard_list(store: &Store, path: &str) -> Result<ShardList> {
     let obj_path = ObjectPath::from(path);
-    match store.get_with_etag(&obj_path).await {
+    match store
+        .get_with_etag_bounded(&obj_path, MAX_SHARD_LIST_BYTES)
+        .await
+    {
         Ok((body, _etag)) => {
             let list: ShardList =
                 serde_json::from_slice(&body).map_err(|e| CrabError::CorruptObject {
                     path: path.to_string(),
                     reason: format!("invalid shard-list JSON: {e}"),
                 })?;
+            if list.entries.len() > MAX_SHARD_LIST_ENTRIES {
+                return Err(CrabError::Configuration {
+                    key: "compact shard-list entries".to_owned(),
+                    origin: format!(
+                        "shard-list contains {} entries; bounded compaction supports at most {MAX_SHARD_LIST_ENTRIES}",
+                        list.entries.len()
+                    ),
+                });
+            }
             Ok(list)
         }
         Err(CrabError::NotFound { .. }) => Ok(ShardList::default()),
@@ -313,14 +329,28 @@ async fn download_shards(
     let shard_file_cache = new_shard_file_cache();
     for hash_hex in shard_hashes {
         let shard_path = canonical_global_content_path("shards", hash_hex);
-
-        let data = match store.get_with_etag(&shard_path).await {
-            Ok((body, _)) => body,
-            Err(e) => {
-                warn!(shard = %hash_hex, error = %e, "failed to download shard, skipping");
-                continue;
-            }
-        };
+        let (data, _) = store
+            .get_with_etag_bounded(&shard_path, MAX_SOURCE_SHARD_BYTES)
+            .await
+            .map_err(|error| match error {
+                CrabError::NotFound { .. } => CrabError::CorruptObject {
+                    path: shard_path.to_string(),
+                    reason: "shard-list references a missing shard".to_owned(),
+                },
+                error => error,
+            })?;
+        let expected =
+            MerkleHash::from_hex(hash_hex).map_err(|error| CrabError::CorruptObject {
+                path: shard_path.to_string(),
+                reason: format!("invalid shard hash: {error}"),
+            })?;
+        let actual = compute_data_hash(&data);
+        if actual != expected {
+            return Err(CrabError::CorruptObject {
+                path: shard_path.to_string(),
+                reason: format!("shard content hash is {actual}, expected {expected}"),
+            });
+        }
 
         // Write shard bytes to the temp directory via MDBShardFile.
         let mut cursor = std::io::Cursor::new(data.as_ref());
@@ -490,7 +520,25 @@ pub fn parse_size_str(s: &str) -> Result<u64> {
         origin: "cli".into(),
     })?;
 
-    Ok(value * multiplier)
+    value
+        .checked_mul(multiplier)
+        .ok_or_else(|| CrabError::Configuration {
+            key: format!("invalid size: {s}"),
+            origin: "size overflows u64".into(),
+        })
+}
+
+fn validate_max_shard_size(value: u64) -> Result<()> {
+    const MIN_SHARD_SIZE: u64 = 1024 * 1024;
+    if !(MIN_SHARD_SIZE..=MAX_SOURCE_SHARD_BYTES).contains(&value) {
+        return Err(CrabError::Configuration {
+            key: "max_shard_size".to_owned(),
+            origin: format!(
+                "expected a value from {MIN_SHARD_SIZE} through {MAX_SOURCE_SHARD_BYTES} bytes"
+            ),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crab/src/cmd/doctor.rs
+++ b/crab/src/cmd/doctor.rs
@@ -31,6 +31,8 @@ use crate::core::project_config::ProjectConfig;
 use crate::core::style::CliStyle;
 use tokio_util::sync::CancellationToken;
 
+const MAX_CACHE_SERVICE_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
 /// Outcome of a single diagnostic check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -257,6 +259,9 @@ pub async fn run_cost_report(
     config: &Config,
     cancel: &CancellationToken,
 ) -> Result<()> {
+    if cancel.is_cancelled() {
+        return Err(CrabError::Cancelled);
+    }
     let remote_path = crate::git::discover::resolve_crab_dir()
         .map_or_else(|| PathBuf::from(".crab/remote"), |dir| dir.join("remote"));
     let remote =
@@ -281,6 +286,9 @@ pub async fn run_cost_report(
         cancel,
     )
     .await?;
+    if cancel.is_cancelled() {
+        return Err(CrabError::Cancelled);
+    }
 
     if mode == OutputMode::Json {
         emit_json("cost", "1.0", &report);
@@ -1088,6 +1096,34 @@ fn cache_service_url_scheme(base_url: &str) -> Option<String> {
         .map(|url| url.scheme().to_owned())
 }
 
+async fn read_cache_service_response_bounded(
+    response: reqwest::Response,
+) -> std::result::Result<Vec<u8>, String> {
+    if response
+        .content_length()
+        .is_some_and(|size| size > MAX_CACHE_SERVICE_RESPONSE_BYTES as u64)
+    {
+        return Err(format!(
+            "response exceeds the {MAX_CACHE_SERVICE_RESPONSE_BYTES}-byte safety limit"
+        ));
+    }
+    let mut body = Vec::new();
+    let mut response = response;
+    while let Some(chunk) = response.chunk().await.map_err(|error| error.to_string())? {
+        let next_len = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(|| "response body length overflow".to_owned())?;
+        if next_len > MAX_CACHE_SERVICE_RESPONSE_BYTES {
+            return Err(format!(
+                "response exceeds the {MAX_CACHE_SERVICE_RESPONSE_BYTES}-byte safety limit"
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
 async fn collect_cache_service_http_probe(
     client: &reqwest::Client,
     url: String,
@@ -1154,7 +1190,7 @@ async fn collect_cache_service_capabilities_snapshot(
         );
     }
 
-    let body = match response.bytes().await {
+    let body = match read_cache_service_response_bounded(response).await {
         Ok(body) => body,
         Err(err) => {
             return (
@@ -1234,7 +1270,7 @@ async fn collect_cache_service_authz_snapshot(
         );
     }
 
-    let body = match response.bytes().await {
+    let body = match read_cache_service_response_bounded(response).await {
         Ok(body) => body,
         Err(err) => {
             return (
@@ -1308,7 +1344,7 @@ async fn collect_cache_service_admin_snapshot(
         );
     }
 
-    let body = match response.bytes().await {
+    let body = match read_cache_service_response_bounded(response).await {
         Ok(body) => body,
         Err(err) => {
             return (
@@ -2127,7 +2163,7 @@ async fn check_cache_service_admin(
         );
     }
 
-    let body = match resp.bytes().await {
+    let body = match read_cache_service_response_bounded(resp).await {
         Ok(body) => body,
         Err(e) => {
             return CheckResult::warn(

--- a/crab/src/cmd/fetch.rs
+++ b/crab/src/cmd/fetch.rs
@@ -1,25 +1,25 @@
-//! `crab fetch` — pre-fetch objects from the remote store into the local cache.
+//! `crab fetch` — prewarm canonical local caches for selected Crab files.
 //!
-//! Downloads xorbs and shards referenced by the current HEAD (or a
-//! specified ref) without hydrating files. This warms the local cache
-//! so subsequent `crab hydrate` or `git checkout` operations are fast.
+//! Selection comes from Git pointer blobs, not bucket-global object listing.
+//! Each selected file is reconstructed into a hash-verifying sink through the
+//! same shard, file-index, replica, and xet-core range-cache path as hydrate.
 
-use std::future::Future;
 use std::io::Stdout;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
+use crate::cmd::hydrate::{HydrateArgs, ShardHydrator};
 use crate::core::config::Config;
 use crate::core::error::{CrabError, Result, check_cancelled};
-use crate::core::output::event_payloads::{
-    PERF_PHASE_SCHEMA, PerfPhasePayload, ProgressPayload, XorbDonePayload,
-};
+use crate::core::output::event_payloads::{PERF_PHASE_SCHEMA, PerfPhasePayload};
 use crate::core::output::{JsonlStream, OutputMode, emit_json};
 use crate::core::perf_phase::PhaseTimer;
+
+const MAX_FETCH_CANDIDATES: usize = 1_000_000;
 
 /// Arguments for the `crab fetch` command.
 pub struct FetchArgs {
@@ -31,9 +31,7 @@ pub struct FetchArgs {
     pub all: bool,
     /// Report what would be fetched without downloading.
     pub dry_run: bool,
-    /// Skip the post-fetch shard-sync step that warms the local
-    /// chunk-index cache. CI workloads that push once and never read
-    /// back can use this to avoid the warming cost.
+    /// Skip the post-fetch shard-sync step that warms the local chunk index.
     pub no_sync_chunk_index: bool,
     /// Output mode resolved from `--json` / `--jsonl` flags.
     pub mode: OutputMode,
@@ -54,355 +52,224 @@ pub struct FetchSummary {
 
 /// Run `crab fetch` in the current working directory.
 pub async fn run_fetch(args: &FetchArgs, cancel: &CancellationToken) -> Result<()> {
-    let cwd = std::env::current_dir()?;
-    run_fetch_in(&cwd, args, cancel).await
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
+    run_fetch_in(&worktree.current_worktree_root, args, cancel).await
 }
 
 fn emit_phase(stream: Option<&Mutex<JsonlStream<Stdout>>>, payload: PerfPhasePayload) {
-    if let Some(stream) = stream {
-        let Ok(mut s) = stream.lock() else {
-            return;
-        };
-        s.emit_schema_event(PERF_PHASE_SCHEMA, "event", payload);
+    if let Some(stream) = stream
+        && let Ok(mut stream) = stream.lock()
+    {
+        stream.emit_schema_event(PERF_PHASE_SCHEMA, "event", payload);
     }
 }
 
-/// Fetch objects for the repository rooted at `root`.
-///
-/// Reads the remote URL from `.crab/remote`, resolves the current
-/// HEAD's tree, and downloads any missing xorbs/shards into the local
-/// cache directory.
+/// Fetch selected repository content through the canonical hydrate path.
 pub async fn run_fetch_in(root: &Path, args: &FetchArgs, cancel: &CancellationToken) -> Result<()> {
     let config = Config::resolve_for_repo(root)?;
-
-    run_fetch_in_with_selector(
-        root,
-        args,
-        cancel,
-        config,
-        |config, parsed, cancel| async move {
-            crate::replication::select_read_store(&config, &parsed, "fetch", &cancel).await
-        },
-    )
-    .await
-}
-
-async fn run_fetch_in_with_selector<F, Fut>(
-    root: &Path,
-    args: &FetchArgs,
-    cancel: &CancellationToken,
-    config: Config,
-    select_read: F,
-) -> Result<()>
-where
-    F: FnOnce(Config, crate::git::url::CrabUrl, tokio_util::sync::CancellationToken) -> Fut,
-    Fut: Future<Output = Result<crate::replication::ReadStoreSelection>>,
-{
-    use futures_util::TryStreamExt;
-
+    let candidates = resolve_candidates(root, args, &config, cancel)?;
+    if candidates.len() > MAX_FETCH_CANDIDATES {
+        return Err(CrabError::Configuration {
+            key: "fetch candidate count".to_owned(),
+            origin: format!(
+                "fetch selection exceeds the safety limit of {MAX_FETCH_CANDIDATES} files"
+            ),
+        });
+    }
+    let logical_bytes = candidates
+        .iter()
+        .try_fold(0u64, |bytes, (_, pointer)| bytes.checked_add(pointer.size))
+        .ok_or_else(|| CrabError::Internal("selected fetch size exceeds u64".to_owned()))?;
+    let selected = u64::try_from(candidates.len())
+        .map_err(|_| CrabError::Internal("selected fetch count exceeds u64".to_owned()))?;
     let start = Instant::now();
 
+    if args.dry_run {
+        return emit_summary(
+            args.mode,
+            FetchSummary {
+                objects_fetched: 0,
+                bytes_downloaded: 0,
+                objects_skipped: selected,
+                duration_ms: elapsed_millis(start),
+            },
+            Some((selected, logical_bytes)),
+            None,
+        );
+    }
+    if candidates.is_empty() {
+        return emit_summary(
+            args.mode,
+            FetchSummary {
+                objects_fetched: 0,
+                bytes_downloaded: 0,
+                objects_skipped: 0,
+                duration_ms: elapsed_millis(start),
+            },
+            None,
+            None,
+        );
+    }
+
     check_cancelled(cancel)?;
-
-    let remote_path = root.join(".crab/remote");
-    let url = std::fs::read_to_string(&remote_path).map_err(|_| CrabError::Configuration {
-        key: "no remote configured".into(),
-        origin: remote_path.display().to_string(),
-    })?;
-    let url = url.trim();
-
-    let parsed = crate::git::url::CrabUrl::parse(url)?;
-
-    tracing::info!(
-        bucket = %parsed.bucket,
-        repo_path = %parsed.repo_path,
-        all = args.all,
-        dry_run = args.dry_run,
-        "starting fetch",
-    );
-
-    check_cancelled(cancel)?;
-
-    let selection = select_read(config.clone(), parsed.clone(), cancel.clone()).await?;
-    let crate::replication::ReadStoreSelection {
-        store,
-        router: read_router,
-        source,
-    } = selection;
-    if let crate::replication::ReadSource::Replica { name } = &source {
+    let parsed = read_remote(root)?;
+    let selection =
+        crate::replication::select_read_store(&config, &parsed, "fetch", cancel).await?;
+    if let crate::replication::ReadSource::Replica { name } = &selection.source {
         tracing::debug!(replica = %name, "selected read replica for fetch");
     }
+    let read_router = selection.router;
+    let caching_store = crab_cache_store::CachingStore::new(selection.store, &config.cache)?;
+    let mut hydrator = ShardHydrator::with_config_from_cli_layout(
+        caching_store.clone(),
+        read_router.clone(),
+        &config,
+    )?;
+    let chunk_cache = crate::cache::xet_chunk_cache_from_config(&config)?;
+    hydrator = hydrator.with_xet_chunk_cache(chunk_cache.cache);
 
-    // Wrap with CachingStore when a cache service is configured.
-    let caching_store = crab_cache_store::CachingStore::new(store, &config.cache)?;
-
-    // List objects under the repo prefix to discover what needs fetching.
-    let prefix = object_store::path::Path::from(parsed.repo_path.as_str());
-
-    if args.dry_run {
-        let summary = FetchSummary {
-            objects_fetched: 0,
-            bytes_downloaded: 0,
-            objects_skipped: 0,
-            duration_ms: start.elapsed().as_millis() as u64,
-        };
-        match args.mode {
-            OutputMode::Text => {
-                eprintln!("fetch (dry run): would fetch objects from {url}");
-                eprintln!("  prefix: {prefix}");
-                eprintln!("  include: {:?}", args.include);
-                eprintln!("  exclude: {:?}", args.exclude);
-            }
-            OutputMode::Json => {
-                emit_json("fetch", "1.0", &summary);
-            }
-            OutputMode::Jsonl => {
-                let mut stream = JsonlStream::new("fetch.event", "1.0", std::io::stdout());
-                stream.emit_result(&summary);
-            }
-        }
-        return Ok(());
-    }
-
-    // Build the optional JSONL stream for streaming mode.
-    let jsonl_stream: Option<Mutex<JsonlStream<Stdout>>> = match args.mode {
-        OutputMode::Jsonl => Some(Mutex::new(JsonlStream::new(
-            "fetch.event",
-            "1.0",
-            std::io::stdout(),
-        ))),
-        _ => None,
-    };
-
-    // Fetch shard metadata first (from global prefix), then xorbs (from global prefix).
-    // Packs remain at the per-repo prefix.
-    let global_shards_prefix = object_store::path::Path::from(".crab/shards");
-    let global_xorbs_prefix = object_store::path::Path::from(".crab/xorbs");
-
-    let mut fetched_count: u64 = 0;
-    let mut fetched_bytes: u64 = 0;
-    let mut skipped_count: u64 = 0;
-
+    let jsonl_stream = (args.mode == OutputMode::Jsonl)
+        .then(|| Mutex::new(JsonlStream::new("fetch.event", "1.0", std::io::stdout())));
     let phase = PhaseTimer::start("fetch", "hydration_prefetch");
-    for obj_prefix in [&global_shards_prefix, &global_xorbs_prefix] {
-        check_cancelled(cancel)?;
-
-        let mut list_stream = caching_store.origin().inner().list(Some(obj_prefix));
-        while let Some(meta) = list_stream.try_next().await.map_err(CrabError::Storage)? {
-            check_cancelled(cancel)?;
-
-            let cache_path = cache_path_for(&meta.location);
-            if cache_path.exists() {
-                tracing::debug!(path = %meta.location, "already cached, skipping");
-                skipped_count += 1;
-                continue;
-            }
-
-            tracing::debug!(path = %meta.location, size = meta.size, "fetching");
-            let (data, _etag) = caching_store.get_with_etag(&meta.location).await?;
-
-            // Ensure parent directory exists.
-            if let Some(parent) = cache_path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::write(&cache_path, &data)?;
-
-            let obj_bytes = data.len() as u64;
-            fetched_count += 1;
-            fetched_bytes += obj_bytes;
-
-            // Emit xorb_done and progress events in JSONL mode.
-            if let Some(ref stream) = jsonl_stream
-                && let Ok(mut s) = stream.lock()
-            {
-                s.emit_xorb_done(XorbDonePayload {
-                    hash: meta.location.to_string(),
-                    bytes: obj_bytes,
-                    compressed_bytes: obj_bytes,
-                    status: "ok".to_owned(),
-                });
-
-                let elapsed = start.elapsed();
-                let rate = if elapsed.as_secs_f64() > 0.0 {
-                    fetched_bytes as f64 / elapsed.as_secs_f64()
-                } else {
-                    0.0
-                };
-                s.emit_progress(ProgressPayload {
-                    operation: "fetching".to_owned(),
-                    current: fetched_count,
-                    total: 0,
-                    bytes: fetched_bytes,
-                    total_bytes: 0,
-                    rate_bytes_per_sec: rate,
-                    xorbs_produced: None,
-                });
-            }
-        }
-    }
+    let prefetched = hydrator.prefetch_batch(&candidates, cancel).await?;
     emit_phase(
         jsonl_stream.as_ref(),
-        phase.finish(0, fetched_bytes, fetched_count),
+        phase.finish(0, prefetched.bytes_prefetched, prefetched.prefetched),
     );
+    if prefetched.failed > 0 {
+        return Err(CrabError::Protocol(format!(
+            "fetch failed to prewarm {} of {} selected file(s)",
+            prefetched.failed, selected
+        )));
+    }
 
-    let elapsed = start.elapsed();
-    let summary = FetchSummary {
-        objects_fetched: fetched_count,
-        bytes_downloaded: fetched_bytes,
-        objects_skipped: skipped_count,
-        duration_ms: elapsed.as_millis() as u64,
-    };
-
-    // After the packs/xorbs/shards are on disk, warm the local
-    // chunk-index cache so the next push can classify most chunks as
-    // already-remote from the local tiers alone. Failures are
-    // non-fatal: the cache is an optimisation, correctness comes from
-    // lazy-on-miss lookups against the remote chunk_index_db.
-    if !args.no_sync_chunk_index && !args.dry_run {
+    if !args.no_sync_chunk_index {
         check_cancelled(cancel)?;
         let phase = PhaseTimer::start("fetch", "shard_sync");
-
         let router = crate::storage::StoreLayout::new(
             crate::storage::Store::from_storage(caching_store.origin().clone()),
             read_router.repo_prefix().to_owned(),
         );
-        let cache_dir = crate::cache::default_cache_root();
         let repo_hash = crate::git::push::compute_repo_hash(&parsed.repo_path);
-
-        let emit_text = matches!(args.mode, OutputMode::Text);
-        match crate::metadata::shard_sync::run_post_fetch_shard_sync(
-            router, &repo_hash, &cache_dir, None, emit_text,
+        crate::metadata::shard_sync::run_post_fetch_shard_sync(
+            router,
+            &repo_hash,
+            &crate::cache::default_cache_root(),
+            None,
+            args.mode == OutputMode::Text,
         )
-        .await
-        {
-            Ok(stats) => {
-                tracing::debug!(
-                    downloaded = stats.shards_downloaded,
-                    skipped = stats.shards_skipped,
-                    failed = stats.shards_failed,
-                    "fetch: post-fetch shard sync finished"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "fetch: post-fetch shard sync failed (non-fatal)");
-            }
-        }
+        .await?;
+        // The sync updates the persistent chunk index and local shard cache;
+        // let that derived-state mutation settle before honoring cancellation.
+        check_cancelled(cancel)?;
         emit_phase(jsonl_stream.as_ref(), phase.finish(0, 0, 1));
     }
 
-    match args.mode {
-        OutputMode::Text => {
-            eprintln!("fetch complete: {fetched_count} objects, {fetched_bytes} bytes downloaded",);
-        }
-        OutputMode::Json => {
-            emit_json("fetch", "1.0", &summary);
-        }
+    emit_summary(
+        args.mode,
+        FetchSummary {
+            objects_fetched: prefetched.prefetched,
+            bytes_downloaded: prefetched.bytes_prefetched,
+            objects_skipped: 0,
+            duration_ms: elapsed_millis(start),
+        },
+        None,
+        jsonl_stream.as_ref(),
+    )
+}
+
+fn resolve_candidates(
+    root: &Path,
+    args: &FetchArgs,
+    config: &Config,
+    cancel: &CancellationToken,
+) -> Result<Vec<(PathBuf, crab_types::pointer::Pointer)>> {
+    if args.all {
+        return crate::cmd::hydrate::resolve_all_ref_pointer_prefetch_candidates(
+            root,
+            &args.include,
+            &args.exclude,
+            cancel,
+        );
+    }
+    let hydrate_args = HydrateArgs {
+        patterns: Vec::new(),
+        include: args.include.clone(),
+        exclude: args.exclude.clone(),
+        all: args.include.is_empty() && args.exclude.is_empty(),
+        mode: OutputMode::Text,
+        manifest: None,
+        manifest_ref: None,
+        profile: None,
+        ignore_sparse: true,
+        recover_from: None,
+    };
+    crate::cmd::hydrate::resolve_git_pointer_prefetch_candidates(
+        root,
+        &hydrate_args,
+        config,
+        cancel,
+    )
+}
+
+fn read_remote(root: &Path) -> Result<crate::git::url::CrabUrl> {
+    let path = root.join(".crab/remote");
+    let url = std::fs::read_to_string(&path).map_err(|_| CrabError::Configuration {
+        key: "no remote configured".into(),
+        origin: path.display().to_string(),
+    })?;
+    crate::git::url::CrabUrl::parse(url.trim())
+}
+
+fn elapsed_millis(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn emit_summary(
+    mode: OutputMode,
+    summary: FetchSummary,
+    dry_run_selection: Option<(u64, u64)>,
+    jsonl_stream: Option<&Mutex<JsonlStream<Stdout>>>,
+) -> Result<()> {
+    match mode {
+        OutputMode::Text => match dry_run_selection {
+            Some((files, bytes)) => {
+                eprintln!("fetch (dry run): would prewarm {files} file(s), {bytes} logical bytes")
+            }
+            None => eprintln!(
+                "fetch complete: {} file(s), {} logical bytes verified",
+                summary.objects_fetched, summary.bytes_downloaded
+            ),
+        },
+        OutputMode::Json => emit_json("fetch", "1.0", &summary),
         OutputMode::Jsonl => {
-            if let Some(ref stream) = jsonl_stream
-                && let Ok(mut s) = stream.lock()
-            {
-                s.emit_result(&summary);
+            if let Some(stream) = jsonl_stream {
+                stream
+                    .lock()
+                    .map_err(|_| CrabError::Internal("fetch output lock poisoned".to_owned()))?
+                    .emit_result(&summary);
+            } else {
+                JsonlStream::new("fetch.event", "1.0", std::io::stdout()).emit_result(&summary);
             }
         }
     }
-
     Ok(())
-}
-
-/// Derive a local cache path for a remote object.
-fn cache_path_for(location: &object_store::path::Path) -> std::path::PathBuf {
-    let cache_root = crate::cache::default_cache_root();
-    cache_root.join(location.as_ref())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use bytes::Bytes;
-    use object_store::memory::InMemory;
-    use object_store::path::Path as ObjectPath;
-    use std::sync::Arc;
-
     #[test]
-    fn cache_path_includes_object_location() {
-        let loc = object_store::path::Path::from("repo/shards/abc123");
-        let path = cache_path_for(&loc);
-        assert!(
-            path.to_string_lossy().contains("repo/shards/abc123"),
-            "cache path should include the object location, got: {}",
-            path.display(),
-        );
-    }
-
-    #[tokio::test]
-    async fn fetch_command_uses_selected_replica_store_for_cached_objects() {
-        let cache_tmp = tempfile::tempdir().expect("cache tempdir");
-        let _cache_guard = crate::test::git_repo::CacheDirGuard::new(cache_tmp.path());
-        let root = tempfile::tempdir().expect("workspace tempdir");
-        std::fs::create_dir_all(root.path().join(".crab")).expect("create .crab");
-        std::fs::write(
-            root.path().join(".crab/remote"),
-            "crab://primary/org/repo\n",
-        )
-        .expect("write remote");
-
-        let primary = crate::storage::store::Store::new(Arc::new(InMemory::new()));
-        primary
-            .put(
-                &ObjectPath::from(".crab/shards/only-primary"),
-                Bytes::from_static(b"primary"),
-            )
-            .await
-            .expect("write primary marker");
-        let replica = crate::storage::store::Store::new(Arc::new(InMemory::new()));
-        replica
-            .put(
-                &ObjectPath::from(".crab/shards/only-replica"),
-                Bytes::from_static(b"replica"),
-            )
-            .await
-            .expect("write replica marker");
-
-        let args = FetchArgs {
-            include: Vec::new(),
-            exclude: Vec::new(),
-            all: false,
-            dry_run: false,
-            no_sync_chunk_index: true,
-            mode: OutputMode::Json,
+    fn dry_run_summary_does_not_claim_downloads() {
+        let summary = FetchSummary {
+            objects_fetched: 0,
+            bytes_downloaded: 0,
+            objects_skipped: 3,
+            duration_ms: 1,
         };
-        let cancel = CancellationToken::new();
-
-        run_fetch_in_with_selector(
-            root.path(),
-            &args,
-            &cancel,
-            Config::default(),
-            move |_, _, _| {
-                let replica = replica.clone();
-                async move {
-                    Ok(crate::replication::ReadStoreSelection {
-                        store: replica.clone(),
-                        router: crate::storage::StoreLayout::new(replica, "org/repo".into()),
-                        source: crate::replication::ReadSource::Replica {
-                            name: "west".into(),
-                        },
-                    })
-                }
-            },
-        )
-        .await
-        .expect("fetch command");
-
-        assert_eq!(
-            std::fs::read(cache_tmp.path().join(".crab/shards/only-replica"))
-                .expect("replica marker cached"),
-            b"replica"
-        );
-        assert!(
-            !cache_tmp.path().join(".crab/shards/only-primary").exists(),
-            "fetch must consume selected replica store, not the primary fallback"
-        );
+        assert_eq!(summary.objects_skipped, 3);
+        assert_eq!(summary.bytes_downloaded, 0);
     }
 }

--- a/crab/src/cmd/fsck_store.rs
+++ b/crab/src/cmd/fsck_store.rs
@@ -29,6 +29,10 @@ use crab_storage::repo_pack_path;
 use crab_xet::hash::MerkleHash;
 use crab_xet::shard::ShardReader;
 
+const MAX_FSCK_SHARD_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_FSCK_REF_BYTES: u64 = 64 * 1024;
+const MAX_FSCK_LOCK_BYTES: u64 = 64 * 1024;
+
 /// Store-backed fsck checker that queries real object storage.
 pub struct StoreChecker {
     store: Store,
@@ -123,7 +127,11 @@ impl StoreChecker {
             };
             let shard_path = self.router.global_path("shards", shard_hex);
             let path = Path::from(shard_path.as_ref());
-            let body = match self.store.get_with_etag(&path).await {
+            let body = match self
+                .store
+                .get_with_etag_bounded(&path, MAX_FSCK_SHARD_BYTES)
+                .await
+            {
                 Ok((body, _)) => body,
                 Err(CrabError::NotFound { .. }) => continue,
                 Err(e) => return Err(e),
@@ -373,7 +381,11 @@ impl FsckChecker for StoreChecker {
             let ref_keys = self.list_keys("refs").await?;
             for ref_key in &ref_keys {
                 let path = Path::from(ref_key.as_str());
-                match self.store.get_with_etag(&path).await {
+                match self
+                    .store
+                    .get_with_etag_bounded(&path, MAX_FSCK_REF_BYTES)
+                    .await
+                {
                     Ok((body, _)) => {
                         let sha = String::from_utf8_lossy(&body).trim().to_string();
                         if sha.is_empty() {
@@ -414,7 +426,11 @@ impl FsckChecker for StoreChecker {
             let mut checked_xorbs = HashSet::new();
             for shard_hash in &shard_list.entries {
                 let shard_path = self.router.global_path("shards", shard_hash);
-                let body = match self.store.get_with_etag(&shard_path).await {
+                let body = match self
+                    .store
+                    .get_with_etag_bounded(&shard_path, MAX_FSCK_SHARD_BYTES)
+                    .await
+                {
                     Ok((body, _etag)) => body,
                     Err(CrabError::NotFound { .. }) => {
                         issues.push(FsckIssue::orphan_shard(shard_hash));
@@ -485,7 +501,11 @@ impl FsckChecker for StoreChecker {
                     continue;
                 }
                 let path = Path::from(lock_key.as_str());
-                match self.store.get_with_etag(&path).await {
+                match self
+                    .store
+                    .get_with_etag_bounded(&path, MAX_FSCK_LOCK_BYTES)
+                    .await
+                {
                     Ok((body, _)) => {
                         if let Ok(payload) = serde_json::from_slice::<PushLockPayload>(&body)
                             && payload.is_expired_at(now_unix)
@@ -609,7 +629,11 @@ impl StoreRepairer {
 
         let shard_path = self.router.global_path("shards", &shard_hash.hex());
         let path = Path::from(shard_path.as_ref());
-        let body = match self.store.get_with_etag(&path).await {
+        let body = match self
+            .store
+            .get_with_etag_bounded(&path, MAX_FSCK_SHARD_BYTES)
+            .await
+        {
             Ok((body, _)) => body,
             Err(CrabError::NotFound { .. }) => return Ok(false),
             Err(e) => return Err(e),

--- a/crab/src/cmd/history_recovery.rs
+++ b/crab/src/cmd/history_recovery.rs
@@ -11,6 +11,8 @@ use crab_coordination::PushLock;
 use crab_git::pack_locator::PackLocationIter;
 use crab_xet::hash::{MerkleHash, compute_data_hash};
 use crab_xet::shard::ShardReader;
+use crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES;
+use crab_xet::xorb::format::MAX_XORB_SIZE;
 use crab_xet::xorb::parser::XorbParser;
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -814,7 +816,9 @@ async fn verify_history(
             reason: format!("invalid shard hash: {error}"),
         })?;
         let path = router.shard_path(&hash);
-        let (bytes, _) = store.get_with_etag(&path).await?;
+        let (bytes, _) = store
+            .get_with_etag_bounded(&path, MAX_SHARD_SIZE_BYTES as u64)
+            .await?;
         let actual = compute_data_hash(&bytes);
         if actual != hash {
             return Err(CrabError::CorruptObject {
@@ -854,7 +858,9 @@ async fn verify_history(
     for hash in &xorb_hashes {
         check_cancelled(cancel)?;
         let path = router.xorb_path(hash);
-        let (bytes, _) = store.get_with_etag(&path).await?;
+        let (bytes, _) = store
+            .get_with_etag_bounded(&path, MAX_XORB_SIZE as u64)
+            .await?;
         let parser =
             XorbParser::parse(bytes.clone()).map_err(|error| CrabError::CorruptObject {
                 path: path.as_ref().to_owned(),

--- a/crab/src/cmd/hydrate.rs
+++ b/crab/src/cmd/hydrate.rs
@@ -11,7 +11,7 @@
 //! safety: a SIGINT mid-write leaves only a tempfile that the OS
 //! cleans up, never a half-written working-tree file.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::io::{Stdout, Write};
 use std::path::{Component, Path, PathBuf};
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 use std::time::{Duration, Instant};
 
-use futures_util::stream::{FuturesUnordered, StreamExt};
+use futures_util::stream::{self, FuturesUnordered, StreamExt};
 use schemars::JsonSchema;
 use serde::Serialize;
 use tokio::task::JoinHandle;
@@ -50,6 +50,7 @@ use crab_metadata::file_index_lookup::SharedFileIndexLookup;
 use crab_types::pointer::{MAX_POINTER_SIZE, Pointer};
 use crab_xet::hash::MerkleHash;
 use crab_xet::shard::FileDataSequenceEntry;
+use crab_xet::xorb::format::MAX_XORB_SIZE;
 
 /// Per-file hydration result sent through the progress channel.
 ///
@@ -546,6 +547,10 @@ pub struct ShardHydrator {
     /// Used by the delta-reconstruction path (`try_delta_reconstruct`)
     /// which fetches xorbs directly rather than via `FileReconstructor`.
     xorb_cache: tokio::sync::Mutex<std::collections::HashMap<MerkleHash, bytes::Bytes>>,
+    /// Tracks the total body bytes held by `xorb_cache`. This is updated only
+    /// while the cache mutex is held, so the atomic avoids a second lock for
+    /// the accounting field without allowing the cache to grow unbounded.
+    xorb_cache_bytes: AtomicU64,
     /// Optional perf counters. When set, shard-hint hit/miss events are recorded.
     metrics: Option<Arc<crate::core::metrics::Metrics>>,
     /// Shared concurrency controller used by [`FileReconstructor`] to
@@ -571,6 +576,11 @@ pub struct ShardHydrator {
 /// `AdaptiveConcurrencyController` stores the tag for logging.
 const HYDRATE_CONCURRENCY_TAG: &str = "crab-hydrate";
 const MAX_HYDRATE_FILE_CONCURRENCY: usize = 4;
+const MAX_PREFETCH_CANDIDATES: usize = 1_000_000;
+const MAX_GIT_INVENTORY_BYTES: usize = 512 * 1024 * 1024;
+const MAX_HYDRATE_SHARD_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_HYDRATE_XORB_CACHE_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_HYDRATE_XORB_CACHE_ENTRIES: usize = 4_096;
 
 fn hydrate_file_concurrency(download_concurrency: usize) -> usize {
     download_concurrency.clamp(1, MAX_HYDRATE_FILE_CONCURRENCY)
@@ -648,6 +658,7 @@ impl ShardHydrator {
             store,
             router,
             xorb_cache: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            xorb_cache_bytes: AtomicU64::new(0),
             metrics: None,
             concurrency,
             buffer_semaphore: hydrate_buffer_semaphore(hydrate.prefetch_budget),
@@ -765,15 +776,33 @@ impl ShardHydrator {
         let file_index_lookup = self.shared_file_index_lookup();
         let result = async {
             let mut summary = CachePrefetchSummary::default();
-            for (path, ptr) in items {
-                error::check_cancelled(cancel)?;
-                match self.reconstruct_file(ptr, Some(&file_index_lookup)).await {
+            let mut results = stream::iter(items.iter())
+                .map(|(path, ptr)| {
+                    let file_index_lookup = file_index_lookup.clone();
+                    async move {
+                        let result = async {
+                            error::check_cancelled(cancel)?;
+                            self.reconstruct_to_writer_with(
+                                ptr,
+                                std::io::sink(),
+                                Some(&file_index_lookup),
+                                cancel,
+                            )
+                            .await
+                        }
+                        .await;
+                        (path, result)
+                    }
+                })
+                .buffer_unordered(self.file_concurrency);
+            while let Some((path, result)) = results.next().await {
+                match result {
                     Ok(bytes) => {
                         summary.prefetched += 1;
-                        summary.bytes_prefetched += bytes.len() as u64;
+                        summary.bytes_prefetched += bytes;
                         debug!(
                             path = %path.display(),
-                            bytes = bytes.len(),
+                            bytes,
                             "cache prefetch reconstructed selected pointer"
                         );
                     }
@@ -811,13 +840,6 @@ impl ShardHydrator {
             self.store.origin(),
             self.router.repo_prefix().to_owned(),
         )
-    }
-
-    fn store_client(
-        &self,
-        file_index_lookup: Option<&SharedFileIndexLookup>,
-    ) -> Arc<dyn xet_client::cas_client::Client> {
-        Arc::new(self.store_client_adapter(file_index_lookup, None))
     }
 
     fn store_client_for_pointer(
@@ -925,9 +947,11 @@ impl ShardHydrator {
         .await?;
         // CachingStore owns the local and remote cache read-through order.
         // Calling the origin directly here bypasses a warmed cache service.
-        let (data, _) = self.store.get_with_etag(&path).await?;
-        let mut cache = self.xorb_cache.lock().await;
-        cache.insert(*hash, data.clone());
+        let (data, _) = self
+            .store
+            .get_with_etag_bounded(&path, MAX_XORB_SIZE as u64)
+            .await?;
+        self.cache_xorb(*hash, &data).await?;
         Ok(data)
     }
 
@@ -945,7 +969,11 @@ impl ShardHydrator {
             self.auto_restore,
         )
         .await?;
-        let (data, _) = self.store.origin().get_with_etag(&path).await?;
+        let (data, _) = self
+            .store
+            .origin()
+            .get_with_etag_bounded(&path, MAX_XORB_SIZE as u64)
+            .await?;
 
         if let Err(e) = self.store.local_cache().put(&key, &data).await {
             warn!(
@@ -954,9 +982,36 @@ impl ShardHydrator {
                 "failed to rewrite repaired hydrate xorb cache entry"
             );
         }
-        let mut cache = self.xorb_cache.lock().await;
-        cache.insert(*hash, data.clone());
+        self.cache_xorb(*hash, &data).await?;
         Ok(data)
+    }
+
+    async fn cache_xorb(&self, hash: MerkleHash, data: &bytes::Bytes) -> Result<()> {
+        if data.len() > MAX_XORB_SIZE {
+            return Err(error::CrabError::CorruptObject {
+                path: self.router.xorb_path(&hash).to_string(),
+                reason: format!(
+                    "xorb body is {} bytes; the Xet format supports at most {MAX_XORB_SIZE} bytes",
+                    data.len()
+                ),
+            });
+        }
+
+        let mut cache = self.xorb_cache.lock().await;
+        let old_len = cache.get(&hash).map_or(0, bytes::Bytes::len) as u64;
+        let incoming_len = data.len() as u64;
+        let mut cached_bytes = self.xorb_cache_bytes.load(Relaxed).saturating_sub(old_len);
+        let replacing = cache.contains_key(&hash);
+        if (!replacing && cache.len() >= MAX_HYDRATE_XORB_CACHE_ENTRIES)
+            || cached_bytes.saturating_add(incoming_len) > MAX_HYDRATE_XORB_CACHE_BYTES
+        {
+            cache.clear();
+            cached_bytes = 0;
+        }
+        cache.insert(hash, data.clone());
+        self.xorb_cache_bytes
+            .store(cached_bytes.saturating_add(incoming_len), Relaxed);
+        Ok(())
     }
 
     async fn decode_xorb_with_cache_repair<T>(
@@ -989,7 +1044,10 @@ impl ShardHydrator {
         debug!(shard_hash = %hash.hex(), "downloading shard");
         // Keep shard reads on the same cache-aware path as xorb reads so
         // push-warmed immutable objects are reusable by new clones.
-        let (data, _) = self.store.get_with_etag(&obj_path).await?;
+        let (data, _) = self
+            .store
+            .get_with_etag_bounded(&obj_path, MAX_HYDRATE_SHARD_BYTES)
+            .await?;
 
         Ok(crab_xet::shard::ShardReader::from_bytes(data, *hash))
     }
@@ -1311,9 +1369,24 @@ impl ShardHydrator {
     where
         W: Write + Send + 'static,
     {
+        self.reconstruct_to_writer_with(ptr, writer, None, &CancellationToken::new())
+            .await
+    }
+
+    async fn reconstruct_to_writer_with<W>(
+        &self,
+        ptr: &Pointer,
+        writer: W,
+        file_index_lookup: Option<&SharedFileIndexLookup>,
+        cancel: &CancellationToken,
+    ) -> Result<u64>
+    where
+        W: Write + Send + 'static,
+    {
+        error::check_cancelled(cancel)?;
         let file_hash = MerkleHash::from(ptr.file_hash);
 
-        let client = self.store_client(None);
+        let client = self.store_client_for_pointer(file_index_lookup, ptr);
 
         self.preflight_shard_coverage(&client, ptr).await?;
 
@@ -1329,21 +1402,22 @@ impl ShardHydrator {
         let xet_context = new_xet_context()?;
         let reconstructor =
             xet_data::file_reconstruction::FileReconstructor::new(&xet_context, &client, file_hash)
-                .with_buffer_semaphore(Arc::clone(&self.buffer_semaphore));
+                .with_buffer_semaphore(Arc::clone(&self.buffer_semaphore))
+                .with_cancellation_token(cancel.clone());
         let reconstructor = match self.chunk_cache.clone() {
             Some(cache) => reconstructor.with_chunk_cache(cache),
             None => reconstructor,
         };
 
-        reconstructor
-            .reconstruct_to_writer(writer)
-            .await
-            .map_err(|e| {
-                error::CrabError::Internal(format!(
-                    "file reconstruction failed for {}: {e}",
-                    file_hash.hex(),
-                ))
-            })?;
+        if let Err(e) = reconstructor.reconstruct_to_writer(writer).await {
+            if cancel.is_cancelled() {
+                return Err(error::CrabError::Cancelled);
+            }
+            return Err(error::CrabError::Internal(format!(
+                "file reconstruction failed for {}: {e}",
+                file_hash.hex(),
+            )));
+        }
 
         let (actual_hash, bytes_written) = {
             let mut guard = tap_state
@@ -1362,6 +1436,14 @@ impl ShardHydrator {
                 requested: crab_types::pointer::hex_encode(&ptr.file_hash),
                 actual: crab_types::pointer::hex_encode(&actual_hash),
             });
+        }
+        if bytes_written != ptr.size {
+            return Err(error::CrabError::Internal(format!(
+                "file reconstruction size mismatch for {}: expected {}, got {}",
+                file_hash.hex(),
+                ptr.size,
+                bytes_written,
+            )));
         }
 
         Ok(bytes_written)
@@ -3606,6 +3688,70 @@ pub fn resolve_git_pointer_prefetch_candidates(
     Ok(candidates)
 }
 
+/// Resolve unique Crab pointer files reachable from every local Git ref.
+///
+/// This is the `crab fetch --all` inventory path. It reads Git objects in two
+/// batch processes, filtering large blobs before materializing pointer bodies.
+pub fn resolve_all_ref_pointer_prefetch_candidates(
+    root: &Path,
+    include: &[String],
+    exclude: &[String],
+    cancel: &CancellationToken,
+) -> Result<Vec<(PathBuf, Pointer)>> {
+    let include = if include.is_empty() {
+        vec!["**/*".to_owned()]
+    } else {
+        include.to_vec()
+    };
+    let filter = build_filter(&include, exclude)?;
+    let refs = git_refs(root)?;
+    let mut entries = Vec::new();
+    let mut seen_entries = HashSet::new();
+    for git_ref in refs {
+        error::check_cancelled(cancel)?;
+        for entry in git_tree_entries(root, &git_ref)? {
+            if filter.matches(&entry.path)
+                && seen_entries.insert((entry.oid.clone(), entry.path.clone()))
+            {
+                if entries.len() >= MAX_PREFETCH_CANDIDATES {
+                    return Err(error::CrabError::Configuration {
+                        key: "fetch candidate count".to_owned(),
+                        origin: format!(
+                            "reachable Git pointer inventory exceeds the safety limit of {MAX_PREFETCH_CANDIDATES}"
+                        ),
+                    });
+                }
+                entries.push(entry);
+            }
+        }
+    }
+
+    let blobs = git_small_blobs(root, entries.iter().map(|entry| entry.oid.as_str()))?;
+    let mut candidates = Vec::new();
+    let mut seen_files = HashSet::new();
+    for entry in entries {
+        error::check_cancelled(cancel)?;
+        let Some(blob) = blobs.get(&entry.oid) else {
+            continue;
+        };
+        let Ok(pointer) = Pointer::parse(blob) else {
+            continue;
+        };
+        if seen_files.insert(pointer.file_hash) {
+            if candidates.len() >= MAX_PREFETCH_CANDIDATES {
+                return Err(error::CrabError::Configuration {
+                    key: "fetch candidate count".to_owned(),
+                    origin: format!(
+                        "reachable Crab pointer inventory exceeds the safety limit of {MAX_PREFETCH_CANDIDATES}"
+                    ),
+                });
+            }
+            candidates.push((root.join(entry.path), pointer));
+        }
+    }
+    Ok(candidates)
+}
+
 fn emit_empty_hydrate_summary(mode: OutputMode) {
     let summary = HydrateSummary::default();
     let payload = HydrateSummaryPayload::from_summary(&summary, Duration::default());
@@ -3744,27 +3890,35 @@ fn collect_git_pointer_blobs(
     if entries.is_empty() {
         entries = git_head_tree_entries(root)?;
     }
+    let entries = entries
+        .into_iter()
+        .filter(|entry| filter.matches(&entry.path))
+        .filter(|entry| is_safe_repo_relative_path(Path::new(&entry.path)))
+        .collect::<Vec<_>>();
+    if entries.len() > MAX_PREFETCH_CANDIDATES {
+        return Err(error::CrabError::Configuration {
+            key: "hydrate candidate count".to_owned(),
+            origin: format!(
+                "Git pointer inventory exceeds the safety limit of {MAX_PREFETCH_CANDIDATES}"
+            ),
+        });
+    }
+    let blobs = git_small_blobs(root, entries.iter().map(|entry| entry.oid.as_str()))?;
+    let mut seen_paths: HashSet<PathBuf> = out.iter().map(|(path, _)| path.clone()).collect();
     for entry in entries {
         error::check_cancelled(cancel)?;
-        if !filter.matches(&entry.path) {
-            continue;
-        }
         let rel_path = Path::new(&entry.path);
-        if !is_safe_repo_relative_path(rel_path) {
-            debug!(path = %entry.path, "skipping unsafe Git path during index hydrate");
-            continue;
-        }
         let full_path = root.join(rel_path);
-        if out.iter().any(|(path, _)| path == &full_path) {
+        if seen_paths.contains(&full_path) {
             continue;
         }
         if matches!(mode, GitPointerCollectionMode::MissingOnly) && full_path.exists() {
             continue;
         }
-        let Some(blob) = git_small_blob(root, &entry.oid)? else {
+        let Some(blob) = blobs.get(&entry.oid) else {
             continue;
         };
-        let Ok(pointer) = Pointer::parse(&blob) else {
+        let Ok(pointer) = Pointer::parse(blob) else {
             continue;
         };
         if matches!(mode, GitPointerCollectionMode::MissingOnly)
@@ -3772,6 +3926,15 @@ fn collect_git_pointer_blobs(
         {
             std::fs::create_dir_all(parent).map_err(error::CrabError::Io)?;
         }
+        if out.len() >= MAX_PREFETCH_CANDIDATES {
+            return Err(error::CrabError::Configuration {
+                key: "hydrate candidate count".to_owned(),
+                origin: format!(
+                    "Git pointer inventory exceeds the safety limit of {MAX_PREFETCH_CANDIDATES}"
+                ),
+            });
+        }
+        seen_paths.insert(full_path.clone());
         out.push((full_path, pointer));
     }
     Ok(())
@@ -3798,15 +3961,27 @@ fn git_index_entries(root: &Path) -> Result<Vec<GitBlobEntry>> {
             String::from_utf8_lossy(&output.stderr)
         )));
     }
-    Ok(parse_git_blob_records(
-        &output.stdout,
-        GitBlobRecordFormat::Index,
-    ))
+    if output.stdout.len() > MAX_GIT_INVENTORY_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "Git index inventory size".to_owned(),
+            origin: format!(
+                "Git index listing exceeds the safety limit of {MAX_GIT_INVENTORY_BYTES} bytes"
+            ),
+        });
+    }
+    parse_git_blob_records(&output.stdout, GitBlobRecordFormat::Index)
 }
 
 fn git_head_tree_entries(root: &Path) -> Result<Vec<GitBlobEntry>> {
+    if !git_ref_exists(root, "HEAD")? {
+        return Ok(Vec::new());
+    }
+    git_tree_entries(root, "HEAD")
+}
+
+fn git_tree_entries(root: &Path, git_ref: &str) -> Result<Vec<GitBlobEntry>> {
     let output = Command::new("git")
-        .args(["ls-tree", "-r", "-z", "HEAD"])
+        .args(["ls-tree", "-r", "-z", git_ref])
         .current_dir(root)
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
@@ -3814,12 +3989,79 @@ fn git_head_tree_entries(root: &Path) -> Result<Vec<GitBlobEntry>> {
         .output()
         .map_err(error::CrabError::Io)?;
     if !output.status.success() {
-        return Ok(Vec::new());
+        return Err(error::CrabError::Internal(format!(
+            "`git ls-tree -r -z {git_ref}` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
     }
-    Ok(parse_git_blob_records(
-        &output.stdout,
-        GitBlobRecordFormat::Tree,
-    ))
+    if output.stdout.len() > MAX_GIT_INVENTORY_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "Git tree inventory size".to_owned(),
+            origin: format!(
+                "Git tree listing exceeds the safety limit of {MAX_GIT_INVENTORY_BYTES} bytes"
+            ),
+        });
+    }
+    parse_git_blob_records(&output.stdout, GitBlobRecordFormat::Tree)
+}
+
+fn git_refs(root: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["for-each-ref", "--format=%(refname)"])
+        .current_dir(root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .output()
+        .map_err(error::CrabError::Io)?;
+    if !output.status.success() {
+        return Err(error::CrabError::Internal(format!(
+            "`git for-each-ref` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    if output.stdout.len() > MAX_GIT_INVENTORY_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "Git ref inventory size".to_owned(),
+            origin: format!(
+                "Git ref listing exceeds the safety limit of {MAX_GIT_INVENTORY_BYTES} bytes"
+            ),
+        });
+    }
+    let mut refs = output
+        .stdout
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| String::from_utf8_lossy(line).into_owned())
+        .collect::<Vec<_>>();
+    if git_ref_exists(root, "HEAD")? {
+        refs.push("HEAD".to_owned());
+    }
+    refs.sort();
+    refs.dedup();
+    if refs.len() > MAX_PREFETCH_CANDIDATES {
+        return Err(error::CrabError::Configuration {
+            key: "Git ref count".to_owned(),
+            origin: format!(
+                "Git ref inventory exceeds the safety limit of {MAX_PREFETCH_CANDIDATES}"
+            ),
+        });
+    }
+    Ok(refs)
+}
+
+fn git_ref_exists(root: &Path, git_ref: &str) -> Result<bool> {
+    let status = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", git_ref])
+        .current_dir(root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(error::CrabError::Io)?;
+    Ok(status.success())
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -3828,7 +4070,15 @@ enum GitBlobRecordFormat {
     Tree,
 }
 
-fn parse_git_blob_records(bytes: &[u8], format: GitBlobRecordFormat) -> Vec<GitBlobEntry> {
+fn parse_git_blob_records(bytes: &[u8], format: GitBlobRecordFormat) -> Result<Vec<GitBlobEntry>> {
+    if bytes.len() > MAX_GIT_INVENTORY_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "Git blob inventory size".to_owned(),
+            origin: format!(
+                "Git blob listing exceeds the safety limit of {MAX_GIT_INVENTORY_BYTES} bytes"
+            ),
+        });
+    }
     let mut entries = Vec::new();
     for record in bytes
         .split(|byte| *byte == 0)
@@ -3845,54 +4095,178 @@ fn parse_git_blob_records(bytes: &[u8], format: GitBlobRecordFormat) -> Vec<GitB
             GitBlobRecordFormat::Tree if fields.len() >= 3 && fields[1] == "blob" => fields[2],
             GitBlobRecordFormat::Tree | GitBlobRecordFormat::Index => continue,
         };
+        if entries.len() >= MAX_PREFETCH_CANDIDATES {
+            return Err(error::CrabError::Configuration {
+                key: "Git blob entry count".to_owned(),
+                origin: format!(
+                    "Git blob inventory exceeds the safety limit of {MAX_PREFETCH_CANDIDATES}"
+                ),
+            });
+        }
         entries.push(GitBlobEntry {
             oid: oid.to_owned(),
             path,
         });
     }
-    entries
+    Ok(entries)
 }
 
-fn git_small_blob(root: &Path, oid: &str) -> Result<Option<Vec<u8>>> {
-    let size = Command::new("git")
-        .args(["cat-file", "-s", oid])
-        .current_dir(root)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_COMMON_DIR")
-        .output()
-        .map_err(error::CrabError::Io)?;
-    if !size.status.success() {
-        return Err(error::CrabError::Internal(format!(
-            "`git cat-file -s {oid}` failed: {}",
-            String::from_utf8_lossy(&size.stderr)
-        )));
+fn git_small_blobs<'a>(
+    root: &Path,
+    oids: impl Iterator<Item = &'a str>,
+) -> Result<HashMap<String, Vec<u8>>> {
+    let mut oids = oids.map(str::to_owned).collect::<Vec<_>>();
+    oids.sort();
+    oids.dedup();
+    if oids.is_empty() {
+        return Ok(HashMap::new());
     }
-    let size = String::from_utf8_lossy(&size.stdout)
-        .trim()
-        .parse::<usize>()
-        .map_err(|e| {
-            error::CrabError::Internal(format!("`git cat-file -s {oid}` returned bad size: {e}"))
-        })?;
-    if size > MAX_POINTER_SIZE {
-        return Ok(None);
+    let input = format!("{}\n", oids.join("\n"));
+    if input.len() > MAX_GIT_INVENTORY_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "Git blob request size".to_owned(),
+            origin: format!(
+                "Git blob request exceeds the safety limit of {MAX_GIT_INVENTORY_BYTES} bytes"
+            ),
+        });
     }
 
-    let blob = Command::new("git")
-        .args(["cat-file", "-p", oid])
+    let mut check = Command::new("git")
+        .args([
+            "cat-file",
+            "--batch-check=%(objectname) %(objecttype) %(objectsize)",
+        ])
         .current_dir(root)
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_COMMON_DIR")
-        .output()
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
         .map_err(error::CrabError::Io)?;
-    if !blob.status.success() {
+    check
+        .stdin
+        .as_mut()
+        .ok_or_else(|| error::CrabError::Internal("git cat-file stdin unavailable".to_owned()))?
+        .write_all(input.as_bytes())
+        .map_err(error::CrabError::Io)?;
+    drop(check.stdin.take());
+    let checked = check.wait_with_output().map_err(error::CrabError::Io)?;
+    if !checked.status.success() {
         return Err(error::CrabError::Internal(format!(
-            "`git cat-file -p {oid}` failed: {}",
-            String::from_utf8_lossy(&blob.stderr)
+            "`git cat-file --batch-check` failed: {}",
+            String::from_utf8_lossy(&checked.stderr)
         )));
     }
-    Ok(Some(blob.stdout))
+    if checked.stdout.len() > MAX_GIT_INVENTORY_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "Git blob metadata response size".to_owned(),
+            origin: format!(
+                "Git blob metadata response exceeds the safety limit of {MAX_GIT_INVENTORY_BYTES} bytes"
+            ),
+        });
+    }
+    let small_oids = String::from_utf8_lossy(&checked.stdout)
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let oid = fields.next()?;
+            let kind = fields.next()?;
+            let size = fields.next()?.parse::<usize>().ok()?;
+            (kind == "blob" && size <= MAX_POINTER_SIZE).then(|| oid.to_owned())
+        })
+        .collect::<Vec<_>>();
+    if small_oids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut batch = Command::new("git")
+        .args(["cat-file", "--batch"])
+        .current_dir(root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .map_err(error::CrabError::Io)?;
+    let batch_input = format!("{}\n", small_oids.join("\n"));
+    if batch_input.len() > MAX_GIT_INVENTORY_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "Git blob request size".to_owned(),
+            origin: format!(
+                "Git blob request exceeds the safety limit of {MAX_GIT_INVENTORY_BYTES} bytes"
+            ),
+        });
+    }
+    batch
+        .stdin
+        .as_mut()
+        .ok_or_else(|| error::CrabError::Internal("git cat-file stdin unavailable".to_owned()))?
+        .write_all(batch_input.as_bytes())
+        .map_err(error::CrabError::Io)?;
+    drop(batch.stdin.take());
+    let output = batch.wait_with_output().map_err(error::CrabError::Io)?;
+    if !output.status.success() {
+        return Err(error::CrabError::Internal(format!(
+            "`git cat-file --batch` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    if output.stdout.len() > MAX_GIT_INVENTORY_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "Git blob response size".to_owned(),
+            origin: format!(
+                "Git blob response exceeds the safety limit of {MAX_GIT_INVENTORY_BYTES} bytes"
+            ),
+        });
+    }
+
+    let mut blobs = HashMap::new();
+    let mut cursor = 0usize;
+    while cursor < output.stdout.len() {
+        let Some(header_len) = output.stdout[cursor..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+        else {
+            return Err(error::CrabError::Internal(
+                "git cat-file batch response ended inside a header".to_owned(),
+            ));
+        };
+        let header_end = cursor + header_len;
+        let header = String::from_utf8_lossy(&output.stdout[cursor..header_end]);
+        let mut fields = header.split_whitespace();
+        let oid = fields.next().ok_or_else(|| {
+            error::CrabError::Internal("git cat-file returned an empty header".to_owned())
+        })?;
+        let kind = fields.next().ok_or_else(|| {
+            error::CrabError::Internal("git cat-file returned a malformed header".to_owned())
+        })?;
+        let size = fields
+            .next()
+            .ok_or_else(|| {
+                error::CrabError::Internal("git cat-file omitted object size".to_owned())
+            })?
+            .parse::<usize>()
+            .map_err(|e| {
+                error::CrabError::Internal(format!("git cat-file returned bad object size: {e}"))
+            })?;
+        let content_start = header_end + 1;
+        let content_end = content_start.checked_add(size).ok_or_else(|| {
+            error::CrabError::Internal("git cat-file object size overflow".to_owned())
+        })?;
+        if kind != "blob" || content_end >= output.stdout.len() {
+            return Err(error::CrabError::Internal(
+                "git cat-file returned a truncated or non-blob response".to_owned(),
+            ));
+        }
+        blobs.insert(
+            oid.to_owned(),
+            output.stdout[content_start..content_end].to_vec(),
+        );
+        cursor = content_end + 1;
+    }
+    Ok(blobs)
 }
 
 fn is_safe_repo_relative_path(path: &Path) -> bool {
@@ -3972,6 +4346,15 @@ fn git_show_ref(git_ref: &str) -> Result<String> {
         return Err(error::CrabError::Internal(format!(
             "`git show {git_ref}` failed: {stderr}"
         )));
+    }
+    if output.stdout.len() > crate::hydrate::manifest::MAX_MANIFEST_BYTES {
+        return Err(error::CrabError::Configuration {
+            key: "manifest-ref size".to_owned(),
+            origin: format!(
+                "git show output exceeds the safety limit of {} bytes",
+                crate::hydrate::manifest::MAX_MANIFEST_BYTES
+            ),
+        });
     }
 
     String::from_utf8(output.stdout).map_err(|e| {
@@ -4233,6 +4616,10 @@ fn walk_and_parse_pointers(
 
         // Must be in pointer state (unhydrated). Parse the pointer for
         // the hydration batch.
+        let metadata = std::fs::metadata(&path)?;
+        if metadata.len() > crab_types::pointer::MAX_POINTER_SIZE as u64 {
+            continue;
+        }
         let content = std::fs::read(&path)?;
         let Ok(ptr) = Pointer::parse(&content) else {
             continue;
@@ -4962,6 +5349,42 @@ mod tests {
         let args = default_args();
         let config = Config::default();
         assert!(resolve_patterns(&args, &config).unwrap().is_none());
+    }
+
+    #[test]
+    fn all_ref_prefetch_inventory_filters_paths_and_deduplicates_file_hashes() {
+        let fixture = GitFixture::new();
+        let root = fixture.work_tree();
+        let main_pointer = sample_pointer(10);
+        std::fs::write(root.join("main.bin"), main_pointer.serialize()).unwrap();
+        run_git(root, &["add", "main.bin"]);
+        run_git(root, &["commit", "-m", "main pointer"]);
+        run_git(root, &["checkout", "-b", "feature"]);
+        let mut feature_pointer = sample_pointer(20);
+        feature_pointer.file_hash[0] ^= 0xff;
+        std::fs::write(root.join("feature.bin"), feature_pointer.serialize()).unwrap();
+        std::fs::write(root.join("large.dat"), vec![0u8; MAX_POINTER_SIZE + 1]).unwrap();
+        run_git(root, &["add", "feature.bin", "large.dat"]);
+        run_git(root, &["commit", "-m", "feature pointer"]);
+
+        let all = resolve_all_ref_pointer_prefetch_candidates(
+            root,
+            &["*.bin".to_owned()],
+            &[],
+            &CancellationToken::new(),
+        )
+        .unwrap();
+        let main_only = resolve_all_ref_pointer_prefetch_candidates(
+            root,
+            &["*.bin".to_owned()],
+            &["feature.bin".to_owned()],
+            &CancellationToken::new(),
+        )
+        .unwrap();
+
+        assert_eq!(all.len(), 2);
+        assert_eq!(main_only.len(), 1);
+        assert_eq!(main_only[0].1.file_hash, main_pointer.file_hash);
     }
 
     #[tokio::test]

--- a/crab/src/cmd/lfs/convert.rs
+++ b/crab/src/cmd/lfs/convert.rs
@@ -7,12 +7,14 @@
 //! hydrated Crab bytes before writing the local LFS cache, uploading the LFS
 //! object, switching tracking to `filter=lfs`, and staging an LFS pointer.
 
+use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use fs4::fs_std::FileExt as LockFileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
@@ -27,6 +29,11 @@ use crab_types::pointer::Pointer;
 use super::store_setup::resolve_lfs_remote_for_operation_sync;
 
 const CONVERT_MANIFEST: &str = "crab-lfs-convert-state.json";
+const CONVERT_LOCK: &str = "crab-lfs-convert.lock";
+const MAX_CONVERSION_CANDIDATES: usize = 1_000_000;
+const MAX_CONVERSION_MANIFEST_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_CONVERSION_GITATTRIBUTES_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_CONVERSION_POINTER_BLOB_BYTES: usize = crab_git::lfs_pointer::MAX_LFS_POINTER_SIZE;
 
 /// Direction of conversion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,7 +74,40 @@ pub fn run_convert(
     dry_run: bool,
     repo_root: &Path,
 ) -> Result<()> {
-    let candidates = collect_candidates(direction, pattern, repo_root)?;
+    run_convert_with_cancel(
+        direction,
+        pattern,
+        dry_run,
+        repo_root,
+        &CancellationToken::new(),
+    )
+}
+
+/// Run conversion while honoring cancellation and a repository conversion lock.
+pub fn run_convert_with_cancel(
+    direction: ConvertDirection,
+    pattern: &str,
+    dry_run: bool,
+    repo_root: &Path,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
+    let _lock = if dry_run {
+        None
+    } else {
+        Some(acquire_convert_lock(repo_root)?)
+    };
+    check_cancelled(cancel)?;
+    let candidates = collect_candidates(direction, pattern, repo_root, cancel)?;
+    if candidates.len() > MAX_CONVERSION_CANDIDATES {
+        return Err(CrabError::Configuration {
+            key: "crab lfs convert candidate count".to_owned(),
+            origin: format!(
+                "conversion selected {} files; bounded conversion supports at most {MAX_CONVERSION_CANDIDATES}",
+                candidates.len()
+            ),
+        });
+    }
     if candidates.is_empty() {
         eprintln!("convert: no matching source pointers for {pattern:?}");
         return Ok(());
@@ -93,12 +133,14 @@ pub fn run_convert(
         return Ok(());
     }
 
+    check_cancelled(cancel)?;
     write_manifest(repo_root, &candidates)?;
 
     match direction {
-        ConvertDirection::LfsToXet => convert_lfs_to_crab(pattern, repo_root, &candidates)?,
-        ConvertDirection::XetToLfs => convert_crab_to_lfs(pattern, repo_root, &candidates)?,
+        ConvertDirection::LfsToXet => convert_lfs_to_crab(pattern, repo_root, &candidates, cancel)?,
+        ConvertDirection::XetToLfs => convert_crab_to_lfs(pattern, repo_root, &candidates, cancel)?,
     }
+    check_cancelled(cancel)?;
 
     eprintln!(
         "convert: converted {} file(s), {}",
@@ -108,20 +150,15 @@ pub fn run_convert(
     Ok(())
 }
 
-/// Run conversion while honoring a caller's cancellation boundary.
-pub fn run_convert_with_cancel(
-    direction: ConvertDirection,
-    pattern: &str,
-    dry_run: bool,
-    repo_root: &Path,
-    cancel: &CancellationToken,
-) -> Result<()> {
-    check_cancelled(cancel)?;
-    run_convert(direction, pattern, dry_run, repo_root)
-}
-
 /// Restore the index and `.gitattributes` from the last conversion manifest.
 pub fn run_rollback(repo_root: &Path) -> Result<()> {
+    run_rollback_with_cancel(repo_root, &CancellationToken::new())
+}
+
+/// Roll back a conversion while honoring cancellation and the conversion lock.
+pub fn run_rollback_with_cancel(repo_root: &Path, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
+    let _lock = acquire_convert_lock(repo_root)?;
     let manifest_path = manifest_path(repo_root)?;
     if !manifest_path.is_file() {
         return Err(CrabError::Configuration {
@@ -130,6 +167,15 @@ pub fn run_rollback(repo_root: &Path) -> Result<()> {
         });
     }
 
+    let size = std::fs::metadata(&manifest_path)
+        .map_err(CrabError::Io)?
+        .len();
+    if size > MAX_CONVERSION_MANIFEST_BYTES {
+        return Err(CrabError::Configuration {
+            key: "conversion manifest".to_owned(),
+            origin: format!("manifest exceeds {MAX_CONVERSION_MANIFEST_BYTES} bytes"),
+        });
+    }
     let raw = std::fs::read_to_string(&manifest_path).map_err(CrabError::Io)?;
     let manifest: ConvertManifest =
         serde_json::from_str(&raw).map_err(|e| CrabError::Configuration {
@@ -137,9 +183,28 @@ pub fn run_rollback(repo_root: &Path) -> Result<()> {
             origin: format!("failed to parse {}: {e}", manifest_path.display()),
         })?;
 
+    if manifest.files.len() > MAX_CONVERSION_CANDIDATES {
+        return Err(CrabError::Configuration {
+            key: "conversion manifest".to_owned(),
+            origin: format!("manifest contains more than {MAX_CONVERSION_CANDIDATES} files"),
+        });
+    }
+    if manifest
+        .gitattributes
+        .as_ref()
+        .is_some_and(|value| value.len() as u64 > MAX_CONVERSION_GITATTRIBUTES_BYTES)
+    {
+        return Err(CrabError::Configuration {
+            key: "conversion manifest".to_owned(),
+            origin: format!(
+                ".gitattributes backup exceeds {MAX_CONVERSION_GITATTRIBUTES_BYTES} bytes"
+            ),
+        });
+    }
     restore_gitattributes(repo_root, manifest.gitattributes.as_deref())?;
 
     for file in &manifest.files {
+        check_cancelled(cancel)?;
         let blob =
             BASE64_STANDARD
                 .decode(&file.index_blob_b64)
@@ -147,6 +212,12 @@ pub fn run_rollback(repo_root: &Path) -> Result<()> {
                     key: file.path.clone(),
                     origin: format!("invalid base64 index blob in conversion manifest: {e}"),
                 })?;
+        if blob.len() > MAX_CONVERSION_POINTER_BLOB_BYTES {
+            return Err(CrabError::Configuration {
+                key: file.path.clone(),
+                origin: format!("index blob exceeds {MAX_CONVERSION_POINTER_BLOB_BYTES} bytes"),
+            });
+        }
         write_blob_to_index(repo_root, &file.path, &blob)?;
     }
 
@@ -155,24 +226,40 @@ pub fn run_rollback(repo_root: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Roll back a conversion while honoring a caller's cancellation boundary.
-pub fn run_rollback_with_cancel(repo_root: &Path, cancel: &CancellationToken) -> Result<()> {
-    check_cancelled(cancel)?;
-    run_rollback(repo_root)
+fn acquire_convert_lock(repo_root: &Path) -> Result<File> {
+    let git_dir = discover_git_dir(repo_root)?;
+    let path = git_dir.join(CONVERT_LOCK);
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(CrabError::Io)?;
+    if !LockFileExt::try_lock_exclusive(&lock).map_err(CrabError::Io)? {
+        return Err(CrabError::Configuration {
+            key: "crab lfs convert".to_owned(),
+            origin: format!("another conversion holds {}", path.display()),
+        });
+    }
+    Ok(lock)
 }
 
 fn convert_lfs_to_crab(
     pattern: &str,
     repo_root: &Path,
     candidates: &[ConvertCandidate],
+    cancel: &CancellationToken,
 ) -> Result<()> {
     for candidate in candidates {
+        check_cancelled(cancel)?;
         let SourcePointer::Lfs(pointer) = &candidate.source else {
             continue;
         };
         let content = resolve_lfs_content(repo_root, &candidate.path, pointer)?;
         write_worktree_file(repo_root, &candidate.path, &content)?;
     }
+    check_cancelled(cancel)?;
 
     crate::lfs::track::untrack(pattern, repo_root)?;
     crate::cmd::track::run_track_in(pattern, repo_root)?;
@@ -184,19 +271,19 @@ fn convert_lfs_to_crab(
         skip_git_add: false,
         mode: OutputMode::Text,
     };
-    super::block_on_runtime(async {
-        crate::cmd::add::run_add(&add_args, &CancellationToken::new()).await
-    })
+    super::block_on_runtime(async { crate::cmd::add::run_add(&add_args, cancel).await })
 }
 
 fn convert_crab_to_lfs(
     pattern: &str,
     repo_root: &Path,
     candidates: &[ConvertCandidate],
+    cancel: &CancellationToken,
 ) -> Result<()> {
     let ctx = resolve_lfs_remote_for_operation_sync("push")?;
 
     for candidate in candidates {
+        check_cancelled(cancel)?;
         let SourcePointer::Crab(pointer) = &candidate.source else {
             continue;
         };
@@ -219,6 +306,7 @@ fn convert_crab_to_lfs(
         };
         write_blob_to_index(repo_root, &candidate.path, &lfs_pointer.serialize())?;
     }
+    check_cancelled(cancel)?;
 
     crate::cmd::track::run_untrack_in(pattern, repo_root)?;
     crate::lfs::track::track_with_opts(pattern, repo_root, true, false)?;
@@ -229,11 +317,13 @@ fn collect_candidates(
     direction: ConvertDirection,
     pattern: &str,
     repo_root: &Path,
+    cancel: &CancellationToken,
 ) -> Result<Vec<ConvertCandidate>> {
     let filter = build_filter(&[pattern.to_owned()], &[])?;
     let mut candidates = Vec::new();
 
     for path in git_ls_files(repo_root)? {
+        check_cancelled(cancel)?;
         if !filter.matches(&path) {
             continue;
         }
@@ -377,6 +467,15 @@ fn write_manifest(repo_root: &Path, candidates: &[ConvertCandidate]) -> Result<(
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
         Err(e) => return Err(CrabError::Io(e)),
     };
+    if gitattributes
+        .as_ref()
+        .is_some_and(|content| content.len() as u64 > MAX_CONVERSION_GITATTRIBUTES_BYTES)
+    {
+        return Err(CrabError::Configuration {
+            key: "crab lfs convert .gitattributes".to_owned(),
+            origin: format!(".gitattributes exceeds {MAX_CONVERSION_GITATTRIBUTES_BYTES} bytes"),
+        });
+    }
 
     let files = candidates
         .iter()
@@ -393,6 +492,12 @@ fn write_manifest(repo_root: &Path, candidates: &[ConvertCandidate]) -> Result<(
     let json = serde_json::to_vec_pretty(&manifest).map_err(|e| {
         CrabError::Internal(format!("failed to serialize conversion manifest: {e}"))
     })?;
+    if json.len() as u64 > MAX_CONVERSION_MANIFEST_BYTES {
+        return Err(CrabError::Configuration {
+            key: "crab lfs convert manifest".to_owned(),
+            origin: format!("manifest exceeds {MAX_CONVERSION_MANIFEST_BYTES} bytes"),
+        });
+    }
     std::fs::write(manifest_path, json).map_err(CrabError::Io)
 }
 
@@ -438,6 +543,12 @@ fn read_index_blob(repo_root: &Path, rel_path: &str) -> Result<Option<Vec<u8>>> 
         .output()
         .map_err(|e| CrabError::Internal(format!("failed to run git show: {e}")))?;
     if output.status.success() {
+        if output.stdout.len() > MAX_CONVERSION_POINTER_BLOB_BYTES {
+            return Err(CrabError::Configuration {
+                key: rel_path.to_owned(),
+                origin: format!("index blob exceeds {MAX_CONVERSION_POINTER_BLOB_BYTES} bytes"),
+            });
+        }
         Ok(Some(output.stdout))
     } else {
         Ok(None)

--- a/crab/src/cmd/lfs/convert.rs
+++ b/crab/src/cmd/lfs/convert.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
 
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::OutputMode;
 use crate::core::pattern::build_filter;
 use crab_git::lfs_pointer::LfsPointer;
@@ -108,6 +108,18 @@ pub fn run_convert(
     Ok(())
 }
 
+/// Run conversion while honoring a caller's cancellation boundary.
+pub fn run_convert_with_cancel(
+    direction: ConvertDirection,
+    pattern: &str,
+    dry_run: bool,
+    repo_root: &Path,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
+    run_convert(direction, pattern, dry_run, repo_root)
+}
+
 /// Restore the index and `.gitattributes` from the last conversion manifest.
 pub fn run_rollback(repo_root: &Path) -> Result<()> {
     let manifest_path = manifest_path(repo_root)?;
@@ -141,6 +153,12 @@ pub fn run_rollback(repo_root: &Path) -> Result<()> {
     std::fs::remove_file(&manifest_path).map_err(CrabError::Io)?;
     eprintln!("convert: rolled back {} file(s)", manifest.files.len());
     Ok(())
+}
+
+/// Roll back a conversion while honoring a caller's cancellation boundary.
+pub fn run_rollback_with_cancel(repo_root: &Path, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
+    run_rollback(repo_root)
 }
 
 fn convert_lfs_to_crab(

--- a/crab/src/cmd/lfs/dedup.rs
+++ b/crab/src/cmd/lfs/dedup.rs
@@ -1,18 +1,28 @@
 //! `crab lfs dedup` — deduplicate checked-out LFS files.
 
 use std::collections::{HashMap, HashSet};
-use std::io::Read;
+use std::io::{BufRead, Read};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use sha2::{Digest, Sha256};
 
 use crate::core::cow_clone;
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crab_git::lfs_pointer::LfsPointer;
 use crab_staging::StagingArea;
 use crab_types::pointer::Pointer;
 use crab_xet::hash::MerkleHash;
+use tokio_util::sync::CancellationToken;
+
+static BACKUP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+const GIT_OBJECT_BATCH_SIZE: usize = 500;
+const MAX_LFS_SCAN_OBJECTS: usize = 5_000_000;
+const MAX_LFS_CHUNKS_PER_FILE: usize = 1_000_000;
+const MAX_DELETE_ERROR_REPORTS: usize = 1_024;
+const MAX_GIT_RECORD_BYTES: usize = 128 * 1024;
+const MAX_GIT_BATCH_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LfsDedupOptions {
@@ -23,34 +33,48 @@ pub struct LfsDedupOptions {
 
 /// Run `crab lfs dedup`.
 pub fn run_lfs_dedup(options: LfsDedupOptions) -> Result<()> {
+    run_lfs_dedup_with_cancel(options, &CancellationToken::new())
+}
+
+/// Run LFS deduplication while honoring the optimize command's cancellation.
+pub fn run_lfs_dedup_with_cancel(
+    options: LfsDedupOptions,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
     if options.crab_cache {
-        return run_crab_cache_dedup(options.dry_run);
+        return run_crab_cache_dedup(options.dry_run, cancel);
     }
 
     if options.test {
-        return run_worktree_dedup_test();
+        return run_worktree_dedup_test(cancel);
     }
 
-    run_worktree_dedup(options.dry_run)
+    run_worktree_dedup(options.dry_run, cancel)
 }
 
-fn run_worktree_dedup_test() -> Result<()> {
+fn run_worktree_dedup_test(cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
     let repo_root = discover_repo_root()?;
     let git_dir = discover_git_dir(&repo_root)?;
+    let lfs_dir = resolve_local_lfs_dir(&repo_root, &git_dir)?;
     ensure_no_lfs_extensions()?;
-    ensure_cow_clone_supported(&git_dir)?;
+    ensure_cow_clone_supported(&lfs_dir)?;
+    check_cancelled(cancel)?;
     println!("OK: This platform and repository support file de-duplication.");
     Ok(())
 }
 
-fn run_worktree_dedup(dry_run: bool) -> Result<()> {
+fn run_worktree_dedup(dry_run: bool, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
     let repo_root = discover_repo_root()?;
     let git_dir = discover_git_dir(&repo_root)?;
+    let lfs_dir = resolve_local_lfs_dir(&repo_root, &git_dir)?;
     ensure_no_lfs_extensions()?;
     ensure_worktree_clean(&repo_root)?;
-    ensure_cow_clone_supported(&git_dir)?;
 
-    let entries = collect_head_lfs_entries(&repo_root, &git_dir)?;
+    let entries = collect_head_lfs_entries_with_cancel(&repo_root, &lfs_dir, cancel)?;
+    check_cancelled(cancel)?;
     if entries.is_empty() {
         println!(
             "Finished successfully.\n  De-duplicated  size: 0 bytes\n                count: 0"
@@ -58,47 +82,36 @@ fn run_worktree_dedup(dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
+    for entry in &entries {
+        check_cancelled(cancel)?;
+        verify_worktree_entry_with_cancel(&repo_root, entry, cancel)?;
+    }
+
+    if !dry_run {
+        ensure_cow_clone_supported(&lfs_dir)?;
+    }
+
     let mut total_count = 0u64;
     let mut total_size = 0u64;
 
     for entry in entries {
-        if !entry.object_path.is_file() {
-            eprintln!(
-                "Skipped: {} (Size: {})\n          Git LFS object file does not exist",
-                entry.path, entry.pointer.size
-            );
-            continue;
-        }
-
+        check_cancelled(cancel)?;
         let dst = repo_root.join(&entry.path);
-        if !dst.is_file() {
-            eprintln!("Skipped: {} (Size: {})", entry.path, entry.pointer.size);
-            continue;
-        }
 
         if dry_run {
             println!(
                 "Would de-duplicate: {} (Size: {})",
                 entry.path, entry.pointer.size
             );
-            total_count += 1;
-            total_size += entry.pointer.size;
+            total_count = total_count.saturating_add(1);
+            total_size = total_size.saturating_add(entry.pointer.size);
             continue;
         }
 
-        match replace_with_cow_clone(&entry.object_path, &dst) {
-            Ok(()) => {
-                println!("Success: {} (Size: {})", entry.path, entry.pointer.size);
-                total_count += 1;
-                total_size += entry.pointer.size;
-            }
-            Err(e) => {
-                eprintln!(
-                    "Skipped: {} (Size: {})\n          {}",
-                    entry.path, entry.pointer.size, e
-                );
-            }
-        }
+        replace_with_cow_clone(&entry.object_path, &dst)?;
+        println!("Success: {} (Size: {})", entry.path, entry.pointer.size);
+        total_count = total_count.saturating_add(1);
+        total_size = total_size.saturating_add(entry.pointer.size);
     }
 
     println!(
@@ -108,23 +121,105 @@ fn run_worktree_dedup(dry_run: bool) -> Result<()> {
     Ok(())
 }
 
-fn run_crab_cache_dedup(dry_run: bool) -> Result<()> {
+fn verify_worktree_entry_with_cancel(
+    repo_root: &Path,
+    entry: &LfsWorktreeEntry,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
+    let object_metadata = std::fs::symlink_metadata(&entry.object_path).map_err(|source| {
+        CrabError::Configuration {
+            key: entry.path.clone(),
+            origin: format!(
+                "Git LFS object {} is unavailable: {source}",
+                entry.object_path.display()
+            ),
+        }
+    })?;
+    if !object_metadata.file_type().is_file() {
+        return Err(CrabError::Configuration {
+            key: entry.path.clone(),
+            origin: format!(
+                "Git LFS object {} is not a regular file",
+                entry.object_path.display()
+            ),
+        });
+    }
+    verify_lfs_file_with_cancel(&entry.object_path, &entry.pointer, &entry.path, cancel)?;
+
+    let worktree_path = repo_root.join(&entry.path);
+    let worktree_metadata =
+        std::fs::symlink_metadata(&worktree_path).map_err(|source| CrabError::Configuration {
+            key: entry.path.clone(),
+            origin: format!("checked-out LFS file is unavailable: {source}"),
+        })?;
+    if !worktree_metadata.file_type().is_file() {
+        return Err(CrabError::Configuration {
+            key: entry.path.clone(),
+            origin: "checked-out LFS path is not a regular file".to_owned(),
+        });
+    }
+    verify_lfs_file_with_cancel(&worktree_path, &entry.pointer, &entry.path, cancel)
+}
+
+#[cfg(test)]
+pub(super) fn verify_lfs_file(path: &Path, pointer: &LfsPointer, context: &str) -> Result<()> {
+    verify_lfs_file_with_cancel(path, pointer, context, &CancellationToken::new())
+}
+
+pub(super) fn verify_lfs_file_with_cancel(
+    path: &Path,
+    pointer: &LfsPointer,
+    context: &str,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
+    let mut file = std::fs::File::open(path).map_err(CrabError::Io)?;
+    let mut sha = Sha256::new();
+    let mut size = 0u64;
+    let mut buf = vec![0u8; 1024 * 1024];
+    loop {
+        check_cancelled(cancel)?;
+        let read = file.read(&mut buf).map_err(CrabError::Io)?;
+        if read == 0 {
+            break;
+        }
+        sha.update(&buf[..read]);
+        size = size.checked_add(read as u64).ok_or_else(|| {
+            CrabError::Internal(format!("LFS byte count overflow while reading {context}"))
+        })?;
+    }
+    let actual: [u8; 32] = sha.finalize().into();
+    if actual != pointer.oid || size != pointer.size {
+        return Err(CrabError::Configuration {
+            key: context.to_owned(),
+            origin: format!(
+                "bytes at {} do not match the indexed LFS SHA-256 and size",
+                path.display()
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn run_crab_cache_dedup(dry_run: bool, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
     let repo_root = discover_repo_root()?;
     let git_dir = discover_git_dir(&repo_root)?;
-    let lfs_objects_dir = git_dir.join("lfs").join("objects");
+    let lfs_objects_dir = resolve_local_lfs_dir(&repo_root, &git_dir)?.join("objects");
 
     if !lfs_objects_dir.is_dir() {
         eprintln!("dedup: no local LFS objects found");
         return Ok(());
     }
 
-    let lfs_objects = collect_local_lfs_objects(&lfs_objects_dir)?;
+    let lfs_objects = collect_local_lfs_objects_with_cancel(&lfs_objects_dir, cancel)?;
     if lfs_objects.is_empty() {
         eprintln!("dedup: no local LFS objects found");
         return Ok(());
     }
 
-    let crab_pointers = collect_crab_pointers(&repo_root)?;
+    let crab_pointers = collect_crab_pointers_with_cancel(&repo_root, cancel)?;
     if crab_pointers.is_empty() {
         eprintln!("dedup: no Crab pointers found; leaving LFS cache unchanged");
         return Ok(());
@@ -134,6 +229,7 @@ fn run_crab_cache_dedup(dry_run: bool) -> Result<()> {
         repo_root.clone(),
         lfs_objects,
         crab_pointers,
+        cancel.clone(),
     ))?;
 
     if report.duplicates.is_empty() {
@@ -144,7 +240,9 @@ fn run_crab_cache_dedup(dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
-    let total_bytes: u64 = report.duplicates.iter().map(|d| d.size).sum();
+    let total_bytes = report.duplicates.iter().fold(0u64, |total, duplicate| {
+        total.saturating_add(duplicate.size)
+    });
     if dry_run {
         eprintln!(
             "dedup: would remove {} local LFS object(s), {}",
@@ -152,6 +250,7 @@ fn run_crab_cache_dedup(dry_run: bool) -> Result<()> {
             format_size(total_bytes)
         );
         for duplicate in &report.duplicates {
+            check_cancelled(cancel)?;
             eprintln!("  {}  {}", &duplicate.oid_hex[..10], duplicate.path);
         }
         if report.skipped > 0 {
@@ -165,11 +264,14 @@ fn run_crab_cache_dedup(dry_run: bool) -> Result<()> {
 
     let mut deleted = 0u64;
     let mut deleted_bytes = 0u64;
+    let mut delete_errors = Vec::new();
+    let mut delete_errors_omitted = 0u64;
     for duplicate in &report.duplicates {
+        check_cancelled(cancel)?;
         match std::fs::remove_file(&duplicate.object_path) {
             Ok(()) => {
-                deleted += 1;
-                deleted_bytes += duplicate.size;
+                deleted = deleted.saturating_add(1);
+                deleted_bytes = deleted_bytes.saturating_add(duplicate.size);
             }
             Err(e) => {
                 tracing::warn!(
@@ -177,10 +279,15 @@ fn run_crab_cache_dedup(dry_run: bool) -> Result<()> {
                     error = %e,
                     "failed to remove duplicate LFS object"
                 );
+                if delete_errors.len() < MAX_DELETE_ERROR_REPORTS {
+                    delete_errors.push(format!("{}: {e}", duplicate.object_path.display()));
+                } else {
+                    delete_errors_omitted = delete_errors_omitted.saturating_add(1);
+                }
             }
         }
     }
-    cleanup_empty_dirs(&lfs_objects_dir);
+    cleanup_empty_dirs_with_cancel(&lfs_objects_dir, cancel)?;
     eprintln!(
         "dedup: removed {deleted} local LFS object(s), {}",
         format_size(deleted_bytes)
@@ -190,6 +297,18 @@ fn run_crab_cache_dedup(dry_run: bool) -> Result<()> {
             "dedup: skipped {} object(s) without Crab proof",
             report.skipped
         );
+    }
+    if !delete_errors.is_empty() || delete_errors_omitted > 0 {
+        return Err(CrabError::Internal(format!(
+            "failed to remove {} verified duplicate LFS object(s): {}{}",
+            (delete_errors.len() as u64).saturating_add(delete_errors_omitted),
+            delete_errors.join("; "),
+            if delete_errors_omitted > 0 {
+                format!(" ({} additional failures omitted)", delete_errors_omitted)
+            } else {
+                String::new()
+            }
+        )));
     }
     Ok(())
 }
@@ -241,7 +360,7 @@ fn ensure_no_lfs_extensions() -> Result<()> {
 }
 
 fn ensure_worktree_clean(repo_root: &Path) -> Result<()> {
-    let output = Command::new("git")
+    let output = git_command(repo_root)
         .args(["status", "--porcelain"])
         .current_dir(repo_root)
         .output()
@@ -262,11 +381,17 @@ fn ensure_worktree_clean(repo_root: &Path) -> Result<()> {
     })
 }
 
-fn collect_head_lfs_entries(repo_root: &Path, git_dir: &Path) -> Result<Vec<LfsWorktreeEntry>> {
+fn collect_head_lfs_entries_with_cancel(
+    repo_root: &Path,
+    lfs_dir: &Path,
+    cancel: &CancellationToken,
+) -> Result<Vec<LfsWorktreeEntry>> {
+    check_cancelled(cancel)?;
     let blob_refs = head_blob_refs(repo_root)?;
     let mut entries = Vec::new();
 
-    for (blob, path) in batch_read_blobs(repo_root, &blob_refs)? {
+    for (blob, path) in batch_read_blobs_with_cancel(repo_root, &blob_refs, cancel)? {
+        check_cancelled(cancel)?;
         let Ok(pointer) = LfsPointer::parse(&blob) else {
             continue;
         };
@@ -277,7 +402,7 @@ fn collect_head_lfs_entries(repo_root: &Path, git_dir: &Path) -> Result<Vec<LfsW
         entries.push(LfsWorktreeEntry {
             path,
             pointer,
-            object_path: local_lfs_object_path(git_dir, &oid_hex),
+            object_path: local_lfs_object_path(lfs_dir, &oid_hex),
         });
     }
 
@@ -285,11 +410,24 @@ fn collect_head_lfs_entries(repo_root: &Path, git_dir: &Path) -> Result<Vec<LfsW
 }
 
 fn head_blob_refs(repo_root: &Path) -> Result<Vec<(String, String)>> {
-    let output = Command::new("git")
-        .args(["ls-tree", "-r", "-z", "HEAD"])
+    let mut child = git_command(repo_root)
+        .args(["ls-tree", "-r", "-z", "-l", "HEAD"])
         .current_dir(repo_root)
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| CrabError::Internal(format!("failed to run git ls-tree: {e}")))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| CrabError::Internal("git ls-tree stdout missing".to_owned()))?;
+    let scan = parse_head_blob_refs(std::io::BufReader::new(stdout));
+    if scan.is_err() {
+        let _ = child.kill();
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| CrabError::Internal(format!("git ls-tree failed: {e}")))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if stderr.contains("Not a valid object name") || stderr.contains("unknown revision") {
@@ -298,18 +436,53 @@ fn head_blob_refs(repo_root: &Path) -> Result<Vec<(String, String)>> {
         return Err(CrabError::Internal(format!("git ls-tree failed: {stderr}")));
     }
 
+    scan
+}
+
+fn parse_head_blob_refs(reader: impl BufRead) -> Result<Vec<(String, String)>> {
     let mut refs = Vec::new();
-    for record in output.stdout.split(|b| *b == 0) {
+    for record in reader.split(0) {
+        let record = record.map_err(CrabError::Io)?;
         if record.is_empty() {
             continue;
+        }
+        if record.len() > MAX_GIT_RECORD_BYTES {
+            return Err(CrabError::Configuration {
+                key: "lfs Git tree record size".to_owned(),
+                origin: format!(
+                    "Git tree record exceeds the safety limit of {MAX_GIT_RECORD_BYTES} bytes"
+                ),
+            });
         }
         let Some(tab) = record.iter().position(|b| *b == b'\t') else {
             continue;
         };
-        let meta = String::from_utf8_lossy(&record[..tab]);
-        let path = String::from_utf8_lossy(&record[tab + 1..]).to_string();
+        let meta = std::str::from_utf8(&record[..tab]).map_err(|error| {
+            CrabError::Internal(format!("git ls-tree returned invalid metadata: {error}"))
+        })?;
+        let path = String::from_utf8(record[tab + 1..].to_vec()).map_err(|error| {
+            CrabError::Configuration {
+                key: "LFS path".to_owned(),
+                origin: format!("Git path is not valid UTF-8: {error}"),
+            }
+        })?;
         let parts: Vec<&str> = meta.split_whitespace().collect();
-        if parts.len() >= 3 && parts[1] == "blob" {
+        let is_regular_file = parts
+            .first()
+            .is_some_and(|mode| matches!(*mode, "100644" | "100755"));
+        let is_small_blob = parts
+            .get(3)
+            .and_then(|size| size.parse::<usize>().ok())
+            .is_some_and(|size| size <= crab_git::lfs_pointer::MAX_LFS_POINTER_SIZE);
+        if parts.len() >= 4 && is_regular_file && parts[1] == "blob" && is_small_blob {
+            if refs.len() >= MAX_LFS_SCAN_OBJECTS {
+                return Err(CrabError::Configuration {
+                    key: "lfs dedup object count".to_owned(),
+                    origin: format!(
+                        "HEAD contains more than {MAX_LFS_SCAN_OBJECTS} candidate blobs; refusing an unbounded dedup scan"
+                    ),
+                });
+            }
             refs.push((parts[2].to_owned(), path));
         }
     }
@@ -317,19 +490,22 @@ fn head_blob_refs(repo_root: &Path) -> Result<Vec<(String, String)>> {
     Ok(refs)
 }
 
-fn local_lfs_object_path(git_dir: &Path, oid_hex: &str) -> PathBuf {
-    git_dir
-        .join("lfs")
+fn local_lfs_object_path(lfs_dir: &Path, oid_hex: &str) -> PathBuf {
+    lfs_dir
         .join("objects")
         .join(&oid_hex[..2])
         .join(&oid_hex[2..4])
         .join(oid_hex)
 }
 
-fn ensure_cow_clone_supported(git_dir: &Path) -> Result<()> {
-    let tmp = git_dir.join("lfs").join("tmp");
+fn ensure_cow_clone_supported(lfs_dir: &Path) -> Result<()> {
+    let tmp = lfs_dir.join("tmp");
     std::fs::create_dir_all(&tmp).map_err(CrabError::Io)?;
-    let stem = format!("dedup-test-{}", std::process::id());
+    let stem = format!(
+        "dedup-test-{}-{}",
+        std::process::id(),
+        BACKUP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    );
     let src = tmp.join(format!("{stem}.src"));
     let dst = tmp.join(format!("{stem}.dst"));
     std::fs::write(&src, b"crab-lfs-dedup").map_err(CrabError::Io)?;
@@ -343,6 +519,11 @@ fn ensure_cow_clone_supported(git_dir: &Path) -> Result<()> {
     })
 }
 
+fn resolve_local_lfs_dir(repo_root: &Path, common_git_dir: &Path) -> Result<PathBuf> {
+    let config = crate::lfs::config::LfsConfig::resolve(repo_root)?;
+    Ok(config.storage_dir(common_git_dir))
+}
+
 fn replace_with_cow_clone(src: &Path, dst: &Path) -> Result<()> {
     let original = std::fs::metadata(dst).map_err(CrabError::Io)?;
     let backup = backup_path(dst);
@@ -351,13 +532,24 @@ fn replace_with_cow_clone(src: &Path, dst: &Path) -> Result<()> {
     let clone_result = cow_clone::clone_file(src, dst)
         .and_then(|()| std::fs::set_permissions(dst, original.permissions()));
     match clone_result {
-        Ok(()) => {
-            let _ = std::fs::remove_file(&backup);
-            Ok(())
-        }
+        Ok(()) => std::fs::remove_file(&backup).map_err(CrabError::Io),
         Err(source) => {
-            let _ = std::fs::remove_file(dst);
-            let _ = std::fs::rename(&backup, dst);
+            if let Err(cleanup_error) = std::fs::remove_file(dst)
+                && cleanup_error.kind() != std::io::ErrorKind::NotFound
+            {
+                return Err(CrabError::Internal(format!(
+                    "dedup clone failed for {}; removing the incomplete clone also failed: {cleanup_error}; original remains at {}",
+                    dst.display(),
+                    backup.display()
+                )));
+            }
+            std::fs::rename(&backup, dst).map_err(|restore_error| {
+                CrabError::Internal(format!(
+                    "dedup clone failed for {}: {source}; restoring the original from {} also failed: {restore_error}",
+                    dst.display(),
+                    backup.display()
+                ))
+            })?;
             Err(CrabError::Configuration {
                 key: "dedup clone failed".to_owned(),
                 origin: source.to_string(),
@@ -371,17 +563,25 @@ fn backup_path(path: &Path) -> PathBuf {
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("file");
-    path.with_file_name(format!(
-        ".{file_name}.crab-lfs-dedup-backup.{}",
-        std::process::id()
-    ))
+    loop {
+        let candidate = path.with_file_name(format!(
+            ".{file_name}.crab-lfs-dedup-backup.{}.{}",
+            std::process::id(),
+            BACKUP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
 }
 
 async fn verify_duplicates(
     repo_root: PathBuf,
     lfs_objects: Vec<LocalLfsObject>,
     crab_pointers: Vec<CrabPointerRef>,
+    cancel: CancellationToken,
 ) -> Result<DedupReport> {
+    check_cancelled(&cancel)?;
     let staging_root = repo_root.join(".crab").join("staging");
     if !staging_root.is_dir() {
         return Ok(DedupReport {
@@ -391,51 +591,71 @@ async fn verify_duplicates(
     }
 
     let staging = StagingArea::open(staging_root).await?;
-    let mut by_hash: HashMap<([u8; 32], u64), Vec<CrabPointerRef>> = HashMap::new();
+    let result =
+        verify_duplicates_with_staging(&staging, lfs_objects, crab_pointers, &cancel).await;
+    let close_result = staging.close().await;
+    match (result, close_result) {
+        (Ok(report), Ok(())) => Ok(report),
+        (Err(primary), Ok(())) => Err(primary),
+        (Ok(_), Err(close_error)) => Err(close_error.into()),
+        (Err(primary), Err(close_error)) => {
+            tracing::warn!(error = %close_error, "failed to close LFS dedup staging after an earlier error");
+            Err(primary)
+        }
+    }
+}
+
+async fn verify_duplicates_with_staging(
+    staging: &StagingArea,
+    lfs_objects: Vec<LocalLfsObject>,
+    crab_pointers: Vec<CrabPointerRef>,
+    cancel: &CancellationToken,
+) -> Result<DedupReport> {
+    let mut by_hash: HashMap<([u8; 32], u64), CrabPointerRef> = HashMap::new();
     for pointer_ref in crab_pointers {
         by_hash
             .entry((pointer_ref.pointer.file_hash, pointer_ref.pointer.size))
-            .or_default()
-            .push(pointer_ref);
+            .or_insert(pointer_ref);
     }
 
     let mut report = DedupReport::default();
     let mut seen_oids = HashSet::new();
 
     for object in &lfs_objects {
-        let digest = match hash_lfs_object(object) {
+        check_cancelled(cancel)?;
+        let digest = match hash_lfs_object_with_cancel(object, cancel) {
             Ok(digest) => digest,
+            Err(CrabError::Cancelled) => return Err(CrabError::Cancelled),
             Err(e) => {
                 tracing::warn!(oid = %object.oid_hex, error = %e, "skipping unreadable LFS object");
-                report.skipped += 1;
+                report.skipped = report.skipped.saturating_add(1);
                 continue;
             }
         };
 
-        if digest.sha256_hex != object.oid_hex {
+        if digest.sha256_hex != object.oid_hex || digest.size != object.size {
             tracing::warn!(
                 oid = %object.oid_hex,
                 actual = %digest.sha256_hex,
                 "skipping corrupt local LFS object"
             );
-            report.skipped += 1;
+            report.skipped = report.skipped.saturating_add(1);
             continue;
         }
 
-        let Some(pointer_refs) = by_hash.get(&(digest.blake3, object.size)) else {
-            report.skipped += 1;
+        let Some(pointer_ref) = by_hash.get(&(digest.blake3, digest.size)) else {
+            report.skipped = report.skipped.saturating_add(1);
             continue;
         };
 
-        let mut matched = None;
-        for pointer_ref in pointer_refs {
-            if staging_matches_lfs_object(&staging, &pointer_ref.pointer, &object.object_path)
-                .await?
-            {
-                matched = Some(pointer_ref.path.clone());
-                break;
-            }
-        }
+        let matched = staging_matches_lfs_object_with_cancel(
+            staging,
+            &pointer_ref.pointer,
+            &object.object_path,
+            cancel,
+        )
+        .await?
+        .then(|| pointer_ref.path.clone());
 
         if let Some(path) = matched {
             if seen_oids.insert(object.oid_hex.clone()) {
@@ -447,11 +667,10 @@ async fn verify_duplicates(
                 });
             }
         } else {
-            report.skipped += 1;
+            report.skipped = report.skipped.saturating_add(1);
         }
     }
 
-    staging.close().await?;
     Ok(report)
 }
 
@@ -459,35 +678,66 @@ async fn verify_duplicates(
 struct LfsDigest {
     sha256_hex: String,
     blake3: [u8; 32],
+    size: u64,
 }
 
+#[cfg(test)]
 fn hash_lfs_object(object: &LocalLfsObject) -> Result<LfsDigest> {
+    hash_lfs_object_with_cancel(object, &CancellationToken::new())
+}
+
+fn hash_lfs_object_with_cancel(
+    object: &LocalLfsObject,
+    cancel: &CancellationToken,
+) -> Result<LfsDigest> {
+    check_cancelled(cancel)?;
     let mut file = std::fs::File::open(&object.object_path).map_err(CrabError::Io)?;
     let mut sha = Sha256::new();
     let mut b3 = blake3::Hasher::new();
+    let mut size = 0u64;
     let mut buf = vec![0u8; 1024 * 1024];
     loop {
+        check_cancelled(cancel)?;
         let n = file.read(&mut buf).map_err(CrabError::Io)?;
         if n == 0 {
             break;
         }
         sha.update(&buf[..n]);
         b3.update(&buf[..n]);
+        size = size.checked_add(n as u64).ok_or_else(|| {
+            CrabError::Internal(format!(
+                "LFS byte count overflow while reading {}",
+                object.object_path.display()
+            ))
+        })?;
     }
     let sha256: [u8; 32] = sha.finalize().into();
     Ok(LfsDigest {
         sha256_hex: crab_git::lfs_pointer::hex_encode(&sha256),
         blake3: *b3.finalize().as_bytes(),
+        size,
     })
 }
 
-async fn staging_matches_lfs_object(
+async fn staging_matches_lfs_object_with_cancel(
     staging: &StagingArea,
     pointer: &Pointer,
     object_path: &Path,
+    cancel: &CancellationToken,
 ) -> Result<bool> {
+    check_cancelled(cancel)?;
     let file_hash = MerkleHash::from(pointer.file_hash);
     let chunk_hashes = staging.chunks_for_file(&file_hash)?;
+    if chunk_hashes.len() > MAX_LFS_CHUNKS_PER_FILE {
+        return Err(CrabError::Configuration {
+            key: "lfs dedup chunks per file".to_owned(),
+            origin: format!(
+                "staging file {} contains {} chunks; bounded dedup supports at most {MAX_LFS_CHUNKS_PER_FILE}",
+                file_hash,
+                chunk_hashes.len()
+            ),
+        });
+    }
     if chunk_hashes.is_empty() {
         return Ok(false);
     }
@@ -496,7 +746,12 @@ async fn staging_matches_lfs_object(
     let mut total = 0u64;
 
     for chunk_hash in &chunk_hashes {
-        let Some(chunk) = staging.get_chunk(chunk_hash).await? else {
+        check_cancelled(cancel)?;
+        let chunk = tokio::select! {
+            _ = cancel.cancelled() => return Err(CrabError::Cancelled),
+            result = staging.get_chunk(chunk_hash) => result?,
+        };
+        let Some(chunk) = chunk else {
             return Ok(false);
         };
         let mut buf = vec![0u8; chunk.len()];
@@ -512,40 +767,70 @@ async fn staging_matches_lfs_object(
     Ok(eof && total == pointer.size)
 }
 
-fn collect_local_lfs_objects(lfs_objects_dir: &Path) -> Result<Vec<LocalLfsObject>> {
+fn collect_local_lfs_objects_with_cancel(
+    lfs_objects_dir: &Path,
+    cancel: &CancellationToken,
+) -> Result<Vec<LocalLfsObject>> {
+    check_cancelled(cancel)?;
     let mut objects = Vec::new();
 
     for aa_entry in std::fs::read_dir(lfs_objects_dir)
         .map_err(|e| CrabError::Internal(format!("failed to read LFS objects dir: {e}")))?
     {
+        check_cancelled(cancel)?;
         let aa_entry = aa_entry.map_err(|e| CrabError::Internal(format!("dir entry: {e}")))?;
         let aa_path = aa_entry.path();
-        if !aa_path.is_dir() {
+        let aa_name = aa_entry.file_name().to_string_lossy().to_string();
+        if !aa_entry.file_type().map_err(CrabError::Io)?.is_dir() || !is_lower_hex_fanout(&aa_name)
+        {
             continue;
         }
 
         for bb_entry in
             std::fs::read_dir(&aa_path).map_err(|e| CrabError::Internal(format!("{e}")))?
         {
+            check_cancelled(cancel)?;
             let bb_entry = bb_entry.map_err(|e| CrabError::Internal(format!("dir entry: {e}")))?;
             let bb_path = bb_entry.path();
-            if !bb_path.is_dir() {
+            let bb_name = bb_entry.file_name().to_string_lossy().to_string();
+            if !bb_entry.file_type().map_err(CrabError::Io)?.is_dir()
+                || !is_lower_hex_fanout(&bb_name)
+            {
                 continue;
             }
 
             for obj_entry in
                 std::fs::read_dir(&bb_path).map_err(|e| CrabError::Internal(format!("{e}")))?
             {
+                check_cancelled(cancel)?;
                 let obj_entry =
                     obj_entry.map_err(|e| CrabError::Internal(format!("dir entry: {e}")))?;
                 let name = obj_entry.file_name().to_string_lossy().to_string();
-                if name.len() != 64 || !name.chars().all(|c| c.is_ascii_hexdigit()) {
+                if name.len() != 64
+                    || !name
+                        .bytes()
+                        .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+                    || name[..2] != aa_name
+                    || name[2..4] != bb_name
+                    || !obj_entry.file_type().map_err(CrabError::Io)?.is_file()
+                {
                     continue;
                 }
                 let object_path = obj_entry.path();
-                let meta = std::fs::metadata(&object_path).map_err(CrabError::Io)?;
+                let meta = std::fs::symlink_metadata(&object_path).map_err(CrabError::Io)?;
+                if !meta.file_type().is_file() {
+                    continue;
+                }
+                if objects.len() >= MAX_LFS_SCAN_OBJECTS {
+                    return Err(CrabError::Configuration {
+                        key: "lfs dedup object count".to_owned(),
+                        origin: format!(
+                            "local LFS object inventory exceeds the safety limit of {MAX_LFS_SCAN_OBJECTS}"
+                        ),
+                    });
+                }
                 objects.push(LocalLfsObject {
-                    oid_hex: name.to_lowercase(),
+                    oid_hex: name,
                     object_path,
                     size: meta.len(),
                 });
@@ -556,90 +841,280 @@ fn collect_local_lfs_objects(lfs_objects_dir: &Path) -> Result<Vec<LocalLfsObjec
     Ok(objects)
 }
 
-fn collect_crab_pointers(repo_root: &Path) -> Result<Vec<CrabPointerRef>> {
-    let mut blob_refs = index_blob_refs(repo_root)?;
-    blob_refs.extend(reachable_blob_refs(repo_root)?);
-    blob_refs.sort();
-    blob_refs.dedup();
+fn is_lower_hex_fanout(value: &str) -> bool {
+    value.len() == 2
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
 
+#[cfg(test)]
+fn collect_crab_pointers(repo_root: &Path) -> Result<Vec<CrabPointerRef>> {
+    collect_crab_pointers_with_cancel(repo_root, &CancellationToken::new())
+}
+
+fn collect_crab_pointers_with_cancel(
+    repo_root: &Path,
+    cancel: &CancellationToken,
+) -> Result<Vec<CrabPointerRef>> {
+    check_cancelled(cancel)?;
     let mut pointers = Vec::new();
-    for (blob, path) in batch_read_blobs(repo_root, &blob_refs)? {
-        if let Ok(pointer) = Pointer::parse(&blob)
-            && pointer.size > 0
-        {
-            pointers.push(CrabPointerRef { path, pointer });
-        }
-    }
+    let mut seen = HashSet::new();
+    visit_index_blob_ref_batches(repo_root, |blob_refs| {
+        check_cancelled(cancel)?;
+        collect_crab_pointers_from_refs_with_cancel(
+            repo_root,
+            blob_refs,
+            &mut pointers,
+            &mut seen,
+            cancel,
+        )
+    })?;
+    visit_reachable_blob_ref_batches(repo_root, |blob_refs| {
+        check_cancelled(cancel)?;
+        collect_crab_pointers_from_refs_with_cancel(
+            repo_root,
+            blob_refs,
+            &mut pointers,
+            &mut seen,
+            cancel,
+        )
+    })?;
     Ok(pointers)
 }
 
-fn index_blob_refs(repo_root: &Path) -> Result<Vec<(String, String)>> {
-    let output = Command::new("git")
-        .args(["ls-files", "-s"])
+fn collect_crab_pointers_from_refs_with_cancel(
+    repo_root: &Path,
+    blob_refs: &[(String, String)],
+    pointers: &mut Vec<CrabPointerRef>,
+    seen: &mut HashSet<([u8; 32], u64)>,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    for (blob, path) in batch_read_blobs_with_cancel(repo_root, blob_refs, cancel)? {
+        check_cancelled(cancel)?;
+        if let Ok(pointer) = Pointer::parse(&blob)
+            && pointer.size > 0
+            && seen.insert((pointer.file_hash, pointer.size))
+        {
+            if pointers.len() >= MAX_LFS_SCAN_OBJECTS {
+                return Err(CrabError::Configuration {
+                    key: "lfs dedup pointer count".to_owned(),
+                    origin: format!(
+                        "Crab pointer inventory exceeds the safety limit of {MAX_LFS_SCAN_OBJECTS}"
+                    ),
+                });
+            }
+            pointers.push(CrabPointerRef { path, pointer });
+        }
+    }
+    Ok(())
+}
+
+fn visit_index_blob_ref_batches(
+    repo_root: &Path,
+    mut visit: impl FnMut(&[(String, String)]) -> Result<()>,
+) -> Result<()> {
+    let mut child = git_command(repo_root)
+        .args(["ls-files", "-s", "-z"])
         .current_dir(repo_root)
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| CrabError::Internal(format!("failed to run git ls-files: {e}")))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| CrabError::Internal("git ls-files stdout missing".to_owned()))?;
+    let scan = visit_index_blob_refs(std::io::BufReader::new(stdout), &mut visit);
+    if scan.is_err() {
+        let _ = child.kill();
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| CrabError::Internal(format!("git ls-files failed: {e}")))?;
     if !output.status.success() {
         return Err(CrabError::Internal(format!(
             "git ls-files failed: {}",
             String::from_utf8_lossy(&output.stderr)
         )));
     }
-    let mut refs = Vec::new();
-    for line in String::from_utf8_lossy(&output.stdout).lines() {
-        let Some((meta, path)) = line.split_once('\t') else {
-            continue;
-        };
-        let parts: Vec<&str> = meta.split_whitespace().collect();
-        if parts.len() >= 2 {
-            refs.push((parts[1].to_owned(), path.to_owned()));
-        }
-    }
-    Ok(refs)
+    scan
 }
 
-fn reachable_blob_refs(repo_root: &Path) -> Result<Vec<(String, String)>> {
-    let output = Command::new("git")
-        .args(["rev-list", "--all", "--objects"])
+fn visit_index_blob_refs(
+    reader: impl BufRead,
+    visit: &mut impl FnMut(&[(String, String)]) -> Result<()>,
+) -> Result<()> {
+    let mut refs = Vec::with_capacity(GIT_OBJECT_BATCH_SIZE);
+    for record in reader.split(0) {
+        let record = record.map_err(CrabError::Io)?;
+        if record.is_empty() {
+            continue;
+        }
+        if record.len() > MAX_GIT_RECORD_BYTES {
+            return Err(CrabError::Configuration {
+                key: "lfs Git index record size".to_owned(),
+                origin: format!(
+                    "Git index record exceeds the safety limit of {MAX_GIT_RECORD_BYTES} bytes"
+                ),
+            });
+        }
+        let Some(tab) = record.iter().position(|byte| *byte == b'\t') else {
+            return Err(CrabError::Internal(
+                "git ls-files returned a malformed index record".to_owned(),
+            ));
+        };
+        let meta = std::str::from_utf8(&record[..tab]).map_err(|error| {
+            CrabError::Internal(format!("git ls-files returned invalid metadata: {error}"))
+        })?;
+        let path = String::from_utf8(record[tab + 1..].to_vec()).map_err(|error| {
+            CrabError::Configuration {
+                key: "LFS path".to_owned(),
+                origin: format!("Git path is not valid UTF-8: {error}"),
+            }
+        })?;
+        let parts: Vec<&str> = meta.split_whitespace().collect();
+        if parts.len() != 3 {
+            return Err(CrabError::Internal(format!(
+                "git ls-files returned malformed metadata {meta:?}"
+            )));
+        }
+        if parts[2] != "0" {
+            return Err(CrabError::Configuration {
+                key: path,
+                origin: "cannot deduplicate the LFS cache while the index has unresolved entries"
+                    .to_owned(),
+            });
+        }
+        if matches!(parts[0], "100644" | "100755") {
+            refs.push((parts[1].to_owned(), path.clone()));
+            if refs.len() == GIT_OBJECT_BATCH_SIZE {
+                visit(&refs)?;
+                refs.clear();
+            }
+        }
+    }
+    if !refs.is_empty() {
+        visit(&refs)?;
+    }
+    Ok(())
+}
+
+fn visit_reachable_blob_ref_batches(
+    repo_root: &Path,
+    mut visit: impl FnMut(&[(String, String)]) -> Result<()>,
+) -> Result<()> {
+    let mut child = git_command(repo_root)
+        .args(["rev-list", "--all", "--objects", "--no-object-names"])
         .current_dir(repo_root)
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| CrabError::Internal(format!("failed to run git rev-list: {e}")))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| CrabError::Internal("git rev-list stdout missing".to_owned()))?;
+    let scan = visit_reachable_blob_refs(std::io::BufReader::new(stdout), &mut visit);
+    if scan.is_err() {
+        let _ = child.kill();
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| CrabError::Internal(format!("git rev-list failed: {e}")))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if stderr.contains("bad default revision") || stderr.contains("does not have any commits") {
-            return Ok(Vec::new());
+            return Ok(());
         }
         return Err(CrabError::Internal(format!(
             "git rev-list failed: {stderr}"
         )));
     }
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| line.split_once(' '))
-        .map(|(hash, path)| (hash.to_owned(), path.to_owned()))
-        .collect())
+    scan
 }
 
-fn batch_read_blobs(
+fn visit_reachable_blob_refs(
+    reader: impl BufRead,
+    visit: &mut impl FnMut(&[(String, String)]) -> Result<()>,
+) -> Result<()> {
+    let mut refs = Vec::with_capacity(GIT_OBJECT_BATCH_SIZE);
+    for line in reader.split(b'\n') {
+        let line = line.map_err(CrabError::Io)?;
+        if line.is_empty() {
+            continue;
+        }
+        if line.len() > MAX_GIT_RECORD_BYTES {
+            return Err(CrabError::Configuration {
+                key: "lfs Git object record size".to_owned(),
+                origin: format!(
+                    "Git object record exceeds the safety limit of {MAX_GIT_RECORD_BYTES} bytes"
+                ),
+            });
+        }
+        let hash = std::str::from_utf8(&line).map_err(|error| {
+            CrabError::Internal(format!(
+                "git rev-list returned an invalid object ID: {error}"
+            ))
+        })?;
+        if !is_git_object_id(hash) {
+            return Err(CrabError::Internal(format!(
+                "git rev-list returned malformed object ID {hash:?}"
+            )));
+        }
+        refs.push((hash.to_owned(), String::from("<reachable object>")));
+        if refs.len() == GIT_OBJECT_BATCH_SIZE {
+            visit(&refs)?;
+            refs.clear();
+        }
+    }
+    if !refs.is_empty() {
+        visit(&refs)?;
+    }
+    Ok(())
+}
+
+fn is_git_object_id(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+pub(super) fn batch_read_blobs(
     repo_root: &Path,
     blob_refs: &[(String, String)],
 ) -> Result<Vec<(Vec<u8>, String)>> {
+    batch_read_blobs_with_cancel(repo_root, blob_refs, &CancellationToken::new())
+}
+
+pub(super) fn batch_read_blobs_with_cancel(
+    repo_root: &Path,
+    blob_refs: &[(String, String)],
+    cancel: &CancellationToken,
+) -> Result<Vec<(Vec<u8>, String)>> {
+    check_cancelled(cancel)?;
     if blob_refs.is_empty() {
         return Ok(Vec::new());
     }
 
     let mut out = Vec::new();
-    for chunk in blob_refs.chunks(500) {
-        let input = chunk
+    for chunk in blob_refs.chunks(GIT_OBJECT_BATCH_SIZE) {
+        check_cancelled(cancel)?;
+        let small_refs = small_blob_refs(repo_root, chunk)?;
+        if small_refs.is_empty() {
+            continue;
+        }
+        let input = small_refs
             .iter()
             .map(|(hash, _)| hash.as_str())
             .collect::<Vec<_>>()
-            .join("\n");
-        let mut child = Command::new("git")
+            .join("\n")
+            + "\n";
+        let mut child = git_command(repo_root)
             .args(["cat-file", "--batch"])
             .current_dir(repo_root)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
             .spawn()
             .map_err(|e| CrabError::Internal(format!("failed to spawn git cat-file: {e}")))?;
         if let Some(stdin) = child.stdin.as_mut() {
@@ -650,73 +1125,199 @@ fn batch_read_blobs(
         let output = child
             .wait_with_output()
             .map_err(|e| CrabError::Internal(format!("git cat-file failed: {e}")))?;
-        parse_batch_output(&output.stdout, chunk, &mut out);
+        if !output.status.success() {
+            return Err(CrabError::Internal(format!(
+                "git cat-file --batch failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        if output.stdout.len() > MAX_GIT_BATCH_OUTPUT_BYTES {
+            return Err(CrabError::Configuration {
+                key: "lfs Git blob response size".to_owned(),
+                origin: format!(
+                    "Git blob response exceeds the safety limit of {MAX_GIT_BATCH_OUTPUT_BYTES} bytes"
+                ),
+            });
+        }
+        parse_batch_output(&output.stdout, &small_refs, &mut out)?;
     }
     Ok(out)
 }
 
-fn parse_batch_output(stdout: &[u8], refs: &[(String, String)], out: &mut Vec<(Vec<u8>, String)>) {
+fn small_blob_refs(repo_root: &Path, refs: &[(String, String)]) -> Result<Vec<(String, String)>> {
+    let input = refs
+        .iter()
+        .map(|(hash, _)| hash.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    let mut child = git_command(repo_root)
+        .args([
+            "cat-file",
+            "--batch-check=%(objectname) %(objecttype) %(objectsize)",
+        ])
+        .current_dir(repo_root)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| CrabError::Internal(format!("failed to spawn git cat-file: {e}")))?;
+    if let Some(stdin) = child.stdin.as_mut() {
+        use std::io::Write;
+        stdin.write_all(input.as_bytes()).map_err(CrabError::Io)?;
+    }
+    drop(child.stdin.take());
+    let output = child
+        .wait_with_output()
+        .map_err(|e| CrabError::Internal(format!("git cat-file --batch-check failed: {e}")))?;
+    if !output.status.success() {
+        return Err(CrabError::Internal(format!(
+            "git cat-file --batch-check failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    if output.stdout.len() > MAX_GIT_BATCH_OUTPUT_BYTES {
+        return Err(CrabError::Configuration {
+            key: "lfs Git blob metadata response size".to_owned(),
+            origin: format!(
+                "Git blob metadata response exceeds the safety limit of {MAX_GIT_BATCH_OUTPUT_BYTES} bytes"
+            ),
+        });
+    }
+    let stdout = std::str::from_utf8(&output.stdout).map_err(|error| {
+        CrabError::Internal(format!(
+            "git cat-file --batch-check returned invalid UTF-8: {error}"
+        ))
+    })?;
+    let lines = stdout.lines().collect::<Vec<_>>();
+    if lines.len() != refs.len() {
+        return Err(CrabError::Internal(format!(
+            "git cat-file --batch-check returned {} responses for {} objects",
+            lines.len(),
+            refs.len()
+        )));
+    }
+
+    let mut small = Vec::new();
+    for (line, reference) in lines.into_iter().zip(refs) {
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        if fields.len() != 3 {
+            return Err(CrabError::Internal(format!(
+                "git cat-file --batch-check returned malformed response {line:?}"
+            )));
+        }
+        let size = fields[2].parse::<usize>().map_err(|error| {
+            CrabError::Internal(format!(
+                "git cat-file returned invalid object size: {error}"
+            ))
+        })?;
+        if fields[1] == "blob" && size <= crab_git::lfs_pointer::MAX_LFS_POINTER_SIZE {
+            small.push(reference.clone());
+        }
+    }
+    Ok(small)
+}
+
+fn parse_batch_output(
+    stdout: &[u8],
+    refs: &[(String, String)],
+    out: &mut Vec<(Vec<u8>, String)>,
+) -> Result<()> {
+    if stdout.len() > MAX_GIT_BATCH_OUTPUT_BYTES {
+        return Err(CrabError::Configuration {
+            key: "lfs Git blob response size".to_owned(),
+            origin: format!(
+                "Git blob response exceeds the safety limit of {MAX_GIT_BATCH_OUTPUT_BYTES} bytes"
+            ),
+        });
+    }
     let mut pos = 0;
     let mut index = 0;
     while pos < stdout.len() && index < refs.len() {
         let Some(header_rel_end) = stdout[pos..].iter().position(|&b| b == b'\n') else {
-            break;
+            return Err(CrabError::Internal(
+                "git cat-file batch response ended inside a header".to_owned(),
+            ));
         };
         let header_end = pos + header_rel_end;
-        let header = String::from_utf8_lossy(&stdout[pos..header_end]);
+        let header = std::str::from_utf8(&stdout[pos..header_end]).map_err(|error| {
+            CrabError::Internal(format!("git cat-file returned invalid header: {error}"))
+        })?;
         let parts: Vec<&str> = header.split_whitespace().collect();
-        if parts.len() < 3 || parts[1] == "missing" {
-            pos = header_end + 1;
-            index += 1;
-            continue;
+        if parts.len() != 3 || parts[1] != "blob" {
+            return Err(CrabError::Internal(format!(
+                "git cat-file returned unexpected response {header:?}"
+            )));
         }
-        let Ok(size) = parts[2].parse::<usize>() else {
-            pos = header_end + 1;
-            index += 1;
-            continue;
-        };
+        let size = parts[2].parse::<usize>().map_err(|error| {
+            CrabError::Internal(format!(
+                "git cat-file returned invalid object size: {error}"
+            ))
+        })?;
         let content_start = header_end + 1;
-        let content_end = content_start + size;
-        if content_end > stdout.len() {
-            break;
-        }
-        if parts[1] == "blob" {
-            out.push((
-                stdout[content_start..content_end].to_vec(),
-                refs[index].1.clone(),
+        let content_end = content_start
+            .checked_add(size)
+            .ok_or_else(|| CrabError::Internal("git cat-file object size overflow".to_owned()))?;
+        if content_end >= stdout.len() || stdout[content_end] != b'\n' {
+            return Err(CrabError::Internal(
+                "git cat-file returned a truncated object response".to_owned(),
             ));
         }
+        out.push((
+            stdout[content_start..content_end].to_vec(),
+            refs[index].1.clone(),
+        ));
         pos = content_end + 1;
         index += 1;
     }
+    if index != refs.len() || pos != stdout.len() {
+        return Err(CrabError::Internal(format!(
+            "git cat-file returned {index} complete responses for {} objects",
+            refs.len()
+        )));
+    }
+    Ok(())
 }
 
 fn discover_repo_root() -> Result<PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .map_err(|e| CrabError::Internal(format!("failed to discover repo root: {e}")))?;
-    if !output.status.success() {
-        return Err(CrabError::Internal("not inside a git repository".into()));
-    }
-    Ok(PathBuf::from(
-        String::from_utf8_lossy(&output.stdout).trim(),
-    ))
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    Ok(crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?.current_worktree_root)
+}
+
+fn git_command(repo_root: &Path) -> Command {
+    let mut command = Command::new("git");
+    command
+        .current_dir(repo_root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env_remove("GIT_QUARANTINE_PATH")
+        .env_remove("GIT_NAMESPACE");
+    command
 }
 
 fn discover_git_dir(repo_root: &Path) -> Result<PathBuf> {
     crate::git::discover::discover_common_git_dir_from(repo_root)
 }
 
-fn cleanup_empty_dirs(lfs_objects_dir: &Path) {
+fn cleanup_empty_dirs_with_cancel(
+    lfs_objects_dir: &Path,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
     if let Ok(top_entries) = std::fs::read_dir(lfs_objects_dir) {
         for aa_entry in top_entries.flatten() {
+            check_cancelled(cancel)?;
             let aa_path = aa_entry.path();
             if !aa_path.is_dir() {
                 continue;
             }
             if let Ok(bb_entries) = std::fs::read_dir(&aa_path) {
                 for bb_entry in bb_entries.flatten() {
+                    check_cancelled(cancel)?;
                     let bb_path = bb_entry.path();
                     if bb_path.is_dir() {
                         let _ = std::fs::remove_dir(&bb_path);
@@ -726,6 +1327,7 @@ fn cleanup_empty_dirs(lfs_objects_dir: &Path) {
             let _ = std::fs::remove_dir(&aa_path);
         }
     }
+    Ok(())
 }
 
 fn format_size(bytes: u64) -> String {
@@ -792,6 +1394,132 @@ mod tests {
         .unwrap();
         assert_eq!(digest.sha256_hex, oid);
         assert_eq!(digest.blake3, *blake3::hash(data).as_bytes());
+        assert_eq!(digest.size, data.len() as u64);
+    }
+
+    #[test]
+    fn verify_lfs_file_rejects_corrupt_cache_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let expected = b"expected bytes";
+        let actual = b"corrupt bytes";
+        let oid: [u8; 32] = Sha256::digest(expected).into();
+        let path = dir.path().join("object");
+        std::fs::write(&path, actual).unwrap();
+
+        let error = verify_lfs_file(
+            &path,
+            &LfsPointer {
+                oid,
+                size: expected.len() as u64,
+                extensions: Vec::new(),
+            },
+            "model.bin",
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("indexed LFS SHA-256 and size"));
+    }
+
+    #[test]
+    fn batch_read_blobs_filters_large_git_objects() {
+        let _guard = GIT_DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let dir = temp_git_repo();
+        let large = vec![b'x'; crab_git::lfs_pointer::MAX_LFS_POINTER_SIZE + 1];
+        let mut child = Command::new("git")
+            .args(["hash-object", "-w", "--stdin"])
+            .current_dir(dir.path())
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        use std::io::Write as _;
+        child.stdin.as_mut().unwrap().write_all(&large).unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(output.status.success());
+        let oid = String::from_utf8(output.stdout).unwrap().trim().to_owned();
+
+        let blobs = batch_read_blobs(
+            dir.path(),
+            &[(oid, String::from("large-not-a-pointer.bin"))],
+        )
+        .unwrap();
+
+        assert!(blobs.is_empty());
+    }
+
+    #[test]
+    fn worktree_dedup_replaces_from_verified_lfs_object() {
+        let _guard = GIT_DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let dir = temp_git_repo();
+        for args in [
+            ["config", "user.email", "test@example.com"],
+            ["config", "user.name", "Test"],
+        ] {
+            assert!(
+                Command::new("git")
+                    .args(args)
+                    .current_dir(dir.path())
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        }
+        let content = b"verified LFS worktree content";
+        let oid: [u8; 32] = Sha256::digest(content).into();
+        let pointer = LfsPointer {
+            oid,
+            size: content.len() as u64,
+            extensions: Vec::new(),
+        };
+        let worktree_path = dir.path().join("model.bin");
+        std::fs::write(&worktree_path, pointer.serialize()).unwrap();
+        assert!(
+            Command::new("git")
+                .args(["add", "model.bin"])
+                .current_dir(dir.path())
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .args(["commit", "-m", "add LFS pointer"])
+                .current_dir(dir.path())
+                .status()
+                .unwrap()
+                .success()
+        );
+        let git_dir = dir.path().join(".git");
+        let object_path = local_lfs_object_path(
+            &git_dir.join("lfs"),
+            &crab_git::lfs_pointer::hex_encode(&oid),
+        );
+        std::fs::create_dir_all(object_path.parent().unwrap()).unwrap();
+        std::fs::write(&object_path, content).unwrap();
+        std::fs::write(&worktree_path, content).unwrap();
+        assert!(
+            Command::new("git")
+                .args(["update-index", "--assume-unchanged", "model.bin"])
+                .current_dir(dir.path())
+                .status()
+                .unwrap()
+                .success()
+        );
+        if ensure_cow_clone_supported(&git_dir).is_err() {
+            return;
+        }
+
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let result = run_worktree_dedup(false, &CancellationToken::new());
+        std::env::set_current_dir(original_cwd).unwrap();
+
+        result.unwrap();
+        assert_eq!(std::fs::read(worktree_path).unwrap(), content);
     }
 
     #[test]
@@ -861,5 +1589,13 @@ mod tests {
                 .to_string_lossy()
                 .contains(".model.bin.crab-lfs-dedup-backup.")
         );
+    }
+
+    #[test]
+    fn optimize_dedup_honors_cancellation_before_repository_discovery() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let error = run_lfs_dedup_with_cancel(LfsDedupOptions::default(), &cancel).unwrap_err();
+        assert!(matches!(error, CrabError::Cancelled));
     }
 }

--- a/crab/src/cmd/lfs/locks.rs
+++ b/crab/src/cmd/lfs/locks.rs
@@ -555,21 +555,14 @@ fn resolve_local_lfs_dir() -> Result<PathBuf> {
     let repo_root = crate::git::discover::resolve_current_worktree_root()
         .map_or_else(std::env::current_dir, Ok)?;
     let config = crate::lfs::config::LfsConfig::resolve(&repo_root)?;
-    if let Some(lfs_dir) = config.lfs_dir {
-        return Ok(if lfs_dir.is_absolute() {
-            lfs_dir
-        } else {
-            repo_root.join(lfs_dir)
-        });
-    }
-
     let git_dir = crate::git::discover::discover_git_dir()?;
     let git_dir = if git_dir.is_absolute() {
         git_dir
     } else {
         repo_root.join(git_dir)
     };
-    Ok(crate::git::discover::resolve_common_dir(&git_dir).join("lfs"))
+    let common_git_dir = crate::git::discover::resolve_common_dir(&git_dir);
+    Ok(config.storage_dir(&common_git_dir))
 }
 
 /// Parse a human-readable duration string like "24h", "7d", "30m".

--- a/crab/src/cmd/lfs/mod.rs
+++ b/crab/src/cmd/lfs/mod.rs
@@ -36,8 +36,9 @@ use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
 
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::OutputMode;
+use tokio_util::sync::CancellationToken;
 
 pub(super) fn hooks_dir_from(root: &Path) -> Result<PathBuf> {
     crate::cmd::install::resolve_hooks_dir(root)
@@ -210,7 +211,7 @@ pub enum LfsCmd {
         #[arg(long)]
         dry_run: bool,
         /// Rollback a previous conversion.
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["from", "to", "pattern", "dry_run"])]
         rollback: bool,
     },
     /// Generate cloud lifecycle policy for LFS objects.
@@ -401,7 +402,7 @@ pub enum LfsCmd {
         /// Continue or halt when verification is disabled; remote verification always halts.
         #[arg(long, value_name = "MODE", value_parser = ["halt", "continue"])]
         when_unverified: Option<String>,
-        /// Accept Git LFS recent-pruning flag; Crab does not retain recent unreferenced objects.
+        /// Prune objects retained only by recent-ref protection.
         #[arg(long)]
         recent: bool,
         /// Report what would be pruned without deleting.
@@ -718,6 +719,15 @@ where
 /// Returns the process exit code. Most subcommands return `SUCCESS`;
 /// `pointer --check` returns a non-zero code for invalid pointers.
 pub fn run_lfs(cmd: &LfsCmd) -> Result<std::process::ExitCode> {
+    run_lfs_with_cancel(cmd, &CancellationToken::new())
+}
+
+/// Dispatch an LFS command while honoring cancellation for optimize-owned paths.
+pub fn run_lfs_with_cancel(
+    cmd: &LfsCmd,
+    cancel: &CancellationToken,
+) -> Result<std::process::ExitCode> {
+    check_cancelled(cancel)?;
     match cmd {
         LfsCmd::Install {
             force,
@@ -927,7 +937,9 @@ pub fn run_lfs(cmd: &LfsCmd) -> Result<std::process::ExitCode> {
             }
         }
         LfsCmd::Untrack { patterns } => {
-            let repo_root = std::env::current_dir()?;
+            let cwd = std::env::current_dir()?;
+            let repo_root = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?
+                .current_worktree_root;
             for pattern in patterns {
                 crate::lfs::track::untrack(pattern, &repo_root)?;
                 println!("Untracking \"{pattern}\"");
@@ -1109,17 +1121,20 @@ pub fn run_lfs(cmd: &LfsCmd) -> Result<std::process::ExitCode> {
             force,
             verbose,
         } => {
-            prune::run_lfs_prune(prune::LfsPruneOptions {
-                verify_remote: *verify_remote,
-                no_verify_remote: *no_verify_remote,
-                verify_unreachable: *verify_unreachable,
-                no_verify_unreachable: *no_verify_unreachable,
-                when_unverified: when_unverified.clone(),
-                recent: *recent,
-                dry_run: *dry_run,
-                force: *force,
-                verbose: *verbose,
-            })?;
+            prune::run_lfs_prune_with_cancel(
+                prune::LfsPruneOptions {
+                    verify_remote: *verify_remote,
+                    no_verify_remote: *no_verify_remote,
+                    verify_unreachable: *verify_unreachable,
+                    no_verify_unreachable: *no_verify_unreachable,
+                    when_unverified: when_unverified.clone(),
+                    recent: *recent,
+                    dry_run: *dry_run,
+                    force: *force,
+                    verbose: *verbose,
+                },
+                cancel,
+            )?;
         }
         LfsCmd::Migrate(migrate_cmd) => match migrate_cmd {
             LfsMigrateCmd::Import {
@@ -1298,11 +1313,14 @@ pub fn run_lfs(cmd: &LfsCmd) -> Result<std::process::ExitCode> {
             test,
             crab_cache,
         } => {
-            dedup::run_lfs_dedup(dedup::LfsDedupOptions {
-                dry_run: *dry_run,
-                test: *test,
-                crab_cache: *crab_cache,
-            })?;
+            dedup::run_lfs_dedup_with_cancel(
+                dedup::LfsDedupOptions {
+                    dry_run: *dry_run,
+                    test: *test,
+                    crab_cache: *crab_cache,
+                },
+                cancel,
+            )?;
         }
         LfsCmd::Logs {
             transfer_history,
@@ -1324,9 +1342,11 @@ pub fn run_lfs(cmd: &LfsCmd) -> Result<std::process::ExitCode> {
             dry_run,
             rollback,
         } => {
-            let repo_root = std::env::current_dir()?;
+            let cwd = std::env::current_dir()?;
+            let repo_root = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?
+                .current_worktree_root;
             if *rollback {
-                convert::run_rollback(&repo_root)?;
+                convert::run_rollback_with_cancel(&repo_root, cancel)?;
                 println!("Rollback complete.");
                 return Ok(std::process::ExitCode::SUCCESS);
             }
@@ -1340,7 +1360,7 @@ pub fn run_lfs(cmd: &LfsCmd) -> Result<std::process::ExitCode> {
                     return Ok(std::process::ExitCode::FAILURE);
                 }
             };
-            convert::run_convert(direction, pattern, *dry_run, &repo_root)?;
+            convert::run_convert_with_cancel(direction, pattern, *dry_run, &repo_root, cancel)?;
         }
         LfsCmd::LifecyclePolicy {
             backend,

--- a/crab/src/cmd/lfs/prune.rs
+++ b/crab/src/cmd/lfs/prune.rs
@@ -43,7 +43,15 @@ pub fn run_lfs_prune_with_cancel(
     cancel: &CancellationToken,
 ) -> Result<()> {
     check_cancelled(cancel)?;
-    run_lfs_prune(options)
+    let prune_options = resolve_prune_options(options)?;
+    let summary = crate::lfs::prune::run_prune_with_cancel(prune_options, cancel)?;
+    tracing::info!(
+        pruned_count = summary.pruned_count,
+        pruned_bytes = summary.pruned_bytes,
+        dry_run = summary.dry_run,
+        "prune complete"
+    );
+    Ok(())
 }
 
 fn resolve_prune_options(options: LfsPruneOptions) -> Result<crate::lfs::prune::PruneOptions> {

--- a/crab/src/cmd/lfs/prune.rs
+++ b/crab/src/cmd/lfs/prune.rs
@@ -2,7 +2,8 @@
 //!
 //! Wires the CLI prune subcommand to [`crate::lfs::prune::run_prune`].
 
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
+use tokio_util::sync::CancellationToken;
 
 /// Options for `crab lfs prune`.
 #[derive(Debug, Clone)]
@@ -34,6 +35,15 @@ pub fn run_lfs_prune(options: LfsPruneOptions) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Run LFS pruning while honoring a caller's cancellation boundary.
+pub fn run_lfs_prune_with_cancel(
+    options: LfsPruneOptions,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
+    run_lfs_prune(options)
 }
 
 fn resolve_prune_options(options: LfsPruneOptions) -> Result<crate::lfs::prune::PruneOptions> {

--- a/crab/src/cmd/lfs/store_setup.rs
+++ b/crab/src/cmd/lfs/store_setup.rs
@@ -37,11 +37,23 @@ pub async fn resolve_lfs_remote_for_operation_with_remote(
     operation: &str,
     remote: Option<&str>,
 ) -> Result<LfsRemoteContext> {
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    resolve_lfs_remote_for_operation_with_remote_from(operation, remote, &cwd).await
+}
+
+/// Resolve the LFS store using the worktree containing `repo_root`.
+pub async fn resolve_lfs_remote_for_operation_with_remote_from(
+    operation: &str,
+    remote: Option<&str>,
+    repo_root: &Path,
+) -> Result<LfsRemoteContext> {
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(repo_root)?;
+    let repo_root = &worktree.current_worktree_root;
     let url = match remote {
-        Some(name) => read_git_remote_url(name)?,
-        None => read_repo_remote_url()?,
+        Some(name) => read_git_remote_url_from(name, repo_root)?,
+        None => read_repo_remote_url_from(repo_root)?,
     };
-    let config = crate::core::config::Config::resolve_local().unwrap_or_default();
+    let config = crate::core::config::Config::resolve_for_repo(repo_root)?;
     let cancel = tokio_util::sync::CancellationToken::new();
     let cache_dir = crab_auth::token_cache::expand_token_cache_path(&config.auth.token_cache_path);
     let managed_resolver = crab_auth_store::ManagedRepositoryResolver::new(cache_dir);
@@ -99,14 +111,9 @@ pub async fn resolve_lfs_remote_for_operation_with_remote(
         }
     };
 
-    let repo_root = std::env::current_dir()?;
-    let lfs_config = LfsConfig::resolve(&repo_root)?;
+    let lfs_config = LfsConfig::resolve(repo_root)?;
 
-    let git_dir = discover_git_dir()?;
-    let local_lfs_dir = lfs_config
-        .lfs_dir
-        .clone()
-        .unwrap_or_else(|| git_dir.join("lfs"));
+    let local_lfs_dir = lfs_config.storage_dir(&worktree.common_git_dir);
 
     Ok(LfsRemoteContext {
         store: lfs_store,
@@ -162,10 +169,22 @@ pub fn resolve_lfs_remote_for_operation_with_remote_sync(
     operation: &str,
     remote: Option<&str>,
 ) -> Result<LfsRemoteContext> {
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    resolve_lfs_remote_for_operation_with_remote_sync_from(operation, remote, &cwd)
+}
+
+/// Synchronous wrapper for resolving an operation-scoped LFS store from an explicit worktree.
+pub fn resolve_lfs_remote_for_operation_with_remote_sync_from(
+    operation: &str,
+    remote: Option<&str>,
+    repo_root: &Path,
+) -> Result<LfsRemoteContext> {
     let operation = operation.to_owned();
     let remote = remote.map(ToOwned::to_owned);
+    let repo_root = repo_root.to_owned();
     super::block_on_runtime(async move {
-        resolve_lfs_remote_for_operation_with_remote(&operation, remote.as_deref()).await
+        resolve_lfs_remote_for_operation_with_remote_from(&operation, remote.as_deref(), &repo_root)
+            .await
     })
 }
 
@@ -178,7 +197,15 @@ fn is_lfs_read_operation(operation: &str) -> bool {
 
 /// Read the remote URL from `.crab/config.toml`.
 pub(crate) fn read_repo_remote_url() -> Result<String> {
-    let config_path = std::path::PathBuf::from(".crab/config.toml");
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    let repo_root =
+        crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?.current_worktree_root;
+    read_repo_remote_url_from(&repo_root)
+}
+
+pub(super) fn read_repo_remote_url_from(repo_root: &Path) -> Result<String> {
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(repo_root)?;
+    let config_path = worktree.shared_crab_dir.join("config.toml");
     if config_path.is_file() {
         let content =
             std::fs::read_to_string(&config_path).map_err(|e| CrabError::Configuration {
@@ -198,10 +225,7 @@ pub(crate) fn read_repo_remote_url() -> Result<String> {
         }
     }
 
-    let remote_path = crate::git::discover::resolve_crab_dir().map_or_else(
-        || std::path::PathBuf::from(".crab/remote"),
-        |d| d.join("remote"),
-    );
+    let remote_path = worktree.shared_crab_dir.join("remote");
     if remote_path.is_file() {
         let url = std::fs::read_to_string(&remote_path).map_err(|e| CrabError::Configuration {
             key: format!("failed to read .crab/remote: {e}"),
@@ -213,8 +237,9 @@ pub(crate) fn read_repo_remote_url() -> Result<String> {
         }
     }
 
-    let output = std::process::Command::new("git")
+    let output = git_command(repo_root)
         .args(["remote", "get-url", "origin"])
+        .current_dir(repo_root)
         .output()
         .ok();
     if let Some(o) = output
@@ -232,12 +257,8 @@ pub(crate) fn read_repo_remote_url() -> Result<String> {
     })
 }
 
-fn read_git_remote_url(name: &str) -> Result<String> {
-    read_git_remote_url_from(name, Path::new("."))
-}
-
 fn read_git_remote_url_from(name: &str, repo_root: &Path) -> Result<String> {
-    let output = std::process::Command::new("git")
+    let output = git_command(repo_root)
         .args(["remote", "get-url", name])
         .current_dir(repo_root)
         .output()
@@ -264,9 +285,19 @@ fn read_git_remote_url_from(name: &str, repo_root: &Path) -> Result<String> {
     Ok(url)
 }
 
-/// Discover the .git directory.
-fn discover_git_dir() -> Result<PathBuf> {
-    crate::git::discover::discover_common_git_dir()
+fn git_command(repo_root: &Path) -> std::process::Command {
+    let mut command = std::process::Command::new("git");
+    command
+        .current_dir(repo_root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env_remove("GIT_QUARANTINE_PATH")
+        .env_remove("GIT_NAMESPACE");
+    command
 }
 
 /// Get the current user identity from git config for lock operations.

--- a/crab/src/cmd/metadb.rs
+++ b/crab/src/cmd/metadb.rs
@@ -29,6 +29,7 @@
 //! one helper set.
 
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -42,12 +43,13 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::core::config::Config;
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::{JsonlStream, OutputMode, emit_json};
 use crate::git::url::CrabUrl;
 use crate::metadata::{MetaDb, MetaDbGuard, XorbRef};
 use crab_staging::recipe::{ChunkingPolicyId, FileRecipe};
-use crab_xet::hash::MerkleHash;
+use crab_xet::hash::{HashedWrite, MerkleHash};
+use crab_xet::xorb::format::MAX_XORB_SIZE;
 use crab_xet::xorb::parser::XorbParser;
 
 /// Which databases the subcommand operates on.
@@ -252,21 +254,27 @@ pub async fn run_metadb(
     match cmd {
         MetadbCommand::Diagnose { db, json, deep } => {
             let mode = if json { OutputMode::Json } else { mode };
-            run_diagnose(db, mode, deep).await
+            run_diagnose(db, mode, deep, cancel).await
         }
         MetadbCommand::Rebuild { db, json } => {
             let mode = if json { OutputMode::Json } else { mode };
-            run_rebuild(db, mode).await
+            run_rebuild(db, mode, cancel).await
         }
         MetadbCommand::Owner {
             once,
             interval,
             jsonl,
         } => Box::pin(run_generation_owner(once, interval, jsonl, cancel)).await,
-        MetadbCommand::Compact { db } => run_compact(db).await,
+        MetadbCommand::Compact { db } => run_compact(db, cancel).await,
         MetadbCommand::Cache(sub) => match sub {
-            CacheCommand::Stats => run_cache_stats(mode),
-            CacheCommand::Clear => run_cache_clear(),
+            CacheCommand::Stats => {
+                check_cancelled(cancel)?;
+                run_cache_stats(mode)
+            }
+            CacheCommand::Clear => {
+                check_cancelled(cancel)?;
+                run_cache_clear(cancel)
+            }
         },
     }
 }
@@ -274,18 +282,21 @@ pub async fn run_metadb(
 /// Resolve the `(store, repo_prefix, bucket_identity, config)` tuple for the current
 /// working directory. Returns a user-facing error when no remote is
 /// configured — every metadb subcommand needs the bucket.
-async fn resolve_repo_store() -> Result<(
+async fn resolve_repo_store(
+    cancel: &CancellationToken,
+) -> Result<(
     Arc<dyn ObjectStore>,
     String,
     crate::storage::store::BucketIdentity,
     Config,
 )> {
-    let cwd = std::env::current_dir()?;
-    resolve_repo_store_in(&cwd).await
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    resolve_repo_store_in(&cwd, cancel).await
 }
 
 async fn resolve_repo_store_in(
     root: &Path,
+    cancel: &CancellationToken,
 ) -> Result<(
     Arc<dyn ObjectStore>,
     String,
@@ -304,9 +315,8 @@ async fn resolve_repo_store_in(
         )));
     }
     let parsed = CrabUrl::parse(&url)?;
-    let config = Config::resolve_local().unwrap_or_default();
-    let cancel = tokio_util::sync::CancellationToken::new();
-    let store = crate::auth::build_store(&config, &parsed, "metadb", &cancel).await?;
+    let config = Config::resolve_for_repo(root)?;
+    let store = crate::auth::build_store(&config, &parsed, "metadb", cancel).await?;
     // `build_store` hands back a `ProbingStoreHandle` which wraps an
     // `Arc<dyn ObjectStore>` via `inner()`. Clone the inner handle out
     // so the metadb layer holds a plain `Arc<dyn ObjectStore>`.
@@ -409,7 +419,7 @@ async fn run_generation_owner(
             origin: "Git generation-owner interval must be at least one second".to_owned(),
         });
     }
-    let (inner, repo_prefix, bucket_identity, config) = resolve_repo_store().await?;
+    let (inner, repo_prefix, bucket_identity, config) = resolve_repo_store(cancel).await?;
     let store = crate::storage::store::Store::new(inner).with_bucket_identity(bucket_identity);
     let router = crate::storage::StoreLayout::new(store.clone(), repo_prefix.clone());
     let lock_ttl = std::time::Duration::from_secs(config.push_lock_ttl_secs);
@@ -724,8 +734,14 @@ fn generation_owner_retry_delay(
 
 // --- diagnose -------------------------------------------------------
 
-async fn run_diagnose(db: DbSelector, mode: OutputMode, deep: bool) -> Result<()> {
-    let (store, repo_prefix, bucket_identity, config) = resolve_repo_store().await?;
+async fn run_diagnose(
+    db: DbSelector,
+    mode: OutputMode,
+    deep: bool,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
+    let (store, repo_prefix, bucket_identity, config) = resolve_repo_store(cancel).await?;
     let metadb_config = config.build_metadb_config(&repo_prefix);
     // Diagnose only reads sys:* keys — open read-only so a
     // concurrent push is not fenced.
@@ -754,8 +770,9 @@ async fn run_diagnose(db: DbSelector, mode: OutputMode, deep: bool) -> Result<()
         chunk_index,
     };
 
-    render_diagnose(&payload, mode);
     guard.close().await?;
+    check_cancelled(cancel)?;
+    render_diagnose(&payload, mode);
     Ok(())
 }
 
@@ -1255,10 +1272,145 @@ struct RebuildPayload {
 /// memory without making the commit fan-out run at tiny-batch
 /// granularity.
 const REBUILD_COMMIT_BATCH: usize = 1000;
+const MAX_METADATA_SHARD_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_METADATA_SHARD_FILE_ENTRIES: usize = 1_000_000;
+const MAX_METADATA_SHARD_CHUNK_ENTRIES: usize = 1_000_000;
+const MAX_METADATA_SHARDS: u64 = 1_000_000;
+const MAX_METADATA_CONTROL_BYTES: u64 = 8 * 1024 * 1024;
 
-async fn run_rebuild(db: DbSelector, mode: OutputMode) -> Result<()> {
-    let (store, repo_prefix, bucket_identity, config) = resolve_repo_store().await?;
-    run_rebuild_in(store, repo_prefix, &bucket_identity, db, mode, &config).await
+fn create_shard_scan_workspace() -> Result<tempfile::TempDir> {
+    let root = crate::cache::default_cache_root().join("maintenance");
+    std::fs::create_dir_all(&root).map_err(CrabError::Io)?;
+    tempfile::Builder::new()
+        .prefix("crab-metadb-shard-")
+        .tempdir_in(root)
+        .map_err(CrabError::Io)
+}
+
+async fn download_and_parse_shard(
+    storage: &crab_storage::Store,
+    shard_path: &ObjectPath,
+    expected_hash: MerkleHash,
+    workspace: &Path,
+    include_file_index: bool,
+    include_chunk_index: bool,
+    cancel: &CancellationToken,
+) -> Result<(
+    Vec<crab_xet::shard_parse::ExtractedFileRecipe>,
+    Vec<(MerkleHash, XorbRef)>,
+)> {
+    check_cancelled(cancel)?;
+    let expected_size = tokio::select! {
+        result = storage.head(shard_path) => result?.size,
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+    };
+    if expected_size > MAX_METADATA_SHARD_BYTES {
+        return Err(CrabError::Configuration {
+            key: "metadata shard size".to_owned(),
+            origin: format!(
+                "shard {expected_hash} is {expected_size} bytes; bounded index scans support at most {MAX_METADATA_SHARD_BYTES} bytes"
+            ),
+        });
+    }
+    let local_path = workspace.join(format!("shard-{}", expected_hash.hex()));
+    let downloaded_size = tokio::select! {
+        result = storage.download_to_path_bounded(shard_path, &local_path, MAX_METADATA_SHARD_BYTES) => result?,
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+    };
+    if downloaded_size != expected_size {
+        return Err(CrabError::CorruptObject {
+            path: shard_path.to_string(),
+            reason: format!(
+                "shard size changed during download: expected {expected_size} bytes, downloaded {downloaded_size}"
+            ),
+        });
+    }
+    let object_path = shard_path.to_string();
+    let result = tokio::task::spawn_blocking(move || {
+        let result = (|| {
+            let mut source = File::open(&local_path).map_err(CrabError::Io)?;
+            let mut hashed = HashedWrite::new(std::io::sink());
+            std::io::copy(&mut source, &mut hashed).map_err(CrabError::Io)?;
+            if hashed.hash() != expected_hash {
+                return Err(CrabError::CorruptObject {
+                    path: object_path.clone(),
+                    reason: "shard body hash mismatch".to_owned(),
+                });
+            }
+
+            let mut source = File::open(&local_path).map_err(CrabError::Io)?;
+            let parsed = match (include_file_index, include_chunk_index) {
+                (true, true) => {
+                    crab_xet::shard_parse::extract_file_and_chunk_entries_from_reader_with_limits(
+                        &mut source,
+                        MAX_METADATA_SHARD_FILE_ENTRIES,
+                        MAX_METADATA_SHARD_CHUNK_ENTRIES,
+                    )
+                }
+                (true, false) => {
+                    crab_xet::shard_parse::extract_file_recipes_from_reader_with_limits(
+                        &mut source,
+                        MAX_METADATA_SHARD_FILE_ENTRIES,
+                        MAX_METADATA_SHARD_CHUNK_ENTRIES,
+                    )
+                    .map(|recipes| (recipes, Vec::new()))
+                }
+                (false, true) => {
+                    crab_xet::shard_parse::extract_chunk_entries_from_reader_with_limit(
+                        &mut source,
+                        MAX_METADATA_SHARD_CHUNK_ENTRIES,
+                    )
+                    .map(|chunks| (Vec::new(), chunks))
+                }
+                (false, false) => Ok((Vec::new(), Vec::new())),
+            };
+            parsed.map_err(|error| CrabError::CorruptObject {
+                path: object_path,
+                reason: format!("failed to parse shard entries: {error}"),
+            })
+        })();
+        let _ = std::fs::remove_file(&local_path);
+        result
+    })
+    .await
+    .map_err(|error| CrabError::Internal(format!("shard scan worker failed: {error}")))?;
+    result
+}
+
+async fn run_rebuild(db: DbSelector, mode: OutputMode, cancel: &CancellationToken) -> Result<()> {
+    let (store, repo_prefix, bucket_identity, config) = resolve_repo_store(cancel).await?;
+    crate::replication::ensure_active_active_maintenance_admitted(
+        &config,
+        "metadata index rebuild",
+    )?;
+    let storage = crate::storage::Store::new(Arc::clone(&store))
+        .with_bucket_identity(bucket_identity.clone());
+    let lease = crate::maintenance::RepositoryMaintenanceLease::acquire(
+        &storage,
+        crab_storage::GLOBAL_PREFIX,
+        &repo_prefix,
+        cancel,
+    )
+    .await?;
+    let operation = run_rebuild_in(
+        store,
+        repo_prefix,
+        &bucket_identity,
+        db,
+        mode,
+        &config,
+        cancel,
+    )
+    .await;
+    let release = lease.release().await;
+    match (operation, release) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(release_error)) => {
+            warn!(error = %release_error, "metadb rebuild lease release also failed");
+            Err(error)
+        }
+    }
 }
 
 /// Core rebuild entry point parameterised on the object store and
@@ -1271,17 +1423,8 @@ async fn run_rebuild_in(
     db: DbSelector,
     mode: OutputMode,
     config: &Config,
+    cancel: &CancellationToken,
 ) -> Result<()> {
-    let storage = crate::storage::Store::new(Arc::clone(&store));
-    let router = crab_storage::StoreLayout::new(storage.clone(), repo_prefix.clone());
-    let cancel = CancellationToken::new();
-    let gc_writer = crate::maintenance::GcWriterLeases::acquire(
-        &storage,
-        router.global_prefix(),
-        router.repo_prefix(),
-        &cancel,
-    )
-    .await?;
     // Rebuild writes fresh entries into one or both databases — must
     // use read-write mode, which fences any concurrent writer on
     // purpose.
@@ -1294,17 +1437,9 @@ async fn run_rebuild_in(
     );
     let guard = MetaDbGuard::new(metadb);
     let emit_progress = !matches!(mode, OutputMode::Json);
-    let result = tokio::select! {
-        biased;
-        () = cancel.cancelled() => Err(CrabError::Cancelled),
-        result = rebuild_with_guard(&store, &repo_prefix, db, emit_progress, &guard) => result,
-    };
+    let result = rebuild_with_guard(&store, &repo_prefix, db, emit_progress, &guard, cancel).await;
     let result = close_rebuild_guard(guard, result).await;
-    let release = gc_writer.release().await;
-    let payload = match (result, release) {
-        (Ok(payload), Ok(())) => payload,
-        (Err(error), _) | (Ok(_), Err(error)) => return Err(error),
-    };
+    let payload = result?;
     render_rebuild_payload(&payload, mode);
     Ok(())
 }
@@ -1314,10 +1449,10 @@ async fn run_rebuild_in(
 pub(crate) async fn rebuild_file_index_for_current_repo_and_verify(
     entries: &[(MerkleHash, MerkleHash)],
 ) -> Result<Vec<bool>> {
-    let (store, repo_prefix, bucket_identity, config) = resolve_repo_store().await?;
+    let cancel = CancellationToken::new();
+    let (store, repo_prefix, bucket_identity, config) = resolve_repo_store(&cancel).await?;
     let storage = crate::storage::Store::new(Arc::clone(&store));
     let router = crab_storage::StoreLayout::new(storage.clone(), repo_prefix.clone());
-    let cancel = CancellationToken::new();
     let gc_writer = crate::maintenance::GcWriterLeases::acquire(
         &storage,
         router.global_prefix(),
@@ -1338,7 +1473,15 @@ pub(crate) async fn rebuild_file_index_for_current_repo_and_verify(
         biased;
         () = cancel.cancelled() => Err(CrabError::Cancelled),
         result = async {
-            rebuild_with_guard(&store, &repo_prefix, DbSelector::FileIndex, false, &guard).await?;
+            rebuild_with_guard(
+                &store,
+                &repo_prefix,
+                DbSelector::FileIndex,
+                false,
+                &guard,
+                &cancel,
+            )
+            .await?;
             let file_store = guard.file_index().await?;
             let file_hashes: Vec<MerkleHash> =
                 entries.iter().map(|(file_hash, _)| *file_hash).collect();
@@ -1374,6 +1517,245 @@ async fn close_rebuild_guard<T>(guard: MetaDbGuard, result: Result<T>) -> Result
     }
 }
 
+/// Counts for generation-pinned rows written before a candidate manifest is visible.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CandidateShardIndexPublication {
+    pub(crate) gc_registry_generation: u64,
+    pub(crate) file_entries_written: u64,
+    pub(crate) chunk_entries_written: u64,
+}
+
+/// Write the immutable receipt proving that a manifest's derived indexes are complete.
+pub(crate) async fn write_generation_index_receipt(
+    store: &crate::storage::store::Store,
+    router: &crate::storage::StoreLayout,
+    manifest: &crab_metadata::manifests::Manifest,
+) -> Result<()> {
+    let parse_hash = |value: &str, label: &str| -> Result<MerkleHash> {
+        if value.is_empty() {
+            return Ok(MerkleHash::default());
+        }
+        MerkleHash::from_hex(value)
+            .map_err(|error| CrabError::Internal(format!("{label} hash invalid: {error}")))
+    };
+    let shard_index_hash = parse_hash(&manifest.shard_index_hash, "manifest shard-index")?;
+    let pack_index_hash = parse_hash(&manifest.pack_index_hash, "manifest pack-index")?;
+    let receipt = crab_metadata::receipts::GenerationIndexReceipt {
+        schema_version: crab_metadata::receipts::RECEIPT_SCHEMA_VERSION,
+        generation: manifest.generation,
+        shard_index_hash: shard_index_hash.into(),
+        pack_index_hash: pack_index_hash.into(),
+        file_index_digest: crab_metadata::receipts::generation_file_index_digest(
+            shard_index_hash.into(),
+        ),
+        git_object_locator_digest: crab_metadata::receipts::generation_git_object_locator_digest(
+            pack_index_hash.into(),
+        ),
+    };
+    receipt
+        .validate(
+            manifest.generation,
+            shard_index_hash.into(),
+            pack_index_hash.into(),
+        )
+        .map_err(CrabError::from)?;
+    let path = router.repo_path(&format!(
+        "metadata/generation-receipts/{:020}.json",
+        manifest.generation
+    ));
+    let body = serde_json::to_vec(&receipt)
+        .map_err(|error| CrabError::Internal(format!("receipt serialize: {error}")))?;
+    match store.put(&path, Bytes::from(body)).await {
+        Ok(()) => Ok(()),
+        Err(CrabError::CasConflict { .. }) => {
+            let (existing, _) = store
+                .get_with_etag_bounded(&path, MAX_METADATA_CONTROL_BYTES)
+                .await?;
+            let existing: crab_metadata::receipts::GenerationIndexReceipt =
+                serde_json::from_slice(&existing).map_err(|error| CrabError::CorruptObject {
+                    path: path.to_string(),
+                    reason: format!("generation-index receipt decode failed: {error}"),
+                })?;
+            existing
+                .validate(
+                    manifest.generation,
+                    shard_index_hash.into(),
+                    pack_index_hash.into(),
+                )
+                .map_err(CrabError::from)?;
+            if existing != receipt {
+                return Err(CrabError::CorruptObject {
+                    path: path.to_string(),
+                    reason: "generation-index receipt conflicts with the committed index digest"
+                        .to_owned(),
+                });
+            }
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Publish generation-bound file/chunk rows before exposing a candidate shard set.
+pub(crate) async fn publish_candidate_shard_indexes(
+    store: &crate::storage::store::Store,
+    repo_prefix: &str,
+    candidate: &crab_metadata::manifests::Manifest,
+    shard_hashes: &[String],
+    config: &Config,
+    cancel: &CancellationToken,
+) -> Result<CandidateShardIndexPublication> {
+    if candidate.generation == 0 || candidate.shard_index_hash.is_empty() {
+        return Err(CrabError::Internal(
+            "candidate shard indexes require a non-zero manifest anchor".to_owned(),
+        ));
+    }
+    let metadb = build_metadb(
+        Arc::clone(store.inner()),
+        repo_prefix.to_owned(),
+        &store.bucket_identity(),
+        false,
+        config,
+    );
+    let guard = MetaDbGuard::new(metadb);
+    let result = publish_candidate_shard_indexes_with_guard(
+        store,
+        repo_prefix,
+        candidate,
+        shard_hashes,
+        &guard,
+        cancel,
+    )
+    .await;
+    close_rebuild_guard(guard, result).await
+}
+
+async fn publish_candidate_shard_indexes_with_guard(
+    store: &crate::storage::store::Store,
+    repo_prefix: &str,
+    candidate: &crab_metadata::manifests::Manifest,
+    shard_hashes: &[String],
+    guard: &MetaDbGuard,
+    cancel: &CancellationToken,
+) -> Result<CandidateShardIndexPublication> {
+    check_cancelled(cancel)?;
+    let storage = store.as_storage();
+    let router = crab_storage::StoreLayout::new(storage.clone(), repo_prefix.to_owned());
+    let shard_index_hash = MerkleHash::from_hex(&candidate.shard_index_hash).map_err(|error| {
+        CrabError::Internal(format!("candidate shard-index hash invalid: {error}"))
+    })?;
+    let gc_registry_generation = crab_metadata::ref_registry::union_register_repo_shards(
+        storage,
+        &router,
+        shard_hashes.to_vec(),
+    )
+    .await?;
+    check_cancelled(cancel)?;
+    let file_store = guard.file_index().await?;
+    let chunk_store = guard.chunk_index().await?;
+    let mut pending_file = Vec::new();
+    let mut pending_chunk = Vec::new();
+    let mut pending_committed_chunk = Vec::new();
+    let mut file_entries_written = 0_u64;
+    let mut chunk_entries_written = 0_u64;
+    let mut verified_xorbs = HashMap::new();
+    let workspace = create_shard_scan_workspace()?;
+
+    for shard_hash_hex in shard_hashes {
+        check_cancelled(cancel)?;
+        let shard_hash =
+            MerkleHash::from_hex(shard_hash_hex).map_err(|error| CrabError::CorruptObject {
+                path: router.shard_path(shard_hash_hex).to_string(),
+                reason: format!("candidate shard hash is invalid: {error}"),
+            })?;
+        let shard_path = router.shard_path(shard_hash_hex);
+        let (recipes, chunk_entries) = download_and_parse_shard(
+            storage,
+            &shard_path,
+            shard_hash,
+            workspace.path(),
+            true,
+            true,
+            cancel,
+        )
+        .await?;
+        let committed_chunk_entries = rebuild_committed_chunk_receipts(
+            storage,
+            &router,
+            repo_prefix,
+            shard_hash,
+            candidate.generation,
+            shard_index_hash,
+            gc_registry_generation,
+            cancel,
+            &chunk_entries,
+            &mut verified_xorbs,
+        )
+        .await?;
+
+        for recipe in recipes {
+            let file_size = recipe.chunks.iter().try_fold(0_u64, |total, (_, size)| {
+                total.checked_add(*size).ok_or_else(|| {
+                    CrabError::StagingCorrupt("candidate recipe size overflow".to_owned())
+                })
+            })?;
+            let recipe_hash = FileRecipe::from_staged_chunks(
+                ChunkingPolicyId::XetGearV1_64KiB,
+                recipe.file_hash,
+                file_size,
+                &recipe.chunks,
+            )?
+            .hash();
+            pending_file.push((
+                recipe.file_hash,
+                crab_metadata::value_codec::CommittedFileRecord {
+                    recipe_hash,
+                    shard_hash,
+                    committed_generation: candidate.generation,
+                    shard_index_hash,
+                },
+            ));
+        }
+        pending_chunk.extend(chunk_entries);
+        pending_committed_chunk.extend(committed_chunk_entries);
+
+        if pending_file.len() >= REBUILD_COMMIT_BATCH || pending_chunk.len() >= REBUILD_COMMIT_BATCH
+        {
+            let (files, chunks) = flush_rebuild_batch(
+                guard,
+                Some(&file_store),
+                Some(&chunk_store),
+                &mut pending_file,
+                &mut pending_chunk,
+                &mut pending_committed_chunk,
+                cancel,
+            )
+            .await?;
+            file_entries_written = file_entries_written.saturating_add(files);
+            chunk_entries_written = chunk_entries_written.saturating_add(chunks);
+            verified_xorbs.clear();
+        }
+    }
+
+    let (files, chunks) = flush_rebuild_batch(
+        guard,
+        Some(&file_store),
+        Some(&chunk_store),
+        &mut pending_file,
+        &mut pending_chunk,
+        &mut pending_committed_chunk,
+        cancel,
+    )
+    .await?;
+    file_entries_written = file_entries_written.saturating_add(files);
+    chunk_entries_written = chunk_entries_written.saturating_add(chunks);
+    Ok(CandidateShardIndexPublication {
+        gc_registry_generation,
+        file_entries_written,
+        chunk_entries_written,
+    })
+}
+
 /// Inner rebuild driver. Kept separate so tests can feed a tempdir-
 /// anchored `MetaDb` in without going through the `build_metadb`
 /// cache-root plumbing.
@@ -1383,7 +1765,9 @@ async fn rebuild_with_guard(
     db: DbSelector,
     emit_progress: bool,
     guard: &MetaDbGuard,
+    cancel: &CancellationToken,
 ) -> Result<RebuildPayload> {
+    check_cancelled(cancel)?;
     let start = std::time::Instant::now();
     let storage = crab_storage::Store::new(Arc::clone(store));
     let router = crab_storage::StoreLayout::new(storage.clone(), repo_prefix.to_owned());
@@ -1391,10 +1775,11 @@ async fn rebuild_with_guard(
     let committed_shards = if manifest.shard_index_hash.is_empty() {
         Vec::new()
     } else {
-        crab_metadata::manifest_store::read_bulk_shard_list(
+        crab_metadata::manifest_store::read_bulk_shard_list_with_limit(
             &storage,
             &router,
             &manifest.shard_index_hash,
+            MAX_METADATA_SHARDS,
         )
         .await?
     };
@@ -1406,12 +1791,14 @@ async fn rebuild_with_guard(
         })?
     };
     let gc_registry_generation = if db.includes_chunk_index() && !committed_shards.is_empty() {
-        crab_metadata::ref_registry::union_register_repo_shards(
+        let generation = crab_metadata::ref_registry::union_register_repo_shards(
             &storage,
             &router,
             committed_shards.clone(),
         )
-        .await?
+        .await?;
+        check_cancelled(cancel)?;
+        generation
     } else {
         0
     };
@@ -1443,8 +1830,10 @@ async fn rebuild_with_guard(
         crab_metadata::receipts::CommittedChunkReceipt,
     )> = Vec::new();
     let mut verified_xorbs = HashMap::new();
+    let workspace = create_shard_scan_workspace()?;
 
     for shard_hash_hex in committed_shards {
+        check_cancelled(cancel)?;
         let Ok(shard_hash) = MerkleHash::from_hex(&shard_hash_hex) else {
             warn!(shard_hash = %shard_hash_hex, "skipping committed shard with invalid hash");
             shards_failed += 1;
@@ -1452,33 +1841,24 @@ async fn rebuild_with_guard(
         };
         let shard_path = router.shard_path(&shard_hash_hex);
 
-        let body = match storage.get_with_etag(&shard_path).await {
-            Ok((body, _)) => body,
-            Err(e) => {
-                warn!(shard = %shard_hash.hex(), error = %e, "failed to download shard during rebuild");
-                shards_failed += 1;
-                continue;
-            }
-        };
-        if crab_xet::hash::compute_data_hash(&body) != shard_hash {
-            warn!(shard = %shard_hash.hex(), "committed shard body hash mismatch during rebuild");
-            shards_failed += 1;
-            continue;
-        }
-
-        let recipes = match crab_xet::shard_parse::extract_file_recipes(&body) {
-            Ok(recipes) => recipes,
+        let (recipes, chunk_entries) = match download_and_parse_shard(
+            &storage,
+            &shard_path,
+            shard_hash,
+            workspace.path(),
+            db.includes_file_index(),
+            db.includes_chunk_index(),
+            cancel,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(CrabError::Cancelled) => return Err(CrabError::Cancelled),
             Err(error) => {
-                warn!(shard = %shard_hash.hex(), error = %error, "failed to reconstruct committed shard recipes");
+                warn!(shard = %shard_hash.hex(), error = %error, "failed to download or parse shard during rebuild");
                 shards_failed += 1;
                 continue;
             }
-        };
-
-        let chunk_entries = if db.includes_chunk_index() {
-            crab_xet::shard_parse::extract_chunk_entries_streaming(&body)
-        } else {
-            Vec::new()
         };
         let committed_chunk_entries = if chunk_entries.is_empty() {
             Vec::new()
@@ -1491,6 +1871,7 @@ async fn rebuild_with_guard(
                 manifest.generation,
                 shard_index_hash,
                 gc_registry_generation,
+                cancel,
                 &chunk_entries,
                 &mut verified_xorbs,
             )
@@ -1551,6 +1932,7 @@ async fn rebuild_with_guard(
                 &mut pending_file,
                 &mut pending_chunk,
                 &mut pending_committed_chunk,
+                cancel,
             )
             .await?;
             file_entries_written += fi;
@@ -1573,13 +1955,14 @@ async fn rebuild_with_guard(
         &mut pending_file,
         &mut pending_chunk,
         &mut pending_committed_chunk,
+        cancel,
     )
     .await?;
     file_entries_written += fi;
     chunk_entries_written += ci;
 
     let (legacy_file_rows_removed, legacy_chunk_rows_removed) = if shards_failed == 0 {
-        retire_legacy_namespaces(guard, file_store.as_ref(), chunk_store.as_ref()).await?
+        retire_legacy_namespaces(guard, file_store.as_ref(), chunk_store.as_ref(), cancel).await?
     } else {
         notes.push(
             "legacy namespaces retained because one or more committed shards failed proof"
@@ -2147,6 +2530,7 @@ async fn rebuild_committed_chunk_receipts(
     committed_generation: u64,
     shard_index_hash: MerkleHash,
     gc_registry_generation: u64,
+    cancel: &CancellationToken,
     entries: &[(MerkleHash, XorbRef)],
     verified_xorbs: &mut HashMap<MerkleHash, RebuildVerifiedXorb>,
 ) -> Result<Vec<(MerkleHash, crab_metadata::receipts::CommittedChunkReceipt)>> {
@@ -2157,9 +2541,13 @@ async fn rebuild_committed_chunk_receipts(
     }
     let mut receipts = Vec::with_capacity(entries.len());
     for (chunk_hash, xorb_ref) in entries {
+        check_cancelled(cancel)?;
         if !verified_xorbs.contains_key(&xorb_ref.xorb_hash) {
             let path = router.xorb_path(&xorb_ref.xorb_hash);
-            let (body, etag) = storage.get_with_etag(&path).await?;
+            let (body, etag) = tokio::select! {
+                result = storage.get_with_etag_bounded(&path, MAX_XORB_SIZE as u64) => result?,
+                () = cancel.cancelled() => return Err(CrabError::Cancelled),
+            };
             let parser = XorbParser::parse(body.clone())?;
             if parser.hash() != xorb_ref.xorb_hash {
                 return Err(CrabError::CorruptObject {
@@ -2239,7 +2627,9 @@ async fn flush_rebuild_batch(
     pending_file: &mut Vec<(MerkleHash, crab_metadata::value_codec::CommittedFileRecord)>,
     pending_chunk: &mut Vec<(MerkleHash, XorbRef)>,
     pending_committed_chunk: &mut Vec<(MerkleHash, crab_metadata::receipts::CommittedChunkReceipt)>,
+    cancel: &CancellationToken,
 ) -> Result<(u64, u64)> {
+    check_cancelled(cancel)?;
     if pending_file.is_empty() && pending_chunk.is_empty() && pending_committed_chunk.is_empty() {
         return Ok((0, 0));
     }
@@ -2277,10 +2667,12 @@ async fn retire_legacy_namespaces(
     guard: &MetaDbGuard,
     file_store: Option<&crate::metadata::FileIndexStore>,
     chunk_store: Option<&crate::metadata::ChunkIndexStore>,
+    cancel: &CancellationToken,
 ) -> Result<(u64, u64)> {
     let mut file_removed = 0u64;
     let mut chunk_removed = 0u64;
     loop {
+        check_cancelled(cancel)?;
         let file_keys = match file_store {
             Some(store) => store.legacy_keys_batch(REBUILD_COMMIT_BATCH).await?,
             None => Vec::new(),
@@ -2309,7 +2701,8 @@ async fn retire_legacy_namespaces(
 
 // --- compact --------------------------------------------------------
 
-async fn run_compact(_db: DbSelector) -> Result<()> {
+async fn run_compact(_db: DbSelector, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
     warn!(
         "crab metadb compact: SlateDB compaction runs automatically in the background; \
          this subcommand currently has no effect. It is provided so operator runbooks can \
@@ -2393,7 +2786,8 @@ fn cache_stats_for(path: &Path) -> Result<CacheStatsPayload> {
     })
 }
 
-fn run_cache_clear() -> Result<()> {
+fn run_cache_clear(cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
     let path = default_local_chunk_index_path()?;
     if !path.exists() {
         println!(
@@ -2419,57 +2813,59 @@ fn run_cache_clear() -> Result<()> {
 /// anything deeper (WAL replay, bloom validation) belongs to
 /// `crab metadb diagnose`.
 pub async fn run_doctor_metadb_in(root: &Path, mode: OutputMode) -> Result<()> {
-    let (store, repo_prefix, bucket_identity, config) = match resolve_repo_store_in(root).await {
-        Ok(v) => v,
-        Err(e) => {
-            // No remote configured — still emit something useful.
-            let empty = DoctorMetadbPayload {
-                repo_prefix: String::from("<unconfigured>"),
-                file_index: DbDiagnosis {
-                    label: "file_index_db",
-                    path: String::new(),
-                    opened: false,
-                    error: Some(e.to_string()),
-                    format_version: None,
-                    epoch: None,
-                    created_at: None,
-                    gc_generation: None,
-                    deep_integrity: None,
-                },
-                chunk_index: DbDiagnosis {
-                    label: "chunk_index_db",
-                    path: String::new(),
-                    opened: false,
-                    error: Some(String::from("skipped: no remote configured")),
-                    format_version: None,
-                    epoch: None,
-                    created_at: None,
-                    gc_generation: None,
-                    deep_integrity: None,
-                },
-                shards_prefix: String::from("<unknown>"),
-                shard_count: None,
-                shard_enumeration_error: None,
-                cache: cache_stats_for(&crate::cache::chunk_index_cache_path(
-                    &crate::cache::default_cache_root(),
-                    &crate::storage::store::BucketIdentity::local_unset(),
-                ))
-                .unwrap_or_else(|_| CacheStatsPayload {
-                    cache_path: String::new(),
-                    exists: false,
-                    file_size_bytes: 0,
-                    entry_count: 0,
-                    installed_shard_count: 0,
-                    cache_gc_generation: 0,
-                }),
-                acceleration: AccelerationHealth::unavailable(
-                    "remote is not configured; generation/index proof unavailable",
-                ),
-            };
-            render_doctor_metadb(&empty, mode);
-            return Ok(());
-        }
-    };
+    let cancel = CancellationToken::new();
+    let (store, repo_prefix, bucket_identity, config) =
+        match resolve_repo_store_in(root, &cancel).await {
+            Ok(v) => v,
+            Err(e) => {
+                // No remote configured — still emit something useful.
+                let empty = DoctorMetadbPayload {
+                    repo_prefix: String::from("<unconfigured>"),
+                    file_index: DbDiagnosis {
+                        label: "file_index_db",
+                        path: String::new(),
+                        opened: false,
+                        error: Some(e.to_string()),
+                        format_version: None,
+                        epoch: None,
+                        created_at: None,
+                        gc_generation: None,
+                        deep_integrity: None,
+                    },
+                    chunk_index: DbDiagnosis {
+                        label: "chunk_index_db",
+                        path: String::new(),
+                        opened: false,
+                        error: Some(String::from("skipped: no remote configured")),
+                        format_version: None,
+                        epoch: None,
+                        created_at: None,
+                        gc_generation: None,
+                        deep_integrity: None,
+                    },
+                    shards_prefix: String::from("<unknown>"),
+                    shard_count: None,
+                    shard_enumeration_error: None,
+                    cache: cache_stats_for(&crate::cache::chunk_index_cache_path(
+                        &crate::cache::default_cache_root(),
+                        &crate::storage::store::BucketIdentity::local_unset(),
+                    ))
+                    .unwrap_or_else(|_| CacheStatsPayload {
+                        cache_path: String::new(),
+                        exists: false,
+                        file_size_bytes: 0,
+                        entry_count: 0,
+                        installed_shard_count: 0,
+                        cache_gc_generation: 0,
+                    }),
+                    acceleration: AccelerationHealth::unavailable(
+                        "remote is not configured; generation/index proof unavailable",
+                    ),
+                };
+                render_doctor_metadb(&empty, mode);
+                return Ok(());
+            }
+        };
 
     let metadb = build_metadb(
         Arc::clone(&store),
@@ -3267,9 +3663,17 @@ mod tests {
         );
         guard.commit(legacy_txn).await.expect("seed legacy rows");
 
-        let payload = rebuild_with_guard(&store, "org/test-repo", DbSelector::Both, true, &guard)
-            .await
-            .expect("rebuild");
+        let cancel = CancellationToken::new();
+        let payload = rebuild_with_guard(
+            &store,
+            "org/test-repo",
+            DbSelector::Both,
+            true,
+            &guard,
+            &cancel,
+        )
+        .await
+        .expect("rebuild");
         assert_eq!(payload.legacy_file_rows_removed, 1);
         assert_eq!(payload.legacy_chunk_rows_removed, 1);
 
@@ -3367,10 +3771,18 @@ mod tests {
         let (metadb, _cache_dir) = test_metadb(Arc::clone(&store));
         let guard = MetaDbGuard::new(metadb);
 
+        let cancel = CancellationToken::new();
         for _ in 0..2 {
-            rebuild_with_guard(&store, "org/test-repo", DbSelector::Both, true, &guard)
-                .await
-                .expect("rebuild");
+            rebuild_with_guard(
+                &store,
+                "org/test-repo",
+                DbSelector::Both,
+                true,
+                &guard,
+                &cancel,
+            )
+            .await
+            .expect("rebuild");
         }
 
         // After two passes, every file and chunk key must still

--- a/crab/src/cmd/optimize.rs
+++ b/crab/src/cmd/optimize.rs
@@ -2,9 +2,11 @@
 
 pub mod xorbs;
 
+use std::fs::{File, OpenOptions};
 use std::process::Stdio;
 
 use clap::Parser;
+use fs4::fs_std::FileExt as LockFileExt;
 use schemars::JsonSchema;
 use serde::Serialize;
 use tokio::io::AsyncRead;
@@ -18,6 +20,18 @@ use tokio_util::sync::CancellationToken;
 pub const OPTIMIZE_PLAN_SCHEMA: &str = "optimize.plan";
 pub const OPTIMIZE_APPLY_SCHEMA: &str = "optimize.apply";
 pub const OPTIMIZE_SCHEMA_VERSION: &str = "1.0";
+const OPTIMIZE_APPLY_LOCK: &str = "optimize-apply.lock";
+const MAX_CHILD_OUTPUT_BYTES: usize = 64 * 1024;
+const GIT_ENV_OVERRIDES: [&str; 8] = [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_QUARANTINE_PATH",
+    "GIT_NAMESPACE",
+];
 
 /// Arguments for `crab optimize plan`.
 #[derive(Debug, Clone, Parser)]
@@ -171,25 +185,109 @@ pub struct OptimizePayload {
 }
 
 /// Build and render `crab optimize plan`.
-pub fn run_plan(args: &OptimizePlanArgs, config: &Config, mode: OutputMode) -> OptimizePayload {
+pub fn run_plan(
+    args: &OptimizePlanArgs,
+    config: &Config,
+    mode: OutputMode,
+) -> Result<OptimizePayload> {
+    validate_inputs(args, config)?;
     let payload = build_payload(args, config, OptimizeWorkflowMode::Plan);
     render_payload(&payload, mode, OPTIMIZE_PLAN_SCHEMA);
-    payload
+    Ok(payload)
 }
 
 /// Build an apply payload with planned steps.
-#[must_use]
-pub fn build_apply_payload(args: &OptimizeApplyArgs, config: &Config) -> OptimizePayload {
-    build_payload(
-        &OptimizePlanArgs::from(args),
+pub fn build_apply_payload(args: &OptimizeApplyArgs, config: &Config) -> Result<OptimizePayload> {
+    let plan_args = OptimizePlanArgs::from(args);
+    validate_inputs(&plan_args, config)?;
+    Ok(build_payload(
+        &plan_args,
         config,
         OptimizeWorkflowMode::Apply,
-    )
+    ))
+}
+
+fn validate_inputs(args: &OptimizePlanArgs, config: &Config) -> Result<()> {
+    if !(1..=crate::cost::inventory::live::MAX_LIST_CONCURRENCY)
+        .contains(&config.cost.list_concurrency)
+    {
+        return Err(CrabError::Configuration {
+            key: format!("cost.list_concurrency={}", config.cost.list_concurrency),
+            origin: format!(
+                "expected a value from 1 through {}",
+                crate::cost::inventory::live::MAX_LIST_CONCURRENCY
+            ),
+        });
+    }
+    if let Some(top_k) = args.top_k
+        && top_k > crate::cost::inventory::live::MAX_TOP_K_COLD
+    {
+        return Err(CrabError::Configuration {
+            key: format!("--top-k={top_k}"),
+            origin: format!(
+                "expected a value from 0 through {}",
+                crate::cost::inventory::live::MAX_TOP_K_COLD
+            ),
+        });
+    }
+    if let Some(source) = args.inventory_source.as_deref() {
+        if !matches!(source, "auto" | "live") {
+            return Err(CrabError::Configuration {
+                key: "--inventory-source".to_owned(),
+                origin: format!("expected auto or live, got {source}"),
+            });
+        }
+    }
+    if let Some(ratio) = args.sample
+        && (!ratio.is_finite() || ratio <= 0.0 || ratio > 1.0)
+    {
+        return Err(CrabError::Configuration {
+            key: "--sample".to_owned(),
+            origin: format!("expected a finite ratio greater than 0 and at most 1, got {ratio}"),
+        });
+    }
+    if args.profile.is_some() && !args.include_xorbs {
+        return Err(CrabError::Configuration {
+            key: "--profile".to_owned(),
+            origin: "--profile requires --include-xorbs".to_owned(),
+        });
+    }
+    if let Some(profile) = args.profile.as_deref() {
+        crate::optimize::xorbs::profile::Profile::from_name(profile, &config.optimize.xorbs)?;
+    }
+    Ok(())
 }
 
 /// Render the final apply payload.
 pub fn render_apply(payload: &OptimizePayload, mode: OutputMode) {
     render_payload(payload, mode, OPTIMIZE_APPLY_SCHEMA);
+}
+
+/// Hold a repository-wide optimizer lock for the full apply workflow.
+pub fn acquire_apply_lock() -> Result<File> {
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
+    acquire_apply_lock_in(&worktree.shared_crab_dir)
+}
+
+fn acquire_apply_lock_in(shared_crab_dir: &std::path::Path) -> Result<File> {
+    let maintenance_dir = shared_crab_dir.join("maintenance");
+    std::fs::create_dir_all(&maintenance_dir).map_err(CrabError::Io)?;
+    let lock_path = maintenance_dir.join(OPTIMIZE_APPLY_LOCK);
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(CrabError::Io)?;
+    if !LockFileExt::try_lock_exclusive(&lock).map_err(CrabError::Io)? {
+        return Err(CrabError::Configuration {
+            key: "crab optimize apply".to_owned(),
+            origin: format!("another optimizer apply holds {}", lock_path.display()),
+        });
+    }
+    Ok(lock)
 }
 
 /// Execute a child `crab` command as one optimizer step.
@@ -204,9 +302,13 @@ pub async fn run_child_step(
     }
 
     step.status = OptimizeStepStatus::Running;
+    let mutates = step.mutates;
     let bin = crate::cmd::init::crab_binary_path();
     let mut command = Command::new(&bin);
     command.args(args);
+    for variable in GIT_ENV_OVERRIDES {
+        command.env_remove(variable);
+    }
     if mode.is_machine() {
         let mut child = command
             .stdout(Stdio::piped())
@@ -215,17 +317,27 @@ pub async fn run_child_step(
             .map_err(CrabError::Io)?;
         let stdout_task = tokio::spawn(read_child_pipe(child.stdout.take()));
         let stderr_task = tokio::spawn(read_child_pipe(child.stderr.take()));
-        let status = tokio::select! {
-            result = child.wait() => result.map_err(CrabError::Io)?,
-            () = cancel.cancelled() => {
-                let _ = child.kill().await;
-                let _ = child.wait().await;
-                stdout_task.abort();
-                stderr_task.abort();
-                step.status = OptimizeStepStatus::Failed;
-                "cancelled".clone_into(&mut step.detail);
-                return Err(CrabError::Cancelled);
+        let (status, cancelled_after_start) = if mutates {
+            tokio::select! {
+                result = child.wait() => (result.map_err(CrabError::Io)?, false),
+                () = cancel.cancelled() => (child.wait().await.map_err(CrabError::Io)?, true),
             }
+        } else {
+            (
+                tokio::select! {
+                    result = child.wait() => result.map_err(CrabError::Io)?,
+                    () = cancel.cancelled() => {
+                        let _ = child.kill().await;
+                        let _ = child.wait().await;
+                        stdout_task.abort();
+                        stderr_task.abort();
+                        step.status = OptimizeStepStatus::Failed;
+                        "cancelled".clone_into(&mut step.detail);
+                        return Err(CrabError::Cancelled);
+                    }
+                },
+                false,
+            )
         };
         let stdout = stdout_task.await.map_err(|error| {
             CrabError::Internal(format!("stdout capture task failed: {error}"))
@@ -238,6 +350,14 @@ pub async fn run_child_step(
         } else {
             bounded_child_output(&stderr).or_else(|| bounded_child_output(&stdout))
         };
+        if cancelled_after_start {
+            step.status = OptimizeStepStatus::Failed;
+            step.detail = match diagnostic.as_deref() {
+                Some(diagnostic) => format!("cancelled after mutation completed: {diagnostic}"),
+                None => "cancelled after mutation completed".to_owned(),
+            };
+            return Err(CrabError::Cancelled);
+        }
         return finish_child_step(step, status, diagnostic.as_deref());
     }
 
@@ -246,16 +366,31 @@ pub async fn run_child_step(
         .stderr(Stdio::inherit())
         .spawn()
         .map_err(CrabError::Io)?;
-    let status = tokio::select! {
-        result = child.wait() => result.map_err(CrabError::Io)?,
-        () = cancel.cancelled() => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            step.status = OptimizeStepStatus::Failed;
-            "cancelled".clone_into(&mut step.detail);
-            return Err(CrabError::Cancelled);
+    let (status, cancelled_after_start) = if mutates {
+        tokio::select! {
+            result = child.wait() => (result.map_err(CrabError::Io)?, false),
+            () = cancel.cancelled() => (child.wait().await.map_err(CrabError::Io)?, true),
         }
+    } else {
+        (
+            tokio::select! {
+                result = child.wait() => result.map_err(CrabError::Io)?,
+                () = cancel.cancelled() => {
+                    let _ = child.kill().await;
+                    let _ = child.wait().await;
+                    step.status = OptimizeStepStatus::Failed;
+                    "cancelled".clone_into(&mut step.detail);
+                    return Err(CrabError::Cancelled);
+                }
+            },
+            false,
+        )
     };
+    if cancelled_after_start {
+        step.status = OptimizeStepStatus::Failed;
+        step.detail = "cancelled after mutation completed".to_owned();
+        return Err(CrabError::Cancelled);
+    }
     finish_child_step(step, status, None)
 }
 
@@ -266,8 +401,19 @@ where
     let Some(mut reader) = reader else {
         return Ok(Vec::new());
     };
-    let mut output = Vec::new();
-    tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut output).await?;
+    let mut output = Vec::with_capacity(MAX_CHILD_OUTPUT_BYTES);
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = tokio::io::AsyncReadExt::read(&mut reader, &mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        output.extend_from_slice(&buffer[..read]);
+        if output.len() > MAX_CHILD_OUTPUT_BYTES {
+            let excess = output.len() - MAX_CHILD_OUTPUT_BYTES;
+            output.drain(..excess);
+        }
+    }
     Ok(output)
 }
 

--- a/crab/src/cmd/optimize/xorbs.rs
+++ b/crab/src/cmd/optimize/xorbs.rs
@@ -147,6 +147,8 @@ pub struct OptimizeXorbsSummary {
     pub elapsed_ms: u64,
     /// List of corrupt source xorb hashes.
     pub corrupt_list: Vec<String>,
+    /// Number of corrupt source hashes omitted from the bounded report.
+    pub corrupt_list_omitted: u64,
 }
 
 /// Per-status counts in the summary.
@@ -564,8 +566,15 @@ async fn run_apply(
     .await?;
 
     // Reconcile.
-    let reconcile_outcome =
-        reconcile::finalize(&journal, &run_id, Some(&store), Some(&router), cancel).await?;
+    let reconcile_outcome = reconcile::finalize(
+        &journal,
+        &run_id,
+        Some(&store),
+        Some(&router),
+        cfg,
+        cancel,
+    )
+    .await?;
 
     let counts = journal.count_by_status(&run_id)?;
     if counts.pending > 0 || counts.staged > 0 {
@@ -610,6 +619,7 @@ async fn run_apply(
         bytes_written: outcome.bytes_written,
         elapsed_ms: elapsed.as_millis() as u64,
         corrupt_list: outcome.corrupt_list.clone(),
+        corrupt_list_omitted: outcome.corrupt_list_omitted,
     };
 
     match output_mode {

--- a/crab/src/cmd/prune.rs
+++ b/crab/src/cmd/prune.rs
@@ -6,10 +6,15 @@
 use std::io::Stdout;
 
 use serde::Serialize;
+use tokio::pin;
+use tokio_util::sync::CancellationToken;
 
-use crate::cache::{LocalCache, PruneOptions, PruneStats};
+use crate::cache::{
+    LocalCache, PruneObjectKind, PruneOptions, PruneStats, PrunedCacheObject,
+    prune_xet_chunk_cache_with_cancel,
+};
 use crate::core::config::Config;
-use crate::core::error::Result;
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::event_payloads::FileDonePayload;
 use crate::core::output::{JsonlStream, OutputMode};
 
@@ -45,15 +50,57 @@ pub async fn run_prune(
     args: &PruneArgs,
     jsonl_stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>,
 ) -> Result<PruneSummary> {
+    run_prune_with_cancel(args, jsonl_stream, &CancellationToken::new()).await
+}
+
+/// Run cache pruning while honoring cancellation during both cache families.
+pub async fn run_prune_with_cancel(
+    args: &PruneArgs,
+    jsonl_stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>,
+    cancel: &CancellationToken,
+) -> Result<PruneSummary> {
+    check_cancelled(cancel)?;
     let config = Config::resolve_local()?;
     let cache = LocalCache::with_limits(
         crate::cache::default_cache_root(),
         config.chunk_cache_bytes,
         config.shard_cache_bytes,
     );
-    run_prune_with_cache(&cache, args, jsonl_stream).await
+    let local_prune = cache.prune_with_options(PruneOptions {
+        dry_run: args.dry_run,
+        record_entries: args.verbose || args.mode == OutputMode::Jsonl,
+    });
+    pin!(local_prune);
+    let mut stats = tokio::select! {
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        result = &mut local_prune => result?,
+    };
+    check_cancelled(cancel)?;
+    let xet = prune_xet_chunk_cache_with_cancel(
+        &config.effective_chunk_cache_dir(),
+        config.chunk_cache_bytes,
+        args.dry_run,
+        args.verbose || args.mode == OutputMode::Jsonl,
+        cancel,
+    )
+    .await?;
+    check_cancelled(cancel)?;
+    stats.chunks_evicted = stats.chunks_evicted.saturating_add(xet.entries_evicted);
+    stats.bytes_freed = stats.bytes_freed.saturating_add(xet.bytes_freed);
+    stats.entries.extend(
+        xet.entries
+            .into_iter()
+            .map(|(path, bytes)| PrunedCacheObject {
+                kind: PruneObjectKind::Chunk,
+                bytes,
+                path,
+            }),
+    );
+    check_cancelled(cancel)?;
+    finish_prune(&stats, args, jsonl_stream)
 }
 
+#[cfg(test)]
 async fn run_prune_with_cache(
     cache: &LocalCache,
     args: &PruneArgs,
@@ -65,7 +112,15 @@ async fn run_prune_with_cache(
             record_entries: args.verbose || args.mode == OutputMode::Jsonl,
         })
         .await?;
-    emit_pruned_entries(&stats, args, jsonl_stream);
+    finish_prune(&stats, args, jsonl_stream)
+}
+
+fn finish_prune(
+    stats: &PruneStats,
+    args: &PruneArgs,
+    jsonl_stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>,
+) -> Result<PruneSummary> {
+    emit_pruned_entries(stats, args, jsonl_stream);
     let summary = PruneSummary::from_stats(&stats, args.dry_run);
     emit_text_summary(&summary, args);
     Ok(summary)
@@ -161,6 +216,22 @@ mod tests {
         assert_eq!(summary.objects_pruned, 0);
         assert_eq!(summary.bytes_freed, 0);
         assert!(summary.dry_run);
+    }
+
+    #[tokio::test]
+    async fn prune_honors_cancellation_before_cache_resolution() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let args = PruneArgs {
+            dry_run: true,
+            verbose: false,
+            mode: OutputMode::Text,
+        };
+
+        let error = run_prune_with_cancel(&args, None, &cancel)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, CrabError::Cancelled));
     }
 
     #[tokio::test]

--- a/crab/src/cmd/repack.rs
+++ b/crab/src/cmd/repack.rs
@@ -127,7 +127,7 @@ pub async fn run_repack(
     let lock = match PushLock::acquire_internal(
         store.inner(),
         router.repo_prefix(),
-        crab_coordination::REPACK_RESOURCE,
+        crab_coordination::REPOSITORY_MAINTENANCE_RESOURCE,
         config.lock_ttl,
     )
     .await

--- a/crab/src/cmd/repack.rs
+++ b/crab/src/cmd/repack.rs
@@ -1,6 +1,6 @@
 //! File-backed consolidation of the Git packs selected by a repository manifest.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs::File;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -18,7 +18,7 @@ use crate::git::push::{
     CommittedManifestAnchor, CommittedPackIndex, publish_committed_pack_locators,
 };
 use crate::metadata::manifest::{
-    BulkData, Manifest, PackManifestEntry, compact_pack_index, read_bulk_pack_list, read_manifest,
+    BulkData, Manifest, PackManifestEntry, compact_pack_index, read_manifest,
     upload_segmented_bulk, write_manifest_cas,
 };
 use crate::storage::StoreLayout;
@@ -29,6 +29,10 @@ use crab_storage::{repo_pack_index_path, repo_pack_path, repo_pack_reverse_index
 use crab_xet::hash::MerkleHash;
 
 const MULTIPART_PART_SIZE: usize = 8 * 1024 * 1024;
+const REPACK_DISK_RESERVE: u64 = 1024 * 1024 * 1024;
+const MAX_PACKS_PER_OPERATION: u64 = 1_000_000;
+const MAX_REPACK_DOWNLOAD_CONCURRENCY: usize = 16;
+const MAX_PACK_INDEX_BYTES: u64 = 512 * 1024 * 1024;
 /// Configuration for the repack operation.
 #[derive(Debug, Clone)]
 pub struct RepackConfig {
@@ -40,6 +44,8 @@ pub struct RepackConfig {
     pub download_concurrency: usize,
     /// Maximum CAS retries while repairing pack metadata sidecars.
     pub max_cas_retries: u32,
+    /// Parent directory for bounded, automatically removed repack files.
+    pub workspace_root: std::path::PathBuf,
 }
 
 impl Default for RepackConfig {
@@ -49,6 +55,7 @@ impl Default for RepackConfig {
             dry_run: false,
             download_concurrency: 8,
             max_cas_retries: 64,
+            workspace_root: crate::cache::default_cache_root().join("maintenance"),
         }
     }
 }
@@ -111,6 +118,15 @@ pub async fn run_repack(
     let start = Instant::now();
     check_cancelled(cancel)?;
     let router = StoreLayout::new(store.clone(), prefix.to_owned());
+    if config.download_concurrency == 0 {
+        return Err(CrabError::Configuration {
+            key: "download_concurrency".to_owned(),
+            origin: "must be greater than zero".to_owned(),
+        });
+    }
+    let download_concurrency = config
+        .download_concurrency
+        .min(MAX_REPACK_DOWNLOAD_CONCURRENCY);
     let gc_writer = if config.dry_run {
         None
     } else {
@@ -149,7 +165,15 @@ pub async fn run_repack(
         lock.ttl() / 3,
         operation_cancel.clone(),
     );
-    let result = run_repack_locked(store, &router, config, &operation_cancel, start).await;
+    let result = run_repack_locked(
+        store,
+        &router,
+        config,
+        download_concurrency,
+        &operation_cancel,
+        start,
+    )
+    .await;
     heartbeat.stop().await;
     let release_result = lock.release().await.map_err(CrabError::from);
     let gc_release_result = match gc_writer {
@@ -166,13 +190,27 @@ async fn run_repack_locked(
     store: &Store,
     router: &StoreLayout,
     config: &RepackConfig,
+    download_concurrency: usize,
     cancel: &CancellationToken,
     start: Instant,
 ) -> Result<RepackOutcome> {
     let (manifest, manifest_etag) = read_manifest(store, router).await?;
-    let packs = read_bulk_pack_list(store, router, &manifest.pack_index_hash).await?;
+    let packs = tokio::select! {
+        result = crate::metadata::manifest::read_bulk_pack_list_with_limit(
+            store,
+            router,
+            &manifest.pack_index_hash,
+            MAX_PACKS_PER_OPERATION,
+        ) => result?,
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+    };
+    validate_pack_inventory(router, &packs)?;
     let packs_before = packs.len();
-    let bytes_before = packs.iter().map(|pack| pack.size).sum();
+    let bytes_before = packs.iter().try_fold(0u64, |total, pack| {
+        total
+            .checked_add(pack.size)
+            .ok_or_else(|| CrabError::Internal("pack inventory byte total overflow".to_owned()))
+    })?;
     if packs_before <= 1 {
         return Ok(outcome(
             packs_before,
@@ -193,7 +231,29 @@ async fn run_repack_locked(
     }
     let visibility = read_current_visibility(store, router, &manifest).await?;
 
-    let temp = tempfile::tempdir()?;
+    std::fs::create_dir_all(&config.workspace_root).map_err(CrabError::Io)?;
+    let required_space = bytes_before
+        .checked_mul(2)
+        .and_then(|bytes| bytes.checked_add(REPACK_DISK_RESERVE))
+        .ok_or_else(|| CrabError::Internal("repack workspace size overflow".to_owned()))?;
+    let available = crate::workflow::cache::available_disk_space(&config.workspace_root)
+        .ok_or_else(|| CrabError::Configuration {
+            key: "repack workspace capacity".to_owned(),
+            origin: format!(
+                "cannot determine free disk space for {}; refusing a large-repository mutation",
+                config.workspace_root.display()
+            ),
+        })?;
+    if available < required_space {
+        return Err(CrabError::InsufficientSpace {
+            needed: required_space,
+            available,
+        });
+    }
+    let temp = tempfile::Builder::new()
+        .prefix("crab-repack-")
+        .tempdir_in(&config.workspace_root)
+        .map_err(CrabError::Io)?;
     let download_dir = temp.path().join("downloads");
     std::fs::create_dir_all(&download_dir)?;
     download_source_packs(
@@ -201,7 +261,7 @@ async fn run_repack_locked(
         router,
         &packs,
         &download_dir,
-        config.download_concurrency,
+        download_concurrency,
         cancel,
     )
     .await?;
@@ -456,16 +516,34 @@ async fn download_source_packs(
 ) -> Result<()> {
     let results = futures_util::stream::iter(packs.iter().cloned().map(|pack| {
         let store = store.clone();
+        let cancel = cancel.clone();
         let pack_path = repo_pack_path(router.repo_prefix(), &pack.pack_id);
         let index_path = repo_pack_index_path(router.repo_prefix(), &pack.pack_id);
         let local_pack = pack_dir.join(format!("pack-{}.pack", pack.pack_id));
         let local_index = pack_dir.join(format!("pack-{}.idx", pack.pack_id));
         let local_reverse_index = pack_dir.join(format!("pack-{}.rev", pack.pack_id));
         async move {
-            let (pack_size, _) = tokio::try_join!(
-                store.download_to_path(&pack_path, &local_pack),
-                store.download_to_path(&index_path, &local_index)
-            )?;
+            if cancel.is_cancelled() {
+                return Err(CrabError::Cancelled);
+            }
+            if pack.size > MAX_PACK_INDEX_BYTES {
+                return Err(CrabError::Configuration {
+                    key: "repack pack size".to_owned(),
+                    origin: format!(
+                        "pack {} is {} bytes; bounded repack supports at most {MAX_PACK_INDEX_BYTES}",
+                        pack.pack_id, pack.size
+                    ),
+                });
+            }
+            let (pack_size, _) = tokio::select! {
+                result = async {
+                    tokio::try_join!(
+                        store.download_to_path_bounded(&pack_path, &local_pack, MAX_PACK_INDEX_BYTES),
+                        store.download_to_path_bounded(&index_path, &local_index, MAX_PACK_INDEX_BYTES)
+                    )
+                } => result?,
+                () = cancel.cancelled() => return Err(CrabError::Cancelled),
+            };
             if pack_size != pack.size {
                 return Err(CrabError::CorruptObject {
                     path: pack_path.as_ref().to_owned(),
@@ -521,6 +599,31 @@ async fn download_source_packs(
     Ok(())
 }
 
+fn validate_pack_inventory(router: &StoreLayout, packs: &[PackManifestEntry]) -> Result<()> {
+    let mut ids = HashSet::with_capacity(packs.len());
+    for pack in packs {
+        if pack.pack_id.is_empty() || !ids.insert(pack.pack_id.clone()) {
+            return Err(CrabError::CorruptObject {
+                path: router.manifest_path().to_string(),
+                reason: format!(
+                    "pack inventory contains duplicate or empty id {}",
+                    pack.pack_id
+                ),
+            });
+        }
+        if pack.size == 0 || pack.size > MAX_PACK_INDEX_BYTES {
+            return Err(CrabError::Configuration {
+                key: "repack pack size".to_owned(),
+                origin: format!(
+                    "pack {} has invalid size {}; expected 1..={MAX_PACK_INDEX_BYTES}",
+                    pack.pack_id, pack.size
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn run_git(command: &mut Command, operation: &str) -> Result<()> {
     debug!(operation, command = ?command, "running git repack subprocess");
     let status = command.status()?;
@@ -546,9 +649,10 @@ async fn upload_generated_pack(
     generated: &crab_git::repack::GeometricRepackedPack,
     cancel: &CancellationToken,
 ) -> Result<()> {
+    let pack_path = repo_pack_path(router.repo_prefix(), &generated.pack_id);
     store
         .put_multipart_file_retry(
-            &repo_pack_path(router.repo_prefix(), &generated.pack_id),
+            &pack_path,
             generated.pack_path(),
             generated.pack_size,
             generated.pack_hash,
@@ -557,9 +661,19 @@ async fn upload_generated_pack(
             None,
         )
         .await?;
+    verify_remote_file(
+        store,
+        &pack_path,
+        generated.pack_size,
+        generated.pack_hash,
+        cancel,
+    )
+    .await?;
+
+    let index_path = repo_pack_index_path(router.repo_prefix(), &generated.pack_id);
     store
         .put_multipart_file_retry(
-            &repo_pack_index_path(router.repo_prefix(), &generated.pack_id),
+            &index_path,
             generated.index_path(),
             generated.index_size,
             generated.index_hash,
@@ -568,9 +682,19 @@ async fn upload_generated_pack(
             None,
         )
         .await?;
+    verify_remote_file(
+        store,
+        &index_path,
+        generated.index_size,
+        generated.index_hash,
+        cancel,
+    )
+    .await?;
+
+    let reverse_path = repo_pack_reverse_index_path(router.repo_prefix(), &generated.pack_id);
     store
         .put_multipart_file_retry(
-            &repo_pack_reverse_index_path(router.repo_prefix(), &generated.pack_id),
+            &reverse_path,
             generated.reverse_index_path(),
             generated.reverse_index_size,
             generated.reverse_index_hash,
@@ -578,7 +702,41 @@ async fn upload_generated_pack(
             cancel,
             None,
         )
-        .await
+        .await?;
+    verify_remote_file(
+        store,
+        &reverse_path,
+        generated.reverse_index_size,
+        generated.reverse_index_hash,
+        cancel,
+    )
+    .await
+}
+
+async fn verify_remote_file(
+    store: &Store,
+    path: &object_store::path::Path,
+    expected_size: u64,
+    expected_hash: [u8; 32],
+    cancel: &CancellationToken,
+) -> Result<()> {
+    let mut hasher = blake3::Hasher::new();
+    let actual_size = tokio::select! {
+        result = store.stream_to_writer(path, &mut hasher) => result?,
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+    };
+    let actual_hash = *hasher.finalize().as_bytes();
+    if actual_size != expected_size || actual_hash != expected_hash {
+        return Err(CrabError::CorruptObject {
+            path: path.to_string(),
+            reason: format!(
+                "remote repack object verification failed: expected {expected_size} bytes and {}, got {actual_size} bytes and {}",
+                blake3::Hash::from_bytes(expected_hash).to_hex(),
+                blake3::Hash::from_bytes(actual_hash).to_hex()
+            ),
+        });
+    }
+    Ok(())
 }
 
 async fn ensure_remote_reverse_index(
@@ -588,8 +746,29 @@ async fn ensure_remote_reverse_index(
     cancel: &CancellationToken,
 ) -> Result<()> {
     let path = repo_pack_reverse_index_path(router.repo_prefix(), &generated.pack_id);
-    match store.head(&path).await {
-        Ok(_) => Ok(()),
+    match tokio::select! {
+        result = store.head(&path) => result,
+        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+    } {
+        Ok(meta) => {
+            if meta.size != generated.reverse_index_size {
+                return Err(CrabError::CorruptObject {
+                    path: path.to_string(),
+                    reason: format!(
+                        "existing reverse index has {} bytes, expected {}",
+                        meta.size, generated.reverse_index_size
+                    ),
+                });
+            }
+            verify_remote_file(
+                store,
+                &path,
+                generated.reverse_index_size,
+                generated.reverse_index_hash,
+                cancel,
+            )
+            .await
+        }
         Err(CrabError::NotFound { .. }) => {
             store
                 .put_multipart_file_retry(
@@ -785,6 +964,7 @@ mod tests {
                 dry_run: false,
                 download_concurrency: 2,
                 max_cas_retries: 4,
+                workspace_root: crate::cache::default_cache_root().join("maintenance"),
             },
             &CancellationToken::new(),
         )
@@ -795,7 +975,12 @@ mod tests {
         let (committed, _) = read_manifest(&store, &router).await?;
         assert_eq!(committed.generation, 2);
         assert_eq!(committed.refs.get("refs/heads/main"), Some(&tip));
-        let replacement = read_bulk_pack_list(&store, &router, &committed.pack_index_hash).await?;
+        let replacement = crate::metadata::manifest::read_bulk_pack_list(
+            &store,
+            &router,
+            &committed.pack_index_hash,
+        )
+        .await?;
         assert_eq!(replacement.len(), outcome.packs_after);
         for pack in &replacement {
             store.head(&router.pack_path(&pack.pack_id)).await?;

--- a/crab/src/cmd/replica.rs
+++ b/crab/src/cmd/replica.rs
@@ -1,6 +1,7 @@
 //! `crab replica` — configure and inspect read replicas for Crab remotes.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -15,7 +16,7 @@ use tracing::warn;
 
 use crate::audit::{AuditEvent, AuditOutcome, NewAuditEvent, append_event, default_log_path};
 use crate::core::config::Config;
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::{JsonlStream, OutputMode, emit_json};
 use crate::core::project_config::{ProjectConfig, RemoteConfig};
 use crate::git::url::CrabUrl;
@@ -60,6 +61,9 @@ const MAX_REPAIR_WATCH_BACKOFF_SECS: u64 = 300;
 const REPAIR_WATCH_LEASE_SCHEMA_VERSION: u32 = 1;
 const COORDINATOR_STATE_WARNING_PERCENT: u64 = 80;
 const COORDINATOR_STATE_CRITICAL_PERCENT: u64 = 95;
+const MAX_EVIDENCE_FILES: usize = 100_000;
+const MAX_EVIDENCE_FILE_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_REPAIR_WATCH_LEASE_BYTES: u64 = 64 * 1024;
 #[cfg(test)]
 const ACTIVE_ACTIVE_SMOKE_SEQUENCE: &[&str] = &[
     "mode-active-active",
@@ -1716,6 +1720,7 @@ pub struct RemovePayload {
 }
 
 pub async fn exec(command: ReplicaCommand, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
     match command {
         ReplicaCommand::Add(args) => run_add(&args).await,
         ReplicaCommand::Export(args) => run_export(&args),
@@ -1735,7 +1740,7 @@ pub async fn exec(command: ReplicaCommand, cancel: &CancellationToken) -> Result
         ReplicaCommand::SetPrimary(args) => run_set_primary(&args).await,
         ReplicaCommand::Diagnostics(args) => run_diagnostics(&args, cancel).await,
         ReplicaCommand::Certify(args) => run_certify(&args, cancel).await,
-        ReplicaCommand::Evidence(command) => run_evidence(&command),
+        ReplicaCommand::Evidence(command) => run_evidence_with_cancel(&command, cancel),
         ReplicaCommand::Status(args) => run_status(&args, cancel).await,
         ReplicaCommand::Doctor(args) => run_doctor(&args, cancel).await,
         ReplicaCommand::Remove(args) => run_remove(&args).await,
@@ -2766,31 +2771,37 @@ fn lease_expires_at_ms(now_ms: u64, ttl_seconds: u64) -> u64 {
 }
 
 fn read_repair_watch_lease(path: &Path) -> Result<Option<RepairWatchWorkerState>> {
-    match std::fs::read(path) {
-        Ok(bytes) => {
-            let state: RepairWatchWorkerState =
-                serde_json::from_slice(&bytes).map_err(|err| CrabError::Configuration {
-                    key: "replica.repair.watch".into(),
-                    origin: format!(
-                        "repair worker lease {} is not valid JSON: {err}",
-                        path.display()
-                    ),
-                })?;
-            if state.schema_version != REPAIR_WATCH_LEASE_SCHEMA_VERSION {
-                return Err(CrabError::Configuration {
-                    key: "replica.repair.watch".into(),
-                    origin: format!(
-                        "repair worker lease {} has unsupported schema version {}",
-                        path.display(),
-                        state.schema_version
-                    ),
-                });
-            }
-            Ok(Some(state))
-        }
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(CrabError::Io(err)),
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(CrabError::Io(error)),
+    };
+    if metadata.len() > MAX_REPAIR_WATCH_LEASE_BYTES {
+        return Err(CrabError::Configuration {
+            key: "replica.repair.watch".to_owned(),
+            origin: format!("repair worker lease exceeds {MAX_REPAIR_WATCH_LEASE_BYTES} bytes"),
+        });
     }
+    let bytes = std::fs::read(path).map_err(CrabError::Io)?;
+    let state: RepairWatchWorkerState =
+        serde_json::from_slice(&bytes).map_err(|err| CrabError::Configuration {
+            key: "replica.repair.watch".into(),
+            origin: format!(
+                "repair worker lease {} is not valid JSON: {err}",
+                path.display()
+            ),
+        })?;
+    if state.schema_version != REPAIR_WATCH_LEASE_SCHEMA_VERSION {
+        return Err(CrabError::Configuration {
+            key: "replica.repair.watch".into(),
+            origin: format!(
+                "repair worker lease {} has unsupported schema version {}",
+                path.display(),
+                state.schema_version
+            ),
+        });
+    }
+    Ok(Some(state))
 }
 
 fn write_repair_watch_lease(path: &Path, state: &RepairWatchWorkerState) -> Result<()> {
@@ -4053,6 +4064,15 @@ fn run_evidence_verify(args: &EvidenceVerifyArgs) -> Result<()> {
     })
 }
 
+fn run_evidence_with_cancel(command: &EvidenceCommand, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
+    let result = match command {
+        EvidenceCommand::Verify(args) => run_evidence_verify(args),
+    };
+    check_cancelled(cancel)?;
+    result
+}
+
 #[cfg(test)]
 fn evidence_verify_payload(
     dir: &Path,
@@ -4133,6 +4153,12 @@ fn evidence_verify_payload_with_expected_run_id(
 }
 
 fn collect_evidence_json_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if out.len() >= MAX_EVIDENCE_FILES {
+        return Err(CrabError::Configuration {
+            key: "replica.evidence.files".to_owned(),
+            origin: format!("evidence inventory exceeds {MAX_EVIDENCE_FILES} files"),
+        });
+    }
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -4142,6 +4168,12 @@ fn collect_evidence_json_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()>
             continue;
         }
         if file_type.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+            if out.len() >= MAX_EVIDENCE_FILES {
+                return Err(CrabError::Configuration {
+                    key: "replica.evidence.files".to_owned(),
+                    origin: format!("evidence inventory exceeds {MAX_EVIDENCE_FILES} files"),
+                });
+            }
             out.push(path);
         }
     }
@@ -4173,8 +4205,30 @@ fn verify_evidence_file(root: &Path, path: &Path, require_redacted: bool) -> Evi
         errors: Vec::new(),
     };
 
-    let value = match std::fs::read_to_string(path)
-        .map_err(|err| format!("failed to read evidence file: {err}"))
+    let value = match std::fs::metadata(path)
+        .map_err(|err| format!("failed to stat evidence file: {err}"))
+        .and_then(|metadata| {
+            if metadata.len() > MAX_EVIDENCE_FILE_BYTES {
+                return Err(format!(
+                    "evidence file exceeds {MAX_EVIDENCE_FILE_BYTES} bytes"
+                ));
+            }
+            Ok(metadata.len())
+        })
+        .and_then(|size| {
+            let file = std::fs::File::open(path)
+                .map_err(|err| format!("failed to read evidence file: {err}"))?;
+            let mut bytes = Vec::with_capacity(size as usize);
+            file.take(MAX_EVIDENCE_FILE_BYTES + 1)
+                .read_to_end(&mut bytes)
+                .map_err(|err| format!("failed to read evidence file: {err}"))?;
+            if bytes.len() as u64 > MAX_EVIDENCE_FILE_BYTES {
+                return Err(format!(
+                    "evidence file exceeds {MAX_EVIDENCE_FILE_BYTES} bytes"
+                ));
+            }
+            String::from_utf8(bytes).map_err(|err| format!("evidence file is not UTF-8: {err}"))
+        })
         .and_then(|text| {
             serde_json::from_str::<serde_json::Value>(&text)
                 .map_err(|err| format!("invalid evidence JSON: {err}"))

--- a/crab/src/cmd/status_workflow.rs
+++ b/crab/src/cmd/status_workflow.rs
@@ -25,6 +25,7 @@ use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use serde::Serialize;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::core::config::Config;
@@ -734,9 +735,14 @@ async fn attach_remote_status(
     repo_root: &Path,
     config: &Config,
 ) -> Result<RemoteStatusSummary> {
-    let (store, prefix) =
-        crate::cmd::workflow::build_remote_store_for(repo_root, config, args.remote.as_deref())
-            .await?;
+    let cancel = CancellationToken::new();
+    let (store, prefix) = crate::cmd::workflow::build_remote_store_for(
+        repo_root,
+        config,
+        args.remote.as_deref(),
+        &cancel,
+    )
+    .await?;
     let remote_url =
         crate::cmd::workflow::read_crab_remote_url_for(repo_root, args.remote.as_deref())?;
     let cache_root = repo_root.join(".crab").join("cache");

--- a/crab/src/cmd/tier/mod.rs
+++ b/crab/src/cmd/tier/mod.rs
@@ -26,14 +26,14 @@ pub enum TierCommand {
         #[arg(long)]
         apply: bool,
         /// Merge with existing non-crab rules instead of failing on conflict.
-        #[arg(long)]
+        #[arg(long, requires = "apply")]
         merge: bool,
         /// Show what would be done without making changes.
-        #[arg(long)]
+        #[arg(long, requires = "apply")]
         dry_run: bool,
         /// Output format: xml, json, or yaml.
-        #[arg(long, default_value = "xml")]
-        output: String,
+        #[arg(long, value_parser = ["xml", "json", "yaml"], conflicts_with_all = ["json", "jsonl"])]
+        output: Option<String>,
         /// Structured JSON output (single envelope with terminal result).
         #[arg(long, conflicts_with = "jsonl")]
         json: bool,
@@ -143,6 +143,7 @@ pub fn plan_output_mode(json: bool, jsonl: bool) -> OutputMode {
 /// For `Rollback`: calls `apply::rollback()` to restore a prior
 /// lifecycle configuration from a backup file.
 pub async fn run_tier(cmd: TierCommand, ctx: &AppContext, mode: OutputMode) -> Result<()> {
+    ctx.check_cancelled()?;
     #[cfg(feature = "otlp")]
     let _span = tracing::info_span!(
         "tier.plan",
@@ -157,7 +158,7 @@ pub async fn run_tier(cmd: TierCommand, ctx: &AppContext, mode: OutputMode) -> R
             apply: should_apply,
             merge,
             dry_run,
-            output: _output,
+            output,
             ..
         } => {
             let tier_cfg = &ctx.config().tier;
@@ -180,12 +181,14 @@ pub async fn run_tier(cmd: TierCommand, ctx: &AppContext, mode: OutputMode) -> R
             let crab_url = crate::tier::runtime::current_crab_url()?;
             let lifecycle_provider =
                 crate::tier::runtime::build_lifecycle_provider(ctx.config(), &crab_url).await?;
+            ctx.check_cancelled()?;
             let probe = crate::tier::runtime::probe_bucket(
                 ctx.config(),
                 &crab_url,
                 lifecycle_provider.as_ref(),
             )
             .await?;
+            ctx.check_cancelled()?;
 
             let tier_plan = plan::build(tier_cfg, &probe)?;
             info!(
@@ -205,34 +208,34 @@ pub async fn run_tier(cmd: TierCommand, ctx: &AppContext, mode: OutputMode) -> R
                     stream.emit_result(&payload);
                 }
                 OutputMode::Text => {
-                    println!("Tier plan for {:?}:", tier_plan.provider);
-                    for rule in &tier_plan.rules {
-                        println!(
-                            "  Rule {}: prefix={}, transitions={}",
-                            rule.id,
-                            rule.prefix,
-                            rule.transitions.len()
-                        );
-                        for t in &rule.transitions {
-                            println!("    → {:?} after {} days", t.to_class, t.days);
-                        }
-                        if let Some(min) = rule.min_object_size_bytes {
-                            println!("    min object size: {min} bytes");
-                        }
-                        if let Some(nc) = rule.noncurrent_expiration_days {
-                            println!("    noncurrent expiration: {nc} days");
-                        }
-                    }
+                    emit_text_plan(lifecycle_provider.as_ref(), &tier_plan, output.as_deref())?;
                 }
             }
 
             if should_apply {
-                let outcome = apply::apply(
-                    lifecycle_provider.as_ref(),
-                    &tier_plan,
-                    ApplyOpts { merge, dry_run },
-                )
-                .await?;
+                ctx.check_cancelled()?;
+                let outcome = if dry_run {
+                    // A dry-run is read-only, so cancellation may interrupt its provider reads.
+                    let cancel = ctx.cancel_token();
+                    tokio::select! {
+                        result = apply::apply(
+                            lifecycle_provider.as_ref(),
+                            &tier_plan,
+                            ApplyOpts { merge, dry_run },
+                        ) => result?,
+                        () = cancel.cancelled() => return Err(CrabError::Cancelled),
+                    }
+                } else {
+                    // Once a lifecycle mutation starts, let the provider CAS/verify sequence
+                    // finish; dropping it on cancellation can leave bucket state unknown.
+                    apply::apply(
+                        lifecycle_provider.as_ref(),
+                        &tier_plan,
+                        ApplyOpts { merge, dry_run },
+                    )
+                    .await?
+                };
+                ctx.check_cancelled()?;
 
                 if matches!(mode, OutputMode::Text) {
                     if dry_run {
@@ -250,6 +253,7 @@ pub async fn run_tier(cmd: TierCommand, ctx: &AppContext, mode: OutputMode) -> R
             Ok(())
         }
         TierCommand::Rollback { path } => {
+            ctx.check_cancelled()?;
             info!(backup = %path, "rolling back lifecycle configuration");
             crate::replication::ensure_active_active_maintenance_admitted(
                 ctx.config(),
@@ -259,7 +263,10 @@ pub async fn run_tier(cmd: TierCommand, ctx: &AppContext, mode: OutputMode) -> R
             let crab_url = crate::tier::runtime::current_crab_url()?;
             let lifecycle_provider =
                 crate::tier::runtime::build_lifecycle_provider(ctx.config(), &crab_url).await?;
+            ctx.check_cancelled()?;
+            // Rollback is a provider mutation; do not drop the future after the request starts.
             apply::rollback(lifecycle_provider.as_ref(), &path).await?;
+            ctx.check_cancelled()?;
             if matches!(mode, OutputMode::Text) {
                 println!("Rolled back lifecycle configuration from backup: {path}");
             }
@@ -267,4 +274,68 @@ pub async fn run_tier(cmd: TierCommand, ctx: &AppContext, mode: OutputMode) -> R
             Ok(())
         }
     }
+}
+
+fn emit_text_plan(
+    provider: &dyn crate::tier::provider::LifecycleProvider,
+    plan: &crate::tier::provider::TierPlan,
+    output: Option<&str>,
+) -> Result<()> {
+    match output {
+        Some("xml") => {
+            let rendered = provider.render(plan)?;
+            if rendered.format != crate::tier::provider::Format::Xml {
+                return Err(CrabError::Configuration {
+                    key: "--output=xml is only valid for an XML lifecycle provider".to_owned(),
+                    origin: "tier plan".to_owned(),
+                });
+            }
+            println!(
+                "{}",
+                String::from_utf8(rendered.body).map_err(|error| {
+                    CrabError::Internal(format!("rendered lifecycle is not UTF-8: {error}"))
+                })?
+            );
+        }
+        Some("json") => println!(
+            "{}",
+            serde_json::to_string_pretty(&TierPlanPayload::from_plan(plan))
+                .map_err(|error| CrabError::Internal(format!("tier plan JSON: {error}")))?
+        ),
+        Some("yaml") => print!(
+            "{}",
+            serde_yaml::to_string(&TierPlanPayload::from_plan(plan))
+                .map_err(|error| CrabError::Internal(format!("tier plan YAML: {error}")))?
+        ),
+        None => {
+            println!("Tier plan for {:?}:", plan.provider);
+            for rule in &plan.rules {
+                println!(
+                    "  Rule {}: prefix={}, transitions={}",
+                    rule.id,
+                    rule.prefix,
+                    rule.transitions.len()
+                );
+                for transition in &rule.transitions {
+                    println!(
+                        "    → {:?} after {} days",
+                        transition.to_class, transition.days
+                    );
+                }
+                if let Some(minimum) = rule.min_object_size_bytes {
+                    println!("    min object size: {minimum} bytes");
+                }
+                if let Some(noncurrent) = rule.noncurrent_expiration_days {
+                    println!("    noncurrent expiration: {noncurrent} days");
+                }
+            }
+        }
+        Some(format) => {
+            return Err(CrabError::Configuration {
+                key: format!("unsupported tier plan output format '{format}'"),
+                origin: "tier plan".to_owned(),
+            });
+        }
+    }
+    Ok(())
 }

--- a/crab/src/cmd/tier/mod.rs
+++ b/crab/src/cmd/tier/mod.rs
@@ -29,7 +29,7 @@ pub enum TierCommand {
         #[arg(long, requires = "apply")]
         merge: bool,
         /// Show what would be done without making changes.
-        #[arg(long, requires = "apply")]
+        #[arg(long)]
         dry_run: bool,
         /// Output format: xml, json, or yaml.
         #[arg(long, value_parser = ["xml", "json", "yaml"], conflicts_with_all = ["json", "jsonl"])]
@@ -297,11 +297,7 @@ fn emit_text_plan(
                 })?
             );
         }
-        Some("json") => println!(
-            "{}",
-            serde_json::to_string_pretty(&TierPlanPayload::from_plan(plan))
-                .map_err(|error| CrabError::Internal(format!("tier plan JSON: {error}")))?
-        ),
+        Some("json") => emit_json("tier.plan", "1.0", TierPlanPayload::from_plan(plan)),
         Some("yaml") => print!(
             "{}",
             serde_yaml::to_string(&TierPlanPayload::from_plan(plan))

--- a/crab/src/cmd/workflow.rs
+++ b/crab/src/cmd/workflow.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::core::config::Config;
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::{OutputMode, emit_json};
 use crate::git::url::CrabUrl;
 use crate::workflow::WorkflowStore;
@@ -54,12 +54,31 @@ pub struct PushCacheResult {
 
 /// Execute `crab workflow push-cache`.
 pub async fn exec_push_cache(args: PushCacheArgs) -> Result<()> {
+    exec_push_cache_with_cancel(args, &CancellationToken::new()).await
+}
+
+/// Execute `crab workflow push-cache` while honoring the process shutdown token.
+pub async fn exec_push_cache_with_cancel(
+    args: PushCacheArgs,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
     let cwd = std::env::current_dir().map_err(CrabError::Io)?;
-    exec_push_cache_in(&args, &cwd).await
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
+    exec_push_cache_in_with_cancel(&args, &worktree.current_worktree_root, cancel).await
 }
 
 /// Testable entry point.
 pub async fn exec_push_cache_in(args: &PushCacheArgs, repo_root: &Path) -> Result<()> {
+    exec_push_cache_in_with_cancel(args, repo_root, &CancellationToken::new()).await
+}
+
+async fn exec_push_cache_in_with_cancel(
+    args: &PushCacheArgs,
+    repo_root: &Path,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
     let config = Config::resolve_for_repo(repo_root)?;
     if !config.workflow.enabled {
         return Err(CrabError::WorkflowDisabled);
@@ -88,18 +107,22 @@ pub async fn exec_push_cache_in(args: &PushCacheArgs, repo_root: &Path) -> Resul
     }
 
     // Build the remote store from the repo's crab remote config.
-    let (store, prefix) = build_remote_store(repo_root, &config).await?;
-    let cancel = CancellationToken::new();
-    let artifact_stores = build_workflow_artifact_stores(&config, &cancel).await;
+    let (store, prefix) = build_remote_store_for(repo_root, &config, None, cancel).await?;
+    let artifact_stores = build_workflow_artifact_stores(&config, cancel).await;
+    check_cancelled(cancel)?;
     let artifact_stores = (!artifact_stores.is_empty()).then_some(artifact_stores);
 
-    let push_result = cache::push_all_local_with_artifact_stores(
-        &store,
-        &prefix,
-        artifact_stores.as_ref(),
-        &cache_root,
-    )
-    .await?;
+    let push_result = tokio::select! {
+        _ = cancel.cancelled() => return Err(CrabError::Cancelled),
+        result = cache::push_all_local_with_artifact_stores_and_cancel(
+            &store,
+            &prefix,
+            artifact_stores.as_ref(),
+            &cache_root,
+            cancel,
+        ) => result?,
+    };
+    check_cancelled(cancel)?;
 
     info!(
         pushed = push_result.pushed,
@@ -123,29 +146,65 @@ pub async fn exec_push_cache_in(args: &PushCacheArgs, repo_root: &Path) -> Resul
         );
     }
 
+    ensure_push_succeeded(push_result.errors)
+}
+
+fn ensure_push_succeeded(errors: u32) -> Result<()> {
+    if errors > 0 {
+        return Err(CrabError::Internal(format!(
+            "workflow cache push failed for {} local entr{}",
+            errors,
+            if errors == 1 { "y" } else { "ies" }
+        )));
+    }
     Ok(())
 }
 
-/// Build a remote Store + prefix from the repo's crab configuration.
-///
-/// Reuses the same credential chain and store construction as
-/// `crab push` — no separate credential configuration needed.
-async fn build_remote_store(repo_root: &Path, config: &Config) -> Result<(WorkflowStore, String)> {
-    build_remote_store_for(repo_root, config, None).await
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_push_errors_fail_the_command() {
+        let error = ensure_push_succeeded(2).unwrap_err();
+
+        assert!(error.to_string().contains("2 local entries"));
+    }
+
+    #[tokio::test]
+    async fn push_cache_honors_cancellation_before_repository_resolution() {
+        let repo = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let error = exec_push_cache_in_with_cancel(
+            &PushCacheArgs {
+                all: true,
+                json: false,
+            },
+            repo.path(),
+            &cancel,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, CrabError::Cancelled));
+    }
 }
 
 pub(crate) async fn build_remote_store_for(
     repo_root: &Path,
     config: &Config,
     remote_name: Option<&str>,
+    cancel: &CancellationToken,
 ) -> Result<(WorkflowStore, String)> {
+    check_cancelled(cancel)?;
     // Read the crab remote URL from git's remote configuration.
     let url_str = read_crab_remote_url_for(repo_root, remote_name)?;
     let crab_url = CrabUrl::parse(&url_str)?;
     let prefix = crab_url.repo_path.clone();
 
-    let cancel = CancellationToken::new();
-    let store = crate::auth::build_store(config, &crab_url, "workflow-push-cache", &cancel).await?;
+    let store = crate::auth::build_store(config, &crab_url, "workflow-push-cache", cancel).await?;
 
     Ok((WorkflowStore::from_storage(store.into_storage()), prefix))
 }
@@ -156,6 +215,9 @@ pub(crate) async fn build_workflow_artifact_stores(
 ) -> RemoteArtifactStores {
     let mut stores = RemoteArtifactStores::default();
     for (name, remote) in &config.workflow.remotes {
+        if cancel.is_cancelled() {
+            return stores;
+        }
         let parsed = match CrabUrl::parse(remote.url.trim()) {
             Ok(parsed) => parsed,
             Err(e) => {
@@ -210,11 +272,19 @@ pub fn read_crab_remote_url_for(repo_root: &Path, remote_name: Option<&str>) -> 
         .unwrap_or("origin");
 
     // Try reading from the selected git remote first.
-    let output = std::process::Command::new("git")
+    let mut command = std::process::Command::new("git");
+    command
         .args(["remote", "get-url", remote_name])
         .current_dir(repo_root)
-        .output()
-        .map_err(CrabError::Io)?;
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env_remove("GIT_QUARANTINE_PATH")
+        .env_remove("GIT_NAMESPACE");
+    let output = command.output().map_err(CrabError::Io)?;
 
     if output.status.success() {
         let url = String::from_utf8_lossy(&output.stdout).trim().to_owned();

--- a/crab/src/cmd/workflow_journal.rs
+++ b/crab/src/cmd/workflow_journal.rs
@@ -19,11 +19,9 @@
 //! `workflow.journal.show`, `workflow.journal.ls`,
 //! `workflow.journal.gc`.
 //!
-//! The command is pure-read (apart from `gc`) — it doesn't acquire
-//! the scheduler lock. `gc` is safe against concurrent runners
-//! because it walks by journal directory age and only removes
-//! terminal journals; an active run's journal is non-terminal by
-//! definition and thus protected.
+//! The command is pure-read (apart from `gc`). `gc` acquires the
+//! workflow scheduler lock before scanning and deleting so a run
+//! cannot transition a journal after the retention decision.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -33,9 +31,10 @@ use serde::Serialize;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::core::error::{CrabError, Result};
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::{OutputMode, emit_json};
 use crate::workflow::journal::{Journal, RunOutcome, RunRow, StageRunRow};
+use tokio_util::sync::CancellationToken;
 
 /// Structured-output schema labels for the three subcommands.
 pub const WORKFLOW_JOURNAL_SHOW_SCHEMA: &str = "workflow.journal.show";
@@ -46,6 +45,9 @@ pub const WORKFLOW_JOURNAL_GC_SCHEMA: &str = "workflow.journal.gc";
 /// recent terminal journals. Tracks the operator-visible default
 /// called out in the design's risk register.
 pub const DEFAULT_GC_KEEP: usize = 50;
+const MAX_WORKFLOW_JOURNALS: usize = 1_000_000;
+const MAX_WORKFLOW_STAGE_ROWS: usize = 1_000_000;
+const MAX_WORKFLOW_GC_FAILURES: usize = 1_024;
 
 // ─── Clap surface ─────────────────────────────────────────────────────
 
@@ -203,19 +205,34 @@ pub struct GcPayload {
 /// `crab workflow journal show`.
 pub fn exec_show(args: ShowArgs) -> Result<()> {
     let cwd = std::env::current_dir().map_err(CrabError::Io)?;
-    run_show(&args, &cwd, args.output_mode())
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
+    run_show(&args, &worktree.current_worktree_root, args.output_mode())
 }
 
 /// `crab workflow journal ls`.
 pub fn exec_ls(args: LsArgs) -> Result<()> {
     let cwd = std::env::current_dir().map_err(CrabError::Io)?;
-    run_ls(&args, &cwd, args.output_mode())
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
+    run_ls(&args, &worktree.current_worktree_root, args.output_mode())
 }
 
 /// `crab workflow journal gc`.
 pub fn exec_gc(args: GcArgs) -> Result<()> {
+    exec_gc_with_cancel(args, &CancellationToken::new())
+}
+
+/// Run workflow journal GC while honoring the caller's cancellation token.
+pub fn exec_gc_with_cancel(args: GcArgs, cancel: &CancellationToken) -> Result<()> {
+    check_cancelled(cancel)?;
     let cwd = std::env::current_dir().map_err(CrabError::Io)?;
-    run_gc(&args, &cwd, args.output_mode()).map(|_| ())
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
+    run_gc_with_cancel(
+        &args,
+        &worktree.current_worktree_root,
+        args.output_mode(),
+        cancel,
+    )
+    .map(|_| ())
 }
 
 /// Testable variant of `show`.
@@ -232,7 +249,7 @@ pub fn run_show(args: &ShowArgs, repo_root: &Path, mode: OutputMode) -> Result<(
     }
     let journal = Journal::open(&journal_path)?;
     let run_row = journal.run_row(run_id)?;
-    let rows = journal.all_stage_rows(run_id)?;
+    let rows = journal.all_stage_rows_with_limit(run_id, MAX_WORKFLOW_STAGE_ROWS)?;
     let payload = build_show_payload(run_id, run_row.as_ref(), &rows);
     emit_show(&payload, mode);
     Ok(())
@@ -252,34 +269,75 @@ pub fn run_ls(_args: &LsArgs, repo_root: &Path, mode: OutputMode) -> Result<()> 
 /// Testable variant of `gc`. Returns the payload so tests can
 /// inspect it without parsing stdout.
 pub fn run_gc(args: &GcArgs, repo_root: &Path, mode: OutputMode) -> Result<GcPayload> {
+    run_gc_with_cancel(args, repo_root, mode, &CancellationToken::new())
+}
+
+/// Testable variant of `gc` with cancellation support.
+pub fn run_gc_with_cancel(
+    args: &GcArgs,
+    repo_root: &Path,
+    mode: OutputMode,
+    cancel: &CancellationToken,
+) -> Result<GcPayload> {
+    check_cancelled(cancel)?;
     let runs_dir = runs_dir(repo_root);
-    let summaries = collect_summaries(&runs_dir)?;
+    let workflow_root = runs_dir
+        .parent()
+        .ok_or_else(|| CrabError::Internal("workflow runs directory has no parent".to_owned()))?;
+    let _scheduler_lock = crate::workflow::scheduler_lock::SchedulerLock::try_acquire(
+        workflow_root,
+    )?
+    .ok_or(CrabError::ConcurrentMaintenance {
+        other: "workflow run",
+    })?;
+    let summaries = collect_summaries_with_cancel(&runs_dir, cancel)?;
     let payload = decide_gc(summaries, args.keep);
+    let mut removed = Vec::new();
+    let mut failures = Vec::new();
+    let mut failures_omitted = 0usize;
     if !args.dry_run {
         for run_id in &payload.removed {
+            check_cancelled(cancel)?;
             let dir = runs_dir.join(run_id);
             match fs::remove_dir_all(&dir) {
-                Ok(()) => info!(run_id = %run_id, "workflow journal gc: removed"),
-                // If another process already cleaned this up (or
-                // the operator manually deleted it between the
-                // scan and the rm), log and keep going — we still
-                // want to remove the rest.
-                Err(e) => warn!(
-                    run_id = %run_id,
-                    error = %e,
-                    "workflow journal gc: could not remove journal directory",
-                ),
+                Ok(()) => {
+                    info!(run_id = %run_id, "workflow journal gc: removed");
+                    removed.push(run_id.clone());
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    removed.push(run_id.clone());
+                }
+                Err(error) if failures.len() < MAX_WORKFLOW_GC_FAILURES => {
+                    failures.push(format!("{run_id}: {error}"));
+                }
+                Err(_) => failures_omitted = failures_omitted.saturating_add(1),
             }
         }
+    } else {
+        check_cancelled(cancel)?;
+        removed.clone_from(&payload.removed);
     }
+    check_cancelled(cancel)?;
     let out = GcPayload {
         keep: args.keep,
         dry_run: args.dry_run,
-        removed: payload.removed.clone(),
+        removed,
         kept: payload.kept.clone(),
         in_flight: payload.in_flight.clone(),
     };
     emit_gc(&out, mode);
+    if !failures.is_empty() || failures_omitted > 0 {
+        return Err(CrabError::Internal(format!(
+            "workflow journal GC failed to remove {} journal(s): {}{}",
+            failures.len().saturating_add(failures_omitted),
+            failures.join("; "),
+            if failures_omitted > 0 {
+                format!(" ({} additional failures omitted)", failures_omitted)
+            } else {
+                String::new()
+            }
+        )));
+    }
     Ok(out)
 }
 
@@ -303,6 +361,14 @@ fn journal_path_for(repo_root: &Path, run_id: Uuid) -> PathBuf {
 /// Returns an empty vector when `runs/` is absent (fresh repo, or a
 /// repo that has never run a workflow).
 fn collect_summaries(runs_dir: &Path) -> Result<Vec<JournalSummary>> {
+    collect_summaries_with_cancel(runs_dir, &CancellationToken::new())
+}
+
+fn collect_summaries_with_cancel(
+    runs_dir: &Path,
+    cancel: &CancellationToken,
+) -> Result<Vec<JournalSummary>> {
+    check_cancelled(cancel)?;
     let mut out: Vec<JournalSummary> = Vec::new();
     let entries = match fs::read_dir(runs_dir) {
         Ok(e) => e,
@@ -310,7 +376,11 @@ fn collect_summaries(runs_dir: &Path) -> Result<Vec<JournalSummary>> {
         Err(e) => return Err(CrabError::Io(e)),
     };
     for entry in entries {
+        check_cancelled(cancel)?;
         let entry = entry.map_err(CrabError::Io)?;
+        if !entry.file_type().map_err(CrabError::Io)?.is_dir() {
+            continue;
+        }
         let name = entry.file_name();
         let run_id_str = name.to_string_lossy().into_owned();
         let Ok(run_id) = Uuid::parse_str(&run_id_str) else {
@@ -319,6 +389,14 @@ fn collect_summaries(runs_dir: &Path) -> Result<Vec<JournalSummary>> {
         let journal_path = entry.path().join("journal.db");
         if !journal_path.exists() {
             continue;
+        }
+        if out.len() >= MAX_WORKFLOW_JOURNALS {
+            return Err(CrabError::Configuration {
+                key: "workflow journal count".to_owned(),
+                origin: format!(
+                    "workflow journal directory contains more than {MAX_WORKFLOW_JOURNALS} readable journals"
+                ),
+            });
         }
         let journal = match Journal::open(&journal_path) {
             Ok(j) => j,
@@ -709,6 +787,37 @@ mod tests {
         assert!(runs_dir(root).join(in_flight.to_string()).exists());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn gc_ignores_symlinked_run_directories() {
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let outside_journal = outside.path().join("journal.db");
+        let journal = Journal::open(&outside_journal).unwrap();
+        journal.insert_run_start(run_id, "test", "host").unwrap();
+        journal
+            .mark_run_outcome(run_id, RunOutcome::Success)
+            .unwrap();
+        let runs = runs_dir(tmp.path());
+        fs::create_dir_all(&runs).unwrap();
+        std::os::unix::fs::symlink(outside.path(), runs.join(run_id.to_string())).unwrap();
+
+        let payload = run_gc(
+            &GcArgs {
+                keep: 0,
+                dry_run: false,
+                json: false,
+            },
+            tmp.path(),
+            OutputMode::Json,
+        )
+        .unwrap();
+
+        assert!(payload.removed.is_empty());
+        assert!(outside_journal.exists());
+    }
+
     #[test]
     fn gc_dry_run_preserves_filesystem() {
         let tmp = TempDir::new().unwrap();
@@ -728,6 +837,26 @@ mod tests {
         assert_eq!(payload.removed, vec![run_id.to_string()]);
         // Directory is still on disk because of --dry-run.
         assert!(runs_dir(root).join(run_id.to_string()).exists());
+    }
+
+    #[test]
+    fn gc_honors_cancellation_before_scanning_or_deleting() {
+        let tmp = TempDir::new().unwrap();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let error = run_gc_with_cancel(
+            &GcArgs {
+                keep: 0,
+                dry_run: false,
+                json: false,
+            },
+            tmp.path(),
+            OutputMode::Json,
+            &cancel,
+        )
+        .unwrap_err();
+        assert!(matches!(error, CrabError::Cancelled));
     }
 
     #[test]

--- a/crab/src/cmd/workflow_journal.rs
+++ b/crab/src/cmd/workflow_journal.rs
@@ -204,16 +204,14 @@ pub struct GcPayload {
 
 /// `crab workflow journal show`.
 pub fn exec_show(args: ShowArgs) -> Result<()> {
-    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
-    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
-    run_show(&args, &worktree.current_worktree_root, args.output_mode())
+    let repo_root = resolve_repo_root()?;
+    run_show(&args, &repo_root, args.output_mode())
 }
 
 /// `crab workflow journal ls`.
 pub fn exec_ls(args: LsArgs) -> Result<()> {
-    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
-    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
-    run_ls(&args, &worktree.current_worktree_root, args.output_mode())
+    let repo_root = resolve_repo_root()?;
+    run_ls(&args, &repo_root, args.output_mode())
 }
 
 /// `crab workflow journal gc`.
@@ -224,15 +222,21 @@ pub fn exec_gc(args: GcArgs) -> Result<()> {
 /// Run workflow journal GC while honoring the caller's cancellation token.
 pub fn exec_gc_with_cancel(args: GcArgs, cancel: &CancellationToken) -> Result<()> {
     check_cancelled(cancel)?;
+    let repo_root = resolve_repo_root()?;
+    run_gc_with_cancel(&args, &repo_root, args.output_mode(), cancel).map(|_| ())
+}
+
+fn resolve_repo_root() -> Result<std::path::PathBuf> {
     let cwd = std::env::current_dir().map_err(CrabError::Io)?;
-    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
-    run_gc_with_cancel(
-        &args,
-        &worktree.current_worktree_root,
-        args.output_mode(),
-        cancel,
-    )
-    .map(|_| ())
+    match crate::git::worktree::WorktreeContext::resolve_from_path(&cwd) {
+        Ok(worktree) => Ok(worktree.current_worktree_root),
+        Err(_error) if cwd.join(".crab").is_dir() => {
+            // Journal inspection is useful before Git initialization; the
+            // durable `.crab` directory is sufficient to identify its root.
+            Ok(cwd)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// Testable variant of `show`.

--- a/crab/src/coordination/cas.rs
+++ b/crab/src/coordination/cas.rs
@@ -9,9 +9,10 @@ use serde::{Deserialize, Serialize};
 use crate::core::error::{CrabError, Result};
 use crate::storage::store::Store;
 
-pub use crab_storage::DEFAULT_MAX_ATTEMPTS;
+pub use crab_storage::{DEFAULT_MAX_ATTEMPTS, MAX_CAS_OBJECT_BYTES};
 
 /// Updates one JSON object with a load, mutate, conditional-write loop.
+/// The default loop rejects objects larger than [`MAX_CAS_OBJECT_BYTES`].
 ///
 /// # Errors
 ///

--- a/crab/src/coordination/heartbeat.rs
+++ b/crab/src/coordination/heartbeat.rs
@@ -46,10 +46,38 @@ impl LockHeartbeat {
         interval: Duration,
         push_cancel: CancellationToken,
     ) -> Self {
+        Self::spawn_with_stop(
+            store,
+            lock_path,
+            holder,
+            ttl,
+            interval,
+            push_cancel.clone(),
+            push_cancel,
+        )
+    }
+
+    /// Spawn a heartbeat whose lifetime is independent from operation
+    /// cancellation.
+    ///
+    /// `push_cancel` is still cancelled when the lock is stolen or lost, but
+    /// cancelling it does not stop the heartbeat. The separate `stop_cancel`
+    /// token is used by maintenance owners that must keep renewing while a
+    /// cancelled blocking operation unwinds and releases its lock.
+    pub fn spawn_with_stop(
+        store: Store,
+        lock_path: String,
+        holder: String,
+        ttl: Duration,
+        interval: Duration,
+        push_cancel: CancellationToken,
+        stop_cancel: CancellationToken,
+    ) -> Self {
         let interval = clamp_interval(interval, ttl);
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
         let push_cancel_clone = push_cancel.clone();
+        let stop_cancel_clone = stop_cancel.clone();
 
         let handle = tokio::spawn(async move {
             heartbeat_loop(
@@ -59,6 +87,7 @@ impl LockHeartbeat {
                 ttl,
                 interval,
                 push_cancel_clone,
+                stop_cancel_clone,
                 cancel_clone,
             )
             .await;
@@ -126,6 +155,7 @@ async fn heartbeat_loop(
     ttl: Duration,
     interval: Duration,
     push_cancel: CancellationToken,
+    stop_cancel: CancellationToken,
     self_cancel: CancellationToken,
 ) {
     let obj_path = Path::from(lock_path.as_str());
@@ -139,14 +169,14 @@ async fn heartbeat_loop(
                 debug!(lock_path = %lock_path, "heartbeat stopped");
                 return;
             }
-            () = push_cancel.cancelled() => {
-                debug!(lock_path = %lock_path, "push cancelled, heartbeat exiting");
+            () = stop_cancel.cancelled() => {
+                debug!(lock_path = %lock_path, "heartbeat stop requested");
                 return;
             }
         }
 
         // After waking, check cancellation before doing any I/O.
-        if self_cancel.is_cancelled() || push_cancel.is_cancelled() {
+        if self_cancel.is_cancelled() || stop_cancel.is_cancelled() {
             return;
         }
 
@@ -462,5 +492,39 @@ mod tests {
         // Stop immediately — should not cancel the push.
         heartbeat.stop().await;
         assert!(!push_cancel.is_cancelled());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn independent_stop_keeps_heartbeat_after_operation_cancel() {
+        let store = memory_store();
+        let lock_path = "repo/locks/refs/heads/main/lock";
+        let holder = "test-holder";
+        let ttl = Duration::from_secs(300);
+
+        put_lock(&store, lock_path, holder, 300).await;
+        let (before, _) = store.get_with_etag(&Path::from(lock_path)).await.unwrap();
+        let before: LockPayload = serde_json::from_slice(&before).unwrap();
+
+        let push_cancel = CancellationToken::new();
+        let stop_cancel = CancellationToken::new();
+        let heartbeat = LockHeartbeat::spawn_with_stop(
+            store.clone(),
+            lock_path.to_owned(),
+            holder.to_owned(),
+            ttl,
+            Duration::from_secs(10),
+            push_cancel.clone(),
+            stop_cancel.clone(),
+        );
+
+        push_cancel.cancel();
+        tokio::time::sleep(Duration::from_secs(15)).await;
+
+        let (body, _) = store.get_with_etag(&Path::from(lock_path)).await.unwrap();
+        let after: LockPayload = serde_json::from_slice(&body).unwrap();
+        heartbeat.stop().await;
+
+        assert!(!stop_cancel.is_cancelled());
+        assert!(after.expires_at >= before.expires_at);
     }
 }

--- a/crab/src/core/config.rs
+++ b/crab/src/core/config.rs
@@ -2740,31 +2740,23 @@ pub fn build_metadb_config_from(
         cfg.cache_gc_grace = v;
     }
 
-    // Shared single-valued SlateDB tunables. file_index wins;
-    // chunk_index fills in any gap. When both are absent the struct
-    // default stands. Keeping the chunk_index values in the TOML
-    // surface lets operators declare them now so the future per-DB
-    // split is a no-op migration for the config file.
-    if let Some(v) = metadb_toml
-        .file_index
-        .compaction_threshold
-        .or(metadb_toml.chunk_index.db.compaction_threshold)
-    {
-        cfg.compaction_threshold = v;
+    if let Some(v) = metadb_toml.file_index.compaction_threshold {
+        cfg.file_index.compaction_threshold = v;
     }
-    if let Some(v) = metadb_toml
-        .file_index
-        .wal_flush_size
-        .or(metadb_toml.chunk_index.db.wal_flush_size)
-    {
-        cfg.wal_flush_size = v;
+    if let Some(v) = metadb_toml.file_index.wal_flush_size {
+        cfg.file_index.wal_flush_size = v;
     }
-    if let Some(v) = metadb_toml
-        .file_index
-        .bloom_bits_per_key
-        .or(metadb_toml.chunk_index.db.bloom_bits_per_key)
-    {
-        cfg.bloom_bits_per_key = v;
+    if let Some(v) = metadb_toml.file_index.bloom_bits_per_key {
+        cfg.file_index.bloom_bits_per_key = v;
+    }
+    if let Some(v) = metadb_toml.chunk_index.db.compaction_threshold {
+        cfg.chunk_index.compaction_threshold = v;
+    }
+    if let Some(v) = metadb_toml.chunk_index.db.wal_flush_size {
+        cfg.chunk_index.wal_flush_size = v;
+    }
+    if let Some(v) = metadb_toml.chunk_index.db.bloom_bits_per_key {
+        cfg.chunk_index.bloom_bits_per_key = v;
     }
 
     cfg
@@ -5209,11 +5201,10 @@ cache_gc_grace = 2
         let meta = cfg.build_metadb_config("org/my-repo");
         assert_eq!(meta.file_index_path, "org/my-repo/file_index_db/");
         assert_eq!(meta.chunk_index_path, ".crab/chunk_index_db/");
-        // Default compaction threshold lives on `MetaDbConfig::default`;
-        // TOML absent means the field is untouched.
-        assert_eq!(meta.compaction_threshold, 4);
-        assert_eq!(meta.wal_flush_size, 4 * 1024 * 1024);
-        assert_eq!(meta.bloom_bits_per_key, 10);
+        // Default engine tunables live on each metadata database.
+        assert_eq!(meta.file_index.compaction_threshold, 4);
+        assert_eq!(meta.file_index.wal_flush_size, 4 * 1024 * 1024);
+        assert_eq!(meta.file_index.bloom_bits_per_key, 10);
         assert_eq!(meta.cache_gc_grace, 3);
         assert_eq!(meta.in_memory_ceiling_bytes, 1024 * 1024 * 1024);
     }
@@ -5259,10 +5250,10 @@ cache_gc_grace = 5
         assert_eq!(meta.file_index_path, "toml/file_index_db/");
         assert_eq!(meta.chunk_index_path, "toml/chunk_index_db/");
 
-        // Shared-field tunables — file_index wins.
-        assert_eq!(meta.compaction_threshold, 8);
-        assert_eq!(meta.wal_flush_size, 8 * 1024 * 1024);
-        assert_eq!(meta.bloom_bits_per_key, 12);
+        // File-index engine tunables come from its TOML section.
+        assert_eq!(meta.file_index.compaction_threshold, 8);
+        assert_eq!(meta.file_index.wal_flush_size, 8 * 1024 * 1024);
+        assert_eq!(meta.file_index.bloom_bits_per_key, 12);
 
         // chunk_index-only — env overrides TOML.
         assert_eq!(meta.in_memory_ceiling_bytes, 256 * 1024 * 1024);
@@ -5273,10 +5264,7 @@ cache_gc_grace = 5
     }
 
     #[test]
-    fn build_metadb_config_chunk_index_fallback_for_shared_tunables() {
-        // When file_index omits a shared tunable, chunk_index's value
-        // is used. Documents the merging strategy today so a future
-        // split of the flat MetaDbConfig keeps known-good behavior.
+    fn build_metadb_config_applies_chunk_index_tunables() {
         let _guard = METADB_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_metadb_env();
 
@@ -5286,9 +5274,9 @@ cache_gc_grace = 5
         cfg.metadb.chunk_index.db.bloom_bits_per_key = Some(15);
 
         let meta = cfg.build_metadb_config("org/my-repo");
-        assert_eq!(meta.compaction_threshold, 6);
-        assert_eq!(meta.wal_flush_size, 2 * 1024 * 1024);
-        assert_eq!(meta.bloom_bits_per_key, 15);
+        assert_eq!(meta.chunk_index.compaction_threshold, 6);
+        assert_eq!(meta.chunk_index.wal_flush_size, 2 * 1024 * 1024);
+        assert_eq!(meta.chunk_index.bloom_bits_per_key, 15);
     }
 
     #[test]

--- a/crab/src/core/error.rs
+++ b/crab/src/core/error.rs
@@ -987,6 +987,7 @@ impl From<crab_xet::error::XetError> for CrabError {
 impl From<crab_cache::CacheError> for CrabError {
     fn from(error: crab_cache::CacheError) -> Self {
         match error {
+            crab_cache::CacheError::Cancelled => Self::Cancelled,
             crab_cache::CacheError::Io(source) => Self::Io(source),
             crab_cache::CacheError::HashMismatch { requested, actual } => {
                 Self::HashMismatch { requested, actual }
@@ -1148,6 +1149,7 @@ impl From<crab_vfs::VfsError> for CrabError {
 impl From<crab_workflow::WorkflowError> for CrabError {
     fn from(error: crab_workflow::WorkflowError) -> Self {
         match error {
+            crab_workflow::WorkflowError::Cancelled => Self::Cancelled,
             crab_workflow::WorkflowError::NetworkTransient(source) => {
                 Self::NetworkTransient(source)
             }

--- a/crab/src/cost/engine.rs
+++ b/crab/src/cost/engine.rs
@@ -24,7 +24,6 @@ use super::report::{self, ClassCost, CostReport};
 
 const BYTES_PER_GIB: u64 = 1_073_741_824;
 const DEFAULT_TOP_K_COLD: usize = 100;
-const MAX_LIST_CONCURRENCY: u32 = 128;
 
 /// CLI overrides for a cost report.
 #[derive(Debug, Clone, Default)]
@@ -73,15 +72,20 @@ pub async fn build_report(
     }
 
     let list_concurrency = config.cost.list_concurrency;
-    if !(1..=MAX_LIST_CONCURRENCY).contains(&list_concurrency) {
+    if !(1..=live::MAX_LIST_CONCURRENCY).contains(&list_concurrency) {
         return Err(CrabError::Configuration {
             key: format!("cost.list_concurrency={list_concurrency}"),
-            origin: format!("expected a value from 1 through {MAX_LIST_CONCURRENCY}"),
+            origin: format!(
+                "expected a value from 1 through {}",
+                live::MAX_LIST_CONCURRENCY
+            ),
         });
     }
 
     let sample_ratio = options.sample_ratio.unwrap_or(config.cost.sample_ratio);
     validate_sample_ratio(sample_ratio)?;
+    let top_k_cold = options.top_k.unwrap_or(DEFAULT_TOP_K_COLD);
+    validate_top_k_cold(top_k_cold)?;
     if config.cost.apply_free_tier {
         return Err(CrabError::Configuration {
             key: "cost.apply_free_tier".to_string(),
@@ -107,7 +111,7 @@ pub async fn build_report(
         LiveWalkConfig {
             list_concurrency,
             sample_ratio: (sample_ratio < 1.0).then_some(sample_ratio),
-            top_k_cold: options.top_k.unwrap_or(DEFAULT_TOP_K_COLD),
+            top_k_cold,
             provider,
         },
         cancel,
@@ -163,6 +167,16 @@ fn validate_sample_ratio(ratio: f64) -> Result<()> {
         return Err(CrabError::Configuration {
             key: format!("cost.sample_ratio={ratio}"),
             origin: "expected a finite value greater than 0 and no greater than 1".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_top_k_cold(top_k: usize) -> Result<()> {
+    if top_k > live::MAX_TOP_K_COLD {
+        return Err(CrabError::Configuration {
+            key: format!("cost.top_k={top_k}"),
+            origin: format!("expected a value from 0 through {}", live::MAX_TOP_K_COLD),
         });
     }
     Ok(())
@@ -325,6 +339,13 @@ mod tests {
         assert!(validate_sample_ratio(1.0).is_ok());
         assert!(validate_sample_ratio(0.25).is_ok());
         assert!(validate_sample_ratio(1.01).is_err());
+    }
+
+    #[test]
+    fn top_k_is_bounded_for_large_inventory_walks() {
+        assert!(validate_top_k_cold(0).is_ok());
+        assert!(validate_top_k_cold(live::MAX_TOP_K_COLD).is_ok());
+        assert!(validate_top_k_cold(live::MAX_TOP_K_COLD + 1).is_err());
     }
 
     #[test]

--- a/crab/src/cost/inventory/live.rs
+++ b/crab/src/cost/inventory/live.rs
@@ -22,9 +22,12 @@ use super::{
     ALL_CRAB_PREFIXES, ClassStats, Inventory, InventoryItem, InventorySourceInfo, PrefixStats,
     sample,
 };
-use crate::core::error::Result;
+use crate::core::error::{CrabError, Result};
 use crate::tier::classes::StorageClass;
 use crate::tier::provider::Provider;
+
+pub(crate) const MAX_LIST_CONCURRENCY: u32 = 128;
+pub(crate) const MAX_TOP_K_COLD: usize = 10_000;
 
 /// Configuration for a live inventory walk.
 #[derive(Debug, Clone)]
@@ -136,7 +139,11 @@ async fn walk_prefix(
             continue;
         }
 
-        let size = meta.size as u64;
+        let size = u64::try_from(meta.size).map_err(|_| {
+            CrabError::Internal(format!(
+                "live inventory object size for {key} exceeds the u64 limit"
+            ))
+        })?;
         let last_modified = meta.last_modified.to_rfc3339();
 
         // Infer storage class from object metadata.
@@ -156,19 +163,43 @@ async fn walk_prefix(
         // Update per-class stats.
         let class_key = format!("{storage_class}");
         let class_stats = result.per_class.entry(class_key).or_default();
-        class_stats.objects += 1;
-        class_stats.bytes += size;
+        class_stats.objects = class_stats.objects.checked_add(1).ok_or_else(|| {
+            CrabError::Internal("live inventory object count overflow".to_string())
+        })?;
+        class_stats.bytes = class_stats
+            .bytes
+            .checked_add(size)
+            .ok_or_else(|| CrabError::Internal("live inventory byte count overflow".to_string()))?;
 
-        result.objects += 1;
-        result.bytes += size;
+        result.objects = result.objects.checked_add(1).ok_or_else(|| {
+            CrabError::Internal("live inventory object count overflow".to_string())
+        })?;
+        result.bytes = result
+            .bytes
+            .checked_add(size)
+            .ok_or_else(|| CrabError::Internal("live inventory byte count overflow".to_string()))?;
 
         // Track top-K cold objects.
         if storage_class.is_archive_class() {
             insert_top_k(&mut result.heaviest_cold, item, config.top_k_cold);
         }
 
-        progress.objects_listed.fetch_add(1, Ordering::Relaxed);
-        progress.bytes_observed.fetch_add(size, Ordering::Relaxed);
+        progress
+            .objects_listed
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                value.checked_add(1)
+            })
+            .map_err(|_| {
+                CrabError::Internal("live inventory progress count overflow".to_string())
+            })?;
+        progress
+            .bytes_observed
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                value.checked_add(size)
+            })
+            .map_err(|_| {
+                CrabError::Internal("live inventory progress byte count overflow".to_string())
+            })?;
     }
 
     Ok(result)
@@ -221,6 +252,19 @@ pub async fn walk_live(
     config: LiveWalkConfig,
     cancel: &CancellationToken,
 ) -> Result<Inventory> {
+    if !(1..=MAX_LIST_CONCURRENCY).contains(&config.list_concurrency) {
+        return Err(CrabError::Configuration {
+            key: format!("cost.list_concurrency={}", config.list_concurrency),
+            origin: format!("expected a value from 1 through {MAX_LIST_CONCURRENCY}"),
+        });
+    }
+    if config.top_k_cold > MAX_TOP_K_COLD {
+        return Err(CrabError::Configuration {
+            key: format!("cost.top_k={}", config.top_k_cold),
+            origin: format!("expected a value from 0 through {MAX_TOP_K_COLD}"),
+        });
+    }
+
     let semaphore = Arc::new(Semaphore::new(config.list_concurrency as usize));
     let progress = Arc::new(WalkProgress::new());
     let config = Arc::new(config);
@@ -241,7 +285,12 @@ pub async fn walk_live(
         let cancel = cancel.clone();
 
         let handle = tokio::spawn(async move {
-            let _permit = sem.acquire().await;
+            let _permit = tokio::select! {
+                () = cancel.cancelled() => return Err(CrabError::Cancelled),
+                permit = sem.acquire() => permit.map_err(|_| {
+                    CrabError::Internal("live inventory semaphore closed unexpectedly".to_string())
+                })?,
+            };
             walk_prefix(store.as_ref(), prefix, &cfg, &prog, &cancel).await
         });
 
@@ -261,8 +310,12 @@ pub async fn walk_live(
             ))
         })??;
 
-        total_objects += result.objects;
-        total_bytes += result.bytes;
+        total_objects = total_objects.checked_add(result.objects).ok_or_else(|| {
+            CrabError::Internal("live inventory object count overflow".to_string())
+        })?;
+        total_bytes = total_bytes
+            .checked_add(result.bytes)
+            .ok_or_else(|| CrabError::Internal("live inventory byte count overflow".to_string()))?;
 
         per_prefix.insert(
             prefix.clone(),
@@ -274,8 +327,12 @@ pub async fn walk_live(
 
         for (class_key, stats) in result.per_class {
             let entry = per_class.entry(class_key).or_default();
-            entry.objects += stats.objects;
-            entry.bytes += stats.bytes;
+            entry.objects = entry.objects.checked_add(stats.objects).ok_or_else(|| {
+                CrabError::Internal("live inventory class object count overflow".to_string())
+            })?;
+            entry.bytes = entry.bytes.checked_add(stats.bytes).ok_or_else(|| {
+                CrabError::Internal("live inventory class byte count overflow".to_string())
+            })?;
         }
 
         for item in result.heaviest_cold {
@@ -289,16 +346,16 @@ pub async fn walk_live(
     let (adjusted_objects, adjusted_bytes) = if let Some(ratio) = config.sample_ratio {
         if ratio > 0.0 && ratio < 1.0 {
             for stats in per_class.values_mut() {
-                stats.objects = scale_sample_value(stats.objects, ratio);
-                stats.bytes = scale_sample_value(stats.bytes, ratio);
+                stats.objects = scale_sample_value(stats.objects, ratio)?;
+                stats.bytes = scale_sample_value(stats.bytes, ratio)?;
             }
             for stats in per_prefix.values_mut() {
-                stats.objects = scale_sample_value(stats.objects, ratio);
-                stats.bytes = scale_sample_value(stats.bytes, ratio);
+                stats.objects = scale_sample_value(stats.objects, ratio)?;
+                stats.bytes = scale_sample_value(stats.bytes, ratio)?;
             }
             (
-                scale_sample_value(total_objects, ratio),
-                scale_sample_value(total_bytes, ratio),
+                scale_sample_value(total_objects, ratio)?,
+                scale_sample_value(total_bytes, ratio)?,
             )
         } else {
             (total_objects, total_bytes)
@@ -332,8 +389,14 @@ pub async fn walk_live(
     })
 }
 
-fn scale_sample_value(value: u64, ratio: f64) -> u64 {
-    ((value as f64) / ratio).round() as u64
+fn scale_sample_value(value: u64, ratio: f64) -> Result<u64> {
+    let scaled = (value as f64) / ratio;
+    if !scaled.is_finite() || scaled > u64::MAX as f64 {
+        return Err(CrabError::Internal(
+            "sampled live inventory exceeds the u64 counter limit".to_string(),
+        ));
+    }
+    Ok(scaled.round() as u64)
 }
 
 /// Returns the current UTC time as an RFC 3339 string.
@@ -443,8 +506,29 @@ mod tests {
 
     #[test]
     fn sample_scaling_rounds_aggregate_values() {
-        assert_eq!(scale_sample_value(25, 0.25), 100);
-        assert_eq!(scale_sample_value(1, 0.3), 3);
+        assert_eq!(scale_sample_value(25, 0.25).unwrap(), 100);
+        assert_eq!(scale_sample_value(1, 0.3).unwrap(), 3);
+    }
+
+    #[test]
+    fn sample_scaling_rejects_counter_overflow() {
+        assert!(scale_sample_value(u64::MAX, f64::MIN_POSITIVE).is_err());
+    }
+
+    #[tokio::test]
+    async fn live_walk_rejects_invalid_concurrency() {
+        let store: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let result = walk_live(
+            store,
+            LiveWalkConfig {
+                list_concurrency: 0,
+                ..LiveWalkConfig::default()
+            },
+            &CancellationToken::new(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(CrabError::Configuration { .. })));
     }
 
     #[test]

--- a/crab/src/git/clean.rs
+++ b/crab/src/git/clean.rs
@@ -1269,6 +1269,12 @@ impl CleanSession {
         self.repo_root = Some(root);
     }
 
+    /// Return the repository root bound to this filter session, when known.
+    #[must_use]
+    pub fn repo_root(&self) -> Option<&Path> {
+        self.repo_root.as_deref()
+    }
+
     /// Check whether an LFS-tracked path should be smudged under LFS fetch filters.
     #[must_use]
     pub fn should_lfs_smudge(&self, pathname: &str) -> bool {

--- a/crab/src/git/filter_process.rs
+++ b/crab/src/git/filter_process.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::core::context::AppContext;
@@ -1226,7 +1226,7 @@ fn smudge_content(
             // Try LFS smudge regardless of blob content type.
             if let Ok(ptr) = crab_git::lfs_pointer::LfsPointer::parse(content) {
                 let oid_hex = crab_git::lfs_pointer::hex_encode(&ptr.oid);
-                if let Some(local) = try_local_lfs_cache(&ptr)? {
+                if let Some(local) = try_local_lfs_cache(&ptr, session.repo_root())? {
                     tracing::debug!(oid = %oid_hex, "smudge: LFS-filtered path resolved from local cache");
                     let content = crate::lfs::extension::smudge_content(&ptr, local, pathname)?;
                     return Ok(Bytes::from(content));
@@ -1235,7 +1235,7 @@ fn smudge_content(
                     tracing::debug!(oid = %oid_hex, "smudge: downloading LFS object for LFS-filtered path");
                     let rt = tokio::runtime::Handle::current();
                     let bytes = rt.block_on(store.verify(&ptr.oid))?;
-                    cache_lfs_locally(&ptr, &bytes)?;
+                    cache_lfs_locally(&ptr, &bytes, session.repo_root())?;
                     let content =
                         crate::lfs::extension::smudge_content(&ptr, bytes.to_vec(), pathname)?;
                     return Ok(Bytes::from(content));
@@ -1311,7 +1311,7 @@ fn smudge_by_blob_classification(
             let oid_hex = crab_git::lfs_pointer::hex_encode(&pointer.oid);
 
             // Non-lazy: try local .git/lfs/objects/ cache first, then remote.
-            if let Some(local) = try_local_lfs_cache(&pointer)? {
+            if let Some(local) = try_local_lfs_cache(&pointer, session.repo_root())? {
                 tracing::debug!(oid = %oid_hex, "smudge: resolved from local LFS cache");
                 let content = crate::lfs::extension::smudge_content(&pointer, local, pathname)?;
                 return Ok(Bytes::from(content));
@@ -1327,7 +1327,7 @@ fn smudge_by_blob_classification(
                 let rt = tokio::runtime::Handle::current();
                 let bytes = rt.block_on(store.verify(&pointer.oid))?;
                 // Cache locally for future checkouts.
-                cache_lfs_locally(&pointer, &bytes)?;
+                cache_lfs_locally(&pointer, &bytes, session.repo_root())?;
                 let content =
                     crate::lfs::extension::smudge_content(&pointer, bytes.to_vec(), pathname)?;
                 return Ok(Bytes::from(content));
@@ -1635,8 +1635,26 @@ fn write_flush<W: Write>(output: &mut W) -> Result<()> {
 }
 
 /// Try to read an LFS object from the local `.git/lfs/objects/` cache.
-fn try_local_lfs_cache(pointer: &crab_git::lfs_pointer::LfsPointer) -> Result<Option<Vec<u8>>> {
-    let ctx = WorktreeContext::resolve()?;
+fn try_local_lfs_cache(
+    pointer: &crab_git::lfs_pointer::LfsPointer,
+    repo_root: Option<&Path>,
+) -> Result<Option<Vec<u8>>> {
+    let ctx = match repo_root {
+        Some(root) => match WorktreeContext::resolve_from_path(root) {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                tracing::debug!(error = %error, "local LFS cache unavailable outside a Git worktree");
+                return Ok(None);
+            }
+        },
+        None => match WorktreeContext::resolve() {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                tracing::debug!(error = %error, "local LFS cache unavailable outside a Git worktree");
+                return Ok(None);
+            }
+        },
+    };
     match crate::lfs::cache::read_pointer(&ctx.common_git_dir.join("lfs"), pointer) {
         Err(CrabError::LfsObjectCorrupt { .. }) => Ok(None),
         result => result,
@@ -1644,8 +1662,27 @@ fn try_local_lfs_cache(pointer: &crab_git::lfs_pointer::LfsPointer) -> Result<Op
 }
 
 /// Cache an LFS object in the local `.git/lfs/objects/` directory.
-fn cache_lfs_locally(pointer: &crab_git::lfs_pointer::LfsPointer, content: &[u8]) -> Result<()> {
-    let ctx = WorktreeContext::resolve()?;
+fn cache_lfs_locally(
+    pointer: &crab_git::lfs_pointer::LfsPointer,
+    content: &[u8],
+    repo_root: Option<&Path>,
+) -> Result<()> {
+    let ctx = match repo_root {
+        Some(root) => match WorktreeContext::resolve_from_path(root) {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                tracing::debug!(error = %error, "skipping local LFS cache outside a Git worktree");
+                return Ok(());
+            }
+        },
+        None => match WorktreeContext::resolve() {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                tracing::debug!(error = %error, "skipping local LFS cache outside a Git worktree");
+                return Ok(());
+            }
+        },
+    };
     crate::lfs::cache::install_bytes(
         &ctx.common_git_dir.join("lfs"),
         &pointer.oid,

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -68,12 +68,13 @@ use crab_xet::shard::{
     FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo, MDBXorbInfo,
     XorbChunkSequenceEntry, XorbChunkSequenceHeader,
 };
+use crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES;
 use crab_xet::upload_concurrency::UploadConcurrency;
 use crab_xet::xorb::builder::{
     CHUNK_META_ENTRY_SIZE, FOOTER_SIZE, RunId, XORB_MAGIC, XorbBuilder, XorbResult,
 };
 use crab_xet::xorb::format::{
-    Chunk, ChunkMeta, ChunkPlacement, CompressionScheme, XorbHash, XorbRef,
+    Chunk, ChunkMeta, ChunkPlacement, CompressionScheme, MAX_XORB_SIZE, XorbHash, XorbRef,
 };
 use crab_xet::xorb::parser::{XorbParser, xorb_metadata_region};
 
@@ -354,7 +355,9 @@ async fn read_remote_shard_for_proof(
         }
     }
 
-    let (body, _) = store.get_with_etag(path).await?;
+    let (body, _) = store
+        .get_with_etag_bounded(path, MAX_SHARD_SIZE_BYTES as u64)
+        .await?;
     Ok(body)
 }
 
@@ -438,6 +441,12 @@ async fn remote_xorb_index(
     path: &ObjectPath,
     object_size: u64,
 ) -> Result<RemoteXorbIndex> {
+    if object_size > MAX_XORB_SIZE as u64 {
+        return Err(corrupt_xorb_index(
+            path,
+            format!("xorb is {object_size} bytes; format limit is {MAX_XORB_SIZE} bytes"),
+        ));
+    }
     if object_size < FOOTER_SIZE as u64 {
         return Err(corrupt_xorb_index(path, "xorb too small for footer"));
     }
@@ -4829,7 +4838,10 @@ async fn warm_uploaded_xorb_cache(
         let Some(store) = store.as_ref() else {
             return stats;
         };
-        let body = match store.get_with_etag(&path).await {
+        let body = match store
+            .get_with_etag_bounded(&path, MAX_XORB_SIZE as u64)
+            .await
+        {
             Ok((body, _)) if body.len() as u64 == bytes => body,
             Ok((body, _)) => {
                 warn!(
@@ -4997,7 +5009,9 @@ async fn read_uploaded_xorb_payload_for_cache_warm(
                     "uploaded xorb cache warm has no payload or origin store".to_owned(),
                 ));
             };
-            let (bytes, _) = store.get_with_etag(path).await?;
+            let (bytes, _) = store
+                .get_with_etag_bounded(path, MAX_XORB_SIZE as u64)
+                .await?;
             bytes
         }
     };

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -556,7 +556,16 @@ impl SessionCache {
 }
 
 fn resolve_remote_helper_config() -> Result<crate::core::config::Config> {
-    let mut config = crate::core::config::Config::resolve_local()?;
+    // Git may launch a nested promisor helper while a push is still running.
+    // That helper can start outside the worktree, so resolve the shared repo
+    // config from Git's explicit directory instead of trusting its cwd.
+    let repo_root = super::discover::discover_git_dir()
+        .ok()
+        .map(|git_dir| repo_root_from_git_dir(&git_dir));
+    let mut config = repo_root.as_deref().map_or_else(
+        crate::core::config::Config::resolve_local,
+        crate::core::config::Config::resolve_for_repo,
+    )?;
     if let Ok(cwd) = std::env::current_dir()
         && let Some(project) = crate::core::project_config::ProjectConfig::discover(&cwd)
     {
@@ -5300,6 +5309,41 @@ mod tests {
             config.contains("lazy = false"),
             "helper must not overwrite explicit checkout policy: {config}"
         );
+    }
+
+    #[test]
+    fn remote_helper_config_uses_git_dir_when_cwd_is_outside_worktree() {
+        let _git_env = CleanGitEnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let init = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .status()
+            .expect("run git init");
+        assert!(init.success());
+        let config_path = repo.join(".crab/config.toml");
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &config_path,
+            "[uploadpack]\nallowReachableSHA1InWant = true\n",
+        )
+        .unwrap();
+
+        let saved_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&outside).unwrap();
+        // SAFETY: `CleanGitEnvGuard` serializes process-global Git env access.
+        unsafe {
+            std::env::set_var("GIT_DIR", repo.join(".git"));
+            std::env::set_var("GIT_WORK_TREE", &repo);
+        }
+        let config = resolve_remote_helper_config().expect("resolve helper config");
+        std::env::set_current_dir(saved_cwd).unwrap();
+
+        assert!(config.uploadpack_allow_reachable_sha_in_want);
     }
 
     #[test]

--- a/crab/src/git/store_client.rs
+++ b/crab/src/git/store_client.rs
@@ -46,6 +46,7 @@ use crate::core::metrics::Metrics;
 use crab_cache_store::CachingStore;
 use crab_metadata::file_index_lookup::{FileIndexLookupSession, SharedFileIndexLookup};
 use crab_xet::shard::ShardReader;
+use crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES;
 type StoreLayout = crab_storage::StoreLayout<crab_storage::Store>;
 use crab_xet::hash::MerkleHash;
 use crab_xet::shard::MDBFileInfo;
@@ -330,7 +331,10 @@ impl StoreClient {
     async fn load_shard(&self, shard_hash: &MerkleHash) -> crate::core::error::Result<ShardReader> {
         let path = self.router.shard_path(shard_hash);
         debug!(shard_hash = %shard_hash.hex(), "store_client: downloading shard");
-        let (data, _) = self.store.get_with_etag(&path).await?;
+        let (data, _) = self
+            .store
+            .get_with_etag_bounded(&path, MAX_SHARD_SIZE_BYTES as u64)
+            .await?;
 
         Ok(ShardReader::from_bytes(data, *shard_hash))
     }

--- a/crab/src/hydrate/batch.rs
+++ b/crab/src/hydrate/batch.rs
@@ -19,6 +19,8 @@ use tracing::{debug, info, warn};
 use crate::cache::CacheKey;
 use crate::cache::LocalCache;
 use crate::core::error::{CrabError, Result};
+
+const MAX_BATCH_SHARD_BYTES: u64 = 512 * 1024 * 1024;
 use crab_cache_store::CachingStore;
 use crab_metadata::bloom_prefilter::{self, BloomCheck};
 use crab_types::pointer::Pointer;
@@ -414,7 +416,9 @@ async fn get_or_download_shard(
             let obj_path = obj_path;
             async move {
                 debug!(shard_hash = %hash.hex(), "batch: downloading shard");
-                let (data, _) = origin.get_with_etag(&obj_path).await?;
+                let (data, _) = origin
+                    .get_with_etag_bounded(&obj_path, MAX_BATCH_SHARD_BYTES)
+                    .await?;
                 Ok::<_, CrabError>(data)
             }
         })

--- a/crab/src/hydrate/manifest.rs
+++ b/crab/src/hydrate/manifest.rs
@@ -6,7 +6,7 @@
 //! (`*`, `?`, `[`, `{`) are parsed as [`globset::Glob`]; everything
 //! else is treated as a literal [`PathBuf`].
 
-use std::io::BufRead;
+use std::io::{self, BufRead};
 use std::path::PathBuf;
 
 use globset::Glob;
@@ -17,6 +17,9 @@ use crate::core::{CrabError, Result};
 /// Characters whose presence in a line signals a glob pattern rather
 /// than a literal path.
 const GLOB_META_CHARS: &[char] = &['*', '?', '[', '{'];
+pub(crate) const MAX_MANIFEST_BYTES: usize = 64 * 1024 * 1024;
+const MAX_MANIFEST_LINE_BYTES: usize = 64 * 1024;
+const MAX_MANIFEST_ENTRIES: usize = 1_000_000;
 
 /// A single entry parsed from a manifest file.
 #[derive(Debug, Clone)]
@@ -35,11 +38,36 @@ pub enum ManifestEntry {
 ///
 /// Returns [`CrabError::ManifestParse`] if a glob pattern is
 /// syntactically invalid.
-pub fn parse_manifest(reader: impl BufRead) -> Result<Vec<ManifestEntry>> {
+pub fn parse_manifest(mut reader: impl BufRead) -> Result<Vec<ManifestEntry>> {
     let mut entries = Vec::new();
+    let mut line = Vec::new();
+    let mut total_bytes = 0usize;
 
-    for (line_idx, line_result) in reader.lines().enumerate() {
-        let raw_line = line_result?;
+    for line_idx in 0.. {
+        let Some(line_bytes) = read_line_limited(&mut reader, &mut line)? else {
+            break;
+        };
+        total_bytes =
+            total_bytes
+                .checked_add(line_bytes)
+                .ok_or_else(|| CrabError::Configuration {
+                    key: "manifest size".to_owned(),
+                    origin: "manifest byte count overflow".to_owned(),
+                })?;
+        if total_bytes > MAX_MANIFEST_BYTES {
+            return Err(CrabError::Configuration {
+                key: "manifest size".to_owned(),
+                origin: format!("manifest exceeds the safety limit of {MAX_MANIFEST_BYTES} bytes"),
+            });
+        }
+        let raw_line = std::str::from_utf8(&line[..line_bytes]).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("manifest is not UTF-8: {error}"),
+            )
+        })?;
+        let raw_line = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+        let raw_line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
         let trimmed = raw_line.trim();
 
         // Skip blank lines.
@@ -70,11 +98,44 @@ pub fn parse_manifest(reader: impl BufRead) -> Result<Vec<ManifestEntry>> {
             ManifestEntry::Path(PathBuf::from(trimmed))
         };
 
+        if entries.len() >= MAX_MANIFEST_ENTRIES {
+            return Err(CrabError::Configuration {
+                key: "manifest entry count".to_owned(),
+                origin: format!(
+                    "manifest exceeds the safety limit of {MAX_MANIFEST_ENTRIES} entries"
+                ),
+            });
+        }
         entries.push(entry);
     }
 
     debug!(count = entries.len(), "manifest: parsed entries");
     Ok(entries)
+}
+
+fn read_line_limited<R: BufRead>(reader: &mut R, line: &mut Vec<u8>) -> io::Result<Option<usize>> {
+    line.clear();
+    loop {
+        let chunk = reader.fill_buf()?;
+        if chunk.is_empty() {
+            return Ok((!line.is_empty()).then_some(line.len()));
+        }
+        let newline = chunk.iter().position(|byte| *byte == b'\n');
+        let take = newline.map_or(chunk.len(), |index| index + 1);
+        if line.len().saturating_add(take) > MAX_MANIFEST_LINE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "manifest line exceeds the safety limit of {MAX_MANIFEST_LINE_BYTES} bytes"
+                ),
+            ));
+        }
+        line.extend_from_slice(&chunk[..take]);
+        reader.consume(take);
+        if newline.is_some() {
+            return Ok(Some(line.len()));
+        }
+    }
 }
 
 /// Convenience: parse a manifest from a file path, or from stdin if
@@ -189,5 +250,25 @@ Cargo.lock
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, CrabError::ManifestParse { line: 1, .. }));
+    }
+
+    #[test]
+    fn rejects_oversized_line_before_materializing_unbounded_input() {
+        let input = "x".repeat(MAX_MANIFEST_LINE_BYTES + 1);
+        let error = parse_manifest(Cursor::new(input)).unwrap_err();
+        assert!(
+            matches!(error, CrabError::Io(source) if source.kind() == std::io::ErrorKind::InvalidData)
+        );
+    }
+
+    #[test]
+    fn rejects_excessive_entry_count() {
+        let input = (0..=MAX_MANIFEST_ENTRIES)
+            .map(|index| format!("file-{index}\n"))
+            .collect::<String>();
+        let error = parse_manifest(Cursor::new(input)).unwrap_err();
+        assert!(
+            matches!(error, CrabError::Configuration { key, .. } if key == "manifest entry count")
+        );
     }
 }

--- a/crab/src/lfs/config.rs
+++ b/crab/src/lfs/config.rs
@@ -12,7 +12,8 @@ use crate::core::error::{CrabError, Result};
 /// Resolved LFS configuration.
 ///
 /// Built by layering defaults ← `.gitconfig` ← `.lfsconfig` ← env vars.
-/// Higher-priority sources override lower ones on a per-key basis.
+/// Higher-priority sources override lower ones on a per-key basis. Storage
+/// redirection is ignored in tracked `.lfsconfig` files.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LfsConfig {
     /// Maximum concurrent upload/download transfers (1–100).
@@ -58,11 +59,21 @@ impl Default for LfsConfig {
 }
 
 impl LfsConfig {
+    /// Resolve the local LFS storage root against the common Git directory.
+    #[must_use]
+    pub fn storage_dir(&self, common_git_dir: &Path) -> PathBuf {
+        match self.lfs_dir.as_ref() {
+            Some(path) if path.is_absolute() => path.clone(),
+            Some(path) => common_git_dir.join(path),
+            None => common_git_dir.join("lfs"),
+        }
+    }
+
     /// Resolve LFS configuration from all sources.
     ///
     /// Precedence (highest to lowest):
     /// 1. Environment variables (`GIT_LFS_*`)
-    /// 2. `.lfsconfig` in the repository root
+    /// 2. `.lfsconfig` in the repository root, except storage redirection
     /// 3. `.gitconfig` (local `.git/config` → global `~/.gitconfig` → system `/etc/gitconfig`)
     /// 4. Compiled defaults
     ///
@@ -85,7 +96,11 @@ impl LfsConfig {
         // Layer 2: .lfsconfig (overrides .gitconfig)
         let lfsconfig_path = repo_root.join(".lfsconfig");
         if lfsconfig_path.is_file() {
-            let values = parse_ini_lfs_section(&lfsconfig_path)?;
+            let mut values = parse_ini_lfs_section(&lfsconfig_path)?;
+            // A tracked file must not redirect local reads or destructive
+            // prune operations outside this repository's Git directory.
+            values.remove("storage");
+            values.remove("lfsdir");
             config.apply_ini_values(&values, &lfsconfig_path.display().to_string())?;
         }
 
@@ -128,6 +143,9 @@ impl LfsConfig {
             self.skip_download_errors = parse_bool(v, "lfs.skipdownloaderrors", origin)?;
         }
         if let Some(v) = values.get("lfsdir") {
+            self.lfs_dir = Some(PathBuf::from(v));
+        }
+        if let Some(v) = values.get("storage") {
             self.lfs_dir = Some(PathBuf::from(v));
         }
         if let Some(v) = values.get("transfer.maxbandwidth") {
@@ -511,7 +529,8 @@ mod tests {
     #[test]
     fn lfs_dir_override() {
         let dir = tempfile::tempdir().unwrap();
-        let lfsconfig = dir.path().join(".lfsconfig");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        let lfsconfig = dir.path().join(".git/config");
         let mut f = std::fs::File::create(&lfsconfig).unwrap();
         writeln!(f, "[lfs]").unwrap();
         writeln!(f, "    lfsdir = /custom/lfs/path").unwrap();
@@ -519,6 +538,39 @@ mod tests {
 
         let config = LfsConfig::resolve(dir.path()).unwrap();
         assert_eq!(config.lfs_dir, Some(PathBuf::from("/custom/lfs/path")));
+    }
+
+    #[test]
+    fn standard_lfs_storage_override() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        let lfsconfig = dir.path().join(".git/config");
+        let mut f = std::fs::File::create(&lfsconfig).unwrap();
+        writeln!(f, "[lfs]").unwrap();
+        writeln!(f, "    storage = relative-lfs-cache").unwrap();
+        drop(f);
+
+        let config = LfsConfig::resolve(dir.path()).unwrap();
+
+        assert_eq!(config.lfs_dir, Some(PathBuf::from("relative-lfs-cache")));
+        assert_eq!(
+            config.storage_dir(Path::new("/repo/.git")),
+            PathBuf::from("/repo/.git/relative-lfs-cache")
+        );
+    }
+
+    #[test]
+    fn tracked_lfsconfig_cannot_redirect_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let lfsconfig = dir.path().join(".lfsconfig");
+        let mut f = std::fs::File::create(&lfsconfig).unwrap();
+        writeln!(f, "[lfs]").unwrap();
+        writeln!(f, "    storage = /outside/repository").unwrap();
+        drop(f);
+
+        let config = LfsConfig::resolve(dir.path()).unwrap();
+
+        assert!(config.lfs_dir.is_none());
     }
 
     #[test]

--- a/crab/src/lfs/prune.rs
+++ b/crab/src/lfs/prune.rs
@@ -19,11 +19,20 @@
 //! `--verify-remote` (download and verify each candidate before local deletion).
 
 use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use crate::core::error::{CrabError, Result};
+use fs4::fs_std::FileExt as LockFileExt;
+use sha2::{Digest, Sha256};
+use tokio_util::sync::CancellationToken;
+
+use crate::core::error::{CrabError, Result, check_cancelled};
 use crab_git::lfs_pointer::LfsPointer;
 use crab_lfs::LfsError;
+
+const PRUNE_LOCK: &str = "crab-lfs-prune.lock";
+const MAX_LFS_SCAN_OBJECTS: usize = 5_000_000;
 
 /// Summary of a prune operation.
 #[derive(Debug, Clone)]
@@ -92,12 +101,36 @@ pub enum WhenUnverified {
 /// - `dry_run`: when true, reports what would be pruned without deleting.
 /// - `force`: when true, skips the confirmation prompt.
 pub fn run_prune(options: PruneOptions) -> Result<PruneSummary> {
+    run_prune_with_cancel(options, &CancellationToken::new())
+}
+
+/// Run LFS pruning with cancellation checks and a repository-scoped lock.
+pub fn run_prune_with_cancel(
+    options: PruneOptions,
+    cancel: &CancellationToken,
+) -> Result<PruneSummary> {
+    check_cancelled(cancel)?;
     // `println!`/`eprintln!` in this function are user-facing CLI output
     // (status messages, dry-run listings, confirmation prompts). These
     // are intentional and match the pattern used by other crab
     // commands. Internal diagnostics use `tracing` and the review
     // accepts this split. See finding CR7-F1.
     let lfs_objects_dir = discover_lfs_objects_dir()?;
+    let git_dir = crate::git::discover::discover_common_git_dir()?;
+    let lock_path = git_dir.join(PRUNE_LOCK);
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(CrabError::Io)?;
+    if !LockFileExt::try_lock_exclusive(&lock).map_err(CrabError::Io)? {
+        return Err(CrabError::Configuration {
+            key: "crab lfs prune".to_owned(),
+            origin: format!("another prune holds {}", lock_path.display()),
+        });
+    }
 
     if !lfs_objects_dir.is_dir() {
         println!("crab lfs prune: no local LFS objects directory found");
@@ -109,7 +142,7 @@ pub fn run_prune(options: PruneOptions) -> Result<PruneSummary> {
     }
 
     // Step 1: Collect all local LFS object OIDs and their file paths.
-    let local_objects = collect_local_objects(&lfs_objects_dir)?;
+    let local_objects = collect_local_objects_with_cancel(&lfs_objects_dir, cancel)?;
 
     if local_objects.is_empty() {
         println!("crab lfs prune: no local LFS objects found");
@@ -213,6 +246,8 @@ pub fn run_prune(options: PruneOptions) -> Result<PruneSummary> {
     let mut deleted_bytes = 0u64;
 
     for obj in &candidates {
+        check_cancelled(cancel)?;
+        verify_local_object(obj, cancel)?;
         match std::fs::remove_file(&obj.path) {
             Ok(()) => {
                 deleted_count += 1;
@@ -242,6 +277,46 @@ pub fn run_prune(options: PruneOptions) -> Result<PruneSummary> {
         pruned_bytes: deleted_bytes,
         dry_run: false,
     })
+}
+
+fn collect_local_objects_with_cancel(
+    lfs_objects_dir: &Path,
+    cancel: &CancellationToken,
+) -> Result<Vec<LocalObject>> {
+    check_cancelled(cancel)?;
+    let objects = collect_local_objects(lfs_objects_dir)?;
+    if objects.len() > MAX_LFS_SCAN_OBJECTS {
+        return Err(CrabError::Configuration {
+            key: "lfs prune object count".to_owned(),
+            origin: format!("local LFS inventory exceeds {MAX_LFS_SCAN_OBJECTS} objects"),
+        });
+    }
+    check_cancelled(cancel)?;
+    Ok(objects)
+}
+
+fn verify_local_object(object: &LocalObject, cancel: &CancellationToken) -> Result<()> {
+    let mut file = File::open(&object.path).map_err(CrabError::Io)?;
+    let mut hasher = Sha256::new();
+    let mut bytes = 0u64;
+    let mut buffer = [0u8; 1024 * 1024];
+    loop {
+        check_cancelled(cancel)?;
+        let read = file.read(&mut buffer).map_err(CrabError::Io)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        bytes = bytes.saturating_add(read as u64);
+    }
+    let digest: [u8; 32] = hasher.finalize().into();
+    let expected = parse_hex32(&object.oid_hex)?;
+    if bytes != object.size || digest != expected {
+        return Err(CrabError::LfsObjectCorrupt {
+            oid: object.oid_hex.clone(),
+        });
+    }
+    Ok(())
 }
 
 fn print_prune_candidates(candidates: &[&LocalObject], verbose: bool) {

--- a/crab/src/lfs/recent.rs
+++ b/crab/src/lfs/recent.rs
@@ -1,5 +1,6 @@
 //! Git LFS recent-ref and recent-commit selection helpers.
 
+use std::path::Path;
 use std::process::Command;
 
 use crate::core::error::{CrabError, Result};
@@ -9,11 +10,21 @@ use crate::core::error::{CrabError, Result};
 /// `extra_days` is added to `lfs.fetchrecentrefsdays`, matching prune's
 /// offset-based retention window.
 pub(crate) fn recent_ref_oids(extra_days: u64) -> Result<Vec<String>> {
-    let fetch_days = git_config_u64("lfs.fetchrecentrefsdays", 7)?;
+    let root = std::env::current_dir().map_err(CrabError::Io)?;
+    recent_ref_oids_in(&root, extra_days)
+}
+
+pub(crate) fn git_config_u64(key: &str, default: u64) -> Result<u64> {
+    let root = std::env::current_dir().map_err(CrabError::Io)?;
+    git_config_u64_in(&root, key, default)
+}
+
+pub(crate) fn recent_ref_oids_in(repo_root: &Path, extra_days: u64) -> Result<Vec<String>> {
+    let fetch_days = git_config_u64_in(repo_root, "lfs.fetchrecentrefsdays", 7)?;
     if fetch_days == 0 {
         return Ok(Vec::new());
     }
-    let include_remotes = git_config_bool("lfs.fetchrecentremoterefs", true)?;
+    let include_remotes = git_config_bool_in(repo_root, "lfs.fetchrecentremoterefs", true)?;
     let cutoff = cutoff_unix(fetch_days.saturating_add(extra_days));
 
     let mut args = vec![
@@ -27,11 +38,15 @@ pub(crate) fn recent_ref_oids(extra_days: u64) -> Result<Vec<String>> {
 
     let output = Command::new("git")
         .args(args)
+        .current_dir(repo_root)
         .output()
         .map_err(|e| CrabError::Internal(format!("failed to list recent refs: {e}")))?;
 
     if !output.status.success() {
-        return Ok(Vec::new());
+        return Err(CrabError::Internal(format!(
+            "git for-each-ref failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
     }
 
     Ok(parse_recent_ref_oids(
@@ -42,11 +57,16 @@ pub(crate) fn recent_ref_oids(extra_days: u64) -> Result<Vec<String>> {
 
 /// Returns commits inside `lfs.fetchrecentcommitsdays` reachable from revisions.
 pub(crate) fn recent_commit_oids(revisions: &[String]) -> Result<Vec<String>> {
+    let root = std::env::current_dir().map_err(CrabError::Io)?;
+    recent_commit_oids_in(&root, revisions)
+}
+
+pub(crate) fn recent_commit_oids_in(repo_root: &Path, revisions: &[String]) -> Result<Vec<String>> {
     if revisions.is_empty() {
         return Ok(Vec::new());
     }
 
-    let days = git_config_u64("lfs.fetchrecentcommitsdays", 0)?;
+    let days = git_config_u64_in(repo_root, "lfs.fetchrecentcommitsdays", 0)?;
     if days == 0 {
         return Ok(Vec::new());
     }
@@ -57,6 +77,7 @@ pub(crate) fn recent_commit_oids(revisions: &[String]) -> Result<Vec<String>> {
 
     let output = Command::new("git")
         .args(&args)
+        .current_dir(repo_root)
         .output()
         .map_err(|e| CrabError::Internal(format!("failed to list recent commits: {e}")))?;
 
@@ -76,14 +97,21 @@ pub(crate) fn recent_commit_oids(revisions: &[String]) -> Result<Vec<String>> {
     ))
 }
 
-pub(crate) fn git_config_u64(key: &str, default: u64) -> Result<u64> {
+pub(crate) fn git_config_u64_in(repo_root: &Path, key: &str, default: u64) -> Result<u64> {
     let output = Command::new("git")
         .args(["config", "--type", "int", "--get", key])
+        .current_dir(repo_root)
         .output()
         .map_err(|e| CrabError::Internal(format!("failed to read {key}: {e}")))?;
 
     if !output.status.success() {
-        return Ok(default);
+        if output.status.code() == Some(1) {
+            return Ok(default);
+        }
+        return Err(CrabError::Internal(format!(
+            "git config failed while reading {key}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
     }
 
     let value = String::from_utf8_lossy(&output.stdout).trim().to_owned();
@@ -93,14 +121,21 @@ pub(crate) fn git_config_u64(key: &str, default: u64) -> Result<u64> {
     })
 }
 
-fn git_config_bool(key: &str, default: bool) -> Result<bool> {
+fn git_config_bool_in(repo_root: &Path, key: &str, default: bool) -> Result<bool> {
     let output = Command::new("git")
         .args(["config", "--type", "bool", "--get", key])
+        .current_dir(repo_root)
         .output()
         .map_err(|e| CrabError::Internal(format!("failed to read {key}: {e}")))?;
 
     if !output.status.success() {
-        return Ok(default);
+        if output.status.code() == Some(1) {
+            return Ok(default);
+        }
+        return Err(CrabError::Internal(format!(
+            "git config failed while reading {key}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
     }
 
     let value = String::from_utf8_lossy(&output.stdout).trim().to_owned();

--- a/crab/src/lfs/track.rs
+++ b/crab/src/lfs/track.rs
@@ -990,7 +990,7 @@ mod tests {
     #[test]
     fn no_modify_attrs_marks_indexed_matches_without_attrs_file() {
         let dir = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
+        git_command(dir.path())
             .arg("init")
             .arg("-q")
             .current_dir(dir.path())
@@ -998,7 +998,7 @@ mod tests {
             .unwrap();
         let path = dir.path().join("data.bin");
         std::fs::write(&path, b"payload").unwrap();
-        std::process::Command::new("git")
+        git_command(dir.path())
             .args(["add", "data.bin"])
             .current_dir(dir.path())
             .status()
@@ -1016,7 +1016,7 @@ mod tests {
     #[test]
     fn filename_match_is_literal_for_index_matches() {
         let dir = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
+        git_command(dir.path())
             .arg("init")
             .arg("-q")
             .current_dir(dir.path())
@@ -1024,7 +1024,7 @@ mod tests {
             .unwrap();
         std::fs::write(dir.path().join("project [1].psd"), b"payload").unwrap();
         std::fs::write(dir.path().join("project X.psd"), b"payload").unwrap();
-        std::process::Command::new("git")
+        git_command(dir.path())
             .args(["add", "project [1].psd", "project X.psd"])
             .current_dir(dir.path())
             .status()

--- a/crab/src/lfs/track.rs
+++ b/crab/src/lfs/track.rs
@@ -419,9 +419,8 @@ pub fn mark_matches_stat_dirty_paths(
 // ---------------------------------------------------------------------------
 
 fn git_index_paths(repo_root: &Path) -> Result<Vec<String>> {
-    let output = Command::new("git")
+    let output = git_command(repo_root)
         .args(["ls-files", "-z"])
-        .current_dir(repo_root)
         .output()
         .map_err(|e| CrabError::Configuration {
             key: "lfs track".to_owned(),
@@ -442,6 +441,23 @@ fn git_index_paths(repo_root: &Path) -> Result<Vec<String>> {
         .filter(|entry| !entry.is_empty())
         .map(|entry| String::from_utf8_lossy(entry).into_owned())
         .collect())
+}
+
+/// Run Git against an explicit repository root, ignoring ambient repository
+/// overrides that could redirect an index scan to another checkout.
+fn git_command(repo_root: &Path) -> Command {
+    let mut command = Command::new("git");
+    command
+        .current_dir(repo_root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env_remove("GIT_QUARANTINE_PATH")
+        .env_remove("GIT_NAMESPACE");
+    command
 }
 
 fn track_pattern_matches(pattern: &str, path: &str, filename: bool) -> bool {

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -5268,7 +5268,7 @@ async fn run_optimize_command(
             let _span = tracing::info_span!("optimize_plan").entered();
             let mode = OutputMode::from_flags(args.json, false);
             let config = Config::resolve_local()?;
-            crab::cmd::optimize::run_plan(&args, &config, mode);
+            crab::cmd::optimize::run_plan(&args, &config, mode)?;
             Ok(ExitCode::SUCCESS)
         }
         OptimizeCmd::Apply(args) => {
@@ -5511,7 +5511,8 @@ async fn run_optimize_apply(
 ) -> Result<ExitCode> {
     let mode = OutputMode::from_flags(args.json, false);
     let config = Config::resolve_local()?;
-    let mut payload = crab::cmd::optimize::build_apply_payload(&args, &config);
+    let _apply_lock = crab::cmd::optimize::acquire_apply_lock()?;
+    let mut payload = crab::cmd::optimize::build_apply_payload(&args, &config)?;
 
     for index in 0..payload.steps.len() {
         if cancel.is_cancelled() {
@@ -5605,7 +5606,7 @@ async fn run_compact_command(
         dry_run,
         max_shard_size: max_size,
     };
-    crab::cmd::compact::run_compact(&args, &store).await?;
+    crab::cmd::compact::run_compact_with_cancel(&args, &store, cancel).await?;
     Ok(ExitCode::SUCCESS)
 }
 
@@ -5641,6 +5642,7 @@ async fn run_repack_command(
         dry_run,
         download_concurrency: config.download_concurrency,
         max_cas_retries: config.push_max_cas_retries,
+        workspace_root: crab::cache::default_cache_root().join("maintenance"),
     };
 
     let outcome = crab::cmd::repack::run_repack(&store, &prefix, &repack_config, cancel).await?;

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -6094,7 +6094,7 @@ async fn run_cache_stats() -> Result<()> {
         }
     };
 
-    let stats = handle.stats().await;
+    let stats = handle.stats().await?;
     println!("Chunk cache:");
     println!("  directory:   {}", handle.directory.display());
     println!(

--- a/crab/src/metadata/manifest.rs
+++ b/crab/src/metadata/manifest.rs
@@ -148,6 +148,23 @@ pub async fn read_bulk_shard_list(
         .map_err(CrabError::from)
 }
 
+pub async fn read_bulk_shard_list_with_limit(
+    store: &Store,
+    router: &StoreLayout,
+    hash: &str,
+    max_records: u64,
+) -> Result<Vec<String>> {
+    let router = storage_layout(store, router);
+    crab_metadata::manifest_store::read_bulk_shard_list_with_limit(
+        store.as_storage(),
+        &router,
+        hash,
+        max_records,
+    )
+    .await
+    .map_err(CrabError::from)
+}
+
 pub async fn read_bulk_pack_list(
     store: &Store,
     router: &StoreLayout,
@@ -157,6 +174,23 @@ pub async fn read_bulk_pack_list(
     crab_metadata::manifest_store::read_bulk_pack_list(store.as_storage(), &router, hash)
         .await
         .map_err(CrabError::from)
+}
+
+pub async fn read_bulk_pack_list_with_limit(
+    store: &Store,
+    router: &StoreLayout,
+    hash: &str,
+    max_records: u64,
+) -> Result<Vec<PackManifestEntry>> {
+    let router = storage_layout(store, router);
+    crab_metadata::manifest_store::read_bulk_pack_list_with_limit(
+        store.as_storage(),
+        &router,
+        hash,
+        max_records,
+    )
+    .await
+    .map_err(CrabError::from)
 }
 
 pub async fn read_shard_index(

--- a/crab/src/metadata/metadb/db.rs
+++ b/crab/src/metadata/metadb/db.rs
@@ -39,6 +39,7 @@ use tracing::Instrument;
 
 use crate::core::error::{CrabError, MetaDbError, Result};
 use crate::core::metrics::Metrics;
+use crate::metadata::metadb::MetaDbEngineConfig;
 
 const GET_BATCH_CONCURRENCY: usize = 256;
 const DENSE_BATCH_SCAN_THRESHOLD: usize = 16_384;
@@ -51,6 +52,76 @@ pub(super) fn new_db_cache() -> Arc<dyn DbCache> {
         max_capacity: DB_CACHE_CAPACITY_BYTES,
         ..FoyerCacheOptions::default()
     }))
+}
+
+pub(crate) fn compactor_options(
+    config: &MetaDbEngineConfig,
+) -> Result<slatedb::config::CompactorOptions> {
+    validate_engine_config(config)?;
+    let threshold =
+        usize::try_from(config.compaction_threshold).map_err(|_| CrabError::Configuration {
+            key: "metadb compaction_threshold".to_owned(),
+            origin: "value cannot be represented by SlateDB".to_owned(),
+        })?;
+    let defaults = slatedb::config::SizeTieredCompactionSchedulerOptions::default();
+    let scheduler = slatedb::config::SizeTieredCompactionSchedulerOptions {
+        min_compaction_sources: threshold,
+        max_compaction_sources: defaults.max_compaction_sources.max(threshold),
+        ..defaults
+    };
+    Ok(slatedb::config::CompactorOptions {
+        scheduler_options: scheduler.into(),
+        ..slatedb::config::CompactorOptions::default()
+    })
+}
+
+pub(crate) fn filter_policies(
+    config: &MetaDbEngineConfig,
+) -> Result<Vec<Arc<dyn slatedb::FilterPolicy>>> {
+    validate_engine_config(config)?;
+    Ok(vec![Arc::new(slatedb::BloomFilterPolicy::new(
+        config.bloom_bits_per_key,
+    ))])
+}
+
+fn validate_engine_config(config: &MetaDbEngineConfig) -> Result<()> {
+    for (key, value) in [
+        (
+            "compaction_threshold",
+            u64::from(config.compaction_threshold),
+        ),
+        ("wal_flush_size", config.wal_flush_size),
+        ("bloom_bits_per_key", u64::from(config.bloom_bits_per_key)),
+    ] {
+        if value == 0 {
+            return Err(CrabError::Configuration {
+                key: format!("metadb {key}"),
+                origin: "value must be greater than zero".to_owned(),
+            });
+        }
+    }
+    usize::try_from(config.wal_flush_size).map_err(|_| CrabError::Configuration {
+        key: "metadb wal_flush_size".to_owned(),
+        origin: "value cannot be represented by SlateDB".to_owned(),
+    })?;
+    Ok(())
+}
+
+fn slatedb_settings(config: &MetaDbEngineConfig) -> Result<slatedb::config::Settings> {
+    Ok(slatedb::config::Settings {
+        // Crab owns explicit durability boundaries. Disabling SlateDB's
+        // 100 ms timer prevents idle and post-commit batch work from
+        // generating one WAL object per timer tick.
+        flush_interval: None,
+        l0_sst_size_bytes: usize::try_from(config.wal_flush_size).map_err(|_| {
+            CrabError::Configuration {
+                key: "metadb wal_flush_size".to_owned(),
+                origin: "value cannot be represented by SlateDB".to_owned(),
+            }
+        })?,
+        compactor_options: Some(compactor_options(config)?),
+        ..slatedb::config::Settings::default()
+    })
 }
 
 fn dense_batch_scan_options() -> ScanOptions {
@@ -217,7 +288,14 @@ impl Db {
         path: ObjectPath,
         label: &'static str,
     ) -> Result<Self> {
-        Self::open_with_cache(store, path, label, new_db_cache()).await
+        Self::open_with_cache(
+            store,
+            path,
+            label,
+            new_db_cache(),
+            &MetaDbEngineConfig::default(),
+        )
+        .await
     }
 
     pub(super) async fn open_with_cache(
@@ -225,18 +303,14 @@ impl Db {
         path: ObjectPath,
         label: &'static str,
         cache: Arc<dyn DbCache>,
+        config: &MetaDbEngineConfig,
     ) -> Result<Self> {
         let span = tracing::debug_span!("metadb.open", db = label, path = %path, mode = "rw");
         let start = std::time::Instant::now();
-        let settings = slatedb::config::Settings {
-            // Crab owns explicit durability boundaries. Disabling SlateDB's
-            // 100 ms timer prevents idle and post-commit batch work from
-            // generating one WAL object per timer tick.
-            flush_interval: None,
-            ..slatedb::config::Settings::default()
-        };
+        let settings = slatedb_settings(config)?;
         match slatedb::Db::builder(path.clone(), store)
             .with_settings(settings)
+            .with_filter_policies(filter_policies(config)?)
             .with_db_cache(Arc::clone(&cache))
             .build()
             .instrument(span.clone())
@@ -292,7 +366,14 @@ impl Db {
         path: ObjectPath,
         label: &'static str,
     ) -> Result<Self> {
-        Self::open_readonly_with_cache(store, path, label, new_db_cache()).await
+        Self::open_readonly_with_cache(
+            store,
+            path,
+            label,
+            new_db_cache(),
+            &MetaDbEngineConfig::default(),
+        )
+        .await
     }
 
     pub(super) async fn open_readonly_with_cache(
@@ -300,6 +381,7 @@ impl Db {
         path: ObjectPath,
         label: &'static str,
         cache: Arc<dyn DbCache>,
+        config: &MetaDbEngineConfig,
     ) -> Result<Self> {
         let span = tracing::debug_span!("metadb.open", db = label, path = %path, mode = "ro");
         let start = std::time::Instant::now();
@@ -309,6 +391,7 @@ impl Db {
         // has the original to surface.
         match slatedb::DbReader::builder(path.clone(), store)
             .with_db_cache(Arc::clone(&cache))
+            .with_filter_policies(filter_policies(config)?)
             .build()
             .instrument(span.clone())
             .await
@@ -804,6 +887,49 @@ mod tests {
 
     fn stub_store() -> Arc<dyn ObjectStore> {
         Arc::new(InMemory::new())
+    }
+
+    #[test]
+    fn engine_config_maps_to_slatedb_settings() {
+        let config = MetaDbEngineConfig {
+            compaction_threshold: 12,
+            wal_flush_size: 8 * 1024 * 1024,
+            bloom_bits_per_key: 14,
+        };
+
+        let settings = slatedb_settings(&config).expect("valid engine config");
+        let compactor = settings.compactor_options.expect("compactor options");
+
+        assert_eq!(settings.l0_sst_size_bytes, 8 * 1024 * 1024);
+        assert_eq!(
+            compactor.scheduler_options.get("min_compaction_sources"),
+            Some(&String::from("12"))
+        );
+        assert_eq!(
+            compactor.scheduler_options.get("max_compaction_sources"),
+            Some(&String::from("12"))
+        );
+        assert_eq!(filter_policies(&config).expect("filter policy").len(), 1);
+    }
+
+    #[test]
+    fn engine_config_rejects_zero_tunables() {
+        for config in [
+            MetaDbEngineConfig {
+                compaction_threshold: 0,
+                ..MetaDbEngineConfig::default()
+            },
+            MetaDbEngineConfig {
+                wal_flush_size: 0,
+                ..MetaDbEngineConfig::default()
+            },
+            MetaDbEngineConfig {
+                bloom_bits_per_key: 0,
+                ..MetaDbEngineConfig::default()
+            },
+        ] {
+            assert!(slatedb_settings(&config).is_err());
+        }
     }
 
     #[tokio::test]

--- a/crab/src/metadata/metadb/mod.rs
+++ b/crab/src/metadata/metadb/mod.rs
@@ -55,7 +55,10 @@ const DEFAULT_CACHE_GC_GRACE: u64 = 3;
 /// before a compaction is scheduled).
 const DEFAULT_COMPACTION_THRESHOLD: u32 = 4;
 
-/// Default WAL flush size per instance (4 MiB).
+/// Default L0 SST target per instance (4 MiB).
+///
+/// The shipped configuration key is named `wal_flush_size`; SlateDB 0.14
+/// exposes this boundary as `l0_sst_size_bytes`.
 const DEFAULT_WAL_FLUSH_SIZE: u64 = 4 * 1024 * 1024;
 
 /// Default bloom-filter density per key in bits. Ten bits per key gives
@@ -108,6 +111,27 @@ pub enum CacheDriftOutcome {
     },
 }
 
+/// SlateDB tuning applied independently to one metadata database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MetaDbEngineConfig {
+    /// Minimum number of similarly sized sources before compaction is proposed.
+    pub compaction_threshold: u32,
+    /// L0 SST target in bytes, retained under the shipped `wal_flush_size` name.
+    pub wal_flush_size: u64,
+    /// Bloom-filter bits per key per SSTable.
+    pub bloom_bits_per_key: u32,
+}
+
+impl Default for MetaDbEngineConfig {
+    fn default() -> Self {
+        Self {
+            compaction_threshold: DEFAULT_COMPACTION_THRESHOLD,
+            wal_flush_size: DEFAULT_WAL_FLUSH_SIZE,
+            bloom_bits_per_key: DEFAULT_BLOOM_BITS_PER_KEY,
+        }
+    }
+}
+
 /// Tunables and paths for a [`MetaDb`] session.
 ///
 /// Defaults are safe for production: paths are derived from the repo
@@ -134,15 +158,11 @@ pub struct MetaDbConfig {
     /// wiped to stay consistent with an advanced remote.
     pub cache_gc_grace: u64,
 
-    /// SlateDB compaction threshold — SSTables at level 0 before a
-    /// compaction runs.
-    pub compaction_threshold: u32,
+    /// SlateDB tuning for the per-repository file index.
+    pub file_index: MetaDbEngineConfig,
 
-    /// WAL flush size per SlateDB instance, in bytes.
-    pub wal_flush_size: u64,
-
-    /// Bloom-filter bits per key per SSTable.
-    pub bloom_bits_per_key: u32,
+    /// SlateDB tuning for the bucket-shared chunk index.
+    pub chunk_index: MetaDbEngineConfig,
 
     /// Open the underlying SlateDB instances in read-only mode.
     ///
@@ -197,9 +217,8 @@ impl Default for MetaDbConfig {
             local_chunk_index_path: PathBuf::from(".cache/crab/chunk-index.sqlite"),
             in_memory_ceiling_bytes: DEFAULT_IN_MEMORY_CEILING_BYTES,
             cache_gc_grace: DEFAULT_CACHE_GC_GRACE,
-            compaction_threshold: DEFAULT_COMPACTION_THRESHOLD,
-            wal_flush_size: DEFAULT_WAL_FLUSH_SIZE,
-            bloom_bits_per_key: DEFAULT_BLOOM_BITS_PER_KEY,
+            file_index: MetaDbEngineConfig::default(),
+            chunk_index: MetaDbEngineConfig::default(),
             read_only: false,
         }
     }
@@ -761,6 +780,7 @@ impl MetaDb {
                             path,
                             stores::file_index::DB_LABEL,
                             Arc::clone(&self.db_cache),
+                            &self.config.file_index,
                         )
                         .await?;
                         m.inc_metadb_open_count();
@@ -772,6 +792,7 @@ impl MetaDb {
                             path,
                             stores::file_index::DB_LABEL,
                             Arc::clone(&self.db_cache),
+                            &self.config.file_index,
                         )
                         .await?
                     }
@@ -781,6 +802,7 @@ impl MetaDb {
                             path,
                             stores::file_index::DB_LABEL,
                             Arc::clone(&self.db_cache),
+                            &self.config.file_index,
                         )
                         .await?;
                         m.inc_metadb_open_count();
@@ -792,6 +814,7 @@ impl MetaDb {
                             path,
                             stores::file_index::DB_LABEL,
                             Arc::clone(&self.db_cache),
+                            &self.config.file_index,
                         )
                         .await?
                     }
@@ -819,6 +842,7 @@ impl MetaDb {
                             path,
                             stores::chunk_index::DB_LABEL,
                             Arc::clone(&self.db_cache),
+                            &self.config.chunk_index,
                         )
                         .await?;
                         m.inc_metadb_open_count();
@@ -830,6 +854,7 @@ impl MetaDb {
                             path,
                             stores::chunk_index::DB_LABEL,
                             Arc::clone(&self.db_cache),
+                            &self.config.chunk_index,
                         )
                         .await?
                     }
@@ -839,6 +864,7 @@ impl MetaDb {
                             path,
                             stores::chunk_index::DB_LABEL,
                             Arc::clone(&self.db_cache),
+                            &self.config.chunk_index,
                         )
                         .await?;
                         m.inc_metadb_open_count();
@@ -850,6 +876,7 @@ impl MetaDb {
                             path,
                             stores::chunk_index::DB_LABEL,
                             Arc::clone(&self.db_cache),
+                            &self.config.chunk_index,
                         )
                         .await?
                     }
@@ -1114,9 +1141,10 @@ mod tests {
         let cfg = MetaDbConfig::default();
         assert_eq!(cfg.in_memory_ceiling_bytes, 1024 * 1024 * 1024);
         assert_eq!(cfg.cache_gc_grace, 3);
-        assert_eq!(cfg.compaction_threshold, 4);
-        assert_eq!(cfg.wal_flush_size, 4 * 1024 * 1024);
-        assert_eq!(cfg.bloom_bits_per_key, 10);
+        assert_eq!(cfg.file_index.compaction_threshold, 4);
+        assert_eq!(cfg.file_index.wal_flush_size, 4 * 1024 * 1024);
+        assert_eq!(cfg.file_index.bloom_bits_per_key, 10);
+        assert_eq!(cfg.chunk_index, cfg.file_index);
         assert_eq!(cfg.chunk_index_path, ".crab/chunk_index_db/");
     }
 

--- a/crab/src/metadata/mod.rs
+++ b/crab/src/metadata/mod.rs
@@ -15,5 +15,5 @@ pub mod shard_sync;
 // without poking into submodules.
 pub use metadb::{
     CacheDriftOutcome, ChunkIndexStore, Db, DbTarget, FileIndexStore, MetaDb, MetaDbConfig,
-    MetaDbGuard, PushWriteReceipt, SystemKeySnapshot, Transaction, XorbRef,
+    MetaDbEngineConfig, MetaDbGuard, PushWriteReceipt, SystemKeySnapshot, Transaction, XorbRef,
 };

--- a/crab/src/metadata/shard_sync.rs
+++ b/crab/src/metadata/shard_sync.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashSet;
 use std::ffi::OsString;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -34,6 +34,7 @@ use crab_metadata::manifests::ShardList;
 use crab_metadata::persistent_chunk_index::PersistentChunkIndex;
 use crab_xet::hash::compute_data_hash;
 use crab_xet::shard::{MDBMinimalShard, MDBShardFile, new_shard_file_cache};
+use crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES;
 use crab_xet::xorb::format::{MerkleHash, XorbRef};
 
 static SHARD_GEN_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -70,7 +71,19 @@ pub struct CachedShardListGen {
 /// Returns `None` if the file is missing or corrupt (triggers full sync
 /// fallback).
 fn load_cached_generation(path: &Path) -> Option<CachedShardListGen> {
-    let data = match std::fs::read(path) {
+    const MAX_GENERATION_FILE_BYTES: u64 = 64 * 1024 * 1024;
+    let data = match std::fs::File::open(path).and_then(|file| {
+        let mut data = Vec::new();
+        file.take(MAX_GENERATION_FILE_BYTES + 1)
+            .read_to_end(&mut data)?;
+        if data.len() as u64 > MAX_GENERATION_FILE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "cached shard-list generation is oversized",
+            ));
+        }
+        Ok(data)
+    }) {
         Ok(d) => d,
         Err(e) => {
             debug!(path = %path.display(), error = %e, "no cached shard-list generation");
@@ -893,13 +906,16 @@ async fn download_one_shard(
     shard_path: &object_store::path::Path,
     hash: MerkleHash,
 ) -> Result<(MerkleHash, Bytes)> {
-    let (body, _etag) = store.get_with_etag(shard_path).await.map_err(|e| {
-        if matches!(e, CrabError::NotFound { .. }) {
-            CrabError::NotFound { path: hash.hex() }
-        } else {
-            e
-        }
-    })?;
+    let (body, _etag) = store
+        .get_with_etag_bounded(shard_path, MAX_SHARD_SIZE_BYTES as u64)
+        .await
+        .map_err(|e| {
+            if matches!(e, CrabError::NotFound { .. }) {
+                CrabError::NotFound { path: hash.hex() }
+            } else {
+                e
+            }
+        })?;
 
     let actual = compute_data_hash(&body);
     if actual == hash {

--- a/crab/src/optimize/xorbs/executor.rs
+++ b/crab/src/optimize/xorbs/executor.rs
@@ -1,66 +1,42 @@
-//! Streaming source-xorb → destination-xorb pipeline for optimization.
+//! Bounded, crash-safe source-xorb to destination-xorb rewrite pipeline.
 //!
-//! The executor processes source xorbs one at a time through a bounded
-//! pipeline:
-//!
-//! 1. HEAD source xorb → class, size, etag.
-//! 2. If cold and `include_cold` → delegate to `RestoreOrchestrator`.
-//!    If cold and `!include_cold` → skip with summary.
-//! 3. Stream-download source xorb (bounded by `budget_factor × target`).
-//! 4. Parse xorb, verify content hash.
-//! 5. Walk chunks; re-pack into destination xorbs per profile.
-//! 6. Upload each dest xorb via `Store::put`.
-//! 7. Mark source xorb entry `status='done'` in journal with dest hashes.
-//! 8. On corrupt source (hash mismatch), mark `status='corrupt'`, continue.
-//!
-//! Crash at steps 3–6 leaves no committed state (staged xorbs become
-//! orphans reclaimed by the next `crab gc`). Crash at step 7 is
-//! recoverable: the journal captures intent and the upload is idempotent.
-//!
-//! SIGINT/SIGTERM: the executor checks the `CancellationToken` between
-//! xorbs. On cancellation it finishes the current xorb (if in-flight),
-//! flushes the journal, and returns `Err(Cancelled)` so the CLI can
-//! exit cleanly. The next invocation with `--resume` picks up where
-//! it left off.
+//! Source rows are consumed in deterministic pages. A page shares one
+//! bounded builder, so fragments from multiple source xorbs are consolidated
+//! without loading the entire journal into memory. Immutable destinations are
+//! uploaded before any source row is committed as done.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::Bytes;
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::info;
 
 use crate::core::error::{CrabError, Result, check_cancelled};
-use crate::optimize::xorbs::journal::{OptimizeXorbsJournal, SourceStatus};
+use crate::optimize::xorbs::journal::{OptimizeXorbsJournal, SourceRow, SourceStatus};
 use crate::optimize::xorbs::profile::Profile;
 use crate::storage::head_class::head_with_class;
 use crate::storage::store::Store;
 use crate::tier::restore::RestoreOrchestrator;
 use crab_storage::canonical_global_content_path;
-use crab_xet::xorb::builder::{FixedCompression, RunId, XorbBuilder};
-use crab_xet::xorb::format::{CompressionScheme, MAX_XORB_SIZE};
+use crab_xet::xorb::builder::{FixedCompression, RunId, XorbBuilder, XorbResult};
+use crab_xet::xorb::format::{CompressionScheme, MAX_XORB_SIZE, MerkleHash};
 use crab_xet::xorb::parser::XorbParser;
 
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
-
+const SOURCES_PER_OPTIMIZE_BATCH: usize = 64;
+const MIN_TARGET_XORB_BYTES: usize = 4 * 1024 * 1024;
+const MAX_TARGET_XORB_BYTES: usize = 256 * 1024 * 1024;
+const MAX_SOURCE_XORB_BYTES: u64 = MAX_XORB_SIZE as u64;
 const MAX_CORRUPT_REPORT_ENTRIES: usize = 1_024;
 
 /// Configuration for the xorb optimization executor.
 #[derive(Debug, Clone)]
 pub struct ExecutorConfig {
-    /// Include archive-class source xorbs. When false, archive xorbs
-    /// are skipped and summarized in the outcome.
     pub include_cold: bool,
-    /// Restore tier for archive sources (e.g. "standard").
     pub restore_tier: String,
-    /// Output storage class for destination xorbs.
     pub output_class: String,
-    /// Memory budget multiplier: the executor will not download a
-    /// source xorb larger than `target_xorb_bytes × budget_factor`.
-    /// Sources exceeding this are skipped with a warning.
     pub budget_factor: u64,
 }
 
@@ -75,85 +51,35 @@ impl Default for ExecutorConfig {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Progress tracking
-// ---------------------------------------------------------------------------
-
 /// Per-xorb progress event emitted during execution.
 #[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
 pub struct XorbProgressEvent {
-    /// Source xorb hash.
     pub src_xorb: String,
-    /// Current state of this xorb's processing.
     pub state: String,
-    /// Destination xorb hashes (populated on completion).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dest_xorbs: Option<Vec<String>>,
-    /// Bytes read from the source.
     pub bytes_read: u64,
-    /// Bytes written to destinations.
     pub bytes_written: u64,
-    /// Elapsed time in milliseconds.
     pub elapsed_ms: u64,
 }
-
-// ---------------------------------------------------------------------------
-// Executor outcome
-// ---------------------------------------------------------------------------
 
 /// Summary of a completed xorb optimization.
 #[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
 pub struct ExecutorOutcome {
-    /// Run identifier.
     pub run_id: String,
-    /// Profile used.
     pub profile: String,
-    /// Total source xorbs processed (attempted).
     pub sources_processed: u64,
-    /// Source xorbs completed successfully.
     pub sources_done: u64,
-    /// Source xorbs found corrupt (hash mismatch or parse failure).
     pub sources_corrupt: u64,
-    /// Source xorbs skipped (archive when `include_cold=false`, not
-    /// found, or exceeding memory budget).
     pub sources_skipped: u64,
-    /// Total bytes read from source xorbs.
     pub bytes_read: u64,
-    /// Total bytes written to destination xorbs.
     pub bytes_written: u64,
-    /// Wall-clock duration in milliseconds.
     pub elapsed_ms: u64,
-    /// List of corrupt source xorb hashes (recommend `crab fsck`).
     pub corrupt_list: Vec<String>,
+    pub corrupt_list_omitted: u64,
 }
 
-// ---------------------------------------------------------------------------
-// Executor
-// ---------------------------------------------------------------------------
-
-/// Execute an xorb optimization run.
-///
-/// Processes each pending source xorb from the journal through the
-/// download → parse → repack → upload pipeline.
-///
-/// # Cancellation
-///
-/// On SIGINT/SIGTERM (detected via `cancel`), finishes the current
-/// xorb, flushes the journal, and returns `Err(Cancelled)` so the
-/// next invocation with `--resume` picks up where it left off.
-///
-/// # Journal-only mode
-///
-/// When `store` is `None` (tests or no remote configured), the
-/// executor marks all pending sources as done with empty dest lists.
-/// This preserves the CLI and journal lifecycle for testing.
-///
-/// # Tier-aware operation
-///
-/// When `restore_orchestrator` is provided and a source xorb is in an
-/// archive storage class, the executor calls `ensure_warm` before
-/// downloading. When `config.include_cold` is false, archive xorbs
-/// are skipped instead.
+/// Execute one bounded xorb optimization run.
 pub async fn execute(
     journal: &OptimizeXorbsJournal,
     run_id: &str,
@@ -164,413 +90,435 @@ pub async fn execute(
     restore_orchestrator: Option<&RestoreOrchestrator>,
 ) -> Result<ExecutorOutcome> {
     let start = Instant::now();
-    let profile_desc = profile.to_json();
-
-    let mut sources_processed: u64 = 0;
-    let mut sources_done: u64 = 0;
-    let mut sources_corrupt: u64 = 0;
-    let mut sources_skipped: u64 = 0;
-    let mut bytes_read: u64 = 0;
-    let mut bytes_written: u64 = 0;
-    let mut corrupt_list: Vec<String> = Vec::new();
-
-    // Compute the memory budget for a single source xorb download.
-    let memory_budget = profile
-        .target_xorb_bytes
-        .saturating_mul(config.budget_factor);
-
-    // Fetch all pending source xorbs from the journal.
-    let pending = journal.sources_by_status(run_id, SourceStatus::Pending)?;
-
-    if pending.is_empty() {
-        info!("xorb optimization executor: no pending source xorbs");
+    let pending = journal.count_by_status(run_id)?.pending;
+    if pending == 0 {
         return Ok(build_outcome(
             run_id,
-            &profile_desc,
+            profile,
             &start,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            Vec::new(),
+            BatchResult::default(),
         ));
     }
 
-    info!(
-        pending = pending.len(),
-        memory_budget_mib = memory_budget / (1024 * 1024),
-        "xorb optimization executor: processing source xorbs"
-    );
+    let compression = resolve_compression(profile)?;
+    validate_target(profile)?;
+    info!(pending, "processing live source xorbs");
 
-    let compression = resolve_compression(profile);
-
-    for source_row in &pending {
-        // Check for cancellation between xorbs (graceful SIGINT/SIGTERM).
+    let mut total = BatchResult::default();
+    let mut after = String::new();
+    loop {
         check_cancelled(cancel)?;
-
-        let src_hash = &source_row.src_xorb;
-        sources_processed += 1;
-
-        debug!(src_xorb = %src_hash, idx = sources_processed, "processing source xorb");
-
-        match process_single_xorb(
-            journal,
+        let rows = journal.sources_by_status_after(
             run_id,
-            src_hash,
-            profile,
-            config,
-            compression,
-            memory_budget,
-            store,
-            restore_orchestrator,
-        )
-        .await
-        {
-            Ok(result) => {
-                bytes_read += result.bytes_read;
-                bytes_written += result.bytes_written;
-                match result.status {
-                    XorbStatus::Done => sources_done += 1,
-                    XorbStatus::Corrupt => {
-                        sources_corrupt += 1;
-                        if corrupt_list.len() < MAX_CORRUPT_REPORT_ENTRIES {
-                            corrupt_list.push(src_hash.clone());
-                        }
-                    }
-                    XorbStatus::Skipped => sources_skipped += 1,
-                }
-            }
-            Err(e) if is_transient(&e) => {
-                // Transient errors: log and skip so the run can continue.
-                // The source stays Pending and will be retried on --resume.
-                warn!(
-                    src_xorb = %src_hash,
-                    error = %e,
-                    "transient error processing source xorb; will retry on resume"
-                );
-                sources_skipped += 1;
-            }
-            Err(e) => {
-                // Permanent errors: log, mark skipped, continue.
-                warn!(
-                    src_xorb = %src_hash,
-                    error = %e,
-                    "failed to process source xorb; skipping"
-                );
-                journal.update_source_status(run_id, src_hash, SourceStatus::Skipped, None)?;
-                sources_skipped += 1;
-            }
+            SourceStatus::Pending,
+            Some(&after),
+            SOURCES_PER_OPTIMIZE_BATCH,
+        )?;
+        if rows.is_empty() {
+            break;
         }
+        let last = rows.last().map(|row| row.src_xorb.clone()).ok_or_else(|| {
+            CrabError::Internal("pending journal page unexpectedly empty".to_owned())
+        })?;
+        let result = match store {
+            Some(store) => {
+                process_batch(
+                    journal,
+                    run_id,
+                    &rows,
+                    profile,
+                    config,
+                    compression,
+                    store,
+                    restore_orchestrator,
+                    cancel,
+                )
+                .await?
+            }
+            None => mark_batch_without_store(journal, run_id, &rows, cancel)?,
+        };
+        total.merge(result);
+        after = last;
     }
 
-    let elapsed = start.elapsed();
     info!(
-        done = sources_done,
-        corrupt = sources_corrupt,
-        skipped = sources_skipped,
-        bytes_read,
-        bytes_written,
-        elapsed_ms = elapsed.as_millis() as u64,
-        "xorb optimization executor: complete"
+        done = total.done,
+        corrupt = total.corrupt.len() as u64 + total.corrupt_omitted,
+        skipped = total.skipped,
+        bytes_read = total.bytes_read,
+        bytes_written = total.bytes_written,
+        elapsed_ms = start.elapsed().as_millis() as u64,
+        "xorb rewrite pipeline complete"
     );
-
-    Ok(build_outcome(
-        run_id,
-        &profile_desc,
-        &start,
-        sources_processed,
-        sources_done,
-        sources_corrupt,
-        sources_skipped,
-        bytes_read,
-        bytes_written,
-        corrupt_list,
-    ))
+    Ok(build_outcome(run_id, profile, &start, total))
 }
 
-// ---------------------------------------------------------------------------
-// Per-xorb processing
-// ---------------------------------------------------------------------------
-
-enum XorbStatus {
-    Done,
-    Corrupt,
-    Skipped,
-}
-
-struct SingleXorbResult {
-    status: XorbStatus,
+#[derive(Default)]
+struct BatchResult {
+    processed: u64,
+    done: u64,
+    skipped: u64,
+    corrupt: Vec<String>,
+    corrupt_omitted: u64,
     bytes_read: u64,
     bytes_written: u64,
 }
 
-/// Process a single source xorb through the optimization pipeline.
-///
-/// Each step is designed so that a crash leaves no committed state
-/// until the final journal update. Destination xorbs uploaded before
-/// a crash become orphans reclaimed by `crab gc`.
-#[expect(clippy::too_many_arguments, reason = "pipeline step needs all context")]
-async fn process_single_xorb(
+impl BatchResult {
+    fn merge(&mut self, other: Self) {
+        self.processed = self.processed.saturating_add(other.processed);
+        self.done = self.done.saturating_add(other.done);
+        self.skipped = self.skipped.saturating_add(other.skipped);
+        self.bytes_read = self.bytes_read.saturating_add(other.bytes_read);
+        self.bytes_written = self.bytes_written.saturating_add(other.bytes_written);
+        self.corrupt.extend(other.corrupt);
+        if self.corrupt.len() > MAX_CORRUPT_REPORT_ENTRIES {
+            let overflow = self.corrupt.len() - MAX_CORRUPT_REPORT_ENTRIES;
+            self.corrupt.truncate(MAX_CORRUPT_REPORT_ENTRIES);
+            self.corrupt_omitted = self.corrupt_omitted.saturating_add(overflow as u64);
+        }
+        self.corrupt_omitted = self.corrupt_omitted.saturating_add(other.corrupt_omitted);
+    }
+
+    fn record_corrupt(&mut self, hash: String) {
+        if self.corrupt.len() < MAX_CORRUPT_REPORT_ENTRIES {
+            self.corrupt.push(hash);
+        } else {
+            self.corrupt_omitted = self.corrupt_omitted.saturating_add(1);
+        }
+    }
+}
+
+fn mark_batch_without_store(
     journal: &OptimizeXorbsJournal,
     run_id: &str,
-    src_hash: &str,
+    rows: &[SourceRow],
+    cancel: &CancellationToken,
+) -> Result<BatchResult> {
+    let mut result = BatchResult::default();
+    for row in rows {
+        check_cancelled(cancel)?;
+        journal.update_source_status(run_id, &row.src_xorb, SourceStatus::Done, Some("[]"))?;
+        result.processed = result.processed.saturating_add(1);
+        result.done = result.done.saturating_add(1);
+    }
+    Ok(result)
+}
+
+#[derive(Debug)]
+struct PreparedSource {
+    hash: String,
+    chunks: Vec<MerkleHash>,
+}
+
+#[expect(clippy::too_many_arguments, reason = "bounded pipeline context")]
+async fn process_batch(
+    journal: &OptimizeXorbsJournal,
+    run_id: &str,
+    source_rows: &[SourceRow],
     profile: &Profile,
     config: &ExecutorConfig,
     compression: CompressionScheme,
-    memory_budget: u64,
-    store: Option<&Store>,
+    store: &Store,
     restore_orchestrator: Option<&RestoreOrchestrator>,
-) -> Result<SingleXorbResult> {
-    // --- Journal-only mode (no store) ---
-    let Some(store) = store else {
-        journal.update_source_status(run_id, src_hash, SourceStatus::Done, Some("[]"))?;
-        return Ok(SingleXorbResult {
-            status: XorbStatus::Done,
-            bytes_read: 0,
-            bytes_written: 0,
-        });
-    };
-
-    let xorb_path = canonical_global_content_path("xorbs", src_hash);
-
-    // --- Step 1: HEAD with class probe ---
-    let head_meta = head_with_class(store, &xorb_path).await;
-    if let Ok(ref meta) = head_meta {
-        if meta.class.is_archive_class() {
-            if !config.include_cold {
-                debug!(src_xorb = %src_hash, class = ?meta.class, "skipping archive xorb (include_cold=false)");
-                journal.update_source_status(run_id, src_hash, SourceStatus::Skipped, None)?;
-                return Ok(SingleXorbResult {
-                    status: XorbStatus::Skipped,
-                    bytes_read: 0,
-                    bytes_written: 0,
-                });
-            }
-            // --- Step 2: Restore if archive ---
-            if let Some(orchestrator) = restore_orchestrator {
-                info!(src_xorb = %src_hash, class = ?meta.class, "restoring archive xorb before download");
-                orchestrator.ensure_warm(&xorb_path.to_string()).await?;
-            } else {
-                return Err(CrabError::ArchiveRestoreRequired {
-                    xorb: xorb_path.to_string(),
-                    class: format!("{}", meta.class),
-                    estimated_eta: None,
-                });
-            }
-        }
-    }
-    // HEAD failure is non-fatal: proceed to download (the GET will
-    // surface the real error if the object is truly inaccessible).
-
-    // --- Step 3: Download source xorb (bounded by memory budget) ---
-    let src_bytes = match store
-        .get_with_etag_bounded(&xorb_path, MAX_XORB_SIZE as u64)
-        .await
-    {
-        Ok((bytes, _etag)) => bytes,
-        Err(CrabError::NotFound { .. }) => {
-            debug!(src_xorb = %src_hash, "source xorb not found; skipping");
-            journal.update_source_status(run_id, src_hash, SourceStatus::Skipped, None)?;
-            return Ok(SingleXorbResult {
-                status: XorbStatus::Skipped,
-                bytes_read: 0,
-                bytes_written: 0,
-            });
-        }
-        Err(e) => return Err(e),
-    };
-
-    let src_size = src_bytes.len() as u64;
-
-    // Enforce memory budget: skip xorbs that exceed the limit.
-    if src_size > memory_budget {
-        warn!(
-            src_xorb = %src_hash,
-            src_size,
-            memory_budget,
-            "source xorb exceeds memory budget; skipping"
-        );
-        journal.update_source_status(run_id, src_hash, SourceStatus::Skipped, None)?;
-        return Ok(SingleXorbResult {
-            status: XorbStatus::Skipped,
-            bytes_read: src_size,
-            bytes_written: 0,
-        });
-    }
-
-    // --- Step 4: Parse and verify content hash ---
-    let parser = match XorbParser::parse(src_bytes) {
-        Ok(p) => p,
-        Err(e) => {
-            warn!(src_xorb = %src_hash, error = %e, "corrupt source xorb (parse failed)");
-            journal.mark_corrupt(run_id, src_hash, "parse_failed", &e.to_string())?;
-            return Ok(SingleXorbResult {
-                status: XorbStatus::Corrupt,
-                bytes_read: src_size,
-                bytes_written: 0,
-            });
-        }
-    };
-
-    let actual_hash = parser.hash().hex();
-    if actual_hash != src_hash {
-        warn!(
-            src_xorb = %src_hash,
-            actual_hash = %actual_hash,
-            "corrupt source xorb (hash mismatch)"
-        );
-        journal.mark_corrupt(
-            run_id,
-            src_hash,
-            "hash_mismatch",
-            &format!("expected {src_hash}, got {actual_hash}"),
-        )?;
-        return Ok(SingleXorbResult {
-            status: XorbStatus::Corrupt,
-            bytes_read: src_size,
-            bytes_written: 0,
-        });
-    }
-
-    // --- Step 5: Extract chunks and repack into destination xorbs ---
-    let num_chunks = parser.num_chunks();
+    cancel: &CancellationToken,
+) -> Result<BatchResult> {
     let policy = Arc::new(FixedCompression::new(compression));
+    let target =
+        usize::try_from(profile.target_xorb_bytes).map_err(|_| CrabError::Configuration {
+            key: "optimize xorbs target size".to_owned(),
+            origin: "target size cannot be represented on this platform".to_owned(),
+        })?;
     let mut builder =
-        XorbBuilder::with_policy(policy as Arc<dyn crab_xet::xorb::builder::CompressionPolicy>);
-
-    // Set the target size from the profile.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "target_xorb_bytes validated ≤ 2 GiB, fits in usize"
-    )]
-    let target = profile.target_xorb_bytes as usize;
+        XorbBuilder::with_policy(policy as Arc<dyn crab_xet::xorb::builder::CompressionPolicy>)
+            .with_size_bounds(MIN_TARGET_XORB_BYTES, MAX_TARGET_XORB_BYTES);
     builder.set_target_size(target);
 
-    // Feed all chunks from the source xorb into the builder.
-    // All chunks share a single RunId since they come from one source.
-    let run_id_num = RunId(0);
-    for idx in 0..num_chunks {
-        let chunk = parser.get_chunk(idx)?;
-        let _ = builder.push(&chunk, run_id_num)?;
-    }
+    let memory_budget = profile
+        .target_xorb_bytes
+        .saturating_mul(config.budget_factor);
+    let mut outcome = BatchResult::default();
+    let mut prepared = Vec::with_capacity(source_rows.len());
+    let mut placements = HashMap::<MerkleHash, String>::new();
 
-    // Finalize the builder to get destination xorbs.
-    let dest_xorbs = builder.finalize()?;
+    for (source_index, source_row) in source_rows.iter().enumerate() {
+        check_cancelled(cancel)?;
+        let source_hash = &source_row.src_xorb;
+        let source_path = canonical_global_content_path("xorbs", source_hash);
+        outcome.processed = outcome.processed.saturating_add(1);
 
-    // --- Step 6: Upload each destination xorb ---
-    let mut dest_hashes: Vec<String> = Vec::with_capacity(dest_xorbs.len());
-    let mut total_written: u64 = 0;
-
-    for xorb_result in &dest_xorbs {
-        let dest_hash = xorb_result.hash.hex();
-        let dest_path = canonical_global_content_path("xorbs", &dest_hash);
-        let dest_bytes = Bytes::copy_from_slice(&xorb_result.bytes);
-        let written = dest_bytes.len() as u64;
-        if written > MAX_XORB_SIZE as u64 {
+        let object = tokio::select! {
+            result = store.head(&source_path) => result,
+            () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        }
+        .map_err(|error| match error {
+            CrabError::NotFound { .. } => CrabError::CorruptObject {
+                path: source_path.to_string(),
+                reason: "journal references a missing source xorb".to_owned(),
+            },
+            error => error,
+        })?;
+        if object.size > MAX_SOURCE_XORB_BYTES {
             return Err(CrabError::Configuration {
-                key: "optimize xorbs destination size".to_owned(),
+                key: "optimize xorbs source size".to_owned(),
                 origin: format!(
-                    "destination xorb {dest_hash} is {written} bytes; bounded rewriting supports at most {} bytes",
-                    MAX_XORB_SIZE
+                    "source {source_hash} is {} bytes; bounded rewriting supports at most {MAX_SOURCE_XORB_BYTES} bytes",
+                    object.size
                 ),
             });
         }
 
-        // CAS put: if the xorb already exists (idempotent retry or
-        // concurrent push wrote the same content), the put succeeds
-        // silently via the Store's create-if-absent semantics.
-        store.put(&dest_path, dest_bytes).await?;
+        let head = tokio::select! {
+            result = head_with_class(store, &source_path) => result?,
+            () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        };
+        if head.class.is_archive_class() {
+            if !config.include_cold {
+                journal.update_source_status(run_id, source_hash, SourceStatus::Skipped, None)?;
+                outcome.skipped = outcome.skipped.saturating_add(1);
+                continue;
+            }
+            let orchestrator =
+                restore_orchestrator.ok_or_else(|| CrabError::ArchiveRestoreRequired {
+                    xorb: source_path.to_string(),
+                    class: head.class.to_string(),
+                    estimated_eta: None,
+                })?;
+            orchestrator.ensure_warm(&source_path.to_string()).await?;
+            check_cancelled(cancel)?;
+        }
 
-        dest_hashes.push(dest_hash);
-        total_written += written;
+        let (source_bytes, _) = tokio::select! {
+            result = store.get_with_etag_bounded(&source_path, MAX_SOURCE_XORB_BYTES) => result?,
+            () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        };
+        let source_size =
+            u64::try_from(source_bytes.len()).map_err(|_| CrabError::Configuration {
+                key: "optimize xorbs source size".to_owned(),
+                origin: "source size cannot be represented".to_owned(),
+            })?;
+        if source_size > memory_budget {
+            journal.update_source_status(run_id, source_hash, SourceStatus::Skipped, None)?;
+            outcome.skipped = outcome.skipped.saturating_add(1);
+            outcome.bytes_read = outcome.bytes_read.saturating_add(source_size);
+            continue;
+        }
+        if source_size != object.size {
+            return Err(CrabError::CorruptObject {
+                path: source_path.to_string(),
+                reason: format!(
+                    "source xorb size changed during read (HEAD reported {}, GET returned {source_size})",
+                    object.size
+                ),
+            });
+        }
+        outcome.bytes_read = outcome.bytes_read.saturating_add(source_size);
+
+        let parser = match XorbParser::parse(source_bytes) {
+            Ok(parser) => parser,
+            Err(error) => {
+                journal.mark_corrupt(run_id, source_hash, "parse_failed", &error.to_string())?;
+                outcome.record_corrupt(source_hash.clone());
+                continue;
+            }
+        };
+        if parser.hash().hex() != *source_hash {
+            let actual = parser.hash().hex();
+            journal.mark_corrupt(
+                run_id,
+                source_hash,
+                "hash_mismatch",
+                &format!("expected {source_hash}, got {actual}"),
+            )?;
+            outcome.record_corrupt(source_hash.clone());
+            continue;
+        }
+        if let Err(error) = parser.verify_payload_digest() {
+            journal.mark_corrupt(run_id, source_hash, "payload_digest", &error.to_string())?;
+            outcome.record_corrupt(source_hash.clone());
+            continue;
+        }
+        if let Err(error) = parser.verify_all_chunks() {
+            journal.mark_corrupt(
+                run_id,
+                source_hash,
+                "chunk_verification",
+                &error.to_string(),
+            )?;
+            outcome.record_corrupt(source_hash.clone());
+            continue;
+        }
+
+        let source_run = RunId(u64::try_from(source_index).map_err(|_| {
+            CrabError::Internal("source batch index cannot be represented".to_owned())
+        })?);
+        let mut chunks = Vec::with_capacity(parser.num_chunks() as usize);
+        for chunk_index in 0..parser.num_chunks() {
+            check_cancelled(cancel)?;
+            let chunk = parser.get_chunk(chunk_index)?;
+            chunks.push(chunk.hash);
+            let _ = builder.push(&chunk, source_run)?;
+            while let Some(destination) = builder.take_completed() {
+                outcome.bytes_written = outcome.bytes_written.saturating_add(
+                    upload_destination(store, destination, &mut placements, cancel).await?,
+                );
+            }
+        }
+        prepared.push(PreparedSource {
+            hash: source_hash.clone(),
+            chunks,
+        });
     }
 
-    // --- Step 7: Commit to journal (crash-safe boundary) ---
-    let dest_json = serde_json::to_string(&dest_hashes).unwrap_or_else(|_| "[]".to_string());
-    journal.update_source_status(run_id, src_hash, SourceStatus::Done, Some(&dest_json))?;
-
-    debug!(
-        src_xorb = %src_hash,
-        dest_count = dest_hashes.len(),
-        bytes_read = src_size,
-        bytes_written = total_written,
-        "source xorb optimized"
-    );
-
-    Ok(SingleXorbResult {
-        status: XorbStatus::Done,
-        bytes_read: src_size,
-        bytes_written: total_written,
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Map the profile's compression config to a `CompressionScheme`.
-fn resolve_compression(profile: &Profile) -> CompressionScheme {
-    use crate::core::config::CompressionConfig;
-    match profile.compression {
-        CompressionConfig::None => CompressionScheme::None,
-        CompressionConfig::Lz4 => CompressionScheme::LZ4,
-        CompressionConfig::Zstd { .. } => CompressionScheme::LZ4,
+    for destination in builder.finalize()? {
+        outcome.bytes_written = outcome
+            .bytes_written
+            .saturating_add(upload_destination(store, destination, &mut placements, cancel).await?);
     }
-}
-
-/// Classify whether an error is transient (worth retrying on --resume)
-/// vs permanent (skip and move on).
-fn is_transient(err: &CrabError) -> bool {
-    matches!(
-        err,
-        CrabError::NetworkTransient(_) | CrabError::Throttled { .. }
-    )
-}
-
-#[expect(clippy::too_many_arguments, reason = "builder helper")]
-fn build_outcome(
-    run_id: &str,
-    profile: &str,
-    start: &Instant,
-    sources_processed: u64,
-    sources_done: u64,
-    sources_corrupt: u64,
-    sources_skipped: u64,
-    bytes_read: u64,
-    bytes_written: u64,
-    corrupt_list: Vec<String>,
-) -> ExecutorOutcome {
-    ExecutorOutcome {
-        run_id: run_id.to_string(),
-        profile: profile.to_string(),
-        sources_processed,
-        sources_done,
-        sources_corrupt,
-        sources_skipped,
-        bytes_read,
-        bytes_written,
-        elapsed_ms: start.elapsed().as_millis() as u64,
-        corrupt_list,
+    check_cancelled(cancel)?;
+    for source in prepared {
+        check_cancelled(cancel)?;
+        let mut destinations = source
+            .chunks
+            .iter()
+            .map(|chunk| {
+                placements.get(chunk).cloned().ok_or_else(|| {
+                    CrabError::Internal(format!(
+                        "source {} chunk {} has no destination placement",
+                        source.hash, chunk
+                    ))
+                })
+            })
+            .collect::<Result<HashSet<_>>>()?
+            .into_iter()
+            .collect::<Vec<_>>();
+        destinations.sort_unstable();
+        let encoded = serde_json::to_string(&destinations).map_err(|error| {
+            CrabError::Internal(format!("destination list serialize failed: {error}"))
+        })?;
+        journal.update_source_status(run_id, &source.hash, SourceStatus::Done, Some(&encoded))?;
+        outcome.done = outcome.done.saturating_add(1);
     }
+    Ok(outcome)
 }
 
-/// Check whether a GC operation is currently running.
-///
-/// Probes for the GC lock file at the standard location. Returns
-/// `ConcurrentMaintenance` if GC is active.
-pub fn check_gc_not_running(crab_dir: &std::path::Path) -> Result<()> {
-    let gc_lock = crab_dir.join("gc.lock");
-    if gc_lock.exists() {
-        return Err(CrabError::ConcurrentMaintenance { other: "gc" });
+async fn upload_destination(
+    store: &Store,
+    destination: XorbResult,
+    placements: &mut HashMap<MerkleHash, String>,
+    cancel: &CancellationToken,
+) -> Result<u64> {
+    let destination_hash = destination.hash;
+    let hash = destination_hash.hex();
+    let path = canonical_global_content_path("xorbs", &hash);
+    let size = u64::try_from(destination.bytes.len()).map_err(|_| CrabError::Configuration {
+        key: "optimize xorbs destination size".to_owned(),
+        origin: format!("destination xorb {hash} size cannot be represented"),
+    })?;
+    if size > MAX_TARGET_XORB_BYTES as u64 {
+        return Err(CrabError::Configuration {
+            key: "optimize xorbs destination size".to_owned(),
+            origin: format!(
+                "destination xorb {hash} is {size} bytes; bounded rewriting supports at most {MAX_TARGET_XORB_BYTES} bytes"
+            ),
+        });
+    }
+
+    match store
+        .put_multipart_retry_with_xet_hash(
+            &path,
+            Bytes::from(destination.bytes.clone()),
+            destination_hash.into(),
+            8 * 1024 * 1024,
+            cancel,
+            None,
+        )
+        .await
+    {
+        Ok(()) => {}
+        Err(CrabError::CasConflict { .. }) => {
+            let (existing, _) = store
+                .get_with_etag_bounded(&path, MAX_TARGET_XORB_BYTES as u64)
+                .await?;
+            let parser = XorbParser::parse(existing).map_err(CrabError::from)?;
+            if parser.hash() != destination_hash {
+                return Err(CrabError::CorruptObject {
+                    path: path.to_string(),
+                    reason: format!("existing xorb hashes to {}, expected {hash}", parser.hash()),
+                });
+            }
+            parser.verify_payload_digest().map_err(CrabError::from)?;
+            parser.verify_all_chunks().map_err(CrabError::from)?;
+        }
+        Err(error) => return Err(error),
+    }
+
+    for placement in destination.placements {
+        if let Some(previous) = placements.insert(placement.chunk_hash, hash.clone())
+            && previous != hash
+        {
+            return Err(CrabError::Internal(format!(
+                "chunk {} was packed into both {previous} and {hash}",
+                placement.chunk_hash
+            )));
+        }
+    }
+    Ok(size)
+}
+
+fn validate_target(profile: &Profile) -> Result<()> {
+    let target =
+        usize::try_from(profile.target_xorb_bytes).map_err(|_| CrabError::Configuration {
+            key: "optimize xorbs target size".to_owned(),
+            origin: "target size cannot be represented on this platform".to_owned(),
+        })?;
+    if !(MIN_TARGET_XORB_BYTES..=MAX_TARGET_XORB_BYTES).contains(&target) {
+        return Err(CrabError::Configuration {
+            key: "optimize xorbs target size".to_owned(),
+            origin: format!(
+                "target must be between {MIN_TARGET_XORB_BYTES} and {MAX_TARGET_XORB_BYTES} bytes"
+            ),
+        });
     }
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+fn resolve_compression(profile: &Profile) -> Result<CompressionScheme> {
+    use crate::core::config::CompressionConfig;
+    match profile.compression {
+        CompressionConfig::None => Ok(CompressionScheme::None),
+        CompressionConfig::Lz4 | CompressionConfig::Zstd { .. } => Ok(CompressionScheme::LZ4),
+    }
+}
+
+fn build_outcome(
+    run_id: &str,
+    profile: &Profile,
+    start: &Instant,
+    result: BatchResult,
+) -> ExecutorOutcome {
+    ExecutorOutcome {
+        run_id: run_id.to_owned(),
+        profile: profile.to_json(),
+        sources_processed: result.processed,
+        sources_done: result.done,
+        sources_corrupt: (result.corrupt.len() as u64).saturating_add(result.corrupt_omitted),
+        sources_skipped: result.skipped,
+        bytes_read: result.bytes_read,
+        bytes_written: result.bytes_written,
+        elapsed_ms: start.elapsed().as_millis() as u64,
+        corrupt_list: result.corrupt,
+        corrupt_list_omitted: result.corrupt_omitted,
+    }
+}
+
+/// Reject local GC implementations that do not participate in the remote lease.
+pub fn check_gc_not_running(crab_dir: &std::path::Path) -> Result<()> {
+    if crab_dir.join("gc.lock").exists() {
+        return Err(CrabError::ConcurrentMaintenance { other: "gc" });
+    }
+    Ok(())
+}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
@@ -579,11 +527,11 @@ mod tests {
 
     #[test]
     fn executor_config_defaults() {
-        let cfg = ExecutorConfig::default();
-        assert!(cfg.include_cold);
-        assert_eq!(cfg.restore_tier, "standard");
-        assert_eq!(cfg.output_class, "STANDARD");
-        assert_eq!(cfg.budget_factor, 2);
+        let config = ExecutorConfig::default();
+        assert!(config.include_cold);
+        assert_eq!(config.restore_tier, "standard");
+        assert_eq!(config.output_class, "STANDARD");
+        assert_eq!(config.budget_factor, 2);
     }
 
     #[test]
@@ -601,125 +549,56 @@ mod tests {
     }
 
     #[test]
-    fn resolve_compression_none() {
-        let mut p = crate::optimize::xorbs::profile::Profile::code();
-        p.compression = crate::core::config::CompressionConfig::None;
-        assert_eq!(resolve_compression(&p), CompressionScheme::None);
-    }
-
-    #[test]
-    fn resolve_compression_lz4() {
-        let mut p = crate::optimize::xorbs::profile::Profile::code();
-        p.compression = crate::core::config::CompressionConfig::Lz4;
-        assert_eq!(resolve_compression(&p), CompressionScheme::LZ4);
-    }
-
-    #[test]
-    fn resolve_compression_zstd_defaults_to_lz4() {
-        let p = crate::optimize::xorbs::profile::Profile::ml();
-        assert_eq!(resolve_compression(&p), CompressionScheme::LZ4);
-    }
-
-    #[test]
-    fn is_transient_classifies_network_errors() {
-        let transient = CrabError::NetworkTransient(object_store::Error::Generic {
-            store: "test",
-            source: "timeout".into(),
-        });
-        assert!(is_transient(&transient));
-
-        let permanent = CrabError::NotFound {
-            path: "x".to_string(),
-        };
-        assert!(!is_transient(&permanent));
+    fn zstd_profile_uses_xet_lz4_scheme() {
+        let mut profile = Profile::code();
+        profile.compression = crate::core::config::CompressionConfig::Zstd { level: 3 };
+        assert_eq!(
+            resolve_compression(&profile).unwrap(),
+            CompressionScheme::LZ4
+        );
     }
 
     #[tokio::test]
     async fn execute_with_no_store_marks_pending_as_done() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("journal.db");
-        let journal = OptimizeXorbsJournal::open(&path).unwrap();
-
-        journal.start_run("test-run", "{}").unwrap();
-        journal.insert_source("test-run", "xorb-aaa").unwrap();
-        journal.insert_source("test-run", "xorb-bbb").unwrap();
-
-        let cancel = CancellationToken::new();
-        let profile = crate::optimize::xorbs::profile::Profile::code();
-        let config = ExecutorConfig::default();
-
-        let outcome = execute(&journal, "test-run", &profile, &config, &cancel, None, None)
-            .await
-            .unwrap();
-
-        assert_eq!(outcome.sources_processed, 2);
-        assert_eq!(outcome.sources_done, 2);
-        assert_eq!(outcome.sources_corrupt, 0);
-        assert_eq!(outcome.sources_skipped, 0);
-
-        let counts = journal.count_by_status("test-run").unwrap();
-        assert_eq!(counts.done, 2);
-        assert_eq!(counts.pending, 0);
-    }
-
-    #[tokio::test]
-    async fn execute_with_no_pending_returns_empty_outcome() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("journal.db");
-        let journal = OptimizeXorbsJournal::open(&path).unwrap();
-        journal.start_run("empty-run", "{}").unwrap();
-
-        let cancel = CancellationToken::new();
-        let profile = crate::optimize::xorbs::profile::Profile::code();
-        let config = ExecutorConfig::default();
-
+        let journal = OptimizeXorbsJournal::open(&dir.path().join("journal.db")).unwrap();
+        journal.start_run("run", "{}").unwrap();
+        journal.insert_source("run", "xorb-a").unwrap();
+        journal.insert_source("run", "xorb-b").unwrap();
         let outcome = execute(
             &journal,
-            "empty-run",
-            &profile,
-            &config,
-            &cancel,
+            "run",
+            &Profile::code(),
+            &ExecutorConfig::default(),
+            &CancellationToken::new(),
             None,
             None,
         )
         .await
         .unwrap();
-
-        assert_eq!(outcome.sources_processed, 0);
-        assert_eq!(outcome.sources_done, 0);
+        assert_eq!(outcome.sources_done, 2);
+        assert_eq!(journal.count_by_status("run").unwrap().pending, 0);
     }
 
     #[tokio::test]
-    async fn execute_cancellation_stops_between_xorbs() {
+    async fn execute_cancellation_stops_before_first_page() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("journal.db");
-        let journal = OptimizeXorbsJournal::open(&path).unwrap();
-
-        journal.start_run("cancel-run", "{}").unwrap();
-        journal.insert_source("cancel-run", "xorb-001").unwrap();
-        journal.insert_source("cancel-run", "xorb-002").unwrap();
-
+        let journal = OptimizeXorbsJournal::open(&dir.path().join("journal.db")).unwrap();
+        journal.start_run("run", "{}").unwrap();
+        journal.insert_source("run", "xorb-a").unwrap();
         let cancel = CancellationToken::new();
-        // Cancel immediately — the first check_cancelled should fire.
         cancel.cancel();
-
-        let profile = crate::optimize::xorbs::profile::Profile::code();
-        let config = ExecutorConfig::default();
-
         let result = execute(
             &journal,
-            "cancel-run",
-            &profile,
-            &config,
+            "run",
+            &Profile::code(),
+            &ExecutorConfig::default(),
             &cancel,
             None,
             None,
         )
         .await;
-
-        assert!(result.is_err());
-        // Both sources should still be pending (cancellation before processing).
-        let counts = journal.count_by_status("cancel-run").unwrap();
-        assert_eq!(counts.pending, 2);
+        assert!(matches!(result, Err(CrabError::Cancelled)));
+        assert_eq!(journal.count_by_status("run").unwrap().pending, 1);
     }
 }

--- a/crab/src/optimize/xorbs/executor.rs
+++ b/crab/src/optimize/xorbs/executor.rs
@@ -39,12 +39,14 @@ use crate::storage::store::Store;
 use crate::tier::restore::RestoreOrchestrator;
 use crab_storage::canonical_global_content_path;
 use crab_xet::xorb::builder::{FixedCompression, RunId, XorbBuilder};
-use crab_xet::xorb::format::CompressionScheme;
+use crab_xet::xorb::format::{CompressionScheme, MAX_XORB_SIZE};
 use crab_xet::xorb::parser::XorbParser;
 
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
+
+const MAX_CORRUPT_REPORT_ENTRIES: usize = 1_024;
 
 /// Configuration for the xorb optimization executor.
 #[derive(Debug, Clone)]
@@ -233,7 +235,9 @@ pub async fn execute(
                     XorbStatus::Done => sources_done += 1,
                     XorbStatus::Corrupt => {
                         sources_corrupt += 1;
-                        corrupt_list.push(src_hash.clone());
+                        if corrupt_list.len() < MAX_CORRUPT_REPORT_ENTRIES {
+                            corrupt_list.push(src_hash.clone());
+                        }
                     }
                     XorbStatus::Skipped => sources_skipped += 1,
                 }
@@ -361,7 +365,10 @@ async fn process_single_xorb(
     // surface the real error if the object is truly inaccessible).
 
     // --- Step 3: Download source xorb (bounded by memory budget) ---
-    let src_bytes = match store.get_with_etag(&xorb_path).await {
+    let src_bytes = match store
+        .get_with_etag_bounded(&xorb_path, MAX_XORB_SIZE as u64)
+        .await
+    {
         Ok((bytes, _etag)) => bytes,
         Err(CrabError::NotFound { .. }) => {
             debug!(src_xorb = %src_hash, "source xorb not found; skipping");
@@ -461,6 +468,15 @@ async fn process_single_xorb(
         let dest_path = canonical_global_content_path("xorbs", &dest_hash);
         let dest_bytes = Bytes::copy_from_slice(&xorb_result.bytes);
         let written = dest_bytes.len() as u64;
+        if written > MAX_XORB_SIZE as u64 {
+            return Err(CrabError::Configuration {
+                key: "optimize xorbs destination size".to_owned(),
+                origin: format!(
+                    "destination xorb {dest_hash} is {written} bytes; bounded rewriting supports at most {} bytes",
+                    MAX_XORB_SIZE
+                ),
+            });
+        }
 
         // CAS put: if the xorb already exists (idempotent retry or
         // concurrent push wrote the same content), the put succeeds

--- a/crab/src/optimize/xorbs/journal.rs
+++ b/crab/src/optimize/xorbs/journal.rs
@@ -118,7 +118,7 @@ impl OptimizeXorbsJournal {
     pub fn open(path: &Path) -> Result<Self> {
         // Ensure parent directory exists.
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| CrabError::Io(e))?;
+            std::fs::create_dir_all(parent).map_err(CrabError::Io)?;
         }
 
         let conn = Connection::open(path).map_err(|e| {
@@ -293,6 +293,36 @@ impl OptimizeXorbsJournal {
         Ok(())
     }
 
+    /// Insert a bounded page of source xorbs in one SQLite transaction.
+    pub fn insert_sources(&self, run_id: &str, src_xorbs: &[String]) -> Result<()> {
+        if src_xorbs.is_empty() {
+            return Ok(());
+        }
+        let transaction = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| CrabError::Internal(format!("failed to begin source page insert: {e}")))?;
+        {
+            let mut statement = transaction
+                .prepare(
+                    "INSERT OR IGNORE INTO sources (run_id, src_xorb, status)
+                     VALUES (?1, ?2, 'pending')",
+                )
+                .map_err(|e| {
+                    CrabError::Internal(format!("failed to prepare source page insert: {e}"))
+                })?;
+            for src_xorb in src_xorbs {
+                statement.execute(params![run_id, src_xorb]).map_err(|e| {
+                    CrabError::Internal(format!("failed to insert source page: {e}"))
+                })?;
+            }
+        }
+        transaction
+            .commit()
+            .map_err(|e| CrabError::Internal(format!("failed to commit source page: {e}")))?;
+        Ok(())
+    }
+
     /// Update a source xorb's status.
     pub fn update_source_status(
         &self,
@@ -370,6 +400,49 @@ impl OptimizeXorbsJournal {
         Ok(result)
     }
 
+    /// Read a bounded, deterministic page of sources in one status.
+    ///
+    /// The exclusive `src_xorb > after` cursor lets long-running operations
+    /// consume a journal without holding every pending row in heap memory.
+    pub fn sources_by_status_after(
+        &self,
+        run_id: &str,
+        status: SourceStatus,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<SourceRow>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).map_err(|_| CrabError::Configuration {
+            key: "restripe journal page size".to_owned(),
+            origin: "page size cannot be represented by SQLite".to_owned(),
+        })?;
+        let mut statement = self
+            .conn
+            .prepare(
+                "SELECT run_id, src_xorb, status, dest_xorbs, started_at,
+                        completed_at, err_kind, err_msg
+                 FROM sources
+                 WHERE run_id = ?1 AND status = ?2 AND src_xorb > ?3
+                 ORDER BY src_xorb
+                 LIMIT ?4",
+            )
+            .map_err(|e| {
+                CrabError::Internal(format!("failed to prepare source page query: {e}"))
+            })?;
+        let rows = statement
+            .query_map(
+                params![run_id, status.as_str(), after.unwrap_or_default(), limit],
+                source_row_from_sql,
+            )
+            .map_err(|e| CrabError::Internal(format!("failed to query source page: {e}")))?;
+        rows.map(|row| {
+            row.map_err(|e| CrabError::Internal(format!("failed to read source page row: {e}")))
+        })
+        .collect()
+    }
+
     /// Count sources by status for a run.
     pub fn count_by_status(&self, run_id: &str) -> Result<StatusCounts> {
         let mut counts = StatusCounts::default();
@@ -404,18 +477,17 @@ impl OptimizeXorbsJournal {
     /// Drop the journal database file. Requires explicit confirmation.
     pub fn drop_journal(path: &Path) -> Result<()> {
         for suffix in &["", "-wal", "-shm"] {
-            let p = path.with_extension(
-                path.extension()
-                    .map(|e| format!("{}{suffix}", e.to_string_lossy()))
-                    .unwrap_or_else(|| suffix.to_string()),
-            );
+            let p = path.with_extension(path.extension().map_or_else(
+                || suffix.to_string(),
+                |extension| format!("{}{suffix}", extension.to_string_lossy()),
+            ));
             if p.exists() {
-                std::fs::remove_file(&p).map_err(|e| CrabError::Io(e))?;
+                std::fs::remove_file(&p).map_err(CrabError::Io)?;
             }
         }
         // Also try the base path directly.
         if path.exists() {
-            std::fs::remove_file(path).map_err(|e| CrabError::Io(e))?;
+            std::fs::remove_file(path).map_err(CrabError::Io)?;
         }
         info!(path = %path.display(), "xorb optimization journal dropped");
         Ok(())
@@ -448,8 +520,21 @@ impl StatusCounts {
 fn epoch_secs() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+        .map_or(0, |duration| duration.as_secs() as i64)
+}
+
+fn source_row_from_sql(row: &rusqlite::Row<'_>) -> rusqlite::Result<SourceRow> {
+    let status_str: String = row.get(2)?;
+    Ok(SourceRow {
+        run_id: row.get(0)?,
+        src_xorb: row.get(1)?,
+        status: SourceStatus::from_str(&status_str).unwrap_or(SourceStatus::Pending),
+        dest_xorbs: row.get(3)?,
+        started_at: row.get(4)?,
+        completed_at: row.get(5)?,
+        err_kind: row.get(6)?,
+        err_msg: row.get(7)?,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -548,6 +633,36 @@ mod tests {
             .sources_by_status("run-004", SourceStatus::Pending)
             .unwrap();
         assert_eq!(pending.len(), 1);
+    }
+
+    #[test]
+    fn source_status_pages_follow_a_stable_cursor() {
+        let (_dir, journal) = temp_journal();
+        journal.start_run("run-page", "{}").unwrap();
+        for source in ["xorb-a", "xorb-b", "xorb-c"] {
+            journal.insert_source("run-page", source).unwrap();
+        }
+
+        let first = journal
+            .sources_by_status_after("run-page", SourceStatus::Pending, Some(""), 2)
+            .unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|row| row.src_xorb.as_str())
+                .collect::<Vec<_>>(),
+            vec!["xorb-a", "xorb-b"]
+        );
+        let second = journal
+            .sources_by_status_after(
+                "run-page",
+                SourceStatus::Pending,
+                Some(&first[1].src_xorb),
+                2,
+            )
+            .unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].src_xorb, "xorb-c");
     }
 
     #[test]

--- a/crab/src/optimize/xorbs/reconcile.rs
+++ b/crab/src/optimize/xorbs/reconcile.rs
@@ -18,6 +18,7 @@ use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
+use crate::core::config::Config;
 use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::metadata::manifest;
 use crate::optimize::xorbs::journal::{OptimizeXorbsJournal, SourceStatus};
@@ -25,6 +26,7 @@ use crate::storage::StoreLayout;
 use crate::storage::store::Store;
 
 use crab_staging::recipe::{ChunkingPolicyId, FileRecipe};
+use crab_xet::hash::HashedWrite;
 use crab_xet::shard::{
     FileDataSequenceEntry, MDBFileInfo, MDBXorbInfo, ShardReader, ShardWriter,
     XorbChunkSequenceEntry, XorbChunkSequenceHeader,
@@ -38,6 +40,8 @@ const MAX_RECONCILIATION_MAPPING_ENTRIES: u64 = 1_000_000;
 const MAX_DESTINATIONS_PER_SOURCE: usize = 1_000_000;
 const MAX_DESTINATION_JSON_BYTES: usize = 80 * 1024 * 1024;
 const MAX_RECONCILIATION_SHARD_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_RECONCILIATION_FILE_ENTRIES: usize = 1_000_000;
+const MAX_RECONCILIATION_XORB_ENTRIES: usize = 1_000_000;
 const MAX_RECONCILIATION_LOADED_CHUNK_ENTRIES: usize = 10_000_000;
 const SOURCES_PER_RECONCILIATION_BATCH: usize = 64;
 
@@ -397,6 +401,7 @@ struct ShardRewrite {
 #[derive(Debug, Default)]
 struct ReconcilePlan {
     replacements: Vec<ShardRewrite>,
+    replaced_sources: HashSet<MerkleHash>,
     final_shards: Vec<MerkleHash>,
     file_entries: Vec<FileIndexEntry>,
 }
@@ -534,9 +539,27 @@ fn rewrite_shard(
     let files = shard_info
         .read_all_file_info_sections(&mut cursor)
         .map_err(|error| corrupt_shard(format!("read file-info section: {error}")))?;
+    if files.len() > MAX_RECONCILIATION_FILE_ENTRIES {
+        return Err(CrabError::Configuration {
+            key: "xorb optimization reconciliation file entries".to_owned(),
+            origin: format!(
+                "shard contains {} file entries; bounded reconciliation supports at most {MAX_RECONCILIATION_FILE_ENTRIES}",
+                files.len()
+            ),
+        });
+    }
     let original_xorbs = shard_info
         .read_all_xorb_blocks_full(&mut cursor)
         .map_err(|error| corrupt_shard(format!("read xorb-info section: {error}")))?;
+    if original_xorbs.len() > MAX_RECONCILIATION_XORB_ENTRIES {
+        return Err(CrabError::Configuration {
+            key: "xorb optimization reconciliation xorb entries".to_owned(),
+            origin: format!(
+                "shard contains {} xorb entries; bounded reconciliation supports at most {MAX_RECONCILIATION_XORB_ENTRIES}",
+                original_xorbs.len()
+            ),
+        });
+    }
     if files.is_empty() {
         return Ok(None);
     }
@@ -640,6 +663,7 @@ async fn build_plan(
         let body = read_shard(store, router, shard_hash).await?;
         if let Some(rewrite) = rewrite_shard(&body, shard_hash, mapping)? {
             replacements_by_old.insert(shard_hash, rewrite.new_hash);
+            plan.replaced_sources.insert(shard_hash);
             plan.file_entries
                 .extend(rewrite.file_entries.iter().cloned());
             plan.replacements.push(rewrite);
@@ -687,72 +711,55 @@ async fn upload_replacements(
     replacements: &[ShardRewrite],
     cancel: &CancellationToken,
 ) -> Result<(u64, u64)> {
+    let workspace = tempfile::tempdir().map_err(CrabError::Io)?;
     let mut uploaded = 0;
     let mut bytes = 0;
     for replacement in replacements {
         check_cancelled(cancel)?;
         let path = router.shard_path(&replacement.new_hash);
-        store.put(&path, replacement.bytes.clone()).await?;
-        crate::cmd::gc::closure::publish(
-            store,
-            router.global_prefix(),
-            &replacement.new_hash,
-            replacement.bytes.clone(),
-            path.as_ref(),
-        )
-        .await?;
-        let (verified, _) = store
-            .get_with_etag_bounded(&path, MAX_RECONCILIATION_SHARD_BYTES)
+        let local_path = workspace
+            .path()
+            .join(format!("replacement-{}.shard", replacement.new_hash.hex()));
+        tokio::fs::write(&local_path, &replacement.bytes)
+            .await
+            .map_err(CrabError::Io)?;
+        let size =
+            u64::try_from(replacement.bytes.len()).map_err(|_| CrabError::Configuration {
+                key: "xorb optimization replacement size".to_owned(),
+                origin: "replacement shard size cannot be represented".to_owned(),
+            })?;
+        store
+            .put_multipart_file_retry_with_xet_hash(
+                &path,
+                &local_path,
+                size,
+                replacement.new_hash.into(),
+                8 * 1024 * 1024,
+                cancel,
+                None,
+            )
             .await?;
-        let actual_hash = crab_xet::hash::compute_data_hash(&verified);
-        if actual_hash != replacement.new_hash {
+        let mut hasher = HashedWrite::new(std::io::sink());
+        let verified_size = tokio::select! {
+            result = store.stream_to_writer(&path, &mut hasher) => result?,
+            () = cancel.cancelled() => return Err(CrabError::Cancelled),
+        };
+        if verified_size != size || hasher.hash() != replacement.new_hash {
             return Err(CrabError::CorruptObject {
                 path: path.to_string(),
                 reason: format!(
-                    "rewritten shard content hash is {actual_hash}, expected {}",
-                    replacement.new_hash
+                    "rewritten shard verification failed: expected {} bytes and hash {}, got {} bytes and hash {}",
+                    size,
+                    replacement.new_hash,
+                    verified_size,
+                    hasher.hash()
                 ),
             });
         }
         uploaded += 1;
-        bytes += replacement.bytes.len() as u64;
+        bytes += size;
     }
     Ok((uploaded, bytes))
-}
-
-async fn publish_file_index(
-    store: &Store,
-    router: &StoreLayout,
-    entries: &[FileIndexEntry],
-    generation: u64,
-    shard_index_hash: MerkleHash,
-) -> Result<()> {
-    let committed = entries
-        .iter()
-        .map(|entry| {
-            (
-                entry.file_hash,
-                crab_metadata::value_codec::CommittedFileRecord {
-                    recipe_hash: entry.recipe_hash,
-                    shard_hash: entry.shard_hash,
-                    committed_generation: generation,
-                    shard_index_hash,
-                },
-            )
-        })
-        .collect::<Vec<_>>();
-    let config = crab_metadata::remote_index::RemoteIndexConfig::for_repo_with_global_prefix(
-        router.repo_prefix(),
-        router.global_prefix(),
-    );
-    crab_metadata::remote_index::write_index_entries(
-        Arc::clone(store.inner()),
-        &config,
-        &committed,
-        &[],
-    )
-    .await
-    .map_err(CrabError::from)
 }
 
 fn now_iso8601() -> String {
@@ -800,6 +807,7 @@ pub async fn finalize(
     run_id: &str,
     store: Option<&Store>,
     router: Option<&StoreLayout>,
+    config: &Config,
     cancel: &CancellationToken,
 ) -> Result<ReconcileOutcome> {
     let (src_to_dest, entries_updated, entries_unchanged) = build_mapping(journal, run_id)?;
@@ -909,26 +917,51 @@ pub async fn finalize(
         total_uploaded += uploaded;
         total_bytes += bytes;
 
-        let shard_index_hash = parse_hash(&shard_index_hash_text, "reconciled shard index")?;
-        publish_file_index(
-            store,
-            router,
-            &plan.file_entries,
-            next_generation,
-            shard_index_hash,
-        )
-        .await?;
-        check_cancelled(cancel)?;
-
         let mut candidate = manifest_before;
         candidate.generation = next_generation;
         candidate.created_at = now_iso8601();
         candidate.session_id = format!("optimize-xorbs-{run_id}");
         candidate.shard_index_hash = shard_index_hash_text;
         candidate.seal_git_validation();
+        // Candidate rows and roots are durable before the manifest CAS. A
+        // cancelled or conflicting attempt may leave extra immutable objects,
+        // but it must never expose a generation with missing index evidence.
+        let publication = crate::cmd::metadb::publish_candidate_shard_indexes(
+            store,
+            router.repo_prefix(),
+            &candidate,
+            &final_shards,
+            config,
+            cancel,
+        )
+        .await?;
+        debug!(
+            gc_registry_generation = publication.gc_registry_generation,
+            file_entries = publication.file_entries_written,
+            chunk_entries = publication.chunk_entries_written,
+            "candidate xorb indexes published"
+        );
+        check_cancelled(cancel)?;
 
         match manifest::write_manifest_cas(store, router, &candidate, &etag).await {
             Ok(_) => {
+                // The manifest CAS is the visibility point. Reconcile only
+                // the exact source roots replaced by this commit and finish
+                // the registry update even when cancellation arrived during
+                // the CAS request.
+                let storage_router = crab_storage::StoreLayout::new(
+                    store.as_storage().clone(),
+                    router.repo_prefix().to_owned(),
+                );
+                crab_metadata::ref_registry::reconcile_compacted_repo_shards(
+                    store.as_storage(),
+                    &storage_router,
+                    plan.replaced_sources.iter().map(MerkleHash::hex).collect(),
+                    plan.final_shards.iter().map(MerkleHash::hex).collect(),
+                )
+                .await?;
+                crate::cmd::metadb::write_generation_index_receipt(store, router, &candidate)
+                    .await?;
                 info!(
                     entries_updated,
                     entries_unchanged,
@@ -937,6 +970,9 @@ pub async fn finalize(
                     cas_attempts = attempt,
                     "xorb optimization reconciliation complete"
                 );
+                if cancel.is_cancelled() {
+                    return Err(CrabError::Cancelled);
+                }
                 return Ok(ReconcileOutcome {
                     entries_updated,
                     entries_unchanged,
@@ -1067,6 +1103,7 @@ mod tests {
             "test-reconcile",
             None,
             None,
+            &Config::default(),
             &CancellationToken::new(),
         )
         .await
@@ -1095,6 +1132,7 @@ mod tests {
             "test-empty",
             None,
             None,
+            &Config::default(),
             &CancellationToken::new(),
         )
         .await

--- a/crab/src/optimize/xorbs/reconcile.rs
+++ b/crab/src/optimize/xorbs/reconcile.rs
@@ -30,10 +30,16 @@ use crab_xet::shard::{
     XorbChunkSequenceEntry, XorbChunkSequenceHeader,
 };
 use crab_xet::shard_parse::extract_file_recipes;
-use crab_xet::xorb::format::{MerkleHash, XorbRef};
+use crab_xet::xorb::format::{MAX_XORB_SIZE, MerkleHash, XorbRef};
 use crab_xet::xorb::parser::XorbParser;
 
 const MAX_CAS_ATTEMPTS: u32 = 8;
+const MAX_RECONCILIATION_MAPPING_ENTRIES: u64 = 1_000_000;
+const MAX_DESTINATIONS_PER_SOURCE: usize = 1_000_000;
+const MAX_DESTINATION_JSON_BYTES: usize = 80 * 1024 * 1024;
+const MAX_RECONCILIATION_SHARD_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_RECONCILIATION_LOADED_CHUNK_ENTRIES: usize = 10_000_000;
+const SOURCES_PER_RECONCILIATION_BATCH: usize = 64;
 
 // ---------------------------------------------------------------------------
 // Reconciliation outcome
@@ -65,22 +71,70 @@ fn build_mapping(
     journal: &OptimizeXorbsJournal,
     run_id: &str,
 ) -> Result<(HashMap<String, Vec<String>>, u64, u64)> {
-    let done_sources = journal.sources_by_status(run_id, SourceStatus::Done)?;
     let counts = journal.count_by_status(run_id)?;
 
-    let mut src_to_dest: HashMap<String, Vec<String>> = HashMap::new();
+    let mut src_to_dest = HashMap::new();
     let mut entries_updated: u64 = 0;
 
-    for source in &done_sources {
-        if let Some(ref dest_json) = source.dest_xorbs {
+    let mut after = String::new();
+    loop {
+        let done_sources = journal.sources_by_status_after(
+            run_id,
+            SourceStatus::Done,
+            Some(&after),
+            SOURCES_PER_RECONCILIATION_BATCH,
+        )?;
+        if done_sources.is_empty() {
+            break;
+        }
+        if let Some(last) = done_sources.last() {
+            after.clone_from(&last.src_xorb);
+        }
+        for source in done_sources {
+            let Some(dest_json) = source.dest_xorbs else {
+                continue;
+            };
+            if dest_json.len() > MAX_DESTINATION_JSON_BYTES {
+                return Err(CrabError::Configuration {
+                    key: "xorb optimization reconciliation destination list".to_owned(),
+                    origin: format!(
+                        "journal destination list for {} exceeds the bounded reconciliation size",
+                        source.src_xorb
+                    ),
+                });
+            }
             let dests: Vec<String> =
-                serde_json::from_str(dest_json).map_err(|error| CrabError::CorruptObject {
+                serde_json::from_str(&dest_json).map_err(|error| CrabError::CorruptObject {
                     path: format!("xorb optimization journal source {}", source.src_xorb),
                     reason: format!("invalid destination xorb list: {error}"),
                 })?;
+            if dests.len() > MAX_DESTINATIONS_PER_SOURCE {
+                return Err(CrabError::Configuration {
+                    key: "xorb optimization reconciliation destination count".to_owned(),
+                    origin: format!(
+                        "journal source {} references {} destination xorbs; bounded reconciliation supports at most {MAX_DESTINATIONS_PER_SOURCE}",
+                        source.src_xorb,
+                        dests.len()
+                    ),
+                });
+            }
             if !dests.is_empty() {
-                entries_updated += 1;
-                src_to_dest.insert(source.src_xorb.clone(), dests);
+                entries_updated =
+                    entries_updated
+                        .checked_add(1)
+                        .ok_or_else(|| CrabError::Configuration {
+                            key: "xorb optimization reconciliation mapping count".to_owned(),
+                            origin: "journal mapping count overflow".to_owned(),
+                        })?;
+                if entries_updated > MAX_RECONCILIATION_MAPPING_ENTRIES {
+                    return Err(CrabError::Configuration {
+                        key: "xorb optimization reconciliation mapping count".to_owned(),
+                        origin: format!(
+                            "journal maps more than {MAX_RECONCILIATION_MAPPING_ENTRIES} source xorbs in one reconciliation"
+                        ),
+                    });
+                }
+                src_to_dest.insert(source.src_xorb, dests);
             }
         }
     }
@@ -119,7 +173,9 @@ fn parse_hash(value: &str, path: &str) -> Result<MerkleHash> {
 /// Read and validate one xorb before using its chunk metadata in a shard.
 async fn load_xorb(store: &Store, router: &StoreLayout, hash: MerkleHash) -> Result<XorbParser> {
     let path = router.xorb_path(&hash);
-    let (bytes, _) = store.get_with_etag(&path).await?;
+    let (bytes, _) = store
+        .get_with_etag_bounded(&path, MAX_XORB_SIZE as u64)
+        .await?;
     let parser = XorbParser::parse(bytes).map_err(CrabError::from)?;
     if parser.hash() != hash {
         return Err(CrabError::CorruptObject {
@@ -198,6 +254,7 @@ async fn load_mapping(
     cancel: &CancellationToken,
 ) -> Result<LoadedMapping> {
     let mut loaded = LoadedMapping::default();
+    let mut loaded_chunk_entries = 0usize;
 
     for (source_text, destination_texts) in mapping {
         check_cancelled(cancel)?;
@@ -205,6 +262,20 @@ async fn load_mapping(
         let source_path = router.xorb_path(&source_hash).to_string();
         let source_parser = load_xorb(store, router, source_hash).await?;
         let chunks = source_chunks(&source_parser, &source_path)?;
+        loaded_chunk_entries = loaded_chunk_entries
+            .checked_add(chunks.len())
+            .ok_or_else(|| CrabError::Configuration {
+                key: "xorb optimization reconciliation chunk metadata".to_owned(),
+                origin: "source chunk metadata count overflows usize".to_owned(),
+            })?;
+        if loaded_chunk_entries > MAX_RECONCILIATION_LOADED_CHUNK_ENTRIES {
+            return Err(CrabError::Configuration {
+                key: "xorb optimization reconciliation chunk metadata".to_owned(),
+                origin: format!(
+                    "loaded source chunk metadata exceeds {MAX_RECONCILIATION_LOADED_CHUNK_ENTRIES} entries"
+                ),
+            });
+        }
         let source_hashes: HashSet<MerkleHash> = chunks.iter().map(|chunk| chunk.hash).collect();
         let mut refs = HashMap::new();
 
@@ -218,6 +289,20 @@ async fn load_mapping(
                 let destination_path = router.xorb_path(&destination_hash).to_string();
                 let destination_parser = load_xorb(store, router, destination_hash).await?;
                 let info = xorb_info(destination_hash, &destination_parser, &destination_path)?;
+                loaded_chunk_entries = loaded_chunk_entries
+                    .checked_add(info.chunks.len())
+                    .ok_or_else(|| CrabError::Configuration {
+                        key: "xorb optimization reconciliation chunk metadata".to_owned(),
+                        origin: "destination chunk metadata count overflows usize".to_owned(),
+                    })?;
+                if loaded_chunk_entries > MAX_RECONCILIATION_LOADED_CHUNK_ENTRIES {
+                    return Err(CrabError::Configuration {
+                        key: "xorb optimization reconciliation chunk metadata".to_owned(),
+                        origin: format!(
+                            "loaded destination chunk metadata exceeds {MAX_RECONCILIATION_LOADED_CHUNK_ENTRIES} entries"
+                        ),
+                    });
+                }
                 loaded
                     .destination_infos
                     .insert(destination_hash, Arc::clone(&info));
@@ -278,6 +363,14 @@ async fn load_mapping(
         loaded
             .sources
             .insert(source_hash, SourcePlacement { chunks, refs });
+        if loaded.sources.len() as u64 > MAX_RECONCILIATION_MAPPING_ENTRIES {
+            return Err(CrabError::Configuration {
+                key: "xorb optimization reconciliation mapping count".to_owned(),
+                origin: format!(
+                    "reconciliation loaded more than {MAX_RECONCILIATION_MAPPING_ENTRIES} source xorbs"
+                ),
+            });
+        }
     }
 
     Ok(loaded)
@@ -515,7 +608,9 @@ fn rewrite_shard(
 
 async fn read_shard(store: &Store, router: &StoreLayout, hash: MerkleHash) -> Result<Bytes> {
     let path = router.shard_path(&hash);
-    let (body, _) = store.get_with_etag(&path).await?;
+    let (body, _) = store
+        .get_with_etag_bounded(&path, MAX_RECONCILIATION_SHARD_BYTES)
+        .await?;
     let actual_hash = crab_xet::hash::compute_data_hash(&body);
     if actual_hash != hash {
         return Err(CrabError::CorruptObject {
@@ -606,7 +701,9 @@ async fn upload_replacements(
             path.as_ref(),
         )
         .await?;
-        let (verified, _) = store.get_with_etag(&path).await?;
+        let (verified, _) = store
+            .get_with_etag_bounded(&path, MAX_RECONCILIATION_SHARD_BYTES)
+            .await?;
         let actual_hash = crab_xet::hash::compute_data_hash(&verified);
         if actual_hash != replacement.new_hash {
             return Err(CrabError::CorruptObject {
@@ -753,9 +850,13 @@ pub async fn finalize(
             });
         }
 
-        let shard_texts =
-            manifest::read_bulk_shard_list(store, router, &manifest_before.shard_index_hash)
-                .await?;
+        let shard_texts = manifest::read_bulk_shard_list_with_limit(
+            store,
+            router,
+            &manifest_before.shard_index_hash,
+            MAX_RECONCILIATION_MAPPING_ENTRIES,
+        )
+        .await?;
         let shard_hashes = shard_texts
             .iter()
             .map(|hash| parse_hash(hash, "manifest shard index"))

--- a/crab/src/replication/mod.rs
+++ b/crab/src/replication/mod.rs
@@ -8631,24 +8631,35 @@ pub async fn replica_statuses_with_options(
 
     let mut statuses = Vec::with_capacity(replication.replicas.len());
     for replica in &replication.replicas {
+        if cancel.is_cancelled() {
+            return Err(CrabError::Cancelled);
+        }
         match build_replica_store(replica, &primary_url.repo_path) {
             Ok((replica_store, replica_prefix)) => {
                 let replica_router = StoreLayout::new(replica_store.clone(), replica_prefix);
-                match replica_readiness(
-                    &primary_store,
-                    &primary_router,
-                    &replica_store,
-                    &replica_router,
-                    replica,
-                    options,
-                )
-                .await
-                {
-                    Ok(status) => statuses.push(status_with_events(
-                        status,
+                let readiness = tokio::select! {
+                    result = replica_readiness(
+                        &primary_store,
+                        &primary_router,
+                        &replica_store,
+                        &replica_router,
                         replica,
-                        replica_router.repo_prefix(),
-                    )),
+                        options,
+                    ) => result,
+                    () = cancel.cancelled() => return Err(CrabError::Cancelled),
+                };
+                match readiness {
+                    Ok(status) => {
+                        if cancel.is_cancelled() {
+                            return Err(CrabError::Cancelled);
+                        }
+                        statuses.push(status_with_events(
+                            status,
+                            replica,
+                            replica_router.repo_prefix(),
+                        ));
+                    }
+                    Err(CrabError::Cancelled) => return Err(CrabError::Cancelled),
                     Err(e) => statuses.push(status_with_events(
                         failed_status(replica, e.to_string()),
                         replica,

--- a/crab/src/storage/store.rs
+++ b/crab/src/storage/store.rs
@@ -186,9 +186,32 @@ impl Store {
             .map_err(CrabError::from)
     }
 
+    pub async fn get_with_etag_bounded(
+        &self,
+        path: &Path,
+        max_bytes: u64,
+    ) -> Result<(Bytes, ETag)> {
+        self.inner
+            .get_with_etag_bounded(path, max_bytes)
+            .await
+            .map_err(CrabError::from)
+    }
+
     pub async fn download_to_path(&self, path: &Path, dest: &std::path::Path) -> Result<u64> {
         self.inner
             .download_to_path(path, dest)
+            .await
+            .map_err(CrabError::from)
+    }
+
+    pub async fn download_to_path_bounded(
+        &self,
+        path: &Path,
+        dest: &std::path::Path,
+        max_bytes: u64,
+    ) -> Result<u64> {
+        self.inner
+            .download_to_path_bounded(path, dest, max_bytes)
             .await
             .map_err(CrabError::from)
     }
@@ -313,6 +336,30 @@ impl Store {
     ) -> Result<()> {
         self.inner
             .put_multipart_file_retry(
+                path,
+                file_path,
+                size,
+                expected_hash,
+                part_size,
+                cancel,
+                on_part_done,
+            )
+            .await
+            .map_err(CrabError::from)
+    }
+
+    pub async fn put_multipart_file_retry_with_xet_hash(
+        &self,
+        path: &Path,
+        file_path: &std::path::Path,
+        size: u64,
+        expected_hash: [u8; 32],
+        part_size: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
+    ) -> Result<()> {
+        self.inner
+            .put_multipart_file_retry_with_xet_hash(
                 path,
                 file_path,
                 size,

--- a/crab/src/storage/store.rs
+++ b/crab/src/storage/store.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use object_store::path::Path;
 use object_store::{MultipartUpload, ObjectMeta, ObjectStore};
+use tokio::io::AsyncReadExt;
 
 use crate::core::error::{CrabError, Result};
 
@@ -324,6 +325,34 @@ impl Store {
             .map_err(CrabError::from)
     }
 
+    /// Verify a bounded in-memory object with its Xet data hash before a
+    /// retryable multipart upload.
+    pub async fn put_multipart_retry_with_xet_hash(
+        &self,
+        path: &Path,
+        data: Bytes,
+        expected_hash: [u8; 32],
+        part_size: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
+    ) -> Result<()> {
+        let actual_hash: [u8; 32] = crab_xet::hash::compute_data_hash(&data).into();
+        if actual_hash != expected_hash {
+            return Err(CrabError::CorruptObject {
+                path: path.to_string(),
+                reason: format!(
+                    "in-memory Xet data hash {} does not match expected {}",
+                    crab_xet::hash::merkle_hex_from_bytes(&actual_hash),
+                    crab_xet::hash::merkle_hex_from_bytes(&expected_hash)
+                ),
+            });
+        }
+        self.inner
+            .put_multipart_retry(path, data, part_size, cancel, on_part_done)
+            .await
+            .map_err(CrabError::from)
+    }
+
     pub async fn put_multipart_file_retry(
         &self,
         path: &Path,
@@ -348,6 +377,8 @@ impl Store {
             .map_err(CrabError::from)
     }
 
+    /// Verify a local file with the Xet data hash before uploading it as a
+    /// bounded, retryable multipart object.
     pub async fn put_multipart_file_retry_with_xet_hash(
         &self,
         path: &Path,
@@ -358,12 +389,56 @@ impl Store {
         cancel: &tokio_util::sync::CancellationToken,
         on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
     ) -> Result<()> {
+        let metadata = tokio::fs::metadata(file_path)
+            .await
+            .map_err(CrabError::Io)?;
+        if metadata.len() != size {
+            return Err(CrabError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: format!(
+                    "local file has {} bytes; upload expects {size}",
+                    metadata.len()
+                ),
+            });
+        }
+
+        let mut file = tokio::fs::File::open(file_path)
+            .await
+            .map_err(CrabError::Io)?;
+        let mut xet_hasher = crab_xet::hash::HashedWrite::new(std::io::sink());
+        let mut blake3_hasher = blake3::Hasher::new();
+        let mut remaining = size;
+        let mut buffer = vec![0u8; part_size.max(1).min(1024 * 1024)];
+        while remaining > 0 {
+            if cancel.is_cancelled() {
+                return Err(CrabError::Cancelled);
+            }
+            let want = remaining.min(buffer.len() as u64) as usize;
+            file.read_exact(&mut buffer[..want])
+                .await
+                .map_err(CrabError::Io)?;
+            std::io::Write::write_all(&mut xet_hasher, &buffer[..want]).map_err(CrabError::Io)?;
+            blake3_hasher.update(&buffer[..want]);
+            remaining -= want as u64;
+        }
+        let actual_hash: [u8; 32] = xet_hasher.hash().into();
+        if actual_hash != expected_hash {
+            return Err(CrabError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: format!(
+                    "local Xet data hash {} does not match expected {}",
+                    crab_xet::hash::merkle_hex_from_bytes(&actual_hash),
+                    crab_xet::hash::merkle_hex_from_bytes(&expected_hash)
+                ),
+            });
+        }
+
         self.inner
-            .put_multipart_file_retry_with_xet_hash(
+            .put_multipart_file_retry(
                 path,
                 file_path,
                 size,
-                expected_hash,
+                *blake3_hasher.finalize().as_bytes(),
                 part_size,
                 cancel,
                 on_part_done,

--- a/crab/src/tier/apply.rs
+++ b/crab/src/tier/apply.rs
@@ -1,4 +1,4 @@
-//! CAS-guarded lifecycle apply, backup writer, and rollback stub.
+//! Guarded lifecycle apply, verified read-back, backup writer, and rollback.
 //!
 //! [`apply`] writes a pre-apply backup, then submits the rendered
 //! lifecycle document through the provider's CAS-guarded `put`. On CAS
@@ -6,8 +6,6 @@
 //! retries up to 3 times before failing with
 //! `TierLifecycleConflict [CRAB-E0300]`.
 //!
-//! [`rollback`] is a placeholder — task 5.4 will flesh it out.
-
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -25,6 +23,8 @@ use super::provider::{Format, Guard, LifecycleProvider, Provider, RenderedLifecy
 
 /// Maximum number of CAS retry attempts before giving up.
 const MAX_CAS_RETRIES: u32 = 3;
+const PROVIDER_VERIFY_ATTEMPTS: u32 = 3;
+const MAX_LIFECYCLE_DOCUMENT_BYTES: usize = 8 * 1024 * 1024;
 static BACKUP_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Options controlling the apply behavior.
@@ -34,7 +34,7 @@ pub struct ApplyOpts {
     /// crab-managed rules.
     pub merge: bool,
     /// When `true`, skip the actual `put` call and return early after
-    /// conflict detection and backup.
+    /// conflict detection.
     pub dry_run: bool,
 }
 
@@ -75,6 +75,10 @@ impl From<&Guard> for GuardSummary {
 pub(crate) struct BackupPayload {
     pub(crate) provider: String,
     pub(crate) rendered_existing: Option<String>,
+    #[serde(default)]
+    pub(crate) rendered_applied: Option<String>,
+    #[serde(default)]
+    pub(crate) applied_rule_ids: Vec<String>,
     pub(crate) cas_guard: String,
     pub(crate) saved_at: String,
 }
@@ -84,10 +88,11 @@ pub(crate) struct BackupPayload {
 /// Flow:
 /// 1. Fetch existing lifecycle and CAS guard.
 /// 2. Detect conflicts; respect `opts.merge`.
-/// 3. Write backup to `.crab/tier/backups/<ts>-pre-apply.json`.
-/// 4. Call `prov.put(new_doc, guard)` with the CAS guard.
-/// 5. On success: emit audit record, return `ApplyOutcome`.
-/// 6. On CAS mismatch: re-read, re-detect, retry up to 3 times.
+/// 3. Reject providers that cannot supply a conditional-write guard.
+/// 4. Write backup to `.crab/tier/backups/<ts>-pre-apply.json`.
+/// 5. Call `prov.put(new_doc, guard)` with the CAS guard.
+/// 6. On success: emit audit record, return `ApplyOutcome`.
+/// 7. On CAS mismatch: re-read, re-detect, retry up to 3 times.
 pub async fn apply(
     prov: &dyn LifecycleProvider,
     plan: &TierPlan,
@@ -109,32 +114,34 @@ pub async fn apply(
         let guard = prov.cas_guard().await?;
 
         // Step 2: detect conflicts.
-        let doc_to_apply = resolve_conflicts(&existing, &new_rendered, &opts)?;
+        let doc_to_apply = resolve_conflicts(existing.as_ref(), &new_rendered, &opts)?;
 
-        // Step 3: write backup.
-        let backup_path = write_backup(
-            existing.as_ref(),
-            guard.as_ref(),
-            &format!("{:?}", prov.kind()),
-        )?;
-
-        // Dry-run: skip the actual put.
+        // Dry-run must remain read-only, including the local worktree.
         if opts.dry_run {
             info!("dry-run: skipping put call");
             return Ok(ApplyOutcome {
                 new_guard: guard
                     .as_ref()
-                    .map(GuardSummary::from)
-                    .unwrap_or(GuardSummary::None),
+                    .map_or(GuardSummary::None, GuardSummary::from),
                 applied_at: now_rfc3339_millis(),
-                backup_path: Some(backup_path),
+                backup_path: None,
             });
         }
+
+        require_conditional_guard(prov.kind(), guard.as_ref())?;
+
+        // Persist recovery data before the provider mutation.
+        let backup_path = write_backup(
+            existing.as_ref(),
+            &doc_to_apply,
+            guard.as_ref(),
+            &format!("{:?}", prov.kind()),
+        )?;
 
         // Step 4: attempt the CAS-guarded put.
         match prov.put(&doc_to_apply, guard.clone()).await {
             Ok(outcome) => {
-                // Step 5: audit + return.
+                verify_present(prov, &doc_to_apply, &backup_path).await?;
                 let apply_outcome = ApplyOutcome {
                     new_guard: GuardSummary::from(&outcome.new_guard),
                     applied_at: outcome.applied_at,
@@ -145,6 +152,9 @@ pub async fn apply(
                 return Ok(apply_outcome);
             }
             Err(e) if is_cas_mismatch(&e) => {
+                if let Err(error) = std::fs::remove_file(&backup_path) {
+                    warn!(error = %error, path = %backup_path, "failed to remove unused CAS backup");
+                }
                 // Step 6: CAS mismatch — retry.
                 if attempt >= MAX_CAS_RETRIES {
                     warn!(
@@ -162,7 +172,6 @@ pub async fn apply(
                     max = MAX_CAS_RETRIES,
                     "CAS mismatch, re-reading and retrying"
                 );
-                continue;
             }
             Err(e) => return Err(e),
         }
@@ -171,11 +180,11 @@ pub async fn apply(
 
 /// Detect conflicts and optionally merge, returning the document to apply.
 fn resolve_conflicts(
-    existing: &Option<RenderedLifecycle>,
+    existing: Option<&RenderedLifecycle>,
     new: &RenderedLifecycle,
     opts: &ApplyOpts,
 ) -> Result<RenderedLifecycle> {
-    let Some(existing) = existing.as_ref() else {
+    let Some(existing) = existing else {
         return Ok(new.clone());
     };
 
@@ -236,6 +245,7 @@ fn is_cas_mismatch(err: &CrabError) -> bool {
 /// Returns the backup file path on success.
 fn write_backup(
     existing: Option<&RenderedLifecycle>,
+    applied: &RenderedLifecycle,
     guard: Option<&Guard>,
     provider: &str,
 ) -> Result<String> {
@@ -243,11 +253,37 @@ fn write_backup(
     // Replace colons in the timestamp for filesystem compatibility.
     let safe_ts = ts.replace(':', "-");
 
-    let backup_dir = PathBuf::from(".crab/tier/backups");
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    let worktree = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)?;
+    let backup_dir = worktree.shared_crab_dir.join("tier/backups");
     std::fs::create_dir_all(&backup_dir)?;
 
     let rendered_existing = existing
-        .map(|r| String::from_utf8(r.body.clone()).unwrap_or_else(|_| "<binary>".to_string()));
+        .map(|rendered| {
+            String::from_utf8(rendered.body.clone()).map_err(|error| {
+                CrabError::Internal(format!(
+                    "existing lifecycle is not UTF-8 and cannot be backed up: {error}"
+                ))
+            })
+        })
+        .transpose()?;
+    let rendered_applied = String::from_utf8(applied.body.clone()).map_err(|error| {
+        CrabError::Internal(format!(
+            "rendered lifecycle is not UTF-8 and cannot be backed up: {error}"
+        ))
+    })?;
+    if rendered_applied.len() > MAX_LIFECYCLE_DOCUMENT_BYTES
+        || rendered_existing
+            .as_ref()
+            .is_some_and(|body| body.len() > MAX_LIFECYCLE_DOCUMENT_BYTES)
+    {
+        return Err(CrabError::Configuration {
+            key: "tier lifecycle document size".to_owned(),
+            origin: format!(
+                "lifecycle documents must be at most {MAX_LIFECYCLE_DOCUMENT_BYTES} bytes"
+            ),
+        });
+    }
 
     let guard_str = match guard {
         Some(Guard::Etag(e)) => format!("etag:{e}"),
@@ -258,6 +294,8 @@ fn write_backup(
     let payload = BackupPayload {
         provider: provider.to_string(),
         rendered_existing,
+        rendered_applied: Some(rendered_applied),
+        applied_rule_ids: applied.rule_ids.clone(),
         cas_guard: guard_str,
         saved_at: ts,
     };
@@ -281,8 +319,14 @@ fn write_backup(
             Err(err) => return Err(err.into()),
         };
         file.write_all(json.as_bytes())?;
+        file.sync_all()?;
 
-        let path_str = backup_path.to_string_lossy().to_string();
+        let path_str = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| backup_path.strip_prefix(cwd).ok().map(PathBuf::from))
+            .unwrap_or(backup_path)
+            .to_string_lossy()
+            .to_string();
         debug!(path = %path_str, "wrote pre-apply backup");
         return Ok(path_str);
     }
@@ -296,54 +340,94 @@ fn write_backup(
 ///
 /// Reads the backup JSON at `backup_path`, extracts the
 /// `rendered_existing` content, and restores it via `prov.put()`.
-/// When the backup indicates no prior lifecycle existed, this is a
-/// no-op (the bucket had no lifecycle before the apply).
+/// When the backup indicates no prior lifecycle existed, the policy created by
+/// apply is deleted after the current provider state passes drift validation.
 ///
 /// Emits an audit record on successful rollback.
 pub async fn rollback(prov: &dyn LifecycleProvider, backup_path: &str) -> Result<()> {
-    let raw = std::fs::read_to_string(backup_path).map_err(|e| {
+    let metadata = std::fs::metadata(backup_path).map_err(|error| {
         CrabError::Internal(format!(
-            "failed to read backup file '{}': {}",
-            backup_path, e
+            "failed to read backup file '{backup_path}': {error}"
+        ))
+    })?;
+    if metadata.len() > MAX_LIFECYCLE_DOCUMENT_BYTES as u64 * 2 {
+        return Err(CrabError::Configuration {
+            key: "tier backup size".to_owned(),
+            origin: format!(
+                "tier backup files must be at most {} bytes",
+                MAX_LIFECYCLE_DOCUMENT_BYTES as u64 * 2
+            ),
+        });
+    }
+    let raw = std::fs::read_to_string(backup_path).map_err(|error| {
+        CrabError::Internal(format!(
+            "failed to read backup file '{backup_path}': {error}"
         ))
     })?;
 
-    let payload: BackupPayload = serde_json::from_str(&raw).map_err(|e| {
+    let payload: BackupPayload = serde_json::from_str(&raw).map_err(|error| {
         CrabError::Internal(format!(
-            "failed to parse backup file '{}': {}",
-            backup_path, e
+            "failed to parse backup file '{backup_path}': {error}"
         ))
     })?;
 
-    match payload.rendered_existing {
-        Some(body) => {
-            // Reconstruct a RenderedLifecycle from the backup body.
-            // The format is inferred from the provider: S3 uses XML,
-            // GCS and Azure use JSON.
-            let format = match prov.kind() {
-                Provider::S3 => Format::Xml,
-                Provider::Gcs | Provider::Azure => Format::Json,
-            };
-            let restored = RenderedLifecycle {
-                format,
-                body: body.into_bytes(),
-                rule_ids: Vec::new(),
-            };
+    let provider = format!("{:?}", prov.kind());
+    if payload.provider != provider {
+        return Err(CrabError::Configuration {
+            key: format!(
+                "tier backup targets provider {}, current repository uses {provider}",
+                payload.provider
+            ),
+            origin: backup_path.to_owned(),
+        });
+    }
 
-            let guard = prov.cas_guard().await?;
-            prov.put(&restored, guard).await?;
+    if let Some(applied) = payload.rendered_applied.as_ref() {
+        let current = prov
+            .get()
+            .await?
+            .ok_or_else(|| CrabError::TierLifecycleConflict {
+                prefix: ".crab/xorbs/".to_owned(),
+                existing_id: "missing-current-lifecycle".to_owned(),
+                new_id: payload
+                    .applied_rule_ids
+                    .first()
+                    .cloned()
+                    .unwrap_or_default(),
+            })?;
+        let intended = RenderedLifecycle {
+            format: lifecycle_format(prov.kind()),
+            body: applied.as_bytes().to_vec(),
+            rule_ids: payload.applied_rule_ids.clone(),
+        };
+        if !prov.equivalent(&current, &intended)? {
+            return Err(CrabError::TierLifecycleConflict {
+                prefix: ".crab/xorbs/".to_owned(),
+                existing_id: current
+                    .rule_ids
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "provider-lifecycle-drift".to_owned()),
+                new_id: intended.rule_ids.first().cloned().unwrap_or_default(),
+            });
+        }
+    }
 
-            info!(backup = %backup_path, "lifecycle rolled back to pre-apply state");
-        }
-        None => {
-            // The bucket had no lifecycle before the apply — nothing to
-            // restore. A future enhancement could call a provider
-            // `delete_lifecycle` method, but for V1 we log and return.
-            info!(
-                backup = %backup_path,
-                "backup indicates no prior lifecycle; rollback is a no-op"
-            );
-        }
+    let guard = prov.cas_guard().await?;
+    require_conditional_guard(prov.kind(), guard.as_ref())?;
+    if let Some(body) = payload.rendered_existing {
+        let restored = RenderedLifecycle {
+            format: lifecycle_format(prov.kind()),
+            body: body.into_bytes(),
+            rule_ids: Vec::new(),
+        };
+        prov.put(&restored, guard).await?;
+        verify_present(prov, &restored, backup_path).await?;
+        info!(backup = %backup_path, "lifecycle rolled back to pre-apply state");
+    } else {
+        prov.delete(guard).await?;
+        verify_absent(prov, backup_path).await?;
+        info!(backup = %backup_path, "lifecycle created by apply was deleted");
     }
 
     audit_shim::record(
@@ -358,10 +442,66 @@ pub async fn rollback(prov: &dyn LifecycleProvider, backup_path: &str) -> Result
     Ok(())
 }
 
+async fn verify_present(
+    prov: &dyn LifecycleProvider,
+    intended: &RenderedLifecycle,
+    backup_path: &str,
+) -> Result<()> {
+    for attempt in 1..=PROVIDER_VERIFY_ATTEMPTS {
+        if let Some(current) = prov.get().await?
+            && prov.equivalent(&current, intended)?
+        {
+            return Ok(());
+        }
+        if attempt < PROVIDER_VERIFY_ATTEMPTS {
+            tokio::time::sleep(std::time::Duration::from_millis(u64::from(attempt) * 100)).await;
+        }
+    }
+    Err(CrabError::Internal(format!(
+        "lifecycle provider read-back differs from requested policy; inspect or restore from {backup_path}"
+    )))
+}
+
+async fn verify_absent(prov: &dyn LifecycleProvider, backup_path: &str) -> Result<()> {
+    for attempt in 1..=PROVIDER_VERIFY_ATTEMPTS {
+        if prov.get().await?.is_none() {
+            return Ok(());
+        }
+        if attempt < PROVIDER_VERIFY_ATTEMPTS {
+            tokio::time::sleep(std::time::Duration::from_millis(u64::from(attempt) * 100)).await;
+        }
+    }
+    Err(CrabError::Internal(format!(
+        "lifecycle provider still returns a policy after rollback delete; inspect {backup_path}"
+    )))
+}
+
+/// Refuse lifecycle mutations when the provider explicitly reports that it
+/// cannot guard the replacement. A read/verify sequence cannot prevent an
+/// external writer from winning between the read and the unconditional PUT.
+fn require_conditional_guard(provider: Provider, guard: Option<&Guard>) -> Result<()> {
+    if matches!(guard, Some(Guard::None)) {
+        return Err(CrabError::TierProviderUnsupported {
+            provider: format!(
+                "{provider:?} lifecycle mutation requires a provider conditional-write guard"
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn lifecycle_format(provider: Provider) -> Format {
+    match provider {
+        Provider::S3 => Format::Xml,
+        Provider::Gcs | Provider::Azure => Format::Json,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tier::provider::{Format, Guard, PutOutcome, RenderedLifecycle, TierPlan};
+    use std::path::PathBuf;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -373,6 +513,7 @@ mod tests {
         existing: Mutex<Option<RenderedLifecycle>>,
         guard: Mutex<Option<Guard>>,
         put_calls: AtomicU32,
+        delete_calls: AtomicU32,
         /// When > 0, the first N put calls return CasConflict.
         cas_failures: AtomicU32,
     }
@@ -383,6 +524,7 @@ mod tests {
                 existing: Mutex::new(None),
                 guard: Mutex::new(None),
                 put_calls: AtomicU32::new(0),
+                delete_calls: AtomicU32::new(0),
                 cas_failures: AtomicU32::new(0),
             }
         }
@@ -392,6 +534,17 @@ mod tests {
                 existing: Mutex::new(Some(existing)),
                 guard: Mutex::new(Some(guard)),
                 put_calls: AtomicU32::new(0),
+                delete_calls: AtomicU32::new(0),
+                cas_failures: AtomicU32::new(0),
+            }
+        }
+
+        fn with_unguarded_first_write() -> Self {
+            Self {
+                existing: Mutex::new(None),
+                guard: Mutex::new(Some(Guard::None)),
+                put_calls: AtomicU32::new(0),
+                delete_calls: AtomicU32::new(0),
                 cas_failures: AtomicU32::new(0),
             }
         }
@@ -403,6 +556,10 @@ mod tests {
 
         fn put_count(&self) -> u32 {
             self.put_calls.load(Ordering::SeqCst)
+        }
+
+        fn delete_count(&self) -> u32 {
+            self.delete_calls.load(Ordering::SeqCst)
         }
     }
 
@@ -426,7 +583,7 @@ mod tests {
             Ok(self.existing.lock().unwrap().clone())
         }
 
-        async fn put(&self, _doc: &RenderedLifecycle, _guard: Option<Guard>) -> Result<PutOutcome> {
+        async fn put(&self, doc: &RenderedLifecycle, _guard: Option<Guard>) -> Result<PutOutcome> {
             self.put_calls.fetch_add(1, Ordering::SeqCst);
 
             let remaining = self.cas_failures.load(Ordering::SeqCst);
@@ -438,8 +595,20 @@ mod tests {
                 });
             }
 
+            *self.existing.lock().unwrap() = Some(doc.clone());
+            *self.guard.lock().unwrap() = Some(Guard::Etag("new-etag".to_string()));
+
             Ok(PutOutcome {
                 new_guard: Guard::Etag("new-etag".to_string()),
+                applied_at: now_rfc3339_millis(),
+            })
+        }
+
+        async fn delete(&self, _guard: Option<Guard>) -> Result<PutOutcome> {
+            self.delete_calls.fetch_add(1, Ordering::SeqCst);
+            *self.existing.lock().unwrap() = None;
+            Ok(PutOutcome {
+                new_guard: Guard::None,
                 applied_at: now_rfc3339_millis(),
             })
         }
@@ -612,22 +781,35 @@ mod tests {
             .expect("dry-run should succeed");
 
         assert_eq!(prov.put_count(), 0, "dry-run should not call put");
-        assert!(outcome.backup_path.is_some());
+        assert!(outcome.backup_path.is_none());
+    }
 
-        if let Some(path) = &outcome.backup_path {
-            cleanup_backup(path);
-        }
+    #[tokio::test]
+    async fn apply_rejects_provider_without_conditional_guard() {
+        let prov = MockProvider::with_unguarded_first_write();
+
+        let err = apply(&prov, &simple_plan(), default_opts())
+            .await
+            .expect_err("unguarded lifecycle mutation must fail closed");
+
+        assert!(matches!(
+            err,
+            CrabError::TierProviderUnsupported { provider }
+                if provider.contains("conditional-write guard")
+        ));
+        assert_eq!(prov.put_count(), 0);
     }
 
     #[tokio::test]
     async fn backup_path_format_is_correct() {
         // Use write_backup directly to avoid parallel-test races on the
         // shared backup directory.
-        let path = write_backup(None, None, "S3").expect("write_backup should succeed");
+        let applied = xml_rendered(&["crab-xorbs-to-ia"]);
+        let path = write_backup(None, &applied, None, "S3").expect("write_backup should succeed");
 
         assert!(
-            path.starts_with(".crab/tier/backups/"),
-            "backup path should start with .crab/tier/backups/, got: {path}"
+            path.starts_with(".crab/tier/backups/") || std::path::Path::new(&path).is_absolute(),
+            "backup path should identify the shared tier backup, got: {path}"
         );
         assert!(
             path.ends_with("-pre-apply.json"),
@@ -702,6 +884,8 @@ mod tests {
             rendered_existing: Some(
                 "<LifecycleConfiguration>old</LifecycleConfiguration>".to_string(),
             ),
+            rendered_applied: None,
+            applied_rule_ids: Vec::new(),
             cas_guard: "etag:abc123".to_string(),
             saved_at: "2026-04-27T20:00:00.000Z".to_string(),
         };
@@ -720,11 +904,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rollback_with_no_existing_lifecycle_is_noop() {
+    async fn rollback_with_no_existing_lifecycle_deletes_applied_policy() {
         let prov = MockProvider::new();
         let backup = BackupPayload {
             provider: "S3".to_string(),
             rendered_existing: None,
+            rendered_applied: None,
+            applied_rule_ids: Vec::new(),
             cas_guard: "none".to_string(),
             saved_at: "2026-04-27T20:00:00.000Z".to_string(),
         };
@@ -734,7 +920,49 @@ mod tests {
             .await
             .expect("rollback should succeed");
 
-        assert_eq!(prov.put_count(), 0, "no-op rollback should not call put");
+        assert_eq!(prov.put_count(), 0, "delete rollback should not call put");
+        assert_eq!(prov.delete_count(), 1, "rollback should delete lifecycle");
+        cleanup_backup(&path);
+    }
+
+    #[tokio::test]
+    async fn apply_then_rollback_deletes_new_policy() {
+        let prov = MockProvider::new();
+        let outcome = apply(&prov, &simple_plan(), default_opts())
+            .await
+            .expect("apply should succeed");
+        let path = outcome
+            .backup_path
+            .expect("apply should write recovery data");
+
+        rollback(&prov, &path)
+            .await
+            .expect("rollback should delete the applied policy");
+
+        assert_eq!(prov.put_count(), 1);
+        assert_eq!(prov.delete_count(), 1);
+        assert!(prov.get().await.expect("read provider").is_none());
+        cleanup_backup(&path);
+    }
+
+    #[tokio::test]
+    async fn rollback_rejects_provider_drift_after_apply() {
+        let prov = MockProvider::new();
+        let outcome = apply(&prov, &simple_plan(), default_opts())
+            .await
+            .expect("apply should succeed");
+        let path = outcome
+            .backup_path
+            .expect("apply should write recovery data");
+        *prov.existing.lock().unwrap() = Some(xml_rendered(&["user-new-policy"]));
+
+        let result = rollback(&prov, &path).await;
+
+        assert!(matches!(
+            result,
+            Err(CrabError::TierLifecycleConflict { .. })
+        ));
+        assert_eq!(prov.delete_count(), 0);
         cleanup_backup(&path);
     }
 

--- a/crab/src/tier/provider/mod.rs
+++ b/crab/src/tier/provider/mod.rs
@@ -245,6 +245,22 @@ pub trait LifecycleProvider: Send + Sync {
     /// guarded by a CAS token.
     async fn put(&self, doc: &RenderedLifecycle, guard: Option<Guard>) -> Result<PutOutcome>;
 
+    /// Remove the lifecycle configuration, optionally guarded by a CAS token.
+    async fn delete(&self, _guard: Option<Guard>) -> Result<PutOutcome> {
+        Err(crate::core::error::CrabError::TierProviderUnsupported {
+            provider: format!("{:?} lifecycle deletion", self.kind()),
+        })
+    }
+
+    /// Return whether a provider read-back preserves an intended document.
+    fn equivalent(
+        &self,
+        current: &RenderedLifecycle,
+        intended: &RenderedLifecycle,
+    ) -> Result<bool> {
+        Ok(current.format == intended.format && current.body == intended.body)
+    }
+
     /// Fetch the provider-side CAS token for the current lifecycle.
     /// Returns `None` on first write (no existing config).
     async fn cas_guard(&self) -> Result<Option<Guard>>;

--- a/crab/src/tier/provider/s3.rs
+++ b/crab/src/tier/provider/s3.rs
@@ -328,10 +328,10 @@ impl LifecycleProvider for S3LifecycleProvider {
     }
 
     async fn put(&self, doc: &RenderedLifecycle, _guard: Option<Guard>) -> Result<PutOutcome> {
-        // S3 PutBucketLifecycleConfiguration does not support
-        // conditional writes (no If-Match header). The CAS retry logic
-        // in apply.rs handles conflict detection by re-reading after
-        // each put.
+        // S3 PutBucketLifecycleConfiguration does not support conditional
+        // writes (no If-Match header). The tier apply boundary rejects this
+        // provider for mutation; this method remains available to the raw
+        // provider API, whose caller owns any last-writer-wins trade-off.
         //
         // We build SDK-typed `LifecycleRule`s from our `TierPlan` rules
         // rather than sending raw XML, because the SDK serializes the
@@ -361,11 +361,37 @@ impl LifecycleProvider for S3LifecycleProvider {
         })
     }
 
+    async fn delete(&self, _guard: Option<Guard>) -> Result<PutOutcome> {
+        self.client
+            .delete_bucket_lifecycle()
+            .bucket(&self.bucket)
+            .send()
+            .await
+            .map_err(|e| map_s3_service_error("DeleteBucketLifecycle", &e.into_service_error()))?;
+        Ok(PutOutcome {
+            new_guard: Guard::None,
+            applied_at: now_rfc3339(),
+        })
+    }
+
+    fn equivalent(
+        &self,
+        current: &RenderedLifecycle,
+        intended: &RenderedLifecycle,
+    ) -> Result<bool> {
+        if current.format != Format::Xml || intended.format != Format::Xml {
+            return Ok(false);
+        }
+        let current = serialize_lifecycle_rules_to_xml(&parse_xml_to_sdk_rules(&current.body)?)?;
+        let intended = serialize_lifecycle_rules_to_xml(&parse_xml_to_sdk_rules(&intended.body)?)?;
+        Ok(current == intended)
+    }
+
     async fn cas_guard(&self) -> Result<Option<Guard>> {
         // S3 lifecycle API does not support conditional writes (no ETag
-        // on lifecycle configuration). Return Guard::None; the CAS
-        // retry logic in apply.rs handles conflict detection by
-        // re-reading the lifecycle after each put.
+        // on lifecycle configuration). Returning Guard::None lets callers
+        // report that capability, while tier apply/rollback fail closed
+        // before any lifecycle mutation.
         Ok(Some(Guard::None))
     }
 }

--- a/crab/src/tier/runtime.rs
+++ b/crab/src/tier/runtime.rs
@@ -3,7 +3,7 @@
 //! This module is intentionally small: it connects resolved config and
 //! repository remote metadata to the provider-neutral tier interfaces.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -19,7 +19,10 @@ use super::restore::RestoreOptions;
 
 /// Read and parse the current repository's `crab://` remote URL.
 pub fn current_crab_url() -> Result<CrabUrl> {
-    let repo_root = repo_root().unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    let cwd = std::env::current_dir().map_err(CrabError::Io)?;
+    let repo_root = crate::git::worktree::WorktreeContext::resolve_from_path(&cwd)
+        .map(|worktree| worktree.current_worktree_root)
+        .unwrap_or(cwd);
     let remote = read_crab_remote_url(&repo_root)?;
     CrabUrl::parse(&remote)
 }
@@ -164,28 +167,24 @@ fn read_crab_remote_url(repo_root: &Path) -> Result<String> {
 }
 
 fn git_origin_crab_url(repo_root: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
+    let mut command = std::process::Command::new("git");
+    command
         .args(["remote", "get-url", "origin"])
         .current_dir(repo_root)
-        .output()
-        .ok()?;
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env_remove("GIT_QUARANTINE_PATH")
+        .env_remove("GIT_NAMESPACE");
+    let output = command.output().ok()?;
     if !output.status.success() {
         return None;
     }
     let url = String::from_utf8_lossy(&output.stdout).trim().to_owned();
     url.starts_with("crab://").then_some(url)
-}
-
-fn repo_root() -> Option<PathBuf> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    (!path.is_empty()).then(|| PathBuf::from(path))
 }
 
 fn aws_region(config: &Config) -> String {

--- a/crab/tests/integration.rs
+++ b/crab/tests/integration.rs
@@ -18,7 +18,8 @@ use std::sync::Arc;
 use bytes::Bytes;
 use object_store::memory::InMemory;
 use object_store::path::Path as ObjectPath;
-use object_store::{ObjectStore, PutPayload};
+#[cfg(feature = "testing")]
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
 use tokio_util::sync::CancellationToken;
 
 use crab::core::config::{Config, EngineConfig};
@@ -26,6 +27,7 @@ use crab::core::context::AppContext;
 use crab::core::error::CrabError;
 use crab::git::clean::CleanSession;
 use crab::storage::store::Store;
+#[cfg(feature = "testing")]
 use crab::storage::{RetryPolicy, retry};
 use crab_types::pointer::{Pointer, is_pointer};
 
@@ -400,6 +402,25 @@ async fn put_multipart_retry_uploads_intact() {
         .put_multipart_retry(&path, body.clone(), 5, &cancel, None)
         .await
         .unwrap();
+
+    let (got, _etag) = store.get_with_etag(&path).await.unwrap();
+    assert_eq!(got, body);
+}
+
+/// Xet-addressed multipart uploads reject a body whose content hash is wrong.
+#[cfg(feature = "testing")]
+#[tokio::test]
+async fn put_multipart_retry_verifies_xet_hash() {
+    let (store, _mock) = retry_store();
+    let path = ObjectPath::from("xorbs/xet-hash");
+    let body = Bytes::from_static(b"xet-addressed-content");
+    let cancel = CancellationToken::new();
+    let expected = crab_xet::hash::compute_data_hash(&body);
+
+    store
+        .put_multipart_retry_with_xet_hash(&path, body.clone(), expected.into(), 5, &cancel, None)
+        .await
+        .expect("matching Xet hash must upload");
 
     let (got, _etag) = store.get_with_etag(&path).await.unwrap();
     assert_eq!(got, body);

--- a/crab/tests/schema_validate.rs
+++ b/crab/tests/schema_validate.rs
@@ -536,6 +536,7 @@ fn validate_optimize_xorbs_event_variants() {
             bytes_written: 900,
             elapsed_ms: 1234,
             corrupt_list: Vec::new(),
+            corrupt_list_omitted: 0,
         }))
         .expect("summary serializes"),
         serde_json::to_value(OptimizeXorbsEventPayload::Control(

--- a/crab/tests/workflow_parallel.rs
+++ b/crab/tests/workflow_parallel.rs
@@ -91,9 +91,9 @@ fn dag_args() -> RunArgs {
     }
 }
 
-/// Diamond DAG: A → {B, C} → D
-/// B and C each sleep for 500ms. With parallelism=2, total time
-/// should be ~500ms (not ~1000ms).
+/// Diamond DAG: A → {B, C} → D.
+/// B and C use a release barrier so the test proves overlap without
+/// depending on a wall-clock margin on a loaded runner.
 #[tokio::test(flavor = "multi_thread")]
 async fn diamond_dag_parallel_execution() {
     let (_lock, _guard) = EnabledGuard::new();
@@ -111,13 +111,13 @@ async fn diamond_dag_parallel_execution() {
     outs:
       - a.out
   b:
-    cmd: "sleep 0.5 && cp a.out b.out"
+    cmd: "printf started > b.started; while [ ! -f release ]; do sleep 0.01; done; cp a.out b.out"
     deps:
       - a.out
     outs:
       - b.out
   c:
-    cmd: "sleep 0.5 && cp a.out c.out"
+    cmd: "printf started > c.started; while [ ! -f release ]; do sleep 0.01; done; cp a.out c.out"
     deps:
       - a.out
     outs:
@@ -136,23 +136,43 @@ async fn diamond_dag_parallel_execution() {
     let prev_cwd = std::env::current_dir().unwrap();
     std::env::set_current_dir(root).unwrap();
 
-    let start = Instant::now();
     let mut args = dag_args();
     args.parallelism = Some(2);
-    let result = run_in(&args, root, OutputMode::Text).await;
-    let elapsed = start.elapsed();
+    let b_started = root.join("b.started");
+    let c_started = root.join("c.started");
+    let release = root.join("release");
+
+    let mut run = Box::pin(run_in(&args, root, OutputMode::Text));
+    let mut marker_wait = Box::pin(async {
+        loop {
+            if b_started.is_file() && c_started.is_file() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    });
+    let mut marker_timeout = Box::pin(tokio::time::sleep(Duration::from_secs(2)));
+    let mut completed = None;
+    let both_started = tokio::select! {
+        result = &mut run => {
+            completed = Some(result);
+            false
+        }
+        () = &mut marker_wait => true,
+        () = &mut marker_timeout => false,
+    };
+    fs::write(&release, b"release").unwrap();
+    let result = match completed {
+        Some(result) => result,
+        None => run.await,
+    };
 
     std::env::set_current_dir(&prev_cwd).unwrap();
 
     assert!(result.is_ok(), "DAG run failed: {:?}", result.err());
-
-    // With parallelism=2, B and C run concurrently. Total time
-    // should be significantly less than 1000ms (serial would be
-    // ~1000ms for B+C). Allow some overhead.
     assert!(
-        elapsed < Duration::from_millis(900),
-        "Expected parallel execution (< 900ms), got {:?}",
-        elapsed
+        both_started,
+        "both independent stages must start before the release barrier"
     );
 
     // Verify outputs exist.

--- a/crates/crab-auth-server/src/view.rs
+++ b/crates/crab-auth-server/src/view.rs
@@ -19,6 +19,7 @@ use crab_types::pointer::Pointer;
 use crab_types::time::now_rfc3339_millis;
 use crab_xet::hash::MerkleHash;
 use crab_xet::shard::ShardReader;
+use crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES;
 use serde::Serialize;
 
 use crate::error::{AuthServerError, Result};
@@ -375,7 +376,9 @@ async fn verify_crab_pointers_backed_by_view(
                         file_hash.hex()
                     ),
                 })?;
-        let (shard_bytes, _) = store.get_with_etag(&router.shard_path(&shard_hash)).await?;
+        let (shard_bytes, _) = store
+            .get_with_etag_bounded(&router.shard_path(&shard_hash), MAX_SHARD_SIZE_BYTES as u64)
+            .await?;
         let shard = ShardReader::from_bytes(shard_bytes, shard_hash);
         let file_info =
             shard
@@ -408,7 +411,9 @@ async fn verify_crab_pointers_backed_by_uploaded_view(
                 AuthServerError::Internal(format!("invalid uploaded view shard hash: {error}"))
             })?;
             let path = router.shard_path(&shard_hash);
-            let (bytes, _) = store.get_with_etag(&path).await?;
+            let (bytes, _) = store
+                .get_with_etag_bounded(&path, MAX_SHARD_SIZE_BYTES as u64)
+                .await?;
             if crab_xet::hash::compute_data_hash(&bytes) != shard_hash {
                 return Err(AuthServerError::CorruptObject {
                     path: path.to_string(),

--- a/crates/crab-cache-store/src/lib.rs
+++ b/crates/crab-cache-store/src/lib.rs
@@ -36,11 +36,12 @@ use crab_cache::path_class::{PathClass, classify_path};
 use crab_cache::{CacheClient, CacheServiceCapabilities};
 use crab_cache::{
     CacheError, CacheKey, CacheObjectHead, CacheObjectRange, CacheServiceAuth, CacheServiceMode,
-    DedupQueryResult, LocalCache, cache_key_for_path, default_cache_root,
+    DedupQueryResult, LocalCache, MAX_CACHE_CHUNK_BYTES, MAX_CACHE_SHARD_BYTES, cache_key_for_path,
+    default_cache_root,
 };
 use crab_storage::{ETag, StorageError, Store};
 use crab_xet::hash::MerkleHash;
-use crab_xet::xorb::format::{ChunkMeta, FOOTER_SIZE};
+use crab_xet::xorb::format::{ChunkMeta, FOOTER_SIZE, MAX_XORB_SIZE};
 use crab_xet::xorb::parser::{
     decode_chunk_range_bytes, xorb_chunks_from_metadata, xorb_metadata_region,
 };
@@ -442,6 +443,15 @@ impl CachingStore {
         } else {
             self.head(path).await?.size
         };
+        if object_len > MAX_XORB_SIZE as u64 {
+            return Err(CacheError::CorruptObject {
+                path: path.to_string(),
+                reason: format!(
+                    "xorb is {object_len} bytes; format limit is {MAX_XORB_SIZE} bytes"
+                ),
+            }
+            .into());
+        }
         let footer_len = FOOTER_SIZE as u64;
         if object_len < footer_len {
             return Err(CacheError::CorruptObject {
@@ -505,13 +515,18 @@ impl CachingStore {
             return self
                 .local_cache
                 .get_or_fetch_read_xorb_with(xorb_hash, || async move {
-                    let (data, _) = origin.get_with_etag(&path).await?;
+                    let (data, _) = origin
+                        .get_with_etag_bounded(&path, MAX_XORB_SIZE as u64)
+                        .await?;
                     Ok::<_, CacheStoreError>(data)
                 })
                 .await;
         }
 
-        let (data, _) = self.origin.get_with_etag(path).await?;
+        let (data, _) = self
+            .origin
+            .get_with_etag_bounded(path, MAX_XORB_SIZE as u64)
+            .await?;
         LocalCache::validate_bytes(&key, &data)?;
         if let Err(error) = self.local_cache.put_bytes(&key, data.clone()).await {
             tracing::warn!(
@@ -524,18 +539,59 @@ impl CachingStore {
     }
 
     async fn complete_xorb_without_install(&self, path: &Path) -> Result<Bytes> {
-        match self.get_cache_service_object_without_install(path).await {
+        match self.get_cache_service_xorb_bounded(path).await {
             Ok(Some(data)) => Ok(data),
-            Ok(None) => Ok(self.origin.get_with_etag(path).await?.0),
+            Ok(None) => Ok(self
+                .origin
+                .get_with_etag_bounded(path, MAX_XORB_SIZE as u64)
+                .await?
+                .0),
             Err(error) => {
                 tracing::warn!(
                     path = %path,
                     error = %error,
                     "cache service xorb read failed, falling back to origin",
                 );
-                Ok(self.origin.get_with_etag(path).await?.0)
+                Ok(self
+                    .origin
+                    .get_with_etag_bounded(path, MAX_XORB_SIZE as u64)
+                    .await?
+                    .0)
             }
         }
+    }
+
+    async fn get_cache_service_xorb_bounded(&self, path: &Path) -> Result<Option<Bytes>> {
+        let Some(head) = self.head_cache_service_object(path).await? else {
+            return Ok(None);
+        };
+        if head.size > MAX_XORB_SIZE as u64 {
+            return Err(CacheError::CorruptObject {
+                path: path.to_string(),
+                reason: format!(
+                    "cache-service xorb is {} bytes; format limit is {MAX_XORB_SIZE} bytes",
+                    head.size
+                ),
+            }
+            .into());
+        }
+        let Some(data) = self
+            .get_cache_service_object_without_install_limit(path, Some(MAX_XORB_SIZE as u64))
+            .await?
+        else {
+            return Ok(None);
+        };
+        if data.len() as u64 > MAX_XORB_SIZE as u64 {
+            return Err(CacheError::CorruptObject {
+                path: path.to_string(),
+                reason: format!(
+                    "cache-service xorb body is {} bytes; format limit is {MAX_XORB_SIZE} bytes",
+                    data.len()
+                ),
+            }
+            .into());
+        }
+        Ok(Some(data))
     }
 
     /// Whether a cache service is configured (regardless of mode).
@@ -611,6 +667,9 @@ impl CachingStore {
     /// Mutable paths (refs, manifests) skip the cache entirely and
     /// always get a real ETag from origin. See finding CR11-F3.
     pub async fn get_with_etag(&self, path: &Path) -> Result<(Bytes, ETag)> {
+        if let Some(max_bytes) = immutable_read_limit(path) {
+            return self.get_with_etag_bounded(path, max_bytes).await;
+        }
         let is_immutable = classify_path(path.as_ref()) == PathClass::Immutable;
 
         if is_immutable {
@@ -673,6 +732,121 @@ impl CachingStore {
         Ok(result)
     }
 
+    /// Read an object while enforcing a maximum body size before consumption.
+    pub async fn get_with_etag_bounded(
+        &self,
+        path: &Path,
+        max_bytes: u64,
+    ) -> Result<(Bytes, ETag)> {
+        let max_bytes = immutable_read_limit(path).map_or(max_bytes, |limit| max_bytes.min(limit));
+        let is_immutable = classify_path(path.as_ref()) == PathClass::Immutable;
+
+        if is_immutable && let Some(key) = cache_key_for_path(path.as_ref()) {
+            if let Some(size) = self.local_cache.cached_size(&key).await?
+                && size > max_bytes
+            {
+                return Err(CacheError::CorruptObject {
+                    path: path.to_string(),
+                    reason: format!(
+                        "cached object is {size} bytes; bounded read supports at most {max_bytes} bytes"
+                    ),
+                }
+                .into());
+            }
+            if let Ok(data) = self
+                .local_cache
+                .get_or_fetch_bounded_with(&key, max_bytes, || async {
+                    Err::<Bytes, CacheStoreError>(CacheStoreError::Storage(
+                        StorageError::NotFound {
+                            path: path.as_ref().to_owned(),
+                        },
+                    ))
+                })
+                .await
+            {
+                if data.len() as u64 > max_bytes {
+                    return Err(CacheError::CorruptObject {
+                        path: path.to_string(),
+                        reason: format!(
+                            "cached object body is {} bytes; bounded read supports at most {max_bytes} bytes",
+                            data.len()
+                        ),
+                    }
+                    .into());
+                }
+                return Ok((
+                    data,
+                    ETag {
+                        e_tag: None,
+                        version: None,
+                    },
+                ));
+            }
+
+            match self.head_cache_service_object(path).await {
+                Ok(Some(head)) if head.size > max_bytes => {
+                    return Err(CacheError::CorruptObject {
+                        path: path.to_string(),
+                        reason: format!(
+                            "cache-service object is {} bytes; bounded read supports at most {max_bytes} bytes",
+                            head.size
+                        ),
+                    }
+                    .into());
+                }
+                Ok(Some(_)) => match self.get_cache_service_object_bounded(path, max_bytes).await {
+                    Ok(Some(data)) => {
+                        if data.len() as u64 > max_bytes {
+                            return Err(CacheError::CorruptObject {
+                                path: path.to_string(),
+                                reason: format!(
+                                    "cache-service object body is {} bytes; bounded read supports at most {max_bytes} bytes",
+                                    data.len()
+                                ),
+                            }
+                            .into());
+                        }
+                        return Ok((
+                            data,
+                            ETag {
+                                e_tag: None,
+                                version: None,
+                            },
+                        ));
+                    }
+                    Ok(None) => {}
+                    Err(error) => tracing::warn!(
+                        path = %path,
+                        error = %error,
+                        "cache service bounded read failed, falling back to origin"
+                    ),
+                },
+                Ok(None) => {}
+                Err(error) => tracing::warn!(
+                    path = %path,
+                    error = %error,
+                    "cache service bounded HEAD failed, falling back to origin"
+                ),
+            }
+        }
+
+        let result = self.origin.get_with_etag_bounded(path, max_bytes).await?;
+        if is_immutable
+            && let Some(key) = cache_key_for_path(path.as_ref())
+            && let Err(error) = self.local_cache.put_bytes(&key, result.0.clone()).await
+        {
+            if cache_integrity_error(&error) {
+                return Err(error.into());
+            }
+            tracing::warn!(
+                path = %path,
+                error = %error,
+                "failed to write bounded origin response to local cache"
+            );
+        }
+        Ok(result)
+    }
+
     /// Read an immutable object from the cache service without origin fallback.
     ///
     /// Returns `Ok(None)` when cache-service reads are not enabled. Any cache
@@ -694,10 +868,42 @@ impl CachingStore {
         }
     }
 
+    async fn get_cache_service_object_bounded(
+        &self,
+        path: &Path,
+        max_bytes: u64,
+    ) -> Result<Option<Bytes>> {
+        let Some(data) = self
+            .get_cache_service_object_without_install_limit(path, Some(max_bytes))
+            .await?
+        else {
+            return Ok(None);
+        };
+        #[cfg(feature = "remote-client")]
+        {
+            self.store_cache_service_response(path, &data).await?;
+            Ok(Some(data))
+        }
+        #[cfg(not(feature = "remote-client"))]
+        {
+            let _ = data;
+            Ok(None)
+        }
+    }
+
     /// Read an immutable object from the cache service without updating the
     /// local cache. Used by full-object hydrate reads that intentionally avoid
     /// installing a second local copy before reconstruction consumes the body.
     async fn get_cache_service_object_without_install(&self, path: &Path) -> Result<Option<Bytes>> {
+        self.get_cache_service_object_without_install_limit(path, immutable_read_limit(path))
+            .await
+    }
+
+    async fn get_cache_service_object_without_install_limit(
+        &self,
+        path: &Path,
+        max_bytes: Option<u64>,
+    ) -> Result<Option<Bytes>> {
         if classify_path(path.as_ref()) == PathClass::Mutable {
             return Ok(None);
         }
@@ -710,10 +916,15 @@ impl CachingStore {
             let Some(client) = &self.cache_client else {
                 return Ok(None);
             };
-            Ok(Some(client.get(path.as_ref()).await?))
+            let data = match max_bytes {
+                Some(max_bytes) => client.get_bounded(path.as_ref(), max_bytes).await?,
+                None => client.get(path.as_ref()).await?,
+            };
+            Ok(Some(data))
         }
         #[cfg(not(feature = "remote-client"))]
         {
+            let _ = max_bytes;
             Ok(None)
         }
     }
@@ -759,6 +970,24 @@ impl CachingStore {
         }
         if !self.cache_reads_enabled() {
             return Ok(None);
+        }
+        if let Some(max_bytes) = immutable_read_limit(path) {
+            let requested_bytes =
+                range
+                    .end
+                    .checked_sub(range.start)
+                    .ok_or_else(|| CacheError::Service {
+                        reason: format!("invalid cache range {}..{}", range.start, range.end),
+                    })?;
+            if requested_bytes > max_bytes {
+                return Err(CacheError::CorruptObject {
+                    path: path.to_string(),
+                    reason: format!(
+                        "cache range is {requested_bytes} bytes; bounded read supports at most {max_bytes} bytes"
+                    ),
+                }
+                .into());
+            }
         }
 
         #[cfg(feature = "remote-client")]
@@ -846,11 +1075,15 @@ impl CachingStore {
 
         let data = self
             .local_cache
-            .get_or_fetch_with(&key, || async {
-                Err(CacheStoreError::Storage(StorageError::NotFound {
-                    path: path.as_ref().to_string(),
-                }))
-            })
+            .get_or_fetch_bounded_with(
+                &key,
+                immutable_read_limit(path).unwrap_or(u64::MAX),
+                || async {
+                    Err(CacheStoreError::Storage(StorageError::NotFound {
+                        path: path.as_ref().to_string(),
+                    }))
+                },
+            )
             .await
             .ok()?;
         let total_size = data.len() as u64;
@@ -1701,6 +1934,15 @@ fn slice_cached_range(data: &Bytes, range: &Range<u64>) -> Option<Bytes> {
     Some(data.slice(start..end))
 }
 
+fn immutable_read_limit(path: &Path) -> Option<u64> {
+    match cache_key_for_path(path.as_ref())? {
+        CacheKey::Chunk(_) => Some(MAX_CACHE_CHUNK_BYTES),
+        CacheKey::Shard(_) => Some(MAX_CACHE_SHARD_BYTES),
+        CacheKey::Xorb(_) => Some(MAX_XORB_SIZE as u64),
+        CacheKey::Stage(_) | CacheKey::Manifest { .. } => None,
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, clippy::expect_used, reason = "test assertions")]
 mod tests {
@@ -1926,6 +2168,33 @@ mod tests {
             service_client_cert: None,
             service_client_key: None,
         }
+    }
+
+    #[tokio::test]
+    async fn bounded_read_rejects_oversized_origin_before_caching() {
+        let hash = "a".repeat(64);
+        let path = content_path("shards", &hash);
+        let origin = origin_store();
+        origin.put(&path, Bytes::from(vec![0u8; 32])).await.unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = Arc::new(LocalCache::new(tempdir.path().join("cache")));
+        let store =
+            CachingStore::new_with_local_cache(origin, &no_cache_config(), Arc::clone(&cache))
+                .unwrap();
+
+        let error = store.get_with_etag_bounded(&path, 8).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            CacheStoreError::Storage(StorageError::CorruptObject { .. })
+        ));
+        assert_eq!(
+            cache
+                .cached_size(&CacheKey::Shard(MerkleHash::from_hex(&hash).unwrap()))
+                .await
+                .unwrap(),
+            None
+        );
     }
 
     #[cfg(feature = "remote-client")]

--- a/crates/crab-cache/Cargo.toml
+++ b/crates/crab-cache/Cargo.toml
@@ -15,13 +15,22 @@ default = []
 active-probe = ["dep:reqwest"]
 local-cache = ["dep:filetime", "dep:rusqlite", "dep:tokio"]
 remote-client = ["active-probe", "dep:tokio"]
-xet-chunk-cache = ["dep:tokio", "dep:xet-client", "dep:xet-runtime"]
+xet-chunk-cache = [
+    "dep:base64",
+    "dep:crc32fast",
+    "dep:tokio",
+    "dep:tokio-util",
+    "dep:xet-client",
+    "dep:xet-runtime",
+]
 
 [dependencies]
 blake3 = { workspace = true, features = ["rayon"] }
+base64 = { version = "0.22", optional = true }
 bytes = { workspace = true }
 crab-types = { workspace = true }
 crab-xet = { workspace = true }
+crc32fast = { version = "1", optional = true }
 filetime = { version = "0.2", optional = true }
 globset = "0.4"
 reqwest = { workspace = true, features = ["rustls-tls", "json"], optional = true }
@@ -30,6 +39,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt", "sync", "time"], optional = true }
+tokio-util = { workspace = true, features = ["rt"], optional = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 xet-client = { workspace = true, optional = true }

--- a/crates/crab-cache/src/active_probe.rs
+++ b/crates/crab-cache/src/active_probe.rs
@@ -4,6 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
 
+const MAX_ACTIVE_PROBE_RESPONSE_BYTES: usize = 64 * 1024;
+
 #[derive(Debug, Clone, Copy)]
 pub enum ActiveProbeAuth<'a> {
     None,
@@ -148,10 +150,9 @@ async fn get_probe_object(
         .get("x-cache")
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
-    let body = response
-        .bytes()
+    let body = read_response_bounded(response)
         .await
-        .map_err(|error| redact_probe_error(base_url, &error.to_string()))?;
+        .map_err(|error| redact_probe_error(base_url, &error))?;
     if body.as_ref() != probe.body.as_slice() {
         return Err("probe read body did not match written bytes".to_string());
     }
@@ -193,10 +194,9 @@ async fn range_probe_object(
         .get("x-cache")
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
-    let body = response
-        .bytes()
+    let body = read_response_bounded(response)
         .await
-        .map_err(|error| redact_probe_error(base_url, &error.to_string()))?;
+        .map_err(|error| redact_probe_error(base_url, &error))?;
     if body.as_ref() != &probe.body[..4] {
         return Err("probe range body did not match written bytes".to_string());
     }
@@ -207,6 +207,32 @@ async fn range_probe_object(
         ));
     }
     Ok(())
+}
+
+async fn read_response_bounded(response: reqwest::Response) -> Result<bytes::Bytes, String> {
+    if response
+        .content_length()
+        .is_some_and(|size| size > MAX_ACTIVE_PROBE_RESPONSE_BYTES as u64)
+    {
+        return Err(format!(
+            "response exceeds the {MAX_ACTIVE_PROBE_RESPONSE_BYTES}-byte safety limit"
+        ));
+    }
+    let mut body = Vec::new();
+    let mut response = response;
+    while let Some(chunk) = response.chunk().await.map_err(|error| error.to_string())? {
+        let next_len = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(|| "response body length overflow".to_owned())?;
+        if next_len > MAX_ACTIVE_PROBE_RESPONSE_BYTES {
+            return Err(format!(
+                "response exceeds the {MAX_ACTIVE_PROBE_RESPONSE_BYTES}-byte safety limit"
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(bytes::Bytes::from(body))
 }
 
 async fn evict_probe_object(
@@ -233,9 +259,8 @@ async fn evict_probe_object(
             status_hint(status, auth_failure_hint)
         ));
     }
-    response
-        .json::<ActiveProbeEvictStats>()
-        .await
+    let body = read_response_bounded(response).await?;
+    serde_json::from_slice::<ActiveProbeEvictStats>(&body)
         .map_err(|error| format!("exact eviction JSON did not match expected schema: {error}"))
 }
 

--- a/crates/crab-cache/src/cache_client.rs
+++ b/crates/crab-cache/src/cache_client.rs
@@ -118,6 +118,50 @@ impl CacheClient {
         resp.bytes().await.map_err(|e| map_reqwest_error(&url, e))
     }
 
+    /// GET an immutable object while bounding response-body consumption.
+    pub async fn get_bounded(&self, path: &str, max_bytes: u64) -> Result<Bytes> {
+        let url = format!("{}/v1/{}", self.base_url, path);
+        let req = self.client.get(&url);
+        let mut resp = self
+            .apply_auth(req)
+            .send()
+            .await
+            .map_err(|e| map_reqwest_error(&url, e))?;
+
+        check_get_status(&url, &resp)?;
+        if let Some(size) = resp.content_length()
+            && size > max_bytes
+        {
+            return Err(CacheError::CorruptObject {
+                path: path.to_owned(),
+                reason: format!(
+                    "cache service object is {size} bytes; bounded read supports at most {max_bytes} bytes"
+                ),
+            });
+        }
+
+        let mut body = Vec::new();
+        while let Some(chunk) = resp.chunk().await.map_err(|e| map_reqwest_error(&url, e))? {
+            let next_len =
+                body.len()
+                    .checked_add(chunk.len())
+                    .ok_or_else(|| CacheError::CorruptObject {
+                        path: path.to_owned(),
+                        reason: "cache service response length overflow".to_owned(),
+                    })?;
+            if next_len as u64 > max_bytes {
+                return Err(CacheError::CorruptObject {
+                    path: path.to_owned(),
+                    reason: format!(
+                        "cache service response exceeded the bounded read limit of {max_bytes} bytes"
+                    ),
+                });
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(Bytes::from(body))
+    }
+
     /// HEAD an immutable object through the cache service.
     pub async fn head(&self, path: &str) -> Result<CacheObjectHead> {
         let url = format!("{}/v1/{}", self.base_url, path);
@@ -172,7 +216,7 @@ impl CacheClient {
             .client
             .get(&url)
             .header(reqwest::header::RANGE, &range_value);
-        let resp = self
+        let mut resp = self
             .apply_auth(req)
             .send()
             .await
@@ -180,15 +224,40 @@ impl CacheClient {
 
         let returned = check_range_status(&url, &resp, &range_value, range.start, last_byte)?;
         let cache_status = response_cache_status(&resp);
-        let body = resp.bytes().await.map_err(|e| map_reqwest_error(&url, e))?;
-        check_range_body_len(
-            &url,
-            &range_value,
-            returned.range.end - returned.range.start,
-            body.len(),
-        )?;
+        let expected_len = returned.range.end - returned.range.start;
+        if resp
+            .content_length()
+            .is_some_and(|length| length > expected_len)
+        {
+            return Err(CacheError::Service {
+                reason: format!(
+                    "range response body exceeds {expected_len} bytes for {range_value}: {url}"
+                ),
+            });
+        }
+
+        let mut body = Vec::new();
+        while let Some(chunk) = resp.chunk().await.map_err(|e| map_reqwest_error(&url, e))? {
+            let next_len =
+                body.len()
+                    .checked_add(chunk.len())
+                    .ok_or_else(|| CacheError::Service {
+                        reason: format!(
+                            "range response body length overflow for {range_value}: {url}"
+                        ),
+                    })?;
+            if u64::try_from(next_len).unwrap_or(u64::MAX) > expected_len {
+                return Err(CacheError::Service {
+                    reason: format!(
+                        "range response body exceeds {expected_len} bytes for {range_value}: {url}"
+                    ),
+                });
+            }
+            body.extend_from_slice(&chunk);
+        }
+        check_range_body_len(&url, &range_value, expected_len, body.len())?;
         Ok(CacheObjectRange {
-            data: body,
+            data: Bytes::from(body),
             range: returned.range,
             total_size: returned.total_size,
             cache_status,
@@ -1054,6 +1123,29 @@ mod tests {
         let err = client.get_range("xorbs/test", 2..5).await.unwrap_err();
 
         assert!(err.to_string().contains("range body length"));
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn get_range_rejects_oversized_body_before_materializing() {
+        let (addr, shutdown) = start_range_server(
+            StatusCode::PARTIAL_CONTENT,
+            Some("bytes 2-4/10"),
+            b"23456789",
+        )
+        .await;
+        let client = CacheClient::new(
+            &format!("http://{addr}"),
+            &CacheServiceAuth::None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let err = client.get_range("xorbs/test", 2..5).await.unwrap_err();
+
+        assert!(err.to_string().contains("exceeds 3 bytes"));
         let _ = shutdown.send(());
     }
 

--- a/crates/crab-cache/src/error.rs
+++ b/crates/crab-cache/src/error.rs
@@ -6,6 +6,10 @@ pub type Result<T> = std::result::Result<T, CacheError>;
 /// Errors raised by cache contracts and local cache storage.
 #[derive(thiserror::Error, Debug)]
 pub enum CacheError {
+    /// A caller cancelled a long-running cache scan or eviction.
+    #[error("cache operation cancelled")]
+    Cancelled,
+
     /// Filesystem I/O failed while reading or writing the local cache.
     #[error("cache I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/crab-cache/src/lib.rs
+++ b/crates/crab-cache/src/lib.rs
@@ -27,7 +27,8 @@ pub use error::{CacheError, Result};
 pub use key::CacheKey;
 #[cfg(feature = "local-cache")]
 pub use local_cache::{
-    CacheStats, CachedXorbCandidate, LocalCache, PruneObjectKind, PruneOptions, PruneStats,
+    CacheStats, CachedXorbCandidate, LocalCache, MAX_CACHE_CHUNK_BYTES, MAX_CACHE_MANIFEST_BYTES,
+    MAX_CACHE_SHARD_BYTES, MAX_CACHE_STAGE_BYTES, PruneObjectKind, PruneOptions, PruneStats,
     PrunedCacheObject, VerifyReport,
 };
 pub use path_class::cache_key_for_path;
@@ -41,6 +42,12 @@ pub use service::{
     CacheServiceLimits, CacheServiceMode, DedupQueryResult, KnownChunk,
 };
 #[cfg(feature = "local-cache")]
-pub use shard_hints::{SHARD_HINTS_FILENAME, ShardHintCache, default_path as shard_hints_path};
+pub use shard_hints::{
+    MAX_SHARD_HINTS_BYTES, SHARD_HINTS_FILENAME, ShardHintCache, default_path as shard_hints_path,
+};
 #[cfg(feature = "xet-chunk-cache")]
-pub use xet_chunk_cache::{XetChunkCacheHandle, XetChunkCacheStats};
+pub use xet_chunk_cache::{
+    XetChunkCacheHandle, XetChunkCachePruneStats, XetChunkCacheStats, XetChunkCacheVerifyStats,
+    prune_xet_chunk_cache, prune_xet_chunk_cache_with_cancel, verify_xet_chunk_cache,
+    verify_xet_chunk_cache_with_cancel, xet_chunk_cache_stats, xet_chunk_cache_stats_with_cancel,
+};

--- a/crates/crab-cache/src/local_cache.rs
+++ b/crates/crab-cache/src/local_cache.rs
@@ -25,9 +25,9 @@ use tracing::{debug, warn};
 
 use crate::error::{CacheError, Result};
 use crate::key::CacheKey;
-use crab_xet::hash::{compute_data_hash, xorb_hash};
+use crab_xet::hash::{HashedWrite, compute_data_hash, xorb_hash};
 use crab_xet::xorb::builder::FOOTER_SIZE;
-use crab_xet::xorb::format::{ChunkMeta, ChunkPlacement, MerkleHash};
+use crab_xet::xorb::format::{ChunkMeta, ChunkPlacement, MAX_XORB_SIZE, MerkleHash};
 use crab_xet::xorb::parser::{
     XorbParser, verify_compressed_chunk, xorb_chunks_from_metadata, xorb_hash_from_metadata,
     xorb_metadata_region,
@@ -35,6 +35,14 @@ use crab_xet::xorb::parser::{
 
 /// Default chunk cache ceiling: 10 GiB.
 const DEFAULT_CHUNK_MAX_BYTES: u64 = 10 * 1024 * 1024 * 1024;
+/// Maximum metadata-shard body retained in or read from the local cache.
+pub const MAX_CACHE_SHARD_BYTES: u64 = 512 * 1024 * 1024;
+/// Maximum uncompressed chunk body retained in or read from the local cache.
+pub const MAX_CACHE_CHUNK_BYTES: u64 = MAX_XORB_SIZE as u64;
+/// Maximum workflow stage entry body retained in or read from the local cache.
+pub const MAX_CACHE_STAGE_BYTES: u64 = 64 * 1024 * 1024;
+/// Maximum metadata manifest body retained in or read from the local cache.
+pub const MAX_CACHE_MANIFEST_BYTES: u64 = 256 * 1024 * 1024;
 const XORB_INDEX_DIR: &str = "xorb-index";
 const XORB_INDEX_DB: &str = "index.db";
 const HASH_BYTES: usize = 32;
@@ -42,6 +50,7 @@ const XORB_INDEX_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 const XORB_INDEX_OPEN_RETRY_DELAYS_MS: [u64; 4] = [5, 20, 50, 100];
 const CACHE_FILL_LOCK_STRIPES: usize = 256;
 const XORB_INDEX_SCHEMA_VERSION: i64 = 2;
+const MAX_CACHE_LRU_ENTRIES: usize = 1_000_000;
 
 fn new_fill_locks() -> Box<[tokio::sync::Mutex<()>]> {
     std::iter::repeat_with(|| tokio::sync::Mutex::new(()))
@@ -237,7 +246,38 @@ impl LocalCache {
         Fut: std::future::Future<Output = std::result::Result<Bytes, E>>,
         E: From<CacheError>,
     {
-        if let Some(data) = self.try_read_key(key).await {
+        self.get_or_fetch_with_limit(key, None, fetch).await
+    }
+
+    /// Get a cached object while bounding every cache and fetch body read.
+    pub async fn get_or_fetch_bounded_with<F, Fut, E>(
+        &self,
+        key: &CacheKey,
+        max_bytes: u64,
+        fetch: F,
+    ) -> std::result::Result<Bytes, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = std::result::Result<Bytes, E>>,
+        E: From<CacheError>,
+    {
+        self.get_or_fetch_with_limit(key, Some(max_bytes), fetch)
+            .await
+    }
+
+    async fn get_or_fetch_with_limit<F, Fut, E>(
+        &self,
+        key: &CacheKey,
+        max_bytes: Option<u64>,
+        fetch: F,
+    ) -> std::result::Result<Bytes, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = std::result::Result<Bytes, E>>,
+        E: From<CacheError>,
+    {
+        let max_bytes = effective_read_limit(key, max_bytes);
+        if let Some(data) = self.try_read_key_limited(key, max_bytes).await {
             return Ok(data);
         }
 
@@ -246,7 +286,7 @@ impl LocalCache {
             _ => self.hash_path(key),
         };
         let _fill_guard = self.fill_lock(&fill_path).lock().await;
-        if let Some(data) = self.try_read_key(key).await {
+        if let Some(data) = self.try_read_key_limited(key, max_bytes).await {
             return Ok(data);
         }
 
@@ -254,6 +294,7 @@ impl LocalCache {
             CacheKey::Chunk(hash) | CacheKey::Shard(hash) => {
                 let path = self.hash_path(key);
                 let data = fetch().await?;
+                enforce_size_limit(key, &data, max_bytes).map_err(E::from)?;
                 verify_data_hash(&data, hash).map_err(E::from)?;
                 self.atomic_write(&path, &data).await.map_err(E::from)?;
                 Ok(data)
@@ -261,6 +302,7 @@ impl LocalCache {
             CacheKey::Xorb(hash) => {
                 let path = self.hash_path(key);
                 let data = fetch().await?;
+                enforce_size_limit(key, &data, max_bytes).map_err(E::from)?;
                 verify_xorb_payload(&data, hash).map_err(E::from)?;
                 self.atomic_write(&path, &data).await.map_err(E::from)?;
                 let payload_hash = *blake3::hash(&data).as_bytes();
@@ -279,6 +321,7 @@ impl LocalCache {
                 // enforced by `workflow::cache` via JSON deserialization.
                 let path = self.hash_path(key);
                 let data = fetch().await?;
+                enforce_size_limit(key, &data, max_bytes).map_err(E::from)?;
                 self.atomic_write(&path, &data).await.map_err(E::from)?;
                 Ok(data)
             }
@@ -286,6 +329,7 @@ impl LocalCache {
                 let data_path = self.manifest_data_path(name);
                 let etag_path = self.manifest_etag_path(name);
                 let data = fetch().await?;
+                enforce_size_limit(key, &data, max_bytes).map_err(E::from)?;
                 self.atomic_write(&data_path, &data)
                     .await
                     .map_err(E::from)?;
@@ -326,6 +370,7 @@ impl LocalCache {
         }
 
         let data = fetch().await?;
+        enforce_size_limit(&key, &data, Some(MAX_XORB_SIZE as u64)).map_err(E::from)?;
         verify_xorb_serialized_payload(&data, hash).map_err(E::from)?;
         self.atomic_write(&path, &data).await.map_err(E::from)?;
         Ok(data)
@@ -344,10 +389,8 @@ impl LocalCache {
     pub async fn get_read_xorb_if_present(&self, hash: &MerkleHash) -> Result<Option<Bytes>> {
         let key = CacheKey::Xorb(*hash);
         let path = self.hash_path(&key);
-        let data = match tokio::fs::read(&path).await {
-            Ok(data) => Bytes::from(data),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(error) => return Err(error.into()),
+        let Some(data) = read_file_bounded_result(&path, MAX_XORB_SIZE as u64).await? else {
+            return Ok(None);
         };
         if let Err(error) = verify_xorb_identity(&data, hash) {
             warn!(
@@ -363,17 +406,24 @@ impl LocalCache {
         Ok(Some(data))
     }
 
-    async fn try_read_key(&self, key: &CacheKey) -> Option<Bytes> {
+    async fn try_read_key_limited(&self, key: &CacheKey, max_bytes: Option<u64>) -> Option<Bytes> {
         match key {
             CacheKey::Chunk(hash) | CacheKey::Shard(hash) => {
-                self.try_read_verified(&self.hash_path(key), hash).await
+                self.try_read_verified_limited(&self.hash_path(key), hash, max_bytes)
+                    .await
             }
-            CacheKey::Xorb(hash) => self.try_read_xorb(&self.hash_path(key), hash).await,
+            CacheKey::Xorb(hash) => {
+                self.try_read_xorb_limited(&self.hash_path(key), hash, max_bytes)
+                    .await
+            }
             CacheKey::Stage(_) => {
                 let path = self.hash_path(key);
-                let data = tokio::fs::read(&path).await.ok()?;
+                let data = match max_bytes {
+                    Some(max_bytes) => read_file_bounded(&path, max_bytes).await?,
+                    None => Bytes::from(tokio::fs::read(&path).await.ok()?),
+                };
                 touch_mtime(&path).await;
-                Some(Bytes::from(data))
+                Some(data)
             }
             CacheKey::Manifest { name, etag } => {
                 let want_etag = etag.as_deref()?;
@@ -381,9 +431,13 @@ impl LocalCache {
                 if cached_etag.trim() != want_etag {
                     return None;
                 }
-                let data = tokio::fs::read(self.manifest_data_path(name)).await.ok()?;
+                let path = self.manifest_data_path(name);
+                let data = match max_bytes {
+                    Some(max_bytes) => read_file_bounded(&path, max_bytes).await?,
+                    None => Bytes::from(tokio::fs::read(&path).await.ok()?),
+                };
                 debug!(manifest = %name, "manifest cache hit (ETag match)");
-                Some(Bytes::from(data))
+                Some(data)
             }
         }
     }
@@ -566,6 +620,7 @@ impl LocalCache {
     /// Manifest and stage entries are keyed by logical identities rather
     /// than body hashes, so this is a no-op for them.
     pub fn validate(key: &CacheKey, data: &[u8]) -> Result<()> {
+        enforce_key_size(key, data.len() as u64)?;
         match key {
             CacheKey::Chunk(hash) | CacheKey::Shard(hash) => verify_data_hash(data, hash),
             CacheKey::Xorb(hash) => verify_xorb_payload(&Bytes::copy_from_slice(data), hash),
@@ -575,6 +630,7 @@ impl LocalCache {
 
     /// Verify that `data` is valid for `key` without copying an existing body.
     pub fn validate_bytes(key: &CacheKey, data: &Bytes) -> Result<()> {
+        enforce_key_size(key, data.len() as u64)?;
         match key {
             CacheKey::Chunk(hash) | CacheKey::Shard(hash) => verify_data_hash(data, hash),
             CacheKey::Xorb(hash) => verify_xorb_payload(data, hash),
@@ -593,6 +649,22 @@ impl LocalCache {
         tokio::fs::metadata(&path).await.is_ok()
     }
 
+    /// Return the size of an existing cache entry without reading its body.
+    pub async fn cached_size(&self, key: &CacheKey) -> Result<Option<u64>> {
+        let path = match key {
+            CacheKey::Chunk(_) | CacheKey::Shard(_) | CacheKey::Xorb(_) | CacheKey::Stage(_) => {
+                self.hash_path(key)
+            }
+            CacheKey::Manifest { name, .. } => self.manifest_data_path(name),
+        };
+        match tokio::fs::metadata(path).await {
+            Ok(metadata) if metadata.is_file() => Ok(Some(metadata.len())),
+            Ok(_) => Ok(None),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     /// Check whether a cache entry exists and matches its key.
     ///
     /// For xorbs this verifies every compressed chunk payload, so callers
@@ -600,10 +672,14 @@ impl LocalCache {
     /// more than the extra local read.
     pub async fn contains_verified(&self, key: &CacheKey) -> bool {
         match key {
-            CacheKey::Chunk(hash) | CacheKey::Shard(hash) => {
-                let path = self.hash_path(key);
-                self.try_read_verified(&path, hash).await.is_some()
-            }
+            CacheKey::Chunk(hash) => self
+                .try_read_verified_limited(&self.hash_path(key), hash, Some(MAX_CACHE_CHUNK_BYTES))
+                .await
+                .is_some(),
+            CacheKey::Shard(hash) => self
+                .try_read_verified_limited(&self.hash_path(key), hash, Some(MAX_CACHE_SHARD_BYTES))
+                .await
+                .is_some(),
             CacheKey::Xorb(hash) => {
                 let path = self.hash_path(key);
                 self.try_verify_xorb_payload_file(&path, hash).await
@@ -805,7 +881,7 @@ impl LocalCache {
         let len = usize::try_from(range.end.checked_sub(range.start)?).ok()?;
         let path = self.hash_path(&CacheKey::Xorb(*hash));
         let meta = tokio::fs::metadata(&path).await.ok()?;
-        if !meta.is_file() || range.end > meta.len() {
+        if !meta.is_file() || meta.len() > MAX_XORB_SIZE as u64 || range.end > meta.len() {
             return None;
         }
         if let Err(e) = verify_xorb_file_identity(&path, meta.len(), hash).await {
@@ -917,7 +993,7 @@ impl LocalCache {
         }
 
         let mut entries: Vec<TargetLruEntry> = collect_hash_entries(&self.root.join("chunks"))
-            .await
+            .await?
             .into_iter()
             .map(|entry| TargetLruEntry {
                 entry,
@@ -926,7 +1002,7 @@ impl LocalCache {
             .collect();
         entries.extend(
             collect_hash_entries(&self.root.join("xorbs"))
-                .await
+                .await?
                 .into_iter()
                 .map(|entry| TargetLruEntry {
                     entry,
@@ -935,7 +1011,7 @@ impl LocalCache {
         );
         entries.extend(
             collect_hash_entries(&self.root.join("shards"))
-                .await
+                .await?
                 .into_iter()
                 .map(|entry| TargetLruEntry {
                     entry,
@@ -1035,9 +1111,24 @@ impl LocalCache {
     /// Returns [`CacheError::Io`] on filesystem failure.
     pub async fn verify(&self) -> Result<VerifyReport> {
         let mut report = VerifyReport::default();
-        verify_dir(&self.root.join("chunks"), &mut report).await?;
-        verify_dir(&self.root.join("shards"), &mut report).await?;
-        verify_xorb_dir(&self.root.join("xorbs"), &mut report).await?;
+        verify_dir(
+            &self.root.join("chunks"),
+            &mut report,
+            Some(MAX_CACHE_CHUNK_BYTES),
+        )
+        .await?;
+        verify_dir(
+            &self.root.join("shards"),
+            &mut report,
+            Some(MAX_CACHE_SHARD_BYTES),
+        )
+        .await?;
+        verify_xorb_dir(
+            &self.root.join("xorbs"),
+            &self.xorb_index_path(),
+            &mut report,
+        )
+        .await?;
         debug!(
             total = report.total,
             valid = report.valid,
@@ -1054,19 +1145,19 @@ impl LocalCache {
     /// Returns [`CacheError::Io`] on filesystem failure.
     pub async fn stats(&self) -> Result<CacheStats> {
         let mut s = CacheStats::default();
-        let (cb, cc) = dir_size(&self.root.join("chunks")).await;
+        let (cb, cc) = dir_size(&self.root.join("chunks")).await?;
         s.chunk_bytes = cb;
         s.chunk_count = cc;
-        let (sb, sc) = dir_size(&self.root.join("shards")).await;
+        let (sb, sc) = dir_size(&self.root.join("shards")).await?;
         s.shard_bytes = sb;
         s.shard_count = sc;
-        let (xb, xc) = dir_size(&self.root.join("xorbs")).await;
+        let (xb, xc) = dir_size(&self.root.join("xorbs")).await?;
         s.xorb_bytes = xb;
         s.xorb_count = xc;
-        let (tb, tc) = dir_size(&self.root.join("stages")).await;
+        let (tb, tc) = dir_size(&self.root.join("stages")).await?;
         s.stage_bytes = tb;
         s.stage_count = tc;
-        s.manifest_count = count_manifests(&self.root.join("manifests")).await;
+        s.manifest_count = count_manifests(&self.root.join("manifests")).await?;
         Ok(s)
     }
 
@@ -1234,7 +1325,7 @@ impl LocalCache {
                 let hex = h.as_hex();
                 self.root.join("stages").join(&hex[..2]).join(&hex)
             }
-            CacheKey::Manifest { .. } => unreachable!("manifest uses name-based path"),
+            CacheKey::Manifest { name, .. } => self.manifest_data_path(name),
         }
     }
 
@@ -1256,32 +1347,46 @@ impl LocalCache {
         read_string_if_exists(&self.manifest_etag_path(name)).await
     }
 
-    /// Read a file and verify its content hash. On mismatch, evict and
-    /// return `None`. On any I/O error, return `None` (cache miss).
-    async fn try_read_verified(&self, path: &Path, expected: &MerkleHash) -> Option<Bytes> {
-        let Ok(data) = tokio::fs::read(path).await else {
-            return None;
-        };
-
-        let actual = compute_data_hash(&data);
-        if actual == *expected {
-            // Touch mtime for LRU ordering.
+    async fn try_read_verified_limited(
+        &self,
+        path: &Path,
+        expected: &MerkleHash,
+        max_bytes: Option<u64>,
+    ) -> Option<Bytes> {
+        let max_bytes = max_bytes?;
+        let data = read_file_bounded(path, max_bytes).await?;
+        if compute_data_hash(&data) == *expected {
             touch_mtime(path).await;
-            Some(Bytes::from(data))
-        } else {
-            warn!(
-                path = %path.display(),
-                expected = %expected.hex(),
-                actual = %actual.hex(),
-                "cache hash mismatch — evicting"
-            );
-            let _ = tokio::fs::remove_file(path).await;
-            None
+            return Some(data);
         }
+
+        warn!(
+            path = %path.display(),
+            expected = %expected.hex(),
+            "cache hash mismatch — evicting"
+        );
+        let _ = tokio::fs::remove_file(path).await;
+        None
     }
 
-    async fn try_read_xorb(&self, path: &Path, expected: &MerkleHash) -> Option<Bytes> {
-        let data = self.try_read_xorb_bytes(path, expected).await?;
+    async fn try_read_xorb_limited(
+        &self,
+        path: &Path,
+        expected: &MerkleHash,
+        max_bytes: Option<u64>,
+    ) -> Option<Bytes> {
+        let data = self
+            .try_read_xorb_bytes_limited(path, expected, max_bytes)
+            .await?;
+        self.finish_xorb_cache_read(path, expected, data).await
+    }
+
+    async fn finish_xorb_cache_read(
+        &self,
+        path: &Path,
+        expected: &MerkleHash,
+        data: Bytes,
+    ) -> Option<Bytes> {
         let index_path = self.xorb_index_path();
         let expected_hash = *expected;
         let expected_len = data.len() as u64;
@@ -1302,10 +1407,20 @@ impl LocalCache {
     }
 
     async fn try_read_xorb_bytes(&self, path: &Path, expected: &MerkleHash) -> Option<Bytes> {
-        let Ok(data) = tokio::fs::read(path).await else {
-            return None;
-        };
-        let data = Bytes::from(data);
+        self.try_read_xorb_bytes_limited(path, expected, Some(MAX_XORB_SIZE as u64))
+            .await
+    }
+
+    async fn try_read_xorb_bytes_limited(
+        &self,
+        path: &Path,
+        expected: &MerkleHash,
+        max_bytes: Option<u64>,
+    ) -> Option<Bytes> {
+        let max_bytes = max_bytes
+            .unwrap_or(MAX_XORB_SIZE as u64)
+            .min(MAX_XORB_SIZE as u64);
+        let data = read_file_bounded(path, max_bytes).await?;
 
         if verify_xorb_identity(&data, expected).is_ok() {
             touch_mtime(path).await;
@@ -1383,6 +1498,98 @@ impl LocalCache {
 
 // --- free-standing helpers ---
 
+fn enforce_size_limit(
+    key: &CacheKey,
+    data: &Bytes,
+    max_bytes: Option<u64>,
+) -> std::result::Result<(), CacheError> {
+    let Some(max_bytes) = max_bytes else {
+        return Ok(());
+    };
+    let actual = data.len() as u64;
+    if actual <= max_bytes {
+        return Ok(());
+    }
+    Err(CacheError::CorruptObject {
+        path: format!("{key:?}"),
+        reason: format!(
+            "object is {actual} bytes; bounded read supports at most {max_bytes} bytes"
+        ),
+    })
+}
+
+fn enforce_key_size(key: &CacheKey, actual: u64) -> std::result::Result<(), CacheError> {
+    let Some(max_bytes) = effective_read_limit(key, None) else {
+        return Ok(());
+    };
+    if actual <= max_bytes {
+        return Ok(());
+    }
+    Err(CacheError::CorruptObject {
+        path: format!("{key:?}"),
+        reason: format!(
+            "object is {actual} bytes; cache format supports at most {max_bytes} bytes"
+        ),
+    })
+}
+
+fn effective_read_limit(key: &CacheKey, requested: Option<u64>) -> Option<u64> {
+    let format_limit = match key {
+        CacheKey::Shard(_) => Some(MAX_CACHE_SHARD_BYTES),
+        CacheKey::Xorb(_) => Some(MAX_XORB_SIZE as u64),
+        CacheKey::Chunk(_) => Some(MAX_CACHE_CHUNK_BYTES),
+        CacheKey::Stage(_) => Some(MAX_CACHE_STAGE_BYTES),
+        CacheKey::Manifest { .. } => Some(MAX_CACHE_MANIFEST_BYTES),
+    };
+    match (requested, format_limit) {
+        (Some(requested), Some(format_limit)) => Some(requested.min(format_limit)),
+        (None, Some(format_limit)) => Some(format_limit),
+        (requested, None) => requested,
+    }
+}
+
+async fn read_file_bounded(path: &Path, max_bytes: u64) -> Option<Bytes> {
+    read_file_bounded_result(path, max_bytes)
+        .await
+        .ok()
+        .flatten()
+}
+
+async fn read_file_bounded_result(path: &Path, max_bytes: u64) -> Result<Option<Bytes>> {
+    let metadata = match tokio::fs::metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.len() > max_bytes {
+        return Err(CacheError::CorruptObject {
+            path: path.display().to_string(),
+            reason: format!(
+                "file is {} bytes; bounded read supports at most {max_bytes} bytes",
+                metadata.len()
+            ),
+        });
+    }
+    let file = match tokio::fs::File::open(path).await {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let mut data = Vec::new();
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut data)
+        .await?;
+    if data.len() as u64 > max_bytes {
+        return Err(CacheError::CorruptObject {
+            path: path.display().to_string(),
+            reason: format!(
+                "file grew beyond the bounded read limit of {max_bytes} bytes while reading"
+            ),
+        });
+    }
+    Ok(Some(Bytes::from(data)))
+}
+
 fn verify_data_hash(data: &[u8], expected: &MerkleHash) -> Result<()> {
     let actual = compute_data_hash(data);
     if actual == *expected {
@@ -1399,6 +1606,12 @@ async fn copy_xorb_temp_file_with_blake3(
     tmp: &Path,
     expected_len: u64,
 ) -> Result<[u8; 32]> {
+    if expected_len > MAX_XORB_SIZE as u64 {
+        return Err(CacheError::CorruptObject {
+            path: source.display().to_string(),
+            reason: format!("xorb is {expected_len} bytes; format limit is {MAX_XORB_SIZE} bytes"),
+        });
+    }
     let mut source_file = tokio::fs::File::open(source).await?;
     let mut tmp_file = tokio::fs::File::create(tmp).await?;
     let mut hasher = blake3::Hasher::new();
@@ -1466,6 +1679,12 @@ async fn verify_xorb_file_identity(
     file_len: u64,
     expected: &MerkleHash,
 ) -> Result<()> {
+    if file_len > MAX_XORB_SIZE as u64 {
+        return Err(CacheError::CorruptObject {
+            path: path.display().to_string(),
+            reason: format!("xorb is {file_len} bytes; format limit is {MAX_XORB_SIZE} bytes"),
+        });
+    }
     let file_len = usize::try_from(file_len).map_err(|_| CacheError::CorruptObject {
         path: path.display().to_string(),
         reason: "xorb file length does not fit usize".to_string(),
@@ -1508,6 +1727,15 @@ async fn verify_xorb_file_identity(
 }
 
 async fn verify_xorb_file_payload(path: &Path, file_len: u64, expected: &MerkleHash) -> Result<()> {
+    let current_len = tokio::fs::metadata(path).await?.len();
+    if current_len != file_len {
+        return Err(CacheError::CorruptObject {
+            path: path.display().to_string(),
+            reason: format!(
+                "xorb changed during verification: indexed size {file_len}, current size {current_len}"
+            ),
+        });
+    }
     let (chunks, actual) = read_xorb_file_metadata(path, file_len).await?;
     if actual != *expected {
         return Err(CacheError::HashMismatch {
@@ -1521,6 +1749,15 @@ async fn verify_xorb_file_payload(path: &Path, file_len: u64, expected: &MerkleH
         let compressed = read_compressed_xorb_chunk(&mut file, chunk).await?;
         verify_compressed_chunk(chunk, &compressed)?;
     }
+    let current_len = tokio::fs::metadata(path).await?.len();
+    if current_len != file_len {
+        return Err(CacheError::CorruptObject {
+            path: path.display().to_string(),
+            reason: format!(
+                "xorb changed during verification: indexed size {file_len}, current size {current_len}"
+            ),
+        });
+    }
     Ok(())
 }
 
@@ -1528,6 +1765,12 @@ async fn read_xorb_file_metadata(
     path: &Path,
     file_len: u64,
 ) -> Result<(Vec<ChunkMeta>, MerkleHash)> {
+    if file_len > MAX_XORB_SIZE as u64 {
+        return Err(CacheError::CorruptObject {
+            path: path.display().to_string(),
+            reason: format!("xorb is {file_len} bytes; format limit is {MAX_XORB_SIZE} bytes"),
+        });
+    }
     let file_len = usize::try_from(file_len).map_err(|_| CacheError::CorruptObject {
         path: path.display().to_string(),
         reason: "xorb file length does not fit usize".to_string(),
@@ -2177,6 +2420,7 @@ struct LruEntry {
     path: PathBuf,
     size: u64,
     mtime: SystemTime,
+    regular: bool,
 }
 
 struct EvictResult {
@@ -2217,7 +2461,7 @@ async fn lru_evict_large_objects(
     options: PruneOptions,
 ) -> Result<LargeEvictResult> {
     let mut entries: Vec<LargeLruEntry> = collect_hash_entries(chunks_dir)
-        .await
+        .await?
         .into_iter()
         .map(|entry| LargeLruEntry {
             entry,
@@ -2226,7 +2470,7 @@ async fn lru_evict_large_objects(
         .collect();
     entries.extend(
         collect_hash_entries(xorbs_dir)
-            .await
+            .await?
             .into_iter()
             .map(|entry| LargeLruEntry {
                 entry,
@@ -2234,7 +2478,7 @@ async fn lru_evict_large_objects(
             }),
     );
 
-    let total: u64 = entries.iter().map(|e| e.entry.size).sum();
+    let total = checked_sum(entries.iter().map(|e| e.entry.size))?;
     if total <= max_bytes {
         return Ok(LargeEvictResult {
             chunks: 0,
@@ -2310,8 +2554,8 @@ async fn lru_evict(
     kind: PruneObjectKind,
     options: PruneOptions,
 ) -> Result<EvictResult> {
-    let entries = collect_hash_entries(dir).await;
-    let total: u64 = entries.iter().map(|e| e.size).sum();
+    let entries = collect_hash_entries(dir).await?;
+    let total = checked_sum(entries.iter().map(|e| e.size))?;
     if total <= max_bytes {
         return Ok(EvictResult {
             count: 0,
@@ -2366,45 +2610,58 @@ fn merkle_hash_from_path(path: &Path) -> Option<MerkleHash> {
 }
 
 /// Collect all files under a two-level hash directory.
-async fn collect_hash_entries(dir: &Path) -> Vec<LruEntry> {
+async fn collect_hash_entries(dir: &Path) -> Result<Vec<LruEntry>> {
     let mut entries = Vec::new();
-    let Ok(mut prefixes) = tokio::fs::read_dir(dir).await else {
-        return entries;
+    let mut prefixes = match tokio::fs::read_dir(dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(entries),
+        Err(error) => return Err(error.into()),
     };
-    while let Ok(Some(prefix_entry)) = prefixes.next_entry().await {
+    while let Some(prefix_entry) = prefixes.next_entry().await? {
         let prefix_path = prefix_entry.path();
-        if !prefix_path.is_dir() {
+        if !prefix_entry.file_type().await?.is_dir() {
             continue;
         }
-        let Ok(mut files) = tokio::fs::read_dir(&prefix_path).await else {
-            continue;
-        };
-        while let Ok(Some(file_entry)) = files.next_entry().await {
+        let mut files = tokio::fs::read_dir(&prefix_path).await?;
+        while let Some(file_entry) = files.next_entry().await? {
             let path = file_entry.path();
-            if let Ok(meta) = tokio::fs::metadata(&path).await
-                && meta.is_file()
-            {
-                let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
-                entries.push(LruEntry {
-                    path,
-                    size: meta.len(),
-                    mtime,
-                });
+            let file_type = file_entry.file_type().await?;
+            if file_type.is_dir() {
+                continue;
             }
+            let meta = tokio::fs::symlink_metadata(&path).await?;
+            if entries.len() >= MAX_CACHE_LRU_ENTRIES {
+                return Err(CacheError::Internal(format!(
+                    "cache directory {} contains more than {MAX_CACHE_LRU_ENTRIES} entries; refusing an unbounded LRU scan",
+                    dir.display()
+                )));
+            }
+            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            entries.push(LruEntry {
+                path,
+                size: meta.len(),
+                mtime,
+                regular: file_type.is_file(),
+            });
         }
     }
-    entries
+    Ok(entries)
 }
 
 /// Verify all hash-keyed files in a two-level directory.
-async fn verify_dir(dir: &Path, report: &mut VerifyReport) -> Result<()> {
-    let entries = collect_hash_entries(dir).await;
+async fn verify_dir(dir: &Path, report: &mut VerifyReport, max_bytes: Option<u64>) -> Result<()> {
+    let entries = collect_hash_entries(dir).await?;
     for entry in &entries {
         report.total += 1;
+        if !entry.regular {
+            report.corrupt += 1;
+            remove_discovered_entry(&entry.path).await?;
+            continue;
+        }
         // The filename is the expected hex hash.
         let Some(filename) = entry.path.file_name().and_then(|f| f.to_str()) else {
             report.corrupt += 1;
-            let _ = tokio::fs::remove_file(&entry.path).await;
+            remove_discovered_entry(&entry.path).await?;
             continue;
         };
         let Ok(expected) = MerkleHash::from_hex(filename) else {
@@ -2413,39 +2670,57 @@ async fn verify_dir(dir: &Path, report: &mut VerifyReport) -> Result<()> {
                 path = %entry.path.display(),
                 "invalid cache entry name — removing"
             );
-            let _ = tokio::fs::remove_file(&entry.path).await;
+            remove_discovered_entry(&entry.path).await?;
             continue;
         };
-        match tokio::fs::read(&entry.path).await {
-            Ok(data) => {
-                let actual = compute_data_hash(&data);
-                if actual == expected {
-                    report.valid += 1;
-                } else {
-                    report.corrupt += 1;
-                    warn!(
-                        path = %entry.path.display(),
-                        "corrupt cache entry — removing"
-                    );
-                    let _ = tokio::fs::remove_file(&entry.path).await;
-                }
-            }
-            Err(_) => {
+        if max_bytes.is_some_and(|limit| entry.size > limit) {
+            report.corrupt += 1;
+            warn!(
+                path = %entry.path.display(),
+                bytes = entry.size,
+                limit = max_bytes.unwrap_or(0),
+                "oversized cache entry — removing"
+            );
+            remove_discovered_entry(&entry.path).await?;
+            continue;
+        }
+        match verify_data_file(&entry.path, expected).await {
+            Ok(true) => report.valid += 1,
+            Ok(false) => {
                 report.corrupt += 1;
+                warn!(
+                    path = %entry.path.display(),
+                    "corrupt cache entry — removing"
+                );
+                remove_discovered_entry(&entry.path).await?;
             }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => report.total -= 1,
+            Err(error) => return Err(error.into()),
         }
     }
     Ok(())
 }
 
 /// Verify all xorb files in a two-level directory.
-async fn verify_xorb_dir(dir: &Path, report: &mut VerifyReport) -> Result<()> {
-    let entries = collect_hash_entries(dir).await;
+async fn verify_xorb_dir(
+    dir: &Path,
+    xorb_index_path: &Path,
+    report: &mut VerifyReport,
+) -> Result<()> {
+    let entries = collect_hash_entries(dir).await?;
     for entry in &entries {
         report.total += 1;
+        if !entry.regular {
+            report.corrupt += 1;
+            remove_discovered_entry(&entry.path).await?;
+            if let Some(hash) = merkle_hash_from_path(&entry.path) {
+                remove_xorb_index_entries(xorb_index_path, &hash)?;
+            }
+            continue;
+        }
         let Some(filename) = entry.path.file_name().and_then(|f| f.to_str()) else {
             report.corrupt += 1;
-            let _ = tokio::fs::remove_file(&entry.path).await;
+            remove_discovered_entry(&entry.path).await?;
             continue;
         };
         let Ok(expected) = MerkleHash::from_hex(filename) else {
@@ -2454,50 +2729,80 @@ async fn verify_xorb_dir(dir: &Path, report: &mut VerifyReport) -> Result<()> {
                 path = %entry.path.display(),
                 "invalid cached xorb name — removing"
             );
-            let _ = tokio::fs::remove_file(&entry.path).await;
+            remove_discovered_entry(&entry.path).await?;
             continue;
         };
-        match tokio::fs::read(&entry.path).await {
-            Ok(data) => {
-                if verify_xorb_payload(&Bytes::from(data), &expected).is_ok() {
-                    report.valid += 1;
-                } else {
-                    report.corrupt += 1;
-                    warn!(
-                        path = %entry.path.display(),
-                        "corrupt cached xorb — removing"
-                    );
-                    let _ = tokio::fs::remove_file(&entry.path).await;
-                }
+        match verify_xorb_file_payload(&entry.path, entry.size, &expected).await {
+            Ok(()) => report.valid += 1,
+            Err(CacheError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                report.total -= 1;
             }
             Err(_) => {
                 report.corrupt += 1;
+                warn!(
+                    path = %entry.path.display(),
+                    "corrupt cached xorb — removing"
+                );
+                remove_discovered_entry(&entry.path).await?;
+                remove_xorb_index_entries(xorb_index_path, &expected)?;
             }
         }
     }
     Ok(())
 }
 
+async fn verify_data_file(path: &Path, expected: MerkleHash) -> std::io::Result<bool> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || {
+        let mut source = std::fs::File::open(path)?;
+        let mut hashed = HashedWrite::new(std::io::sink());
+        std::io::copy(&mut source, &mut hashed)?;
+        Ok(hashed.hash() == expected)
+    })
+    .await
+    .map_err(|error| std::io::Error::other(format!("cache verification worker failed: {error}")))?
+}
+
 /// Sum file sizes and count in a two-level hash directory.
-async fn dir_size(dir: &Path) -> (u64, u64) {
-    let entries = collect_hash_entries(dir).await;
-    let bytes = entries.iter().map(|e| e.size).sum();
+async fn dir_size(dir: &Path) -> Result<(u64, u64)> {
+    let entries = collect_hash_entries(dir).await?;
+    let bytes = checked_sum(entries.iter().map(|e| e.size))?;
     let count = entries.len() as u64;
-    (bytes, count)
+    Ok((bytes, count))
+}
+
+fn checked_sum(mut values: impl Iterator<Item = u64>) -> Result<u64> {
+    values.try_fold(0u64, |total, value| {
+        total
+            .checked_add(value)
+            .ok_or_else(|| CacheError::Internal("cache byte total overflow".to_owned()))
+    })
+}
+
+async fn remove_discovered_entry(path: &Path) -> Result<()> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Count manifest data files (*.json) in the manifests directory.
-async fn count_manifests(dir: &Path) -> u64 {
-    let Ok(mut rd) = tokio::fs::read_dir(dir).await else {
-        return 0;
+async fn count_manifests(dir: &Path) -> Result<u64> {
+    let mut rd = match tokio::fs::read_dir(dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error.into()),
     };
     let mut count = 0u64;
-    while let Ok(Some(entry)) = rd.next_entry().await {
-        if entry.path().extension().is_some_and(|ext| ext == "json") {
+    while let Some(entry) = rd.next_entry().await? {
+        if entry.file_type().await?.is_file()
+            && entry.path().extension().is_some_and(|ext| ext == "json")
+        {
             count += 1;
         }
     }
-    count
+    Ok(count)
 }
 
 #[cfg(test)]
@@ -2588,6 +2893,30 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(&result2[..], data);
+    }
+
+    #[tokio::test]
+    async fn bounded_read_does_not_serve_an_oversized_cached_body() {
+        let (_dir, cache) = temp_cache();
+        let data = Bytes::from_static(b"oversized cached body");
+        let key = CacheKey::Shard(compute_data_hash(&data));
+        let path = cache.hash_path(&key);
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        let error = cache
+            .get_or_fetch_bounded_with(&key, 4, || async {
+                Err::<Bytes, CacheError>(CacheError::CorruptObject {
+                    path: "fetch sentinel".to_owned(),
+                    reason: "oversized cache must not be served".to_owned(),
+                })
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, CacheError::CorruptObject { .. }));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2911,6 +3240,13 @@ mod tests {
         assert_eq!(report.valid, 0);
         assert_eq!(report.corrupt, 1);
         assert!(!path.exists());
+        assert!(
+            cache
+                .cached_xorb_candidates_for_chunks(&[compute_data_hash(b"corrupt cached xorb")])
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/crab-cache/src/prefetch_profile.rs
+++ b/crates/crab-cache/src/prefetch_profile.rs
@@ -4,6 +4,7 @@
 //! warming and eager hydration decisions.
 
 use std::collections::BTreeMap;
+use std::io::Read;
 use std::path::Path;
 
 use globset::Glob;
@@ -14,6 +15,7 @@ use crate::{CacheError, Result};
 
 /// File name of the prefetch profile config inside a repo's shared `.crab/`.
 pub const PREFETCH_TOML_FILE: &str = "prefetch.toml";
+const MAX_PREFETCH_CONFIG_BYTES: usize = 8 * 1024 * 1024;
 
 /// Parsed prefetch configuration with profiles indexed by name.
 ///
@@ -45,8 +47,22 @@ pub fn load_prefetch_from_crab_dir(crab_dir: &Path) -> Result<PrefetchConfig> {
 /// optional. Malformed TOML, unsupported versions, and invalid glob patterns
 /// are hard errors.
 pub fn load_prefetch_path(path: &Path) -> Result<PrefetchConfig> {
-    let contents = match std::fs::read_to_string(path) {
-        Ok(contents) => contents,
+    let contents = match std::fs::File::open(path) {
+        Ok(file) => {
+            let mut bytes = Vec::new();
+            file.take((MAX_PREFETCH_CONFIG_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > MAX_PREFETCH_CONFIG_BYTES {
+                return Err(CacheError::PrefetchParse {
+                    reason: format!(
+                        "prefetch.toml exceeds the safety limit of {MAX_PREFETCH_CONFIG_BYTES} bytes"
+                    ),
+                });
+            }
+            String::from_utf8(bytes).map_err(|error| CacheError::PrefetchParse {
+                reason: format!("prefetch.toml is not valid UTF-8: {error}"),
+            })?
+        }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             debug!(path = %path.display(), "prefetch.toml not found, using empty config");
             return Ok(PrefetchConfig {
@@ -62,6 +78,14 @@ pub fn load_prefetch_path(path: &Path) -> Result<PrefetchConfig> {
 /// Parses a prefetch TOML string.
 pub fn parse_prefetch(contents: &str) -> Result<PrefetchConfig> {
     const SUPPORTED_VERSION: u32 = 1;
+
+    if contents.len() > MAX_PREFETCH_CONFIG_BYTES {
+        return Err(CacheError::PrefetchParse {
+            reason: format!(
+                "prefetch.toml exceeds the safety limit of {MAX_PREFETCH_CONFIG_BYTES} bytes"
+            ),
+        });
+    }
 
     let raw: RawPrefetchFile =
         toml::from_str(contents).map_err(|error| CacheError::PrefetchParse {
@@ -297,6 +321,15 @@ paths = ["*.rs"]
 "#;
         assert!(matches!(
             parse_prefetch(toml),
+            Err(CacheError::PrefetchParse { .. })
+        ));
+    }
+
+    #[test]
+    fn oversized_prefetch_config_is_rejected() {
+        let contents = "x".repeat(MAX_PREFETCH_CONFIG_BYTES + 1);
+        assert!(matches!(
+            parse_prefetch(&contents),
             Err(CacheError::PrefetchParse { .. })
         ));
     }

--- a/crates/crab-cache/src/shard_hints.rs
+++ b/crates/crab-cache/src/shard_hints.rs
@@ -14,10 +14,11 @@
 //! a mix.
 
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, warn};
 
 use crate::{CacheError, Result};
@@ -26,6 +27,9 @@ use crab_xet::xorb::format::MerkleHash;
 
 /// Filename for the shard-hint JSON cache inside the crab cache root.
 pub const SHARD_HINTS_FILENAME: &str = "shard-hints.json";
+/// Maximum serialized shard-hint cache body read into memory.
+pub const MAX_SHARD_HINTS_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_SHARD_HINTS_ENTRIES: usize = 1_000_000;
 
 /// On-disk representation: hex-encoded file_hash → hex-encoded shard_hash.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -59,10 +63,18 @@ impl ShardHintCache {
     /// failing — hints are advisory, so a corrupt cache degrades to the
     /// slow path instead of breaking push.
     pub async fn load(path: &Path) -> Result<Self> {
-        let bytes = match tokio::fs::read(path).await {
+        let bytes = match read_async_bounded(path).await {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 debug!(path = %path.display(), "shard-hints cache missing, starting empty");
+                return Ok(Self::new());
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "shard-hints cache exceeds the safety limit, treating as empty"
+                );
                 return Ok(Self::new());
             }
             Err(e) => return Err(CacheError::Io(e)),
@@ -76,10 +88,18 @@ impl ShardHintCache {
     /// like the git filter-process clean loop (which runs inside
     /// `spawn_blocking`) without needing a tokio handle.
     pub fn load_sync(path: &Path) -> Result<Self> {
-        let bytes = match std::fs::read(path) {
+        let bytes = match read_sync_bounded(path) {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 debug!(path = %path.display(), "shard-hints cache missing, starting empty");
+                return Ok(Self::new());
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "shard-hints cache exceeds the safety limit, treating as empty"
+                );
                 return Ok(Self::new());
             }
             Err(e) => return Err(CacheError::Io(e)),
@@ -90,6 +110,15 @@ impl ShardHintCache {
     /// Parse a shard-hints JSON blob, tolerating corrupt data by returning
     /// an empty cache with a `warn!` log — hints are advisory.
     fn from_bytes(path: &Path, bytes: &[u8]) -> Self {
+        if bytes.len() as u64 > MAX_SHARD_HINTS_BYTES {
+            warn!(
+                path = %path.display(),
+                bytes = bytes.len(),
+                limit = MAX_SHARD_HINTS_BYTES,
+                "shard-hints cache exceeds the safety limit, treating as empty"
+            );
+            return Self::new();
+        }
         let parsed: ShardHintsFile = match serde_json::from_slice(bytes) {
             Ok(v) => v,
             Err(e) => {
@@ -101,6 +130,15 @@ impl ShardHintCache {
                 return Self::new();
             }
         };
+        if parsed.hints.len() > MAX_SHARD_HINTS_ENTRIES {
+            warn!(
+                path = %path.display(),
+                entries = parsed.hints.len(),
+                limit = MAX_SHARD_HINTS_ENTRIES,
+                "shard-hints cache contains too many entries, treating as empty"
+            );
+            return Self::new();
+        }
 
         let mut hints = HashMap::with_capacity(parsed.hints.len());
         for (file_hex, shard_hex) in parsed.hints {
@@ -177,16 +215,47 @@ impl ShardHintCache {
         let on_disk = ShardHintsFile {
             hints: self.hints.iter().map(|(f, s)| (f.hex(), s.hex())).collect(),
         };
+        if on_disk.hints.len() > MAX_SHARD_HINTS_ENTRIES {
+            return Err(CacheError::CorruptObject {
+                path: path.display().to_string(),
+                reason: format!(
+                    "shard-hints cache contains {} entries; limit is {MAX_SHARD_HINTS_ENTRIES}",
+                    on_disk.hints.len()
+                ),
+            });
+        }
         let body = serde_json::to_vec(&on_disk).map_err(|e| {
             CacheError::Internal(format!("failed to serialize shard-hints cache: {e}"))
         })?;
+        if body.len() as u64 > MAX_SHARD_HINTS_BYTES {
+            return Err(CacheError::CorruptObject {
+                path: path.display().to_string(),
+                reason: format!(
+                    "serialized shard-hints cache is {} bytes; limit is {MAX_SHARD_HINTS_BYTES}",
+                    body.len()
+                ),
+            });
+        }
 
-        let tmp = tmp_path(path);
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+        let tmp = tmp_path(
+            path,
+            std::process::id(),
+            TMP_COUNTER.fetch_add(1, Ordering::Relaxed),
+        );
         let mut f = tokio::fs::File::create(&tmp).await?;
-        f.write_all(&body).await?;
-        f.flush().await?;
-        drop(f);
-        tokio::fs::rename(&tmp, path).await?;
+        let write_result = async {
+            f.write_all(&body).await?;
+            f.flush().await?;
+            drop(f);
+            tokio::fs::rename(&tmp, path).await
+        }
+        .await;
+        if let Err(error) = write_result {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(error.into());
+        }
 
         debug!(path = %path.display(), entries = self.hints.len(), "saved shard-hints cache");
         Ok(())
@@ -206,18 +275,47 @@ impl ShardHintCache {
     }
 }
 
+async fn read_async_bounded(path: &Path) -> std::io::Result<Vec<u8>> {
+    let file = tokio::fs::File::open(path).await?;
+    let mut bytes = Vec::new();
+    file.take(MAX_SHARD_HINTS_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .await?;
+    if bytes.len() as u64 > MAX_SHARD_HINTS_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("file exceeds {MAX_SHARD_HINTS_BYTES} bytes"),
+        ));
+    }
+    Ok(bytes)
+}
+
+fn read_sync_bounded(path: &Path) -> std::io::Result<Vec<u8>> {
+    let file = std::fs::File::open(path)?;
+    let mut bytes = Vec::new();
+    file.take(MAX_SHARD_HINTS_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_SHARD_HINTS_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("file exceeds {MAX_SHARD_HINTS_BYTES} bytes"),
+        ));
+    }
+    Ok(bytes)
+}
+
 /// Default on-disk path for the shard-hint cache.
 #[must_use]
 pub fn default_path() -> PathBuf {
     super::default_cache_root().join(SHARD_HINTS_FILENAME)
 }
 
-fn tmp_path(path: &Path) -> PathBuf {
+fn tmp_path(path: &Path, pid: u32, sequence: u64) -> PathBuf {
     match path.file_name() {
         Some(name) => {
             let mut tmp_name = std::ffi::OsString::from(".");
             tmp_name.push(name);
-            tmp_name.push(".tmp");
+            tmp_name.push(format!(".tmp.{pid}.{sequence}"));
             match path.parent() {
                 Some(parent) => parent.join(tmp_name),
                 None => PathBuf::from(tmp_name),
@@ -316,6 +414,13 @@ mod tests {
         tokio::fs::write(&path, b"{ not valid json").await.unwrap();
 
         let cache = ShardHintCache::load(&path).await.unwrap();
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn oversized_body_is_treated_as_empty() {
+        let body = vec![b' '; usize::try_from(MAX_SHARD_HINTS_BYTES).unwrap() + 1];
+        let cache = ShardHintCache::from_bytes(Path::new("oversized"), &body);
         assert!(cache.is_empty());
     }
 

--- a/crates/crab-cache/src/xet_chunk_cache.rs
+++ b/crates/crab-cache/src/xet_chunk_cache.rs
@@ -5,14 +5,21 @@
 //! resolved directory and byte budget; owner-specific config stays above this
 //! Module.
 
-use std::path::PathBuf;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::SystemTime;
 
-use tracing::{debug, warn};
-use xet_client::chunk_cache::{CacheConfig, ChunkCache, DiskCache, get_cache};
+use base64::Engine as _;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use xet_client::chunk_cache::{CacheConfig, ChunkCache, get_cache};
 use xet_runtime::config::XetConfig;
 
 use crate::{CacheError, Result};
+
+const MAX_XET_CHUNK_CACHE_ENTRIES: usize = 1_000_000;
 
 /// Resolved handle over the xet-core chunk cache.
 ///
@@ -48,6 +55,22 @@ pub struct XetChunkCacheStats {
     pub entries: usize,
     /// Total resident bytes across all entries.
     pub total_bytes: u64,
+}
+
+/// Result of explicitly pruning xet-core range-cache files to a byte budget.
+#[derive(Debug, Clone, Default)]
+pub struct XetChunkCachePruneStats {
+    pub entries_evicted: u64,
+    pub bytes_freed: u64,
+    pub entries: Vec<(PathBuf, u64)>,
+}
+
+/// Integrity report for xet-core range-cache files.
+#[derive(Debug, Clone, Default)]
+pub struct XetChunkCacheVerifyStats {
+    pub total: u64,
+    pub valid: u64,
+    pub corrupt: u64,
 }
 
 impl XetChunkCacheHandle {
@@ -92,40 +115,399 @@ impl XetChunkCacheHandle {
 
     /// Snapshot the cache directory's entry count and resident bytes.
     ///
-    /// Re-initializes a local `DiskCache` view so callers do not need to
-    /// downcast the `Arc<dyn ChunkCache>`. Returns zeroed stats on failure
-    /// because stats are diagnostic output and should not tear down commands.
-    pub async fn stats(&self) -> XetChunkCacheStats {
-        let config = CacheConfig {
-            cache_directory: self.directory.clone(),
-            cache_size: self.size_bytes,
-        };
+    /// Scans the xet-core cache layout without opening or repairing it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CacheError::Io`] when an existing cache directory cannot be
+    /// read. A missing directory is an empty cache.
+    pub async fn stats(&self) -> Result<XetChunkCacheStats> {
+        xet_chunk_cache_stats(&self.directory).await
+    }
 
-        let xet_config = XetConfig::new();
-        match DiskCache::initialize(&xet_config, &config) {
-            Ok(disk) => XetChunkCacheStats {
-                entries: disk.num_items().await,
-                total_bytes: disk.total_bytes().await,
-            },
-            Err(e) => {
-                warn!(
-                    directory = %self.directory.display(),
-                    error = %e,
-                    "failed to scan chunk cache for stats",
-                );
-                XetChunkCacheStats {
-                    entries: 0,
-                    total_bytes: 0,
+    /// Snapshot the cache directory while honoring a caller cancellation.
+    pub async fn stats_with_cancel(
+        &self,
+        cancel: &CancellationToken,
+    ) -> Result<XetChunkCacheStats> {
+        xet_chunk_cache_stats_with_cancel(&self.directory, cancel).await
+    }
+}
+
+/// Snapshot an xet-core range-cache directory without mutating it.
+pub async fn xet_chunk_cache_stats(directory: &std::path::Path) -> Result<XetChunkCacheStats> {
+    xet_chunk_cache_stats_with_cancel(directory, &CancellationToken::new()).await
+}
+
+/// Snapshot the xet-core range-cache directory while honoring cancellation.
+pub async fn xet_chunk_cache_stats_with_cancel(
+    directory: &std::path::Path,
+    cancel: &CancellationToken,
+) -> Result<XetChunkCacheStats> {
+    run_blocking_cache_scan(directory, cancel, |directory, cancel| {
+        let mut stats = XetChunkCacheStats {
+            entries: 0,
+            total_bytes: 0,
+        };
+        visit_xet_chunk_cache_entries(directory, cancel, |entry| {
+            stats.entries = stats.entries.saturating_add(1);
+            stats.total_bytes = stats.total_bytes.saturating_add(entry.bytes);
+            Ok(())
+        })?;
+        Ok(stats)
+    })
+    .await
+}
+
+/// Evict oldest xet-core range files until `max_bytes` is satisfied.
+pub async fn prune_xet_chunk_cache(
+    directory: &Path,
+    max_bytes: u64,
+    dry_run: bool,
+    record_paths: bool,
+) -> Result<XetChunkCachePruneStats> {
+    prune_xet_chunk_cache_with_cancel(
+        directory,
+        max_bytes,
+        dry_run,
+        record_paths,
+        &CancellationToken::new(),
+    )
+    .await
+}
+
+/// Evict xet-core range files while honoring a caller cancellation.
+pub async fn prune_xet_chunk_cache_with_cancel(
+    directory: &Path,
+    max_bytes: u64,
+    dry_run: bool,
+    record_paths: bool,
+    cancel: &CancellationToken,
+) -> Result<XetChunkCachePruneStats> {
+    run_blocking_cache_scan(directory, cancel, move |directory, cancel| {
+        let mut entries = collect_xet_chunk_cache_entries(directory, cancel)?;
+        let total = entries
+            .iter()
+            .fold(0u64, |total, entry| total.saturating_add(entry.bytes));
+        if total <= max_bytes {
+            return Ok(XetChunkCachePruneStats::default());
+        }
+        entries.sort_by_key(|entry| entry.modified);
+        let target = total - max_bytes;
+        let mut stats = XetChunkCachePruneStats::default();
+        for entry in entries {
+            check_cancelled(cancel)?;
+            if stats.bytes_freed >= target {
+                break;
+            }
+            if !dry_run {
+                match fs::remove_file(&entry.path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(error.into()),
                 }
+            }
+            stats.entries_evicted = stats.entries_evicted.saturating_add(1);
+            stats.bytes_freed = stats.bytes_freed.saturating_add(entry.bytes);
+            if record_paths {
+                stats.entries.push((entry.path, entry.bytes));
+            }
+        }
+        Ok(stats)
+    })
+    .await
+}
+
+/// Validate xet-core range-cache filenames, lengths, headers, and CRCs.
+pub async fn verify_xet_chunk_cache(directory: &Path) -> Result<XetChunkCacheVerifyStats> {
+    verify_xet_chunk_cache_with_cancel(directory, &CancellationToken::new()).await
+}
+
+/// Validate xet-core range files while honoring a caller cancellation.
+pub async fn verify_xet_chunk_cache_with_cancel(
+    directory: &Path,
+    cancel: &CancellationToken,
+) -> Result<XetChunkCacheVerifyStats> {
+    run_blocking_cache_scan(directory, cancel, |directory, cancel| {
+        let mut stats = XetChunkCacheVerifyStats::default();
+        visit_xet_chunk_cache_entries(directory, cancel, |entry| {
+            let valid = match verify_xet_chunk_cache_entry(&entry.path, entry.bytes, cancel) {
+                Ok(valid) => valid,
+                Err(CacheError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(());
+                }
+                Err(error) => return Err(error),
+            };
+            stats.total = stats.total.saturating_add(1);
+            if valid {
+                stats.valid = stats.valid.saturating_add(1);
+                return Ok(());
+            }
+            stats.corrupt = stats.corrupt.saturating_add(1);
+            check_cancelled(cancel)?;
+            match fs::remove_file(&entry.path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error.into()),
+            }
+        })?;
+        Ok(stats)
+    })
+    .await
+}
+
+async fn run_blocking_cache_scan<T, F>(
+    directory: &Path,
+    cancel: &CancellationToken,
+    scan: F,
+) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce(&Path, &CancellationToken) -> Result<T> + Send + 'static,
+{
+    let directory = directory.to_owned();
+    let cancel = cancel.clone();
+    tokio::task::spawn_blocking(move || {
+        check_cancelled(&cancel)?;
+        scan(&directory, &cancel)
+    })
+    .await
+    .map_err(|error| CacheError::Internal(format!("xet cache scan task failed: {error}")))?
+}
+
+fn check_cancelled(cancel: &CancellationToken) -> Result<()> {
+    if cancel.is_cancelled() {
+        return Err(CacheError::Cancelled);
+    }
+    Ok(())
+}
+
+fn verify_xet_chunk_cache_entry(
+    path: &Path,
+    bytes: u64,
+    cancel: &CancellationToken,
+) -> Result<bool> {
+    check_cancelled(cancel)?;
+    const ITEM_NAME_BYTES: usize = 20;
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(false);
+    };
+    let Ok(encoded) = base64::engine::general_purpose::URL_SAFE.decode(name) else {
+        return Ok(false);
+    };
+    let Ok(encoded): std::result::Result<[u8; ITEM_NAME_BYTES], _> = encoded.try_into() else {
+        return Ok(false);
+    };
+    let start = u32::from_le_bytes([encoded[0], encoded[1], encoded[2], encoded[3]]);
+    let end = u32::from_le_bytes([encoded[4], encoded[5], encoded[6], encoded[7]]);
+    let expected_bytes = u64::from_le_bytes([
+        encoded[8],
+        encoded[9],
+        encoded[10],
+        encoded[11],
+        encoded[12],
+        encoded[13],
+        encoded[14],
+        encoded[15],
+    ]);
+    let expected_crc = u32::from_le_bytes([encoded[16], encoded[17], encoded[18], encoded[19]]);
+    if start >= end || expected_bytes != bytes || bytes < 8 {
+        return Ok(false);
+    }
+
+    let mut file = fs::File::open(path)?;
+    let mut count_bytes = [0u8; 4];
+    if !read_exact_or_corrupt(&mut file, &mut count_bytes)? {
+        return Ok(false);
+    }
+    let count = u32::from_le_bytes(count_bytes);
+    let expected_count = u64::from(end) - u64::from(start) + 1;
+    if u64::from(count) != expected_count {
+        return Ok(false);
+    }
+    let header_bytes = u64::from(count).saturating_add(1).saturating_mul(4);
+    if header_bytes > bytes {
+        return Ok(false);
+    }
+    let mut previous = None;
+    let mut offset_bytes = [0u8; 4];
+    for _ in 0..count {
+        check_cancelled(cancel)?;
+        if !read_exact_or_corrupt(&mut file, &mut offset_bytes)? {
+            return Ok(false);
+        }
+        let offset = u32::from_le_bytes(offset_bytes);
+        if previous.is_none() && offset != 0 || previous.is_some_and(|previous| previous >= offset)
+        {
+            return Ok(false);
+        }
+        previous = Some(offset);
+    }
+    if u64::from(previous.unwrap_or(0)) != bytes - header_bytes {
+        return Ok(false);
+    }
+
+    let mut file = fs::File::open(path)?;
+    let mut hasher = crc32fast::Hasher::new();
+    let mut buffer = vec![0u8; 64 * 1024];
+    loop {
+        check_cancelled(cancel)?;
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize() == expected_crc)
+}
+
+fn read_exact_or_corrupt(file: &mut fs::File, buffer: &mut [u8]) -> Result<bool> {
+    match file.read_exact(buffer) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+struct XetChunkCacheEntry {
+    path: PathBuf,
+    bytes: u64,
+    modified: SystemTime,
+}
+
+fn collect_xet_chunk_cache_entries(
+    directory: &Path,
+    cancel: &CancellationToken,
+) -> Result<Vec<XetChunkCacheEntry>> {
+    let mut entries = Vec::new();
+    visit_xet_chunk_cache_entries(directory, cancel, |entry| {
+        if entries.len() >= MAX_XET_CHUNK_CACHE_ENTRIES {
+            return Err(CacheError::Internal(format!(
+                "xet chunk cache contains more than {MAX_XET_CHUNK_CACHE_ENTRIES} entries; refusing an unbounded LRU scan"
+            )));
+        }
+        entries.push(entry);
+        Ok(())
+    })?;
+    Ok(entries)
+}
+
+fn visit_xet_chunk_cache_entries(
+    directory: &Path,
+    cancel: &CancellationToken,
+    mut visit: impl FnMut(XetChunkCacheEntry) -> Result<()>,
+) -> Result<()> {
+    check_cancelled(cancel)?;
+    let prefixes = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for prefix in prefixes {
+        check_cancelled(cancel)?;
+        let prefix = match prefix {
+            Ok(prefix) => prefix,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        let Some(prefix_name) = prefix.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let prefix_type = match prefix.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        if prefix_name.len() != 2 || !prefix_name.is_ascii() || !prefix_type.is_dir() {
+            continue;
+        }
+        let keys = match fs::read_dir(prefix.path()) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        for key in keys {
+            check_cancelled(cancel)?;
+            let key = match key {
+                Ok(key) => key,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
+            };
+            let Some(key_name) = key.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            let key_type = match key.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
+            };
+            if !key_name
+                .as_bytes()
+                .get(..2)
+                .is_some_and(|key_prefix| key_prefix.eq_ignore_ascii_case(prefix_name.as_bytes()))
+                || !key_type.is_dir()
+            {
+                continue;
+            }
+            let items = match fs::read_dir(key.path()) {
+                Ok(entries) => entries,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
+            };
+            for item in items {
+                check_cancelled(cancel)?;
+                let item = match item {
+                    Ok(item) => item,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(error.into()),
+                };
+                let item_type = match item.file_type() {
+                    Ok(file_type) => file_type,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(error.into()),
+                };
+                if !item_type.is_file() {
+                    continue;
+                }
+                let metadata = match item.metadata() {
+                    Ok(metadata) => metadata,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(error.into()),
+                };
+                visit(XetChunkCacheEntry {
+                    path: item.path(),
+                    bytes: metadata.len(),
+                    modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+                })?;
             }
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
+
+    async fn write_xet_range(cache_dir: &Path, payload: &[u8]) -> PathBuf {
+        let mut body = Vec::new();
+        body.extend_from_slice(&2u32.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes());
+        body.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(payload);
+        let mut name = Vec::new();
+        name.extend_from_slice(&0u32.to_le_bytes());
+        name.extend_from_slice(&1u32.to_le_bytes());
+        name.extend_from_slice(&u64::try_from(body.len()).unwrap().to_le_bytes());
+        name.extend_from_slice(&crc32fast::hash(&body).to_le_bytes());
+        let name = base64::engine::general_purpose::URL_SAFE.encode(name);
+        let dir = cache_dir.join("ab").join("ab-key");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let path = dir.join(name);
+        tokio::fs::write(&path, body).await.unwrap();
+        path
+    }
 
     #[tokio::test]
     async fn open_reads_empty_cache_stats() {
@@ -137,7 +519,7 @@ mod tests {
         assert_eq!(handle.directory, cache_dir);
         assert_eq!(handle.size_bytes, 64 * 1024);
 
-        let stats = handle.stats().await;
+        let stats = handle.stats().await.unwrap();
         assert_eq!(stats.entries, 0);
         assert_eq!(stats.total_bytes, 0);
     }
@@ -163,5 +545,141 @@ mod tests {
         let second = XetChunkCacheHandle::open(cache_dir, 64 * 1024).unwrap();
 
         assert!(Arc::ptr_eq(&first.cache, &second.cache));
+    }
+
+    #[tokio::test]
+    async fn stats_is_read_only_and_counts_range_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("chunks");
+        let item_dir = cache_dir.join("ab").join("ab-key");
+        tokio::fs::create_dir_all(&item_dir).await.unwrap();
+        tokio::fs::write(item_dir.join("range"), b"12345")
+            .await
+            .unwrap();
+        tokio::fs::write(cache_dir.join("unknown"), b"ignored")
+            .await
+            .unwrap();
+
+        let stats = xet_chunk_cache_stats(&cache_dir).await.unwrap();
+
+        assert_eq!(stats.entries, 1);
+        assert_eq!(stats.total_bytes, 5);
+        assert!(cache_dir.join("unknown").exists());
+    }
+
+    #[tokio::test]
+    async fn stats_does_not_create_a_missing_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("missing");
+
+        let stats = xet_chunk_cache_stats(&cache_dir).await.unwrap();
+
+        assert_eq!(stats.entries, 0);
+        assert_eq!(stats.total_bytes, 0);
+        assert!(!cache_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn scans_honor_cancellation_before_worker_start() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let error = xet_chunk_cache_stats_with_cancel(&tmp.path().join("missing"), &cancel)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, CacheError::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn prune_dry_run_and_apply_cover_xet_range_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("chunks");
+        let item_dir = cache_dir.join("ab").join("ab-key");
+        tokio::fs::create_dir_all(&item_dir).await.unwrap();
+        tokio::fs::write(item_dir.join("old"), vec![1u8; 8])
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        tokio::fs::write(item_dir.join("new"), vec![2u8; 8])
+            .await
+            .unwrap();
+
+        let plan = prune_xet_chunk_cache(&cache_dir, 8, true, true)
+            .await
+            .unwrap();
+        assert_eq!(plan.entries_evicted, 1);
+        assert_eq!(plan.bytes_freed, 8);
+        assert_eq!(xet_chunk_cache_stats(&cache_dir).await.unwrap().entries, 2);
+
+        let applied = prune_xet_chunk_cache(&cache_dir, 8, false, true)
+            .await
+            .unwrap();
+        assert_eq!(applied.entries, plan.entries);
+        assert_eq!(xet_chunk_cache_stats(&cache_dir).await.unwrap().entries, 1);
+    }
+
+    #[tokio::test]
+    async fn verify_accepts_valid_ranges_and_evicts_crc_mismatches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("chunks");
+        let valid = write_xet_range(&cache_dir, b"valid").await;
+
+        let report = verify_xet_chunk_cache(&cache_dir).await.unwrap();
+        assert_eq!(report.total, 1);
+        assert_eq!(report.valid, 1);
+
+        let mut corrupt = tokio::fs::read(&valid).await.unwrap();
+        *corrupt.last_mut().unwrap() ^= 0xff;
+        tokio::fs::write(&valid, corrupt).await.unwrap();
+        let report = verify_xet_chunk_cache(&cache_dir).await.unwrap();
+
+        assert_eq!(report.corrupt, 1);
+        assert!(!valid.exists());
+    }
+
+    #[tokio::test]
+    async fn stats_and_verify_stream_large_range_file_inventories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("chunks");
+        for index in 0..1_001u32 {
+            write_xet_range(&cache_dir, &index.to_le_bytes()).await;
+        }
+
+        let stats = xet_chunk_cache_stats(&cache_dir).await.unwrap();
+        let report = verify_xet_chunk_cache(&cache_dir).await.unwrap();
+
+        assert_eq!(stats.entries, 1_001);
+        assert_eq!(report.total, 1_001);
+        assert_eq!(report.valid, 1_001);
+    }
+
+    #[tokio::test]
+    async fn verify_accepts_single_chunk_ranges_and_evicts_truncation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("chunks");
+        let mut body = Vec::new();
+        body.extend_from_slice(&2u32.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes());
+        body.extend_from_slice(&7u32.to_le_bytes());
+        body.extend_from_slice(b"payload");
+        let mut name = Vec::new();
+        name.extend_from_slice(&7u32.to_le_bytes());
+        name.extend_from_slice(&8u32.to_le_bytes());
+        name.extend_from_slice(&u64::try_from(body.len()).unwrap().to_le_bytes());
+        name.extend_from_slice(&crc32fast::hash(&body).to_le_bytes());
+        let name = base64::engine::general_purpose::URL_SAFE.encode(name);
+        let dir = cache_dir.join("ab").join("ab-key");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let path = dir.join(name);
+        tokio::fs::write(&path, &body).await.unwrap();
+
+        let report = verify_xet_chunk_cache(&cache_dir).await.unwrap();
+        assert_eq!(report.valid, 1);
+
+        tokio::fs::write(&path, &body[..3]).await.unwrap();
+        let report = verify_xet_chunk_cache(&cache_dir).await.unwrap();
+        assert_eq!(report.corrupt, 1);
+        assert!(!path.exists());
     }
 }

--- a/crates/crab-coordination/src/push_lock.rs
+++ b/crates/crab-coordination/src/push_lock.rs
@@ -22,8 +22,6 @@ pub const GIT_OBJECT_LOCATOR_RESOURCE: &str = "git-object-locator";
 pub const GIT_GENERATION_OWNER_RESOURCE: &str = "git-generation-owner";
 /// Internal resource serializing unified manifest publication.
 pub const GIT_MANIFEST_RESOURCE: &str = "git-manifest";
-/// Internal resource serializing repository repacks.
-pub const REPACK_RESOURCE: &str = "repack";
 /// Internal resource used when a push has no destination ref.
 pub const BATCH_RESOURCE: &str = "batch";
 /// Internal resource serializing history recovery without existing refs.
@@ -1367,8 +1365,8 @@ mod tests {
             "org/repo/acl-views/v1/scope/7-deadbeef/locks/refs/tags/releases/v1/lock"
         );
         assert_eq!(
-            internal_lock_path(prefix, REPACK_RESOURCE).unwrap(),
-            "org/repo/acl-views/v1/scope/7-deadbeef/locks/internal/repack/lock"
+            internal_lock_path(prefix, REPOSITORY_MAINTENANCE_RESOURCE).unwrap(),
+            "org/repo/acl-views/v1/scope/7-deadbeef/locks/internal/repository-maintenance/lock"
         );
     }
 

--- a/crates/crab-metadata/src/bloom_prefilter.rs
+++ b/crates/crab-metadata/src/bloom_prefilter.rs
@@ -24,6 +24,7 @@ use object_store::path::Path;
 use crate::error::{MetadataError, Result};
 use crab_storage::Store;
 use crab_xet::shard_bloom::ShardBloom;
+use crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES;
 use crab_xet::xorb::format::MerkleHash;
 
 /// Size of the v2 shard trailer: `bloom_offset` (8 bytes) + magic (4 bytes).
@@ -122,6 +123,15 @@ pub async fn check_shard_chunk_bloom(
 async fn load_bloom_if_any(store: &Store, shard_path: &Path) -> Result<Option<ShardBloom>> {
     let meta = store.head(shard_path).await?;
     let shard_size = meta.size;
+
+    if shard_size > MAX_SHARD_SIZE_BYTES as u64 {
+        return Err(MetadataError::CorruptObject {
+            path: shard_path.to_string(),
+            reason: format!(
+                "shard is {shard_size} bytes; format limit is {MAX_SHARD_SIZE_BYTES} bytes"
+            ),
+        });
+    }
 
     if shard_size < SHARD_V2_TRAILER_SIZE {
         return Ok(None);

--- a/crates/crab-metadata/src/file_index_lookup.rs
+++ b/crates/crab-metadata/src/file_index_lookup.rs
@@ -335,7 +335,12 @@ impl FileIndexLookupSession {
                         let router = self.router.clone();
                         async move {
                             let path = router.shard_path(&shard_hash);
-                            let (body, _) = storage.get_with_etag(&path).await?;
+                            let (body, _) = storage
+                                .get_with_etag_bounded(
+                                    &path,
+                                    crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES as u64,
+                                )
+                                .await?;
                             if crab_xet::hash::compute_data_hash(&body) != shard_hash {
                                 return Err(MetadataError::CorruptObject {
                                     path: path.to_string(),

--- a/crates/crab-metadata/src/git_visibility.rs
+++ b/crates/crab-metadata/src/git_visibility.rs
@@ -725,7 +725,9 @@ mod storage {
                 ),
             });
         }
-        let (body, _) = store.get_with_etag(path).await?;
+        let (body, _) = store
+            .get_with_etag_bounded(path, MAX_GIT_VISIBILITY_INDEX_BYTES)
+            .await?;
         if body.len() as u64 > MAX_GIT_VISIBILITY_INDEX_BYTES {
             return Err(crate::error::MetadataError::CorruptObject {
                 path: path.as_ref().to_owned(),
@@ -922,7 +924,9 @@ mod storage {
                         ),
                     });
                 }
-                let (existing, _) = store.get_with_etag(&path).await?;
+                let (existing, _) = store
+                    .get_with_etag_bounded(&path, MAX_GIT_VISIBILITY_INDEX_BYTES)
+                    .await?;
                 if existing.len() as u64 > MAX_GIT_VISIBILITY_INDEX_BYTES {
                     return Err(crate::error::MetadataError::CorruptObject {
                         path: path.as_ref().to_owned(),
@@ -1003,7 +1007,9 @@ mod storage {
                 ),
             });
         }
-        let (body, _) = store.get_with_etag(&path).await?;
+        let (body, _) = store
+            .get_with_etag_bounded(&path, MAX_GIT_VISIBILITY_INDEX_BYTES)
+            .await?;
         if blake3::hash(&body).to_hex().as_str() != evidence_hash {
             return Err(crate::error::MetadataError::CorruptObject {
                 path: path.as_ref().to_owned(),

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -464,6 +464,24 @@ where
     .await
 }
 
+/// Read a shard index while enforcing a caller-provided record limit.
+pub async fn read_bulk_shard_list_with_limit(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    hash: &str,
+    max_records: u64,
+) -> Result<Vec<String>> {
+    let entries = segmented_store::read_records_with_limit::<ShardSegmentEntry>(
+        store,
+        router,
+        SegmentKind::Shard,
+        hash,
+        max_records,
+    )
+    .await?;
+    Ok(entries.into_iter().map(|entry| entry.shard_hash).collect())
+}
+
 /// Read the segmented pack-index object and parse it into pack records.
 pub async fn read_bulk_pack_list(
     store: &Store,
@@ -473,6 +491,27 @@ pub async fn read_bulk_pack_list(
     let packs =
         segmented_store::read_records::<PackManifestEntry>(store, router, SegmentKind::Pack, hash)
             .await?;
+    for pack in &packs {
+        validate_pack_manifest_entry(pack)?;
+    }
+    Ok(packs)
+}
+
+/// Read a pack index while enforcing a caller-provided record limit.
+pub async fn read_bulk_pack_list_with_limit(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    hash: &str,
+    max_records: u64,
+) -> Result<Vec<PackManifestEntry>> {
+    let packs = segmented_store::read_records_with_limit::<PackManifestEntry>(
+        store,
+        router,
+        SegmentKind::Pack,
+        hash,
+        max_records,
+    )
+    .await?;
     for pack in &packs {
         validate_pack_manifest_entry(pack)?;
     }

--- a/crates/crab-metadata/src/pack_origin.rs
+++ b/crates/crab-metadata/src/pack_origin.rs
@@ -10,6 +10,7 @@ use crab_storage::{StorageError, Store, StoreLayout};
 
 const PACK_ORIGIN_NAMESPACE: &str = "canonical-origin";
 const MAX_STABILITY_ATTEMPTS: usize = 3;
+const MAX_ORIGIN_RECEIPT_BYTES: u64 = 8 * 1024 * 1024;
 
 fn corrupt(path: &str, reason: impl Into<String>) -> MetadataError {
     MetadataError::CorruptObject {
@@ -42,7 +43,10 @@ async fn read_matching_receipt(
     expected_size: u64,
     meta: &ObjectMeta,
 ) -> Result<bool> {
-    let body = match store.get_with_etag(receipt_path).await {
+    let body = match store
+        .get_with_etag_bounded(receipt_path, MAX_ORIGIN_RECEIPT_BYTES)
+        .await
+    {
         Ok((body, _)) => body,
         Err(StorageError::NotFound { .. }) => return Ok(false),
         Err(error) => return Err(error.into()),

--- a/crates/crab-metadata/src/persistent_chunk_index.rs
+++ b/crates/crab-metadata/src/persistent_chunk_index.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 
-use rusqlite::{Connection, ErrorCode, OptionalExtension, params, params_from_iter};
+use rusqlite::{Connection, ErrorCode, OpenFlags, OptionalExtension, params, params_from_iter};
 use tracing::info;
 
 use crate::error::{MetadataError, Result};
@@ -32,10 +32,90 @@ pub struct PersistentChunkIndex {
     path: PathBuf,
 }
 
+/// Non-mutating summary of an existing persistent chunk index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PersistentChunkIndexStats {
+    /// Number of cached chunk-to-xorb mappings.
+    pub entry_count: u64,
+    /// Number of shard installation receipts.
+    pub installed_shard_count: u64,
+    /// Last remote GC generation observed by this cache.
+    pub cache_gc_generation: u64,
+}
+
 static SHARED_INDICES: OnceLock<Mutex<HashMap<PathBuf, Weak<PersistentChunkIndex>>>> =
     OnceLock::new();
 
 impl PersistentChunkIndex {
+    /// Inspect an existing index through a read-only SQLite connection.
+    ///
+    /// Returns `None` when the database file does not exist. Unlike
+    /// [`Self::open_or_create`], this never creates, migrates, repairs, or
+    /// replaces the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the existing database cannot be read or does not
+    /// use the current persistent chunk-index schema.
+    pub fn inspect(path: &Path) -> Result<Option<PersistentChunkIndexStats>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(map_sqlite_err)?;
+        conn.busy_timeout(std::time::Duration::from_secs(5))
+            .map_err(map_sqlite_err)?;
+        let schema: Option<String> = conn
+            .query_row(
+                "SELECT value FROM meta_v1 WHERE key = ?1",
+                params![SCHEMA_VERSION_KEY],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(map_sqlite_err)?;
+        if schema.as_deref() != Some(SCHEMA_VERSION) {
+            return Err(MetadataError::CorruptObject {
+                path: path.display().to_string(),
+                reason: format!("unexpected schema version {schema:?}"),
+            });
+        }
+        let count = |table: &str| -> Result<u64> {
+            let value: i64 = conn
+                .query_row(&format!("SELECT COUNT(1) FROM {table}"), [], |row| {
+                    row.get(0)
+                })
+                .map_err(map_sqlite_err)?;
+            u64::try_from(value).map_err(|error| {
+                MetadataError::Internal(format!("negative row count for {table}: {error}"))
+            })
+        };
+        let raw_generation: Option<String> = conn
+            .query_row(
+                "SELECT value FROM meta_v1 WHERE key = ?1",
+                params![CACHE_GC_GENERATION_KEY],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(map_sqlite_err)?;
+        let cache_gc_generation = match raw_generation {
+            Some(raw) => raw
+                .parse::<u64>()
+                .map_err(|error| MetadataError::CorruptObject {
+                    path: path.display().to_string(),
+                    reason: format!("cache_gc_generation not a u64: {raw:?} ({error})"),
+                })?,
+            None => 0,
+        };
+        Ok(Some(PersistentChunkIndexStats {
+            entry_count: count("chunks_v1")?,
+            installed_shard_count: count("shards_v1")?,
+            cache_gc_generation,
+        }))
+    }
+
     /// Open or reuse the process-wide handle for an index path.
     ///
     /// SQLite permits multiple live connections, but sharing one handle per
@@ -901,6 +981,35 @@ mod tests {
         let idx = PersistentChunkIndex::open_or_create(&path).unwrap();
         assert_eq!(idx.get(&hash(10)).unwrap(), Some(xorb_ref(100, 0)));
         assert_eq!(idx.installed_shards().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn inspect_is_read_only_and_counts_without_loading_rows() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("chunk-index.sqlite");
+        let idx = PersistentChunkIndex::open_or_create(&path).unwrap();
+        idx.install_shard(
+            hash(1),
+            &[(hash(10), xorb_ref(100, 0)), (hash(11), xorb_ref(100, 1))],
+        )
+        .unwrap();
+        idx.set_cache_gc_generation(7).unwrap();
+        drop(idx);
+
+        let stats = PersistentChunkIndex::inspect(&path).unwrap().unwrap();
+
+        assert_eq!(stats.entry_count, 2);
+        assert_eq!(stats.installed_shard_count, 1);
+        assert_eq!(stats.cache_gc_generation, 7);
+    }
+
+    #[test]
+    fn inspect_missing_index_does_not_create_it() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.sqlite");
+
+        assert_eq!(PersistentChunkIndex::inspect(&path).unwrap(), None);
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/crab-metadata/src/ref_registry.rs
+++ b/crates/crab-metadata/src/ref_registry.rs
@@ -174,6 +174,26 @@ impl RefRegistry {
         self.complete_repos.insert(repo_prefix.to_owned());
     }
 
+    /// Replace one committed shard set while preserving concurrent candidates.
+    ///
+    /// Compaction passes the exact source set pinned before manifest CAS and
+    /// the exact replacement set committed by that CAS. Any other entries are
+    /// retained because they may protect an in-flight writer from GC.
+    pub fn reconcile_compaction(
+        &mut self,
+        repo_prefix: &str,
+        source_shards: &HashSet<String>,
+        replacement_shards: &[String],
+    ) {
+        self.schema_version = REF_REGISTRY_SCHEMA_VERSION;
+        let entry = self.repos.entry(repo_prefix.to_owned()).or_default();
+        entry.retain(|hash| !source_shards.contains(hash));
+        entry.extend(replacement_shards.iter().cloned());
+        entry.sort();
+        entry.dedup();
+        self.complete_repos.insert(repo_prefix.to_owned());
+    }
+
     /// Mark bucket-wide repo discovery complete after a manifest repair scan.
     pub fn mark_coverage_complete(&mut self) {
         self.schema_version = REF_REGISTRY_SCHEMA_VERSION;
@@ -792,6 +812,41 @@ pub async fn union_register_repo_shards(
     })
     .await
     .map(|record| record.generation)
+}
+
+/// Remove only the source shards replaced by a committed compaction.
+///
+/// Candidate roots added by concurrent writers remain registered. This may
+/// retain an extra root after a failed writer, but it cannot make live data
+/// collectible.
+#[cfg(feature = "storage")]
+pub async fn reconcile_compacted_repo_shards(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    source_shards: HashSet<String>,
+    replacement_shards: Vec<String>,
+) -> Result<u64> {
+    let registry_path = router.ref_registry_path();
+    let repo_prefix = router.repo_prefix().to_owned();
+    crab_storage::cas::cas_update_default::<RefRegistry, _>(
+        store,
+        registry_path.as_ref(),
+        |registry| {
+            let before = registry
+                .repos
+                .get(&repo_prefix)
+                .cloned()
+                .unwrap_or_default();
+            let was_complete = registry.complete_repos.contains(&repo_prefix);
+            registry.reconcile_compaction(&repo_prefix, &source_shards, &replacement_shards);
+            if registry.repos.get(&repo_prefix) != Some(&before) || !was_complete {
+                registry.generation += 1;
+            }
+        },
+    )
+    .await
+    .map(|registry| registry.generation)
+    .map_err(MetadataError::from)
 }
 
 /// Publish conservative workflow GC roots after immutable experiment
@@ -1469,6 +1524,48 @@ mod tests {
             store.get_with_etag(&target.ref_registry_path()).await,
             Err(crab_storage::StorageError::NotFound { .. })
         ));
+    }
+
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn compaction_reconciliation_preserves_concurrent_candidates() {
+        use std::sync::Arc;
+
+        use object_store::ObjectStore;
+        use object_store::memory::InMemory;
+
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(inner);
+        let router = StoreLayout::new(store.clone(), "org/models".to_owned());
+        union_register_repo_shards(
+            &store,
+            &router,
+            vec!["source-a".to_owned(), "source-b".to_owned()],
+        )
+        .await
+        .unwrap();
+        union_register_repo_shards(&store, &router, vec!["concurrent".to_owned()])
+            .await
+            .unwrap();
+
+        reconcile_compacted_repo_shards(
+            &store,
+            &router,
+            HashSet::from(["source-a".to_owned(), "source-b".to_owned()]),
+            vec!["replacement".to_owned()],
+        )
+        .await
+        .unwrap();
+
+        let (body, _) = store
+            .get_with_etag(&router.ref_registry_path())
+            .await
+            .unwrap();
+        let registry: RefRegistry = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            registry.repos["org/models"],
+            vec!["concurrent".to_owned(), "replacement".to_owned()]
+        );
     }
 
     #[test]

--- a/crates/crab-metadata/src/ref_registry.rs
+++ b/crates/crab-metadata/src/ref_registry.rs
@@ -826,27 +826,57 @@ pub async fn reconcile_compacted_repo_shards(
     source_shards: HashSet<String>,
     replacement_shards: Vec<String>,
 ) -> Result<u64> {
-    let registry_path = router.ref_registry_path();
     let repo_prefix = router.repo_prefix().to_owned();
-    crab_storage::cas::cas_update_default::<RefRegistry, _>(
-        store,
-        registry_path.as_ref(),
-        |registry| {
-            let before = registry
-                .repos
-                .get(&repo_prefix)
-                .cloned()
-                .unwrap_or_default();
-            let was_complete = registry.complete_repos.contains(&repo_prefix);
-            registry.reconcile_compaction(&repo_prefix, &source_shards, &replacement_shards);
-            if registry.repos.get(&repo_prefix) != Some(&before) || !was_complete {
-                registry.generation += 1;
-            }
-        },
-    )
+    let mut partitions = HashMap::<String, (HashSet<String>, Vec<String>)>::new();
+    for hash in source_shards {
+        partitions
+            .entry(shard_root_partition(&hash))
+            .or_default()
+            .0
+            .insert(hash);
+    }
+    for hash in replacement_shards {
+        partitions
+            .entry(shard_root_partition(&hash))
+            .or_default()
+            .1
+            .push(hash);
+    }
+
+    for (partition, (sources, mut replacements)) in partitions {
+        normalize(&mut replacements);
+        let path = shard_root_partition_path(router, &repo_prefix, &partition);
+        let repo_for_update = repo_prefix.clone();
+        let partition_for_update = partition.clone();
+        let root = crab_storage::cas::cas_update_default::<ShardRootPartition, _>(
+            store,
+            path.as_ref(),
+            |root| {
+                if root.repo_prefix.is_empty() {
+                    root.repo_prefix.clone_from(&repo_for_update);
+                    root.partition.clone_from(&partition_for_update);
+                }
+                if root.repo_prefix == repo_for_update && root.partition == partition_for_update {
+                    root.schema_version = REF_REGISTRY_ROOT_SCHEMA_VERSION;
+                    root.shard_hashes.retain(|hash| !sources.contains(hash));
+                    root.shard_hashes.extend(replacements.clone());
+                    normalize(&mut root.shard_hashes);
+                    root.generation = root.generation.saturating_add(1);
+                }
+            },
+        )
+        .await
+        .map_err(MetadataError::from)?;
+        validate_shard_root_partition(&root, router, &path)?;
+    }
+
+    update_repo_record(store, router, |record| {
+        record.schema_version = REF_REGISTRY_RECORD_SCHEMA_VERSION;
+        record.complete = true;
+        record.generation = record.generation.saturating_add(1);
+    })
     .await
-    .map(|registry| registry.generation)
-    .map_err(MetadataError::from)
+    .map(|record| record.generation)
 }
 
 /// Publish conservative workflow GC roots after immutable experiment
@@ -1557,11 +1587,7 @@ mod tests {
         .await
         .unwrap();
 
-        let (body, _) = store
-            .get_with_etag(&router.ref_registry_path())
-            .await
-            .unwrap();
-        let registry: RefRegistry = serde_json::from_slice(&body).unwrap();
+        let registry = load_ref_registry(&store, &router).await.unwrap();
         assert_eq!(
             registry.repos["org/models"],
             vec!["concurrent".to_owned(), "replacement".to_owned()]

--- a/crates/crab-metadata/src/segmented_store.rs
+++ b/crates/crab-metadata/src/segmented_store.rs
@@ -15,6 +15,8 @@ use crate::segmented::{
 
 const MAX_SEGMENT_INDEX_BYTES: usize = 16 * 1024 * 1024;
 const MAX_STREAMED_SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_BOUNDED_METADATA_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_METADATA_RECORDS: u64 = 1_000_000;
 
 fn content_hash(path: &object_store::path::Path, value: &str) -> Result<[u8; 32]> {
     blake3::Hash::from_hex(value)
@@ -61,16 +63,81 @@ pub async fn read_records<T: for<'de> Deserialize<'de>>(
     kind: SegmentKind,
     index_hash: &str,
 ) -> Result<Vec<T>> {
+    read_records_with_limit(store, router, kind, index_hash, MAX_METADATA_RECORDS).await
+}
+
+/// Read records while enforcing a cardinality and byte budget before bodies
+/// are downloaded or decoded.
+pub async fn read_records_with_limit<T: for<'de> Deserialize<'de>>(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    kind: SegmentKind,
+    index_hash: &str,
+    max_records: u64,
+) -> Result<Vec<T>> {
     let index = read_index(store, router, kind, index_hash).await?;
-    let mut out = Vec::with_capacity(index.total_records as usize);
+    if index.total_records > max_records {
+        return Err(MetadataError::CorruptObject {
+            path: index_relative_path(kind, index_hash),
+            reason: format!(
+                "{} metadata index declares {} records, exceeding safety limit {max_records}",
+                kind.as_str(),
+                index.total_records
+            ),
+        });
+    }
+    if index.total_bytes > MAX_BOUNDED_METADATA_BYTES {
+        return Err(MetadataError::CorruptObject {
+            path: index_relative_path(kind, index_hash),
+            reason: format!(
+                "{} metadata index declares {} bytes, exceeding bounded read limit of {MAX_BOUNDED_METADATA_BYTES} bytes",
+                kind.as_str(),
+                index.total_bytes
+            ),
+        });
+    }
+    let capacity = usize::try_from(index.total_records).unwrap_or(0);
+    let mut out = Vec::with_capacity(capacity);
     for segment in &index.segments {
+        if segment.bytes > MAX_BOUNDED_METADATA_BYTES {
+            return Err(MetadataError::CorruptObject {
+                path: segment.path.clone(),
+                reason: format!(
+                    "{} metadata segment declares {} bytes, exceeding bounded read limit of {MAX_BOUNDED_METADATA_BYTES} bytes",
+                    kind.as_str(),
+                    segment.bytes
+                ),
+            });
+        }
         let path = router.repo_path(&segment.path);
         let expected = content_hash(&path, &segment.hash)?;
-        let body = store.verify(&path, &expected).await?;
+        let body = read_verified_bounded(store, &path, &expected).await?;
         let mut records = parse_segment_records::<T>(kind, segment, &body, path.as_ref())?;
         out.append(&mut records);
     }
     Ok(out)
+}
+
+async fn read_verified_bounded(
+    store: &Store,
+    path: &object_store::path::Path,
+    expected: &[u8; 32],
+) -> Result<Bytes> {
+    let (body, _) = store
+        .get_with_etag_bounded(path, MAX_BOUNDED_METADATA_BYTES)
+        .await?;
+    let actual = *blake3::hash(&body).as_bytes();
+    if actual != *expected {
+        return Err(MetadataError::CorruptObject {
+            path: path.as_ref().to_owned(),
+            reason: format!(
+                "expected blake3 {}, got {}",
+                blake3::Hash::from_bytes(*expected).to_hex(),
+                blake3::Hash::from_bytes(actual).to_hex()
+            ),
+        });
+    }
+    Ok(body)
 }
 
 /// Visit records in an ordered segment index without retaining the complete

--- a/crates/crab-read/src/selection.rs
+++ b/crates/crab-read/src/selection.rs
@@ -4,7 +4,10 @@ use crab_metadata::ref_journal::list_active_transactions;
 use crab_metadata::{error::MetadataError, manifest_store, manifests::Manifest};
 use crab_storage::{StorageError, Store, StoreLayout};
 use crab_types::replication::ReplicaConfig;
-use crab_xet::{shard_parse::extract_chunk_entries_streaming, xorb::format::MerkleHash};
+use crab_xet::{
+    shard_parse::{MAX_SHARD_SIZE_BYTES, extract_chunk_entries_streaming},
+    xorb::format::MerkleHash,
+};
 use object_store::path::Path as ObjectPath;
 
 use crate::{ReadError, Result};
@@ -370,7 +373,10 @@ async fn referenced_object_gap(
             let shard_hash = parse_merkle_hash(&shard, "shard")?;
             let shard_path = router.shard_path(&shard_hash);
             stats.object_read_count = stats.object_read_count.saturating_add(1);
-            let shard_bytes = match store.get_with_etag(&shard_path).await {
+            let shard_bytes = match store
+                .get_with_etag_bounded(&shard_path, MAX_SHARD_SIZE_BYTES as u64)
+                .await
+            {
                 Ok((bytes, _etag)) => bytes,
                 Err(StorageError::NotFound { .. }) => {
                     return Ok(Some(format!("shard missing at {}", shard_path.as_ref())));

--- a/crates/crab-read/src/store_client.rs
+++ b/crates/crab-read/src/store_client.rs
@@ -9,6 +9,7 @@ use crab_cache_store::CachingStore;
 use crab_metadata::file_index_lookup::{FileIndexLookupSession, SharedFileIndexLookup};
 use crab_xet::hash::MerkleHash;
 use crab_xet::shard::{MDBFileInfo, ShardReader};
+use crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES;
 use crab_xet::xorb::format::SerializedXorbObject;
 use tracing::{debug, warn};
 use xet_client::cas_client::ShardUploadProgressCallback;
@@ -231,7 +232,9 @@ impl StoreClient {
                 let path = path;
                 async move {
                     debug!(shard_hash = %hash.hex(), "read store_client: downloading shard");
-                    let (data, _) = origin.get_with_etag(&path).await?;
+                    let (data, _) = origin
+                        .get_with_etag_bounded(&path, MAX_SHARD_SIZE_BYTES as u64)
+                        .await?;
                     Ok::<_, ReadError>(data)
                 }
             })

--- a/crates/crab-read/src/term_resolver.rs
+++ b/crates/crab-read/src/term_resolver.rs
@@ -21,6 +21,7 @@ use crab_storage::Store;
 use crab_xet::hash::{MerkleHash, xorb_hash};
 use crab_xet::shard::ShardReader;
 use crab_xet::shard::{FileDataSequenceEntry, XorbChunkSequenceEntry};
+use crab_xet::shard_parse::MAX_SHARD_SIZE_BYTES;
 use crab_xet::xorb::builder::{CHUNK_META_ENTRY_SIZE, FOOTER_SIZE, XORB_MAGIC};
 use tokio_util::sync::CancellationToken;
 
@@ -925,7 +926,9 @@ async fn get_or_download_shard(
             let obj_path = obj_path;
             async move {
                 debug!(shard_hash = %hash.hex(), "downloading shard");
-                let (data, _) = origin.get_with_etag(&obj_path).await?;
+                let (data, _) = origin
+                    .get_with_etag_bounded(&obj_path, MAX_SHARD_SIZE_BYTES as u64)
+                    .await?;
                 Ok::<_, ReadError>(data)
             }
         })

--- a/crates/crab-storage/Cargo.toml
+++ b/crates/crab-storage/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt", "rt-mul
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 url = "2.5"
-xet-core-structures = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/crab-storage/Cargo.toml
+++ b/crates/crab-storage/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt", "rt-mul
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 url = "2.5"
+xet-core-structures = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/crab-storage/src/cas.rs
+++ b/crates/crab-storage/src/cas.rs
@@ -19,6 +19,15 @@ use crate::store::Store;
 /// Default maximum CAS attempts before returning `StateConflict`.
 pub const DEFAULT_MAX_ATTEMPTS: u32 = 10;
 
+/// Maximum JSON object size loaded or written by the default CAS loop.
+///
+/// CAS objects include shared ref registries and other coordination metadata.
+/// Keeping this limit in the storage layer prevents a malformed or unbounded
+/// coordination object from turning every CAS caller into an arbitrary-memory
+/// read. Callers with a smaller domain-specific limit should use
+/// [`cas_update_bounded`].
+pub const MAX_CAS_OBJECT_BYTES: u64 = 512 * 1024 * 1024;
+
 const CAS_BACKOFF_BASE: Duration = Duration::from_millis(50);
 const CAS_BACKOFF_CAP: Duration = Duration::from_millis(500);
 
@@ -37,6 +46,31 @@ where
     T: Serialize + for<'de> Deserialize<'de> + Default + Clone,
     F: Fn(&mut T),
 {
+    cas_update_bounded(store, path, max_attempts, MAX_CAS_OBJECT_BYTES, mutate).await
+}
+
+/// Updates one JSON object with an explicit read/write size ceiling.
+///
+/// Existing objects are rejected before their body is consumed when the
+/// provider advertises a size above `max_bytes`. Newly serialized values are
+/// checked before the conditional write as well, so a successful update can
+/// never create an object the next CAS attempt would refuse to read.
+///
+/// # Errors
+///
+/// Returns [`StorageError::CorruptObject`] when an existing or newly serialized
+/// object exceeds `max_bytes`.
+pub async fn cas_update_bounded<T, F>(
+    store: &Store,
+    path: &str,
+    max_attempts: u32,
+    max_bytes: u64,
+    mutate: F,
+) -> Result<T>
+where
+    T: Serialize + for<'de> Deserialize<'de> + Default + Clone,
+    F: Fn(&mut T),
+{
     let obj_path = Path::from(path);
     let max = if max_attempts == 0 {
         DEFAULT_MAX_ATTEMPTS
@@ -45,7 +79,7 @@ where
     };
 
     for attempt in 0..max {
-        let (mut value, etag) = match store.get_with_etag(&obj_path).await {
+        let (mut value, etag) = match store.get_with_etag_bounded(&obj_path, max_bytes).await {
             Ok((body, etag)) => {
                 let parsed: T = serde_json::from_slice(&body).map_err(|source| {
                     StorageError::CorruptObject {
@@ -62,6 +96,15 @@ where
         mutate(&mut value);
         let new_body = serde_json::to_vec(&value)
             .map_err(|source| StorageError::Internal(format!("CAS serialize: {source}")))?;
+        let new_size = u64::try_from(new_body.len()).unwrap_or(u64::MAX);
+        if new_size > max_bytes {
+            return Err(StorageError::CorruptObject {
+                path: path.to_owned(),
+                reason: format!(
+                    "serialized CAS object is {new_size} bytes; bounded update supports at most {max_bytes} bytes"
+                ),
+            });
+        }
         let new_bytes = Bytes::from(new_body);
 
         let write_result = match etag {
@@ -173,6 +216,40 @@ mod tests {
 
         assert_eq!(result.generation, 2);
         assert_eq!(result.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn bounded_cas_rejects_oversized_existing_object() {
+        let store = memory_store();
+        let path = Path::from("repo/oversized-cas");
+        store
+            .put(&path, Bytes::from_static(b"0123456789"))
+            .await
+            .unwrap();
+
+        let error = cas_update_bounded::<TestManifest, _>(&store, path.as_ref(), 3, 9, |_| {})
+            .await
+            .expect_err("bounded CAS must reject an oversized existing object");
+
+        assert!(matches!(error, StorageError::CorruptObject { .. }));
+    }
+
+    #[tokio::test]
+    async fn bounded_cas_rejects_oversized_serialized_update() {
+        let store = memory_store();
+        let path = "repo/oversized-cas-write";
+
+        let error = cas_update_bounded::<TestManifest, _>(&store, path, 3, 8, |manifest| {
+            manifest.entries.push("0123456789".to_owned())
+        })
+        .await
+        .expect_err("bounded CAS must reject an oversized serialized update");
+
+        assert!(matches!(error, StorageError::CorruptObject { .. }));
+        assert!(matches!(
+            store.get_with_etag(&Path::from(path)).await,
+            Err(StorageError::NotFound { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/crab-storage/src/lib.rs
+++ b/crates/crab-storage/src/lib.rs
@@ -12,7 +12,9 @@ pub mod provider_store;
 pub mod retry;
 pub mod store;
 
-pub use cas::{DEFAULT_MAX_ATTEMPTS, cas_update, cas_update_default};
+pub use cas::{
+    DEFAULT_MAX_ATTEMPTS, MAX_CAS_OBJECT_BYTES, cas_update, cas_update_bounded, cas_update_default,
+};
 pub use crab_types::storage::StorageScope;
 pub use error::{Result, StorageError};
 pub use error_map::{classify_auth_error, map_object_store_error};

--- a/crates/crab-storage/src/store.rs
+++ b/crates/crab-storage/src/store.rs
@@ -31,6 +31,7 @@ use object_store::{
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncReadExt;
 use tracing::debug;
+use xet_core_structures::merklehash::HashedWrite;
 
 use crab_types::storage::StorageScope;
 
@@ -48,6 +49,56 @@ pub type ETag = object_store::UpdateVersion;
 
 /// Bounded-memory byte stream returned by object reads.
 pub type StorageByteStream = Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + 'static>>;
+
+#[derive(Clone, Copy)]
+enum FileHashAlgorithm {
+    Blake3,
+    Xet,
+}
+
+#[derive(Clone, Copy)]
+struct FileHashExpectation {
+    expected: [u8; 32],
+    algorithm: FileHashAlgorithm,
+}
+
+enum FileHasher {
+    Blake3(blake3::Hasher),
+    Xet(HashedWrite<std::io::Sink>),
+}
+
+impl FileHasher {
+    fn new(algorithm: FileHashAlgorithm) -> Self {
+        match algorithm {
+            FileHashAlgorithm::Blake3 => Self::Blake3(blake3::Hasher::new()),
+            FileHashAlgorithm::Xet => Self::Xet(HashedWrite::new(std::io::sink())),
+        }
+    }
+
+    fn update(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Blake3(hasher) => {
+                hasher.update(bytes);
+                Ok(())
+            }
+            Self::Xet(hasher) => std::io::Write::write_all(hasher, bytes),
+        }
+    }
+
+    fn finalize(self) -> [u8; 32] {
+        match self {
+            Self::Blake3(hasher) => *hasher.finalize().as_bytes(),
+            Self::Xet(hasher) => hasher.hash().into(),
+        }
+    }
+}
+
+fn file_hash_algorithm_name(algorithm: FileHashAlgorithm) -> &'static str {
+    match algorithm {
+        FileHashAlgorithm::Blake3 => "blake3",
+        FileHashAlgorithm::Xet => "Xet data hash",
+    }
+}
 
 /// CAS-aware facade over an `object_store::ObjectStore`.
 ///
@@ -737,6 +788,79 @@ impl Store {
         .await
     }
 
+    /// Reads `path` into memory only when the provider advertises and
+    /// delivers at most `max_bytes`.
+    ///
+    /// The metadata check happens before the response stream is consumed, so
+    /// malformed or unexpectedly large immutable objects fail closed without
+    /// allocating their full body. The streamed body is checked again because
+    /// provider metadata and response bytes must agree.
+    pub async fn get_with_etag_bounded(
+        &self,
+        path: &Path,
+        max_bytes: u64,
+    ) -> Result<(Bytes, ETag)> {
+        retry(&self.retry, || {
+            let path = path.clone();
+            async move {
+                let read_inner = self.read_inner_for(&path);
+                self.record_read_request(StorageReadKind::Get);
+                let got = read_inner
+                    .get(&path)
+                    .await
+                    .map_err(|e| map_object_store_error(e, path.as_ref()))?;
+                let expected_size = got.meta.size;
+                if expected_size > max_bytes {
+                    return Err(StorageError::CorruptObject {
+                        path: path.to_string(),
+                        reason: format!(
+                            "object is {expected_size} bytes; bounded read supports at most {max_bytes} bytes"
+                        ),
+                    });
+                }
+                let etag = ETag {
+                    e_tag: got.meta.e_tag.clone(),
+                    version: got.meta.version.clone(),
+                };
+                let capacity = usize::try_from(expected_size).map_err(|_| {
+                    StorageError::Internal(format!(
+                        "object size {expected_size} cannot be represented on this platform"
+                    ))
+                })?;
+                let mut body = Vec::new();
+                body.try_reserve_exact(capacity).map_err(|error| {
+                    StorageError::Internal(format!(
+                        "failed to reserve {expected_size} bytes for bounded object read: {error}"
+                    ))
+                })?;
+                let mut stream = got.into_stream();
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk.map_err(|e| map_object_store_error(e, path.as_ref()))?;
+                    let next_len = body.len().checked_add(chunk.len()).ok_or_else(|| {
+                        StorageError::CorruptObject {
+                            path: path.to_string(),
+                            reason: "object body length overflowed while reading".to_owned(),
+                        }
+                    })?;
+                    let next_size = u64::try_from(next_len).unwrap_or(u64::MAX);
+                    if next_size > max_bytes {
+                        return Err(StorageError::CorruptObject {
+                            path: path.to_string(),
+                            reason: format!(
+                                "streamed body exceeds bounded read limit of {max_bytes} bytes"
+                            ),
+                        });
+                    }
+                    body.extend_from_slice(&chunk);
+                }
+                ensure_complete_body(&path, expected_size, body.len() as u64)?;
+                self.record_read_bytes(body.len() as u64);
+                Ok((Bytes::from(body), etag))
+            }
+        })
+        .await
+    }
+
     /// Reads one exact provider object version and returns its metadata.
     ///
     /// # Errors
@@ -855,6 +979,80 @@ impl Store {
                 file.flush().await?;
                 self.record_read_bytes(written);
                 Ok(written)
+            }
+        })
+        .await
+    }
+
+    /// Stream `path` to a local file while enforcing a maximum body size.
+    ///
+    /// The provider's advertised size is checked before creating the
+    /// destination, and the streamed body is checked again so a changed or
+    /// malformed response cannot fill the workspace beyond the caller's
+    /// bound. Partial files are removed before the error is returned.
+    pub async fn download_to_path_bounded(
+        &self,
+        path: &Path,
+        dest: &std::path::Path,
+        max_bytes: u64,
+    ) -> Result<u64> {
+        retry(&self.retry, || {
+            let path = path.clone();
+            let dest = dest.to_owned();
+            async move {
+                use futures_util::StreamExt;
+                use tokio::io::AsyncWriteExt;
+
+                let _ = tokio::fs::remove_file(&dest).await;
+                let result = async {
+                    let read_inner = self.read_inner_for(&path);
+                    let got = read_inner
+                        .get(&path)
+                        .await
+                        .map_err(|e| map_object_store_error(e, path.as_ref()))?;
+                    if got.meta.size > max_bytes {
+                        return Err(StorageError::CorruptObject {
+                            path: path.as_ref().to_owned(),
+                            reason: format!(
+                                "object advertises {} bytes, bounded download allows {max_bytes}",
+                                got.meta.size
+                            ),
+                        });
+                    }
+                    let expected_size = got.meta.size;
+                    let mut stream = got.into_stream();
+                    let mut file = tokio::fs::File::create(&dest).await?;
+                    let mut written = 0u64;
+
+                    while let Some(chunk) = stream.next().await {
+                        let chunk = chunk.map_err(|e| map_object_store_error(e, path.as_ref()))?;
+                        let next = written.checked_add(chunk.len() as u64).ok_or_else(|| {
+                            StorageError::CorruptObject {
+                                path: path.as_ref().to_owned(),
+                                reason: "streamed body size overflows u64".to_owned(),
+                            }
+                        })?;
+                        if next > max_bytes {
+                            return Err(StorageError::CorruptObject {
+                                path: path.as_ref().to_owned(),
+                                reason: format!(
+                                    "streamed body exceeds bounded download limit of {max_bytes} bytes"
+                                ),
+                            });
+                        }
+                        file.write_all(&chunk).await?;
+                        written = next;
+                    }
+                    file.flush().await?;
+                    ensure_complete_body(&path, expected_size, written)?;
+                    self.record_read_bytes(written);
+                    Ok(written)
+                }
+                .await;
+                if result.is_err() {
+                    let _ = tokio::fs::remove_file(&dest).await;
+                }
+                result
             }
         })
         .await
@@ -1220,6 +1418,11 @@ impl Store {
         cancel: &tokio_util::sync::CancellationToken,
         on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
     ) -> Result<()> {
+        if part_size == 0 {
+            return Err(StorageError::Internal(
+                "multipart part size must be greater than zero".to_owned(),
+            ));
+        }
         let expected_hash = *blake3::hash(&data).as_bytes();
         let size = data.len() as u64;
         let (write_path, write_inner, record_staged_write) = self.exact_write_target(path);
@@ -1261,6 +1464,63 @@ impl Store {
         cancel: &tokio_util::sync::CancellationToken,
         on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
     ) -> Result<()> {
+        self.put_multipart_file_retry_with_algorithm(
+            path,
+            file_path,
+            size,
+            FileHashExpectation {
+                expected: expected_hash,
+                algorithm: FileHashAlgorithm::Blake3,
+            },
+            part_size,
+            cancel,
+            on_part_done,
+        )
+        .await
+    }
+
+    /// Upload a local file while verifying the keyed Xet data hash used by
+    /// Xet metadata shards and xorbs.
+    pub async fn put_multipart_file_retry_with_xet_hash(
+        &self,
+        path: &Path,
+        file_path: &std::path::Path,
+        size: u64,
+        expected_hash: [u8; 32],
+        part_size: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
+    ) -> Result<()> {
+        self.put_multipart_file_retry_with_algorithm(
+            path,
+            file_path,
+            size,
+            FileHashExpectation {
+                expected: expected_hash,
+                algorithm: FileHashAlgorithm::Xet,
+            },
+            part_size,
+            cancel,
+            on_part_done,
+        )
+        .await
+    }
+
+    async fn put_multipart_file_retry_with_algorithm(
+        &self,
+        path: &Path,
+        file_path: &std::path::Path,
+        size: u64,
+        expectation: FileHashExpectation,
+        part_size: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
+    ) -> Result<()> {
+        if part_size == 0 {
+            return Err(StorageError::Internal(
+                "multipart part size must be greater than zero".to_owned(),
+            ));
+        }
         let (write_path, write_inner, record_staged_write) = self.exact_write_target(path);
 
         let result = retry(&self.retry, || {
@@ -1274,6 +1534,7 @@ impl Store {
                     &path,
                     &file_path,
                     size,
+                    expectation,
                     part_size,
                     &cancel,
                     on_part_done,
@@ -1283,7 +1544,7 @@ impl Store {
         })
         .await;
         if result.is_ok() && record_staged_write {
-            self.record_staged_write(path, &write_path, &expected_hash, size);
+            self.record_staged_write(path, &write_path, &expectation.expected, size);
         }
         result
     }
@@ -1386,6 +1647,7 @@ impl Store {
         path: &Path,
         file_path: &std::path::Path,
         size: u64,
+        expectation: FileHashExpectation,
         part_size: usize,
         cancel: &tokio_util::sync::CancellationToken,
         on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
@@ -1409,7 +1671,28 @@ impl Store {
             }
         };
 
-        let mut file = tokio::fs::File::open(file_path).await?;
+        let mut file = match tokio::fs::File::open(file_path).await {
+            Ok(file) => file,
+            Err(error) => {
+                abort_on(upload).await;
+                return Err(error.into());
+            }
+        };
+        let actual_size = match file.metadata().await {
+            Ok(metadata) => metadata.len(),
+            Err(error) => {
+                abort_on(upload).await;
+                return Err(error.into());
+            }
+        };
+        if actual_size != size {
+            abort_on(upload).await;
+            return Err(StorageError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: format!("local file has {actual_size} bytes; upload expects {size}"),
+            });
+        }
+        let mut hasher = FileHasher::new(expectation.algorithm);
         let mut remaining = size;
         let mut pending = FuturesUnordered::new();
         while remaining > 0 {
@@ -1439,7 +1722,11 @@ impl Store {
 
             let want = std::cmp::min(part_size as u64, remaining) as usize;
             let mut buf = vec![0u8; want];
-            file.read_exact(&mut buf).await?;
+            if let Err(error) = file.read_exact(&mut buf).await {
+                abort_on(upload).await;
+                return Err(error.into());
+            }
+            hasher.update(&buf)?;
             remaining -= want as u64;
 
             let bytes = want as u64;
@@ -1459,6 +1746,36 @@ impl Store {
                     return Err(map_object_store_error(e, path.as_ref()));
                 }
             }
+        }
+
+        let actual_hash = hasher.finalize();
+        if actual_hash != expectation.expected {
+            abort_on(upload).await;
+            return Err(StorageError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: format!(
+                    "local {} hash {} does not match expected {}",
+                    file_hash_algorithm_name(expectation.algorithm),
+                    hex_lower(&actual_hash),
+                    hex_lower(&expectation.expected)
+                ),
+            });
+        }
+        let final_size = match file.metadata().await {
+            Ok(metadata) => metadata.len(),
+            Err(error) => {
+                abort_on(upload).await;
+                return Err(error.into());
+            }
+        };
+        if final_size != size {
+            abort_on(upload).await;
+            return Err(StorageError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: format!(
+                    "local file changed during upload: expected {size} bytes, found {final_size}"
+                ),
+            });
         }
 
         if cancel.is_cancelled() {
@@ -1659,6 +1976,74 @@ mod tests {
         store.put(&path, body.clone()).await.unwrap();
         let (got, _etag) = store.get_with_etag(&path).await.unwrap();
         assert_eq!(got, body);
+    }
+
+    #[tokio::test]
+    async fn bounded_get_rejects_objects_before_consuming_oversized_body() {
+        let store = memory_store();
+        let path = Path::from("blobs/oversized");
+        store
+            .put(&path, Bytes::from_static(b"0123456789"))
+            .await
+            .unwrap();
+
+        let error = store
+            .get_with_etag_bounded(&path, 9)
+            .await
+            .expect_err("bounded read must reject an oversized object");
+        assert!(matches!(error, StorageError::CorruptObject { .. }));
+    }
+
+    #[tokio::test]
+    async fn bounded_get_roundtrips_objects_at_the_limit() {
+        let store = memory_store();
+        let path = Path::from("blobs/bounded");
+        let body = Bytes::from_static(b"0123456789");
+        store.put(&path, body.clone()).await.unwrap();
+
+        let (got, _etag) = store
+            .get_with_etag_bounded(&path, body.len() as u64)
+            .await
+            .unwrap();
+        assert_eq!(got, body);
+    }
+
+    #[tokio::test]
+    async fn bounded_download_rejects_oversized_objects_before_creating_file() {
+        let store = memory_store();
+        let path = Path::from("blobs/oversized-download");
+        store
+            .put(&path, Bytes::from_static(b"0123456789"))
+            .await
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("download");
+
+        let error = store
+            .download_to_path_bounded(&path, &dest, 9)
+            .await
+            .expect_err("bounded download must reject an oversized object");
+
+        assert!(matches!(error, StorageError::CorruptObject { .. }));
+        assert!(!dest.exists());
+    }
+
+    #[tokio::test]
+    async fn bounded_download_roundtrips_objects_at_the_limit() {
+        let store = memory_store();
+        let path = Path::from("blobs/bounded-download");
+        let body = Bytes::from_static(b"0123456789");
+        store.put(&path, body.clone()).await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("download");
+
+        let size = store
+            .download_to_path_bounded(&path, &dest, body.len() as u64)
+            .await
+            .unwrap();
+
+        assert_eq!(size, body.len() as u64);
+        assert_eq!(std::fs::read(dest).unwrap(), body);
     }
 
     #[tokio::test]
@@ -1989,6 +2374,103 @@ mod tests {
                 size: body.len() as u64,
             }]
         );
+    }
+
+    #[tokio::test]
+    async fn multipart_file_rejects_hash_mismatch_before_completion() {
+        let store = memory_store();
+        let path = Path::from("blobs/file-hash-mismatch");
+        let body = Bytes::from_static(b"file body");
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, &body).await.unwrap();
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let error = store
+            .put_multipart_file_retry(&path, &source, body.len() as u64, [0; 32], 3, &cancel, None)
+            .await
+            .expect_err("multipart file upload must verify its expected hash");
+        assert!(matches!(error, StorageError::CorruptObject { .. }));
+        assert!(matches!(
+            store.head(&path).await,
+            Err(StorageError::NotFound { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn multipart_file_verifies_keyed_xet_hash() {
+        let store = memory_store();
+        let path = Path::from("blobs/xet-hash");
+        let body = Bytes::from_static(b"keyed Xet body");
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, &body).await.unwrap();
+        let mut hasher = xet_core_structures::merklehash::HashedWrite::new(std::io::sink());
+        std::io::Write::write_all(&mut hasher, &body).unwrap();
+        let expected_hash: [u8; 32] = hasher.hash().into();
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        store
+            .put_multipart_file_retry_with_xet_hash(
+                &path,
+                &source,
+                body.len() as u64,
+                expected_hash,
+                3,
+                &cancel,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let (got, _) = store.get_with_etag(&path).await.unwrap();
+        assert_eq!(got, body);
+    }
+
+    #[tokio::test]
+    async fn multipart_file_rejects_size_mismatch_before_upload() {
+        let store = memory_store();
+        let path = Path::from("blobs/file-size-mismatch");
+        let body = Bytes::from_static(b"file body");
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, &body).await.unwrap();
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let error = store
+            .put_multipart_file_retry(
+                &path,
+                &source,
+                body.len() as u64 + 1,
+                *blake3::hash(&body).as_bytes(),
+                3,
+                &cancel,
+                None,
+            )
+            .await
+            .expect_err("multipart file upload must verify its expected size");
+        assert!(matches!(error, StorageError::CorruptObject { .. }));
+        assert!(matches!(
+            store.head(&path).await,
+            Err(StorageError::NotFound { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn multipart_upload_rejects_zero_part_size() {
+        let store = memory_store();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let error = store
+            .put_multipart_retry(
+                &Path::from("blobs/zero-part"),
+                Bytes::from_static(b"body"),
+                0,
+                &cancel,
+                None,
+            )
+            .await
+            .expect_err("zero-sized multipart parts are invalid");
+        assert!(matches!(error, StorageError::Internal(_)));
     }
 
     #[tokio::test]

--- a/crates/crab-storage/src/store.rs
+++ b/crates/crab-storage/src/store.rs
@@ -31,7 +31,6 @@ use object_store::{
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncReadExt;
 use tracing::debug;
-use xet_core_structures::merklehash::HashedWrite;
 
 use crab_types::storage::StorageScope;
 
@@ -49,56 +48,6 @@ pub type ETag = object_store::UpdateVersion;
 
 /// Bounded-memory byte stream returned by object reads.
 pub type StorageByteStream = Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + 'static>>;
-
-#[derive(Clone, Copy)]
-enum FileHashAlgorithm {
-    Blake3,
-    Xet,
-}
-
-#[derive(Clone, Copy)]
-struct FileHashExpectation {
-    expected: [u8; 32],
-    algorithm: FileHashAlgorithm,
-}
-
-enum FileHasher {
-    Blake3(blake3::Hasher),
-    Xet(HashedWrite<std::io::Sink>),
-}
-
-impl FileHasher {
-    fn new(algorithm: FileHashAlgorithm) -> Self {
-        match algorithm {
-            FileHashAlgorithm::Blake3 => Self::Blake3(blake3::Hasher::new()),
-            FileHashAlgorithm::Xet => Self::Xet(HashedWrite::new(std::io::sink())),
-        }
-    }
-
-    fn update(&mut self, bytes: &[u8]) -> std::io::Result<()> {
-        match self {
-            Self::Blake3(hasher) => {
-                hasher.update(bytes);
-                Ok(())
-            }
-            Self::Xet(hasher) => std::io::Write::write_all(hasher, bytes),
-        }
-    }
-
-    fn finalize(self) -> [u8; 32] {
-        match self {
-            Self::Blake3(hasher) => *hasher.finalize().as_bytes(),
-            Self::Xet(hasher) => hasher.hash().into(),
-        }
-    }
-}
-
-fn file_hash_algorithm_name(algorithm: FileHashAlgorithm) -> &'static str {
-    match algorithm {
-        FileHashAlgorithm::Blake3 => "blake3",
-        FileHashAlgorithm::Xet => "Xet data hash",
-    }
-}
 
 /// CAS-aware facade over an `object_store::ObjectStore`.
 ///
@@ -1464,58 +1413,6 @@ impl Store {
         cancel: &tokio_util::sync::CancellationToken,
         on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
     ) -> Result<()> {
-        self.put_multipart_file_retry_with_algorithm(
-            path,
-            file_path,
-            size,
-            FileHashExpectation {
-                expected: expected_hash,
-                algorithm: FileHashAlgorithm::Blake3,
-            },
-            part_size,
-            cancel,
-            on_part_done,
-        )
-        .await
-    }
-
-    /// Upload a local file while verifying the keyed Xet data hash used by
-    /// Xet metadata shards and xorbs.
-    pub async fn put_multipart_file_retry_with_xet_hash(
-        &self,
-        path: &Path,
-        file_path: &std::path::Path,
-        size: u64,
-        expected_hash: [u8; 32],
-        part_size: usize,
-        cancel: &tokio_util::sync::CancellationToken,
-        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
-    ) -> Result<()> {
-        self.put_multipart_file_retry_with_algorithm(
-            path,
-            file_path,
-            size,
-            FileHashExpectation {
-                expected: expected_hash,
-                algorithm: FileHashAlgorithm::Xet,
-            },
-            part_size,
-            cancel,
-            on_part_done,
-        )
-        .await
-    }
-
-    async fn put_multipart_file_retry_with_algorithm(
-        &self,
-        path: &Path,
-        file_path: &std::path::Path,
-        size: u64,
-        expectation: FileHashExpectation,
-        part_size: usize,
-        cancel: &tokio_util::sync::CancellationToken,
-        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
-    ) -> Result<()> {
         if part_size == 0 {
             return Err(StorageError::Internal(
                 "multipart part size must be greater than zero".to_owned(),
@@ -1534,7 +1431,7 @@ impl Store {
                     &path,
                     &file_path,
                     size,
-                    expectation,
+                    expected_hash,
                     part_size,
                     &cancel,
                     on_part_done,
@@ -1544,7 +1441,7 @@ impl Store {
         })
         .await;
         if result.is_ok() && record_staged_write {
-            self.record_staged_write(path, &write_path, &expectation.expected, size);
+            self.record_staged_write(path, &write_path, &expected_hash, size);
         }
         result
     }
@@ -1647,7 +1544,7 @@ impl Store {
         path: &Path,
         file_path: &std::path::Path,
         size: u64,
-        expectation: FileHashExpectation,
+        expected_hash: [u8; 32],
         part_size: usize,
         cancel: &tokio_util::sync::CancellationToken,
         on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
@@ -1692,7 +1589,7 @@ impl Store {
                 reason: format!("local file has {actual_size} bytes; upload expects {size}"),
             });
         }
-        let mut hasher = FileHasher::new(expectation.algorithm);
+        let mut hasher = blake3::Hasher::new();
         let mut remaining = size;
         let mut pending = FuturesUnordered::new();
         while remaining > 0 {
@@ -1726,7 +1623,7 @@ impl Store {
                 abort_on(upload).await;
                 return Err(error.into());
             }
-            hasher.update(&buf)?;
+            hasher.update(&buf);
             remaining -= want as u64;
 
             let bytes = want as u64;
@@ -1748,16 +1645,15 @@ impl Store {
             }
         }
 
-        let actual_hash = hasher.finalize();
-        if actual_hash != expectation.expected {
+        let actual_hash = *hasher.finalize().as_bytes();
+        if actual_hash != expected_hash {
             abort_on(upload).await;
             return Err(StorageError::CorruptObject {
                 path: file_path.display().to_string(),
                 reason: format!(
-                    "local {} hash {} does not match expected {}",
-                    file_hash_algorithm_name(expectation.algorithm),
+                    "local blake3 hash {} does not match expected {}",
                     hex_lower(&actual_hash),
-                    hex_lower(&expectation.expected)
+                    hex_lower(&expected_hash)
                 ),
             });
         }
@@ -2395,36 +2291,6 @@ mod tests {
             store.head(&path).await,
             Err(StorageError::NotFound { .. })
         ));
-    }
-
-    #[tokio::test]
-    async fn multipart_file_verifies_keyed_xet_hash() {
-        let store = memory_store();
-        let path = Path::from("blobs/xet-hash");
-        let body = Bytes::from_static(b"keyed Xet body");
-        let dir = tempfile::tempdir().unwrap();
-        let source = dir.path().join("payload");
-        tokio::fs::write(&source, &body).await.unwrap();
-        let mut hasher = xet_core_structures::merklehash::HashedWrite::new(std::io::sink());
-        std::io::Write::write_all(&mut hasher, &body).unwrap();
-        let expected_hash: [u8; 32] = hasher.hash().into();
-        let cancel = tokio_util::sync::CancellationToken::new();
-
-        store
-            .put_multipart_file_retry_with_xet_hash(
-                &path,
-                &source,
-                body.len() as u64,
-                expected_hash,
-                3,
-                &cancel,
-                None,
-            )
-            .await
-            .unwrap();
-
-        let (got, _) = store.get_with_etag(&path).await.unwrap();
-        assert_eq!(got, body);
     }
 
     #[tokio::test]

--- a/crates/crab-workflow/src/cache.rs
+++ b/crates/crab-workflow/src/cache.rs
@@ -13,15 +13,18 @@
 //! write. A v1→v1 identity migration scaffolds the ladder.
 
 use std::collections::BTreeMap;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::Serialize;
+use tokio_util::sync::CancellationToken;
 
 use crate::stage::OutKind;
 use crate::stage_cache_entry::{
-    decode_b3_hash, validate_stage_cache_entry, validate_stage_cache_entry_at,
+    MAX_STAGE_CACHE_ARTIFACT_BYTES, MAX_STAGE_CACHE_ENTRY_BYTES, decode_b3_hash,
+    validate_stage_cache_entry, validate_stage_cache_entry_at,
 };
 pub use crate::{
     CachedCmd, CachedOut, ENTRY_SCHEMA_MAX_SUPPORTED, ENTRY_SCHEMA_VERSION, StageCacheEntry,
@@ -145,10 +148,12 @@ pub fn read_local(cache_root: &Path, hash: &StageHash) -> Result<Option<StageCac
         return Ok(None);
     }
     let path = entry_path(cache_root, hash);
-    let bytes = match std::fs::read(&path) {
-        Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(CrabError::Io(e)),
+    let bytes = match read_stage_cache_file_bounded(&path, &hash.as_hex()) {
+        Ok(bytes) => bytes,
+        Err(CrabError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
     };
 
     let raw: serde_json::Value =
@@ -216,6 +221,15 @@ pub fn write_local(cache_root: &Path, entry: &StageCacheEntry) -> Result<()> {
         })?;
     }
     let bytes = canonical_json(entry)?;
+    if bytes.len() > MAX_STAGE_CACHE_ENTRY_BYTES {
+        return Err(CrabError::CacheEntryInvalid {
+            stage_hash: entry.stage_hash.as_hex(),
+            detail: format!(
+                "stage cache manifest is {} bytes; safety limit is {MAX_STAGE_CACHE_ENTRY_BYTES}",
+                bytes.len()
+            ),
+        });
+    }
     match atomic_write(&path, &bytes) {
         Ok(()) => Ok(()),
         Err(CrabError::Io(e)) if is_permission_or_readonly(&e) => {
@@ -261,7 +275,7 @@ pub fn store_local_xorbs<'a>(
                 } else {
                     base.join(&out.path)
                 };
-                let bytes = std::fs::read(&source).map_err(CrabError::Io)?;
+                let bytes = read_artifact_file_bounded(&source, &out.file_hash)?;
                 write_local_xorb(cache_root, &out.file_hash, &bytes)?;
             }
             OutKind::Directory => {
@@ -277,7 +291,8 @@ pub fn store_local_xorbs<'a>(
                     if entry.kind == "dir" {
                         continue;
                     }
-                    let bytes = std::fs::read(root.join(&entry.path)).map_err(CrabError::Io)?;
+                    let path = root.join(&entry.path);
+                    let bytes = read_artifact_file_bounded(&path, &entry.hash)?;
                     write_local_xorb(cache_root, &entry.hash, &bytes)?;
                 }
             }
@@ -293,25 +308,25 @@ pub fn read_local_xorb(cache_root: &Path, xorb_hash: &str) -> Result<Option<Vec<
     }
 
     let path = local_xorb_path(cache_root, xorb_hash)?;
-    let bytes = match std::fs::read(&path) {
+    let bytes = match read_artifact_file_bounded(&path, xorb_hash) {
         Ok(bytes) => bytes,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(CrabError::Io(e)),
+        Err(CrabError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
     };
-
-    let actual = format!("b3:{}", blake3::hash(&bytes).to_hex());
-    if actual != xorb_hash {
-        return Err(CrabError::CacheEntryCorrupt {
-            stage_hash: String::new(),
-            path: path.display().to_string(),
-            expected: xorb_hash.to_owned(),
-            actual,
-        });
-    }
     Ok(Some(bytes))
 }
 
 fn write_local_xorb(cache_root: &Path, xorb_hash: &str, bytes: &[u8]) -> Result<()> {
+    if bytes.len() as u64 > MAX_STAGE_CACHE_ARTIFACT_BYTES {
+        return Err(CrabError::CacheEntryCorrupt {
+            stage_hash: String::new(),
+            path: xorb_hash.to_owned(),
+            expected: format!("at most {MAX_STAGE_CACHE_ARTIFACT_BYTES} bytes"),
+            actual: format!("{} bytes", bytes.len()),
+        });
+    }
     let path = local_xorb_path(cache_root, xorb_hash)?;
     if path.exists() {
         return Ok(());
@@ -341,6 +356,70 @@ fn write_local_xorb(cache_root: &Path, xorb_hash: &str, bytes: &[u8]) -> Result<
         }
         Err(other) => Err(other),
     }
+}
+
+fn read_artifact_file_bounded(path: &Path, expected_hash: &str) -> Result<Vec<u8>> {
+    let metadata = std::fs::metadata(path).map_err(CrabError::Io)?;
+    if metadata.len() > MAX_STAGE_CACHE_ARTIFACT_BYTES {
+        return Err(CrabError::CacheEntryCorrupt {
+            stage_hash: String::new(),
+            path: path.display().to_string(),
+            expected: format!("{expected_hash} and at most {MAX_STAGE_CACHE_ARTIFACT_BYTES} bytes"),
+            actual: format!("{} bytes", metadata.len()),
+        });
+    }
+
+    let file = std::fs::File::open(path).map_err(CrabError::Io)?;
+    let mut bytes = Vec::new();
+    file.take(MAX_STAGE_CACHE_ARTIFACT_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(CrabError::Io)?;
+    if bytes.len() as u64 > MAX_STAGE_CACHE_ARTIFACT_BYTES {
+        return Err(CrabError::CacheEntryCorrupt {
+            stage_hash: String::new(),
+            path: path.display().to_string(),
+            expected: format!("{expected_hash} and at most {MAX_STAGE_CACHE_ARTIFACT_BYTES} bytes"),
+            actual: format!("{} bytes", bytes.len()),
+        });
+    }
+    let actual_hash = format!("b3:{}", blake3::hash(&bytes).to_hex());
+    if actual_hash != expected_hash {
+        return Err(CrabError::CacheEntryCorrupt {
+            stage_hash: String::new(),
+            path: path.display().to_string(),
+            expected: expected_hash.to_owned(),
+            actual: actual_hash,
+        });
+    }
+    Ok(bytes)
+}
+
+fn read_stage_cache_file_bounded(path: &Path, stage_hash: &str) -> Result<Vec<u8>> {
+    let metadata = std::fs::metadata(path).map_err(CrabError::Io)?;
+    if metadata.len() > MAX_STAGE_CACHE_ENTRY_BYTES as u64 {
+        return Err(CrabError::CacheEntryInvalid {
+            stage_hash: stage_hash.to_owned(),
+            detail: format!(
+                "stage cache manifest is {} bytes; safety limit is {MAX_STAGE_CACHE_ENTRY_BYTES}",
+                metadata.len()
+            ),
+        });
+    }
+
+    let file = std::fs::File::open(path).map_err(CrabError::Io)?;
+    let mut bytes = Vec::new();
+    file.take(MAX_STAGE_CACHE_ENTRY_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(CrabError::Io)?;
+    if bytes.len() > MAX_STAGE_CACHE_ENTRY_BYTES {
+        return Err(CrabError::CacheEntryInvalid {
+            stage_hash: stage_hash.to_owned(),
+            detail: format!(
+                "stage cache manifest is larger than the safety limit of {MAX_STAGE_CACHE_ENTRY_BYTES} bytes"
+            ),
+        });
+    }
+    Ok(bytes)
 }
 
 fn local_xorb_path(cache_root: &Path, xorb_hash: &str) -> Result<PathBuf> {
@@ -686,6 +765,25 @@ fn remote_xorb_path(prefix: &str, xorb_hash: &str) -> ObjectPath {
     ObjectPath::from(format!("{prefix}/workflow/xorbs/{xorb_hash}.xorb"))
 }
 
+async fn get_remote_bounded(store: &Store, path: &ObjectPath, max_bytes: u64) -> Result<Bytes> {
+    let metadata = store.head(path).await?;
+    if metadata.size > max_bytes {
+        return Err(CrabError::CacheEntryInvalid {
+            stage_hash: String::new(),
+            detail: format!(
+                "remote workflow cache object {} is {} bytes; safety limit is {max_bytes}",
+                path, metadata.size
+            ),
+        });
+    }
+    let (bytes, _) = store
+        .as_storage()
+        .get_with_etag_bounded(path, max_bytes)
+        .await
+        .map_err(CrabError::from)?;
+    Ok(bytes)
+}
+
 fn remote_ref_path(prefix: &str, stage_hash: &StageHash) -> ObjectPath {
     let hex = stage_hash.as_hex();
     ObjectPath::from(format!("{prefix}/refs/crab/stages/{hex}"))
@@ -814,6 +912,15 @@ async fn push_remote_inner(
     // Step 2: Upload the manifest JSON.
     let manifest_path = remote_manifest_path(prefix, stage_hash);
     let manifest_bytes = canonical_json(entry)?;
+    if manifest_bytes.len() > MAX_STAGE_CACHE_ENTRY_BYTES {
+        return Err(CrabError::CacheEntryInvalid {
+            stage_hash: stage_hash.as_hex(),
+            detail: format!(
+                "stage cache manifest is {} bytes; safety limit is {MAX_STAGE_CACHE_ENTRY_BYTES}",
+                manifest_bytes.len()
+            ),
+        });
+    }
     store
         .put(&manifest_path, Bytes::from(manifest_bytes))
         .await?;
@@ -999,14 +1106,29 @@ fn xorb_bytes_for_remote_push(
     xorb_hash: &str,
     local_path: &Path,
 ) -> Result<Option<Vec<u8>>> {
-    if let Some(bytes) = read_local_xorb(cache_root, xorb_hash)? {
-        return Ok(Some(bytes));
-    }
-
-    let bytes = match std::fs::read(local_path) {
-        Ok(bytes) => bytes,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(CrabError::Io(e)),
+    let bytes = if let Some(bytes) = read_local_xorb(cache_root, xorb_hash)? {
+        bytes
+    } else {
+        let metadata = match std::fs::metadata(local_path) {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(CrabError::Io(e)),
+        };
+        if metadata.len() > MAX_STAGE_CACHE_ARTIFACT_BYTES {
+            return Err(CrabError::CacheEntryCorrupt {
+                stage_hash: stage_hash.as_hex(),
+                path: local_path.display().to_string(),
+                expected: format!("at most {MAX_STAGE_CACHE_ARTIFACT_BYTES} bytes"),
+                actual: format!("{} bytes", metadata.len()),
+            });
+        }
+        match read_artifact_file_bounded(local_path, xorb_hash) {
+            Ok(bytes) => bytes,
+            Err(CrabError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        }
     };
 
     let actual = format!("b3:{}", blake3::hash(&bytes).to_hex());
@@ -1054,25 +1176,26 @@ pub async fn pull_remote_with_artifact_stores(
 ) -> Result<Option<StageCacheEntry>> {
     // Step 1: Download the manifest.
     let manifest_path = remote_manifest_path(prefix, stage_hash);
-    let manifest_bytes = match store.get_with_etag(&manifest_path).await {
-        Ok((bytes, _)) => bytes,
-        Err(CrabError::NotFound { .. }) => {
-            debug!(stage_hash = %stage_hash, "remote cache miss: manifest not found");
-            return Ok(None);
-        }
-        Err(CrabError::Storage(ref e)) if is_not_found_storage(e) => {
-            debug!(stage_hash = %stage_hash, "remote cache miss: manifest not found (storage)");
-            return Ok(None);
-        }
-        Err(e) => {
-            debug!(
-                stage_hash = %stage_hash,
-                error = %e,
-                "remote cache pull failed during manifest download"
-            );
-            return Ok(None);
-        }
-    };
+    let manifest_bytes =
+        match get_remote_bounded(store, &manifest_path, MAX_STAGE_CACHE_ENTRY_BYTES as u64).await {
+            Ok(bytes) => bytes,
+            Err(CrabError::NotFound { .. }) => {
+                debug!(stage_hash = %stage_hash, "remote cache miss: manifest not found");
+                return Ok(None);
+            }
+            Err(CrabError::Storage(ref e)) if is_not_found_storage(e) => {
+                debug!(stage_hash = %stage_hash, "remote cache miss: manifest not found (storage)");
+                return Ok(None);
+            }
+            Err(e) => {
+                debug!(
+                    stage_hash = %stage_hash,
+                    error = %e,
+                    "remote cache pull failed during manifest download"
+                );
+                return Ok(None);
+            }
+        };
 
     // Step 2: Parse and verify the manifest.
     let entry: StageCacheEntry = match serde_json::from_slice(&manifest_bytes) {
@@ -1119,8 +1242,14 @@ pub async fn pull_remote_with_artifact_stores(
         match out.kind {
             OutKind::File | OutKind::Stdout => {
                 let xorb_path = remote_xorb_path(target.prefix, &out.file_hash);
-                let xorb_bytes = match target.store.get_with_etag(&xorb_path).await {
-                    Ok((bytes, _)) => bytes,
+                let xorb_bytes = match get_remote_bounded(
+                    target.store,
+                    &xorb_path,
+                    MAX_STAGE_CACHE_ARTIFACT_BYTES,
+                )
+                .await
+                {
+                    Ok(bytes) => bytes,
                     Err(e) => {
                         debug!(
                             stage_hash = %stage_hash,
@@ -1177,8 +1306,14 @@ pub async fn pull_remote_with_artifact_stores(
                             continue;
                         }
                         let file_xorb_path = remote_xorb_path(target.prefix, &tree_entry.hash);
-                        let file_bytes = match target.store.get_with_etag(&file_xorb_path).await {
-                            Ok((bytes, _)) => bytes,
+                        let file_bytes = match get_remote_bounded(
+                            target.store,
+                            &file_xorb_path,
+                            MAX_STAGE_CACHE_ARTIFACT_BYTES,
+                        )
+                        .await
+                        {
+                            Ok(bytes) => bytes,
                             Err(e) => {
                                 debug!(
                                     stage_hash = %stage_hash,
@@ -1279,7 +1414,14 @@ pub async fn push_all_local(
     prefix: &str,
     cache_root: &Path,
 ) -> Result<PushAllResult> {
-    push_all_local_with_artifact_stores(store, prefix, None, cache_root).await
+    push_all_local_with_artifact_stores_and_cancel(
+        store,
+        prefix,
+        None,
+        cache_root,
+        &CancellationToken::new(),
+    )
+    .await
 }
 
 pub async fn push_all_local_with_artifact_stores(
@@ -1288,6 +1430,29 @@ pub async fn push_all_local_with_artifact_stores(
     artifact_stores: Option<&RemoteArtifactStores>,
     cache_root: &Path,
 ) -> Result<PushAllResult> {
+    push_all_local_with_artifact_stores_and_cancel(
+        store,
+        prefix,
+        artifact_stores,
+        cache_root,
+        &CancellationToken::new(),
+    )
+    .await
+}
+
+/// Scan and push local stage cache entries while honoring cancellation.
+pub async fn push_all_local_with_artifact_stores_and_cancel(
+    store: &Store,
+    prefix: &str,
+    artifact_stores: Option<&RemoteArtifactStores>,
+    cache_root: &Path,
+    cancel: &CancellationToken,
+) -> Result<PushAllResult> {
+    const MAX_LOCAL_STAGE_CACHE_ENTRIES: usize = 1_000_000;
+
+    if cancel.is_cancelled() {
+        return Err(CrabError::Cancelled);
+    }
     let stages_dir = cache_root.join("stages");
     let mut pushed = 0u32;
     let mut skipped = 0u32;
@@ -1303,7 +1468,11 @@ pub async fn push_all_local_with_artifact_stores(
 
     // Walk the 2-char shard directories.
     let shards = std::fs::read_dir(&stages_dir).map_err(CrabError::Io)?;
+    let mut scanned_entries = 0usize;
     for shard_entry in shards {
+        if cancel.is_cancelled() {
+            return Err(CrabError::Cancelled);
+        }
         let shard_entry = shard_entry.map_err(CrabError::Io)?;
         let shard_path = shard_entry.path();
         if !shard_path.is_dir() {
@@ -1312,6 +1481,9 @@ pub async fn push_all_local_with_artifact_stores(
 
         let files = std::fs::read_dir(&shard_path).map_err(CrabError::Io)?;
         for file_entry in files {
+            if cancel.is_cancelled() {
+                return Err(CrabError::Cancelled);
+            }
             let file_entry = file_entry.map_err(CrabError::Io)?;
             let file_path = file_entry.path();
             let Some(ext) = file_path.extension() else {
@@ -1320,51 +1492,66 @@ pub async fn push_all_local_with_artifact_stores(
             if ext != "json" {
                 continue;
             }
+            scanned_entries = scanned_entries.saturating_add(1);
+            if scanned_entries > MAX_LOCAL_STAGE_CACHE_ENTRIES {
+                return Err(CrabError::Configuration {
+                    key: "workflow cache entry count".to_owned(),
+                    origin: format!(
+                        "local stage cache contains more than {MAX_LOCAL_STAGE_CACHE_ENTRIES} entries"
+                    ),
+                });
+            }
 
             // Read and parse the entry.
-            let bytes = match std::fs::read(&file_path) {
-                Ok(b) => b,
-                Err(_) => {
-                    errors += 1;
+            let bytes = match read_stage_cache_file_bounded(&file_path, "") {
+                Ok(bytes) => bytes,
+                Err(error) => {
+                    warn!(path = %file_path.display(), error = %error, "failed to read local stage cache entry");
+                    errors = errors.saturating_add(1);
                     continue;
                 }
             };
             let entry: StageCacheEntry = match serde_json::from_slice(&bytes) {
                 Ok(e) => e,
-                Err(_) => {
-                    errors += 1;
+                Err(error) => {
+                    warn!(path = %file_path.display(), error = %error, "failed to parse local stage cache entry");
+                    errors = errors.saturating_add(1);
                     continue;
                 }
             };
 
-            if validate_stage_cache_entry_at(&entry, cache_validation_root(cache_root)).is_err() {
-                errors += 1;
+            if let Err(error) =
+                validate_stage_cache_entry_at(&entry, cache_validation_root(cache_root))
+            {
+                warn!(path = %file_path.display(), error = %error, "local stage cache entry failed validation");
+                errors = errors.saturating_add(1);
                 continue;
             }
 
             if !entry.remote_push_enabled() {
-                skipped += 1;
+                skipped = skipped.saturating_add(1);
                 continue;
             }
 
-            match push_remote_with_artifact_stores(
-                store,
-                prefix,
-                artifact_stores,
-                &entry,
-                cache_root,
-            )
-            .await
-            {
-                Ok(true) => pushed += 1,
-                Ok(false) => skipped += 1,
+            match tokio::select! {
+                result = push_remote_with_artifact_stores(
+                    store,
+                    prefix,
+                    artifact_stores,
+                    &entry,
+                    cache_root,
+                ) => result,
+                () = cancel.cancelled() => return Err(CrabError::Cancelled),
+            } {
+                Ok(true) => pushed = pushed.saturating_add(1),
+                Ok(false) => skipped = skipped.saturating_add(1),
                 Err(e) => {
                     warn!(
                         stage = %entry.stage_name,
                         error = %e,
                         "failed to push stage cache entry to remote"
                     );
-                    errors += 1;
+                    errors = errors.saturating_add(1);
                 }
             }
         }
@@ -1460,6 +1647,22 @@ mod tests {
         assert_eq!(result.errors, 0);
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn push_all_reports_malformed_local_entries() {
+        let tmp = TempDir::new().unwrap();
+        let shard = tmp.path().join("stages/aa");
+        std::fs::create_dir_all(&shard).unwrap();
+        std::fs::write(shard.join("broken.json"), b"not json").unwrap();
+        let store = crate::WorkflowStore::new(Arc::new(object_store::memory::InMemory::new()));
+
+        let result = push_all_local(&store, "org/repo", tmp.path())
+            .await
+            .unwrap();
+
+        assert_eq!(result.errors, 1);
+        assert_eq!(result.pushed, 0);
+    }
+
     #[test]
     fn read_missing_returns_none() {
         let tmp = TempDir::new().unwrap();
@@ -1472,6 +1675,20 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let error = read_local_xorb(tmp.path(), "../escape").unwrap_err();
         assert!(matches!(error, CrabError::Internal(_)));
+    }
+
+    #[test]
+    fn local_artifact_read_rejects_oversized_file_before_consuming_it() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oversized-artifact");
+        std::fs::File::create(&path)
+            .unwrap()
+            .set_len(MAX_STAGE_CACHE_ARTIFACT_BYTES + 1)
+            .unwrap();
+
+        let error = read_artifact_file_bounded(&path, "b3:expected").unwrap_err();
+
+        assert!(matches!(error, CrabError::CacheEntryCorrupt { .. }));
     }
 
     #[test]

--- a/crates/crab-workflow/src/error.rs
+++ b/crates/crab-workflow/src/error.rs
@@ -53,6 +53,10 @@ pub enum WorkflowError {
     #[error("internal workflow error: {0}")]
     Internal(String),
 
+    /// The caller cancelled an in-progress workflow operation.
+    #[error("workflow operation cancelled")]
+    Cancelled,
+
     /// Experiment id string is not the canonical UUIDv7 form.
     #[error("experiment id {raw:?} is invalid: {reason}")]
     ExperimentIdInvalid {

--- a/crates/crab-workflow/src/journal.rs
+++ b/crates/crab-workflow/src/journal.rs
@@ -638,6 +638,57 @@ impl Journal {
         }
         Ok(out)
     }
+
+    /// Return every stage row while refusing to materialize an oversized
+    /// journal in memory.
+    pub fn all_stage_rows_with_limit(
+        &self,
+        run_id: Uuid,
+        max_rows: usize,
+    ) -> Result<Vec<StageRunRow>> {
+        let limit = i64::try_from(max_rows)
+            .ok()
+            .and_then(|value| value.checked_add(1))
+            .ok_or_else(|| CrabError::Configuration {
+                key: "workflow journal stage row limit".to_owned(),
+                origin: "limit cannot be represented by SQLite".to_owned(),
+            })?;
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT run_id, stage_name, attempt, state, stage_hash, pid,
+                        exit_code, signal, timed_out, started_at, updated_at,
+                        stderr_tail, payload_json
+                 FROM stage_runs
+                 WHERE run_id = ?1
+                 ORDER BY stage_name, attempt
+                 LIMIT ?2",
+            )
+            .map_err(|source| CrabError::WorkflowJournalOpen {
+                path: self.path.clone(),
+                source,
+            })?;
+        let rows = stmt
+            .query_map(params![run_id.to_string(), limit], Self::map_stage_row)
+            .map_err(|source| CrabError::WorkflowJournalOpen {
+                path: self.path.clone(),
+                source,
+            })?;
+        let mut out = Vec::with_capacity(max_rows.min(1024));
+        for row in rows {
+            out.push(row.map_err(|source| CrabError::WorkflowJournalOpen {
+                path: self.path.clone(),
+                source,
+            })?);
+        }
+        if out.len() > max_rows {
+            return Err(CrabError::Configuration {
+                key: "workflow journal stage row count".to_owned(),
+                origin: format!("journal {run_id} contains more than {max_rows} stage rows"),
+            });
+        }
+        Ok(out)
+    }
 }
 
 /// Map a rusqlite error to the appropriate `CrabError`. Detects

--- a/crates/crab-workflow/src/stage_cache_entry.rs
+++ b/crates/crab-workflow/src/stage_cache_entry.rs
@@ -17,6 +17,18 @@ pub const ENTRY_SCHEMA_VERSION: u16 = 3;
 /// Maximum schema version this crate can read.
 pub const ENTRY_SCHEMA_MAX_SUPPORTED: u16 = 3;
 
+/// Maximum serialized size accepted for one stage-cache manifest.
+pub const MAX_STAGE_CACHE_ENTRY_BYTES: usize = 64 * 1024 * 1024;
+
+/// Maximum number of output records accepted in one stage-cache manifest.
+pub const MAX_STAGE_CACHE_OUTPUTS: usize = 1_000_000;
+
+/// Maximum number of entries accepted in one directory output manifest.
+pub const MAX_STAGE_CACHE_TREE_ENTRIES: usize = 1_000_000;
+
+/// Maximum serialized xorb body accepted by the workflow cache.
+pub const MAX_STAGE_CACHE_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
+
 /// One output recorded in a stage cache entry.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CachedOut {
@@ -134,6 +146,15 @@ pub(crate) fn validate_stage_cache_entry_at(
         ("metric", entry.metrics.as_slice()),
         ("plot", entry.plots.as_slice()),
     ] {
+        if outputs.len() > MAX_STAGE_CACHE_OUTPUTS {
+            return Err(cache_entry_invalid(
+                &stage_hash,
+                format!(
+                    "{kind} output count {} exceeds the safety limit of {MAX_STAGE_CACHE_OUTPUTS}",
+                    outputs.len()
+                ),
+            ));
+        }
         for (index, output) in outputs.iter().enumerate() {
             validate_cached_out(
                 output,
@@ -150,6 +171,15 @@ pub(crate) fn validate_stage_cache_entry_at(
 
 /// Validate a directory manifest before it is joined to a staging path.
 pub(crate) fn validate_tree_manifest(manifest: &[TreeManifestEntry]) -> Result<([u8; 32], u64)> {
+    if manifest.len() > MAX_STAGE_CACHE_TREE_ENTRIES {
+        return Err(cache_entry_invalid(
+            "",
+            format!(
+                "directory manifest contains {} entries; safety limit is {MAX_STAGE_CACHE_TREE_ENTRIES}",
+                manifest.len()
+            ),
+        ));
+    }
     let mut paths = BTreeSet::new();
     let mut kinds = BTreeMap::new();
     let mut entries = Vec::with_capacity(manifest.len());
@@ -170,6 +200,15 @@ pub(crate) fn validate_tree_manifest(manifest: &[TreeManifestEntry]) -> Result<(
             return Err(cache_entry_invalid(
                 "",
                 format!("directory manifest mode is invalid for {:?}", entry.path),
+            ));
+        }
+        if entry.size > MAX_STAGE_CACHE_ARTIFACT_BYTES {
+            return Err(cache_entry_invalid(
+                "",
+                format!(
+                    "directory entry {:?} is {} bytes; safety limit is {MAX_STAGE_CACHE_ARTIFACT_BYTES}",
+                    entry.path, entry.size
+                ),
             ));
         }
 
@@ -316,6 +355,15 @@ fn validate_cached_out(
         return Err(cache_entry_invalid(
             stage_hash,
             format!("{category}[{index}] mode is invalid"),
+        ));
+    }
+    if output.size > MAX_STAGE_CACHE_ARTIFACT_BYTES {
+        return Err(cache_entry_invalid(
+            stage_hash,
+            format!(
+                "{category}[{index}] is {} bytes; safety limit is {MAX_STAGE_CACHE_ARTIFACT_BYTES}",
+                output.size
+            ),
         ));
     }
     if decode_b3_hash(&output.file_hash).is_none() {
@@ -549,6 +597,14 @@ mod tests {
 
         entry.outs[0].path = PathBuf::from("model.bin");
         entry.outs[0].file_hash = "b3:short".to_owned();
+        let error = validate_stage_cache_entry(&entry).unwrap_err();
+        assert!(matches!(error, WorkflowError::CacheEntryInvalid { .. }));
+    }
+
+    #[test]
+    fn cache_entry_validation_rejects_oversized_artifacts() {
+        let mut entry = entry_with_outs(vec![cached_out("model.bin", true)]);
+        entry.outs[0].size = MAX_STAGE_CACHE_ARTIFACT_BYTES + 1;
         let error = validate_stage_cache_entry(&entry).unwrap_err();
         assert!(matches!(error, WorkflowError::CacheEntryInvalid { .. }));
     }

--- a/crates/crab-xet/src/shard_parse.rs
+++ b/crates/crab-xet/src/shard_parse.rs
@@ -18,10 +18,12 @@
 //! bucket.
 
 use std::collections::HashMap;
+use std::io::Read;
 
 use bytes::Bytes;
 use tracing::warn;
 use xet_core_structures::metadata_shard::MDBShardFileHeader;
+use xet_core_structures::metadata_shard::file_structs::FileDataSequenceEntry;
 use xet_core_structures::metadata_shard::streaming_shard::{
     process_shard_file_info_section, process_shard_xorb_info_section,
 };
@@ -36,11 +38,27 @@ pub struct ExtractedFileRecipe {
     pub chunks: Vec<(MerkleHash, u64)>,
 }
 
+/// File recipes and chunk-index entries extracted from one metadata shard.
+pub type ExtractedFileAndChunkEntries = (Vec<ExtractedFileRecipe>, Vec<(MerkleHash, XorbRef)>);
+
 /// Magic bytes at the end of a v2 shard.
 const SHARD_V2_MAGIC: &[u8; 4] = b"SH02";
 
 /// Size of the v2 trailer: `bloom_offset (u64 LE)` + `magic (4 bytes)`.
 const SHARD_V2_TRAILER_SIZE: usize = 12;
+
+/// Maximum shard body accepted by the in-memory Xet readers.
+///
+/// Larger shards must be rejected by the object-store boundary before they
+/// reach these parsers. Keeping the same limit here also protects callers
+/// that already hold a `Bytes` value from spending unbounded CPU on it.
+pub const MAX_SHARD_SIZE_BYTES: usize = 512 * 1024 * 1024;
+
+/// Maximum number of file records accepted from one shard.
+pub const MAX_SHARD_FILE_ENTRIES: usize = 1_000_000;
+
+/// Maximum number of chunk records accepted from one shard.
+pub const MAX_SHARD_CHUNK_ENTRIES: usize = 1_000_000;
 
 /// Strip the v2 bloom trailer from shard bytes, returning the v1 portion.
 ///
@@ -74,25 +92,57 @@ pub fn strip_v2_trailer(data: &[u8]) -> &[u8] {
 /// multi-shard operation (sync, rebuild, inventory).
 #[must_use]
 pub fn extract_chunk_entries_streaming(data: &Bytes) -> Vec<(MerkleHash, XorbRef)> {
+    if data.len() > MAX_SHARD_SIZE_BYTES {
+        warn!(
+            size = data.len(),
+            limit = MAX_SHARD_SIZE_BYTES,
+            "refusing to parse oversized shard for streaming chunk extraction"
+        );
+        return Vec::new();
+    }
     let v1_data = strip_v2_trailer(data);
     let mut cursor = std::io::Cursor::new(v1_data);
 
-    // Read and discard the shard header (version verification only).
-    if let Err(e) = MDBShardFileHeader::deserialize(&mut cursor) {
-        warn!(error = %e, "failed to parse shard header for streaming chunk extraction");
-        return Vec::new();
+    match extract_chunk_entries_from_reader(&mut cursor) {
+        Ok(entries) => entries,
+        Err(e) => {
+            warn!(error = %e, "failed to parse shard for streaming chunk extraction");
+            Vec::new()
+        }
     }
+}
 
-    // Skip through the file-info section without collecting entries.
-    if let Err(e) = process_shard_file_info_section(&mut cursor, |_| Ok(())) {
-        warn!(error = %e, "failed to skip file-info section during streaming chunk extraction");
-        return Vec::new();
-    }
+/// Extract chunk-index entries from a reader without materializing the shard body.
+pub fn extract_chunk_entries_from_reader<R: Read>(
+    reader: &mut R,
+) -> Result<Vec<(MerkleHash, XorbRef)>> {
+    extract_chunk_entries_from_reader_with_limit(reader, MAX_SHARD_CHUNK_ENTRIES)
+}
 
-    // Stream through the xorb-info section, extracting chunk→XorbRef mappings.
+/// Extract chunk-index entries while enforcing a record-count cap.
+pub fn extract_chunk_entries_from_reader_with_limit<R: Read>(
+    reader: &mut R,
+    max_entries: usize,
+) -> Result<Vec<(MerkleHash, XorbRef)>> {
+    MDBShardFileHeader::deserialize(reader).map_err(|error| XetError::CorruptObject {
+        path: "shard header".to_owned(),
+        reason: error.to_string(),
+    })?;
+    process_shard_file_info_section(reader, |_| Ok(())).map_err(|error| {
+        XetError::CorruptObject {
+            path: "shard file-info".to_owned(),
+            reason: error.to_string(),
+        }
+    })?;
+
     let mut entries = Vec::new();
-    if let Err(e) = process_shard_xorb_info_section(&mut cursor, |xorb_view| {
+    let mut over_limit = false;
+    process_shard_xorb_info_section(reader, |xorb_view| {
         let xorb_hash = xorb_view.xorb_hash();
+        if xorb_view.num_entries() > max_entries.saturating_sub(entries.len()) {
+            over_limit = true;
+            return Ok(());
+        }
         for idx in 0..xorb_view.num_entries() {
             let chunk = xorb_view.chunk(idx);
             entries.push((
@@ -105,63 +155,59 @@ pub fn extract_chunk_entries_streaming(data: &Bytes) -> Vec<(MerkleHash, XorbRef
             ));
         }
         Ok(())
-    }) {
-        warn!(error = %e, "failed to read xorb-info section during streaming chunk extraction");
-        return Vec::new();
+    })
+    .map_err(|error| XetError::CorruptObject {
+        path: "shard xorb-info".to_owned(),
+        reason: error.to_string(),
+    })?;
+    if over_limit {
+        return Err(XetError::CorruptObject {
+            path: "shard xorb-info".to_owned(),
+            reason: format!("chunk entry count exceeds safety limit {max_entries}"),
+        });
     }
-
-    entries
+    Ok(entries)
 }
 
-/// Extract `(file_hash, shard_hash)` pairs from raw shard bytes via a
-/// streaming parse.
-///
-/// The `shard_hash` argument is the containing shard's content hash;
-/// callers typically parse it from the last segment of the shard
-/// object key (`.crab/shards/{first-two-hex}/{hex}`). Each file-info entry in the
-/// shard contributes one pair.
-///
-/// On any parse failure the helper logs a `warn!` and returns an
-/// empty vec.
-#[must_use]
-pub fn extract_file_entries_streaming(
-    data: &Bytes,
-    shard_hash: MerkleHash,
-) -> Vec<(MerkleHash, MerkleHash)> {
-    let v1_data = strip_v2_trailer(data);
-    let mut cursor = std::io::Cursor::new(v1_data);
-
-    if let Err(e) = MDBShardFileHeader::deserialize(&mut cursor) {
-        warn!(error = %e, "failed to parse shard header for streaming file extraction");
-        return Vec::new();
-    }
-
-    let mut entries = Vec::new();
-    if let Err(e) = process_shard_file_info_section(&mut cursor, |file_view| {
-        entries.push((file_view.file_hash(), shard_hash));
-        Ok(())
-    }) {
-        warn!(error = %e, "failed to read file-info section during streaming file extraction");
-        return Vec::new();
-    }
-
-    entries
+/// Extract file recipes and chunk-index entries in one bounded reader pass.
+pub fn extract_file_and_chunk_entries_from_reader<R: Read>(
+    reader: &mut R,
+) -> Result<ExtractedFileAndChunkEntries> {
+    extract_file_and_chunk_entries_from_reader_with_limits(
+        reader,
+        MAX_SHARD_FILE_ENTRIES,
+        MAX_SHARD_CHUNK_ENTRIES,
+    )
 }
 
-/// Extract exact ordered file recipes and reject incomplete shard terms.
-pub fn extract_file_recipes(data: &Bytes) -> Result<Vec<ExtractedFileRecipe>> {
-    let v1_data = strip_v2_trailer(data);
-    let mut cursor = std::io::Cursor::new(v1_data);
-    MDBShardFileHeader::deserialize(&mut cursor).map_err(|error| XetError::CorruptObject {
+/// Extract file recipes and chunk-index entries while enforcing per-section
+/// record limits. The parser continues to the section bookends after a limit
+/// is observed so malformed input is consumed and reported deterministically.
+pub fn extract_file_and_chunk_entries_from_reader_with_limits<R: Read>(
+    reader: &mut R,
+    max_file_entries: usize,
+    max_chunk_entries: usize,
+) -> Result<ExtractedFileAndChunkEntries> {
+    MDBShardFileHeader::deserialize(reader).map_err(|error| XetError::CorruptObject {
         path: "shard header".to_owned(),
         reason: error.to_string(),
     })?;
 
     let mut files = Vec::new();
-    process_shard_file_info_section(&mut cursor, |file_view| {
-        let terms = (0..file_view.num_entries())
+    let mut file_terms = 0usize;
+    let mut over_file_limit = false;
+    process_shard_file_info_section(reader, |file_view| {
+        let term_count = file_view.num_entries();
+        if files.len() >= max_file_entries
+            || term_count > max_chunk_entries.saturating_sub(file_terms)
+        {
+            over_file_limit = true;
+            return Ok(());
+        }
+        let terms = (0..term_count)
             .map(|index| file_view.entry(index))
             .collect::<Vec<_>>();
+        file_terms += term_count;
         files.push((file_view.file_hash(), terms));
         Ok(())
     })
@@ -170,15 +216,29 @@ pub fn extract_file_recipes(data: &Bytes) -> Result<Vec<ExtractedFileRecipe>> {
         reason: error.to_string(),
     })?;
 
-    let mut xorbs: HashMap<MerkleHash, Vec<(MerkleHash, u64)>> = HashMap::new();
-    process_shard_xorb_info_section(&mut cursor, |xorb_view| {
-        let chunks = (0..xorb_view.num_entries())
-            .map(|index| {
-                let chunk = xorb_view.chunk(index);
-                (chunk.chunk_hash, u64::from(chunk.unpacked_segment_bytes))
-            })
-            .collect();
-        xorbs.insert(xorb_view.xorb_hash(), chunks);
+    let mut xorbs = HashMap::new();
+    let mut chunk_entries = Vec::new();
+    let mut over_chunk_limit = false;
+    process_shard_xorb_info_section(reader, |xorb_view| {
+        let xorb_hash = xorb_view.xorb_hash();
+        if xorb_view.num_entries() > max_chunk_entries.saturating_sub(chunk_entries.len()) {
+            over_chunk_limit = true;
+            return Ok(());
+        }
+        let mut chunks = Vec::with_capacity(xorb_view.num_entries());
+        for index in 0..xorb_view.num_entries() {
+            let chunk = xorb_view.chunk(index);
+            chunks.push((chunk.chunk_hash, u64::from(chunk.unpacked_segment_bytes)));
+            chunk_entries.push((
+                chunk.chunk_hash,
+                XorbRef {
+                    xorb_hash,
+                    chunk_index: index as u32,
+                    uncompressed_size: chunk.unpacked_segment_bytes,
+                },
+            ));
+        }
+        xorbs.insert(xorb_hash, chunks);
         Ok(())
     })
     .map_err(|error| XetError::CorruptObject {
@@ -186,6 +246,26 @@ pub fn extract_file_recipes(data: &Bytes) -> Result<Vec<ExtractedFileRecipe>> {
         reason: error.to_string(),
     })?;
 
+    if over_file_limit {
+        return Err(XetError::CorruptObject {
+            path: "shard file-info".to_owned(),
+            reason: format!("file entry count exceeds safety limit {max_file_entries}"),
+        });
+    }
+    if over_chunk_limit {
+        return Err(XetError::CorruptObject {
+            path: "shard xorb-info".to_owned(),
+            reason: format!("chunk entry count exceeds safety limit {max_chunk_entries}"),
+        });
+    }
+
+    Ok((assemble_file_recipes(files, xorbs)?, chunk_entries))
+}
+
+fn assemble_file_recipes(
+    files: Vec<(MerkleHash, Vec<FileDataSequenceEntry>)>,
+    xorbs: HashMap<MerkleHash, Vec<(MerkleHash, u64)>>,
+) -> Result<Vec<ExtractedFileRecipe>> {
     files
         .into_iter()
         .map(|(file_hash, terms)| {
@@ -240,6 +320,216 @@ pub fn extract_file_recipes(data: &Bytes) -> Result<Vec<ExtractedFileRecipe>> {
             Ok(ExtractedFileRecipe { file_hash, chunks })
         })
         .collect()
+}
+
+/// Extract exact file recipes from a reader without materializing the shard body.
+pub fn extract_file_recipes_from_reader<R: Read>(
+    reader: &mut R,
+) -> Result<Vec<ExtractedFileRecipe>> {
+    extract_file_recipes_from_reader_with_limits(
+        reader,
+        MAX_SHARD_FILE_ENTRIES,
+        MAX_SHARD_CHUNK_ENTRIES,
+    )
+}
+
+/// Extract file recipes while enforcing a file-entry cap.
+pub fn extract_file_recipes_from_reader_with_limit<R: Read>(
+    reader: &mut R,
+    max_file_entries: usize,
+) -> Result<Vec<ExtractedFileRecipe>> {
+    extract_file_recipes_from_reader_with_limits(reader, max_file_entries, MAX_SHARD_CHUNK_ENTRIES)
+}
+
+/// Extract file recipes while enforcing file and chunk-entry caps.
+pub fn extract_file_recipes_from_reader_with_limits<R: Read>(
+    reader: &mut R,
+    max_file_entries: usize,
+    max_chunk_entries: usize,
+) -> Result<Vec<ExtractedFileRecipe>> {
+    MDBShardFileHeader::deserialize(reader).map_err(|error| XetError::CorruptObject {
+        path: "shard header".to_owned(),
+        reason: error.to_string(),
+    })?;
+
+    let mut files = Vec::new();
+    let mut file_terms = 0usize;
+    let mut over_file_limit = false;
+    process_shard_file_info_section(reader, |file_view| {
+        let term_count = file_view.num_entries();
+        if files.len() >= max_file_entries
+            || term_count > max_chunk_entries.saturating_sub(file_terms)
+        {
+            over_file_limit = true;
+            return Ok(());
+        }
+        let terms = (0..term_count)
+            .map(|index| file_view.entry(index))
+            .collect::<Vec<_>>();
+        file_terms += term_count;
+        files.push((file_view.file_hash(), terms));
+        Ok(())
+    })
+    .map_err(|error| XetError::CorruptObject {
+        path: "shard file-info".to_owned(),
+        reason: error.to_string(),
+    })?;
+
+    if over_file_limit {
+        return Err(XetError::CorruptObject {
+            path: "shard file-info".to_owned(),
+            reason: format!(
+                "file recipe or term count exceeds safety limits ({max_file_entries} files, {max_chunk_entries} terms)"
+            ),
+        });
+    }
+
+    let mut xorbs = HashMap::new();
+    let mut chunk_entries = 0usize;
+    let mut over_chunk_limit = false;
+    process_shard_xorb_info_section(reader, |xorb_view| {
+        let entry_count = xorb_view.num_entries();
+        if entry_count > max_chunk_entries.saturating_sub(chunk_entries) {
+            over_chunk_limit = true;
+            return Ok(());
+        }
+        let chunks = (0..entry_count)
+            .map(|index| {
+                let chunk = xorb_view.chunk(index);
+                (chunk.chunk_hash, u64::from(chunk.unpacked_segment_bytes))
+            })
+            .collect();
+        chunk_entries += entry_count;
+        xorbs.insert(xorb_view.xorb_hash(), chunks);
+        Ok(())
+    })
+    .map_err(|error| XetError::CorruptObject {
+        path: "shard xorb-info".to_owned(),
+        reason: error.to_string(),
+    })?;
+
+    if over_chunk_limit {
+        return Err(XetError::CorruptObject {
+            path: "shard xorb-info".to_owned(),
+            reason: format!("chunk entry count exceeds safety limit {max_chunk_entries}"),
+        });
+    }
+
+    assemble_file_recipes(files, xorbs)
+}
+
+/// Extract exact file recipes from raw shard bytes.
+pub fn extract_file_recipes(data: &Bytes) -> Result<Vec<ExtractedFileRecipe>> {
+    if data.len() > MAX_SHARD_SIZE_BYTES {
+        return Err(XetError::CorruptObject {
+            path: "shard".to_owned(),
+            reason: format!(
+                "body size {} exceeds safety limit {MAX_SHARD_SIZE_BYTES}",
+                data.len()
+            ),
+        });
+    }
+    let v1_data = strip_v2_trailer(data);
+    let mut cursor = std::io::Cursor::new(v1_data);
+    extract_file_recipes_from_reader(&mut cursor)
+}
+
+/// Extract `(file_hash, shard_hash)` pairs from raw shard bytes via a
+/// streaming parse.
+///
+/// The `shard_hash` argument is the containing shard's content hash;
+/// callers typically parse it from the last segment of the shard
+/// object key (`.crab/shards/{first-two-hex}/{hex}`). Each file-info entry in the
+/// shard contributes one pair.
+///
+/// On any parse failure the helper logs a `warn!` and returns an
+/// empty vec.
+#[must_use]
+pub fn extract_file_entries_streaming(
+    data: &Bytes,
+    shard_hash: MerkleHash,
+) -> Vec<(MerkleHash, MerkleHash)> {
+    if data.len() > MAX_SHARD_SIZE_BYTES {
+        warn!(
+            size = data.len(),
+            limit = MAX_SHARD_SIZE_BYTES,
+            "refusing to parse oversized shard for streaming file extraction"
+        );
+        return Vec::new();
+    }
+    let v1_data = strip_v2_trailer(data);
+    let mut cursor = std::io::Cursor::new(v1_data);
+
+    if let Err(e) = MDBShardFileHeader::deserialize(&mut cursor) {
+        warn!(error = %e, "failed to parse shard header for streaming file extraction");
+        return Vec::new();
+    }
+
+    let mut entries = Vec::new();
+    let mut over_limit = false;
+    if let Err(e) = process_shard_file_info_section(&mut cursor, |file_view| {
+        if entries.len() >= MAX_SHARD_FILE_ENTRIES {
+            over_limit = true;
+            return Ok(());
+        }
+        entries.push((file_view.file_hash(), shard_hash));
+        Ok(())
+    }) {
+        warn!(error = %e, "failed to read file-info section during streaming file extraction");
+        return Vec::new();
+    }
+
+    if over_limit {
+        warn!(
+            limit = MAX_SHARD_FILE_ENTRIES,
+            "shard file-info entry count exceeds streaming safety limit"
+        );
+        return Vec::new();
+    }
+
+    entries
+}
+
+/// Extract every xorb hash referenced by file-info terms from a reader.
+///
+/// The reader is consumed through the shard header and file-info section only;
+/// the full shard body never needs to be materialized in memory.
+pub fn extract_file_xorb_hashes_from_reader<R: Read>(reader: &mut R) -> Result<Vec<MerkleHash>> {
+    extract_file_xorb_hashes_from_reader_with_limit(reader, MAX_SHARD_CHUNK_ENTRIES)
+}
+
+/// Extract file-referenced xorbs while enforcing a caller-provided count cap.
+pub fn extract_file_xorb_hashes_from_reader_with_limit<R: Read>(
+    reader: &mut R,
+    max_hashes: usize,
+) -> Result<Vec<MerkleHash>> {
+    MDBShardFileHeader::deserialize(reader).map_err(|error| XetError::CorruptObject {
+        path: "shard header".to_owned(),
+        reason: error.to_string(),
+    })?;
+
+    let mut hashes = Vec::new();
+    let mut over_limit = false;
+    process_shard_file_info_section(reader, |file_view| {
+        let entries = file_view.num_entries();
+        if entries > max_hashes.saturating_sub(hashes.len()) {
+            over_limit = true;
+            return Ok(());
+        }
+        hashes.extend((0..entries).map(|index| file_view.entry(index).xorb_hash));
+        Ok(())
+    })
+    .map_err(|error| XetError::CorruptObject {
+        path: "shard file-info".to_owned(),
+        reason: error.to_string(),
+    })?;
+    if over_limit {
+        return Err(XetError::CorruptObject {
+            path: "shard file-info".to_owned(),
+            reason: format!("file-info xorb reference count exceeds safety limit {max_hashes}"),
+        });
+    }
+    Ok(hashes)
 }
 
 #[cfg(test)]
@@ -320,10 +610,46 @@ mod tests {
             );
         }
 
+        let mut reader = std::io::Cursor::new(bytes.as_ref());
+        let file_xorb_hashes = extract_file_xorb_hashes_from_reader(&mut reader).unwrap();
+        assert_eq!(
+            file_xorb_hashes,
+            vec![
+                MerkleHash::from([1, 1, 1, 1]),
+                MerkleHash::from([2, 2, 2, 2])
+            ]
+        );
+
+        let mut limited_reader = std::io::Cursor::new(bytes.as_ref());
+        let limited = extract_file_xorb_hashes_from_reader_with_limit(&mut limited_reader, 1);
+        assert!(
+            limited.is_err(),
+            "the per-shard xorb-reference cap must fail closed"
+        );
+
         let recipes = extract_file_recipes(&bytes).expect("extract recipes");
         assert_eq!(recipes.len(), 2);
         assert_eq!(recipes[0].chunks.len(), 1);
         assert_eq!(recipes[0].chunks[0].1, 1024);
+
+        let mut reader = std::io::Cursor::new(bytes.as_ref());
+        let (streamed_recipes, streamed_chunks) =
+            extract_file_and_chunk_entries_from_reader(&mut reader).unwrap();
+        assert_eq!(streamed_recipes, recipes);
+        assert_eq!(streamed_chunks, chunk_entries);
+
+        let mut limited_reader = std::io::Cursor::new(bytes.as_ref());
+        assert!(
+            extract_file_and_chunk_entries_from_reader_with_limits(&mut limited_reader, 1, 5)
+                .is_err()
+        );
+        let mut limited_reader = std::io::Cursor::new(bytes.as_ref());
+        assert!(
+            extract_file_and_chunk_entries_from_reader_with_limits(&mut limited_reader, 2, 4)
+                .is_err()
+        );
+        let mut limited_reader = std::io::Cursor::new(bytes.as_ref());
+        assert!(extract_file_recipes_from_reader_with_limits(&mut limited_reader, 2, 4).is_err());
     }
 
     #[test]

--- a/crates/crab-xet/src/xorb/format.rs
+++ b/crates/crab-xet/src/xorb/format.rs
@@ -6,6 +6,7 @@
 //! of compression level.
 
 pub use xet_core_structures::merklehash::MerkleHash;
+pub use xet_core_structures::xorb_object::constants::MAX_XORB_CHUNKS;
 pub use xet_core_structures::xorb_object::{Chunk, CompressionScheme, SerializedXorbObject};
 
 /// Xorb content hash, a [`MerkleHash`] over the ordered chunk-hash sequence.

--- a/crates/crab-xet/src/xorb/parser.rs
+++ b/crates/crab-xet/src/xorb/parser.rs
@@ -10,7 +10,8 @@ use xet_core_structures::xorb_object::Chunk;
 
 use crate::error::{Result, XetError};
 use crate::xorb::format::{
-    CHUNK_META_ENTRY_SIZE, ChunkMeta, CompressionScheme, FOOTER_SIZE, XORB_MAGIC, XorbHash,
+    CHUNK_META_ENTRY_SIZE, ChunkMeta, CompressionScheme, FOOTER_SIZE, MAX_XORB_CHUNKS,
+    MAX_XORB_SIZE, XORB_MAGIC, XorbHash,
 };
 
 /// Byte range of the serialized xorb metadata section.
@@ -201,6 +202,7 @@ pub fn xorb_chunks_from_metadata(
 
 /// Verify a compressed chunk payload against its metadata.
 pub fn verify_compressed_chunk(meta: &ChunkMeta, compressed: &[u8]) -> Result<()> {
+    validate_chunk_size(meta.uncompressed_len)?;
     let _ = decompress_chunk_data(meta, compressed)?;
     Ok(())
 }
@@ -284,6 +286,11 @@ fn parse_xorb_footer(data_len: usize, footer: &[u8]) -> Result<ParsedXorbFooter>
     if data_len < FOOTER_SIZE {
         return Err(corrupt("xorb too small for footer"));
     }
+    if data_len > MAX_XORB_SIZE {
+        return Err(corrupt(format!(
+            "xorb exceeds maximum size of {MAX_XORB_SIZE} bytes"
+        )));
+    }
     if footer.len() != FOOTER_SIZE {
         return Err(corrupt("bad footer length"));
     }
@@ -308,6 +315,12 @@ fn parse_xorb_footer(data_len: usize, footer: &[u8]) -> Result<ParsedXorbFooter>
         .map_err(|_| corrupt("bad payload digest bytes"))?;
     let num_chunks_usize =
         usize::try_from(num_chunks).map_err(|_| corrupt("num_chunks does not fit usize"))?;
+    if num_chunks_usize > *MAX_XORB_CHUNKS {
+        return Err(corrupt(format!(
+            "xorb contains {num_chunks_usize} chunks; maximum is {}",
+            *MAX_XORB_CHUNKS
+        )));
+    }
     let metadata_len = num_chunks_usize
         .checked_mul(CHUNK_META_ENTRY_SIZE)
         .ok_or_else(|| corrupt("metadata size overflow"))?;
@@ -369,6 +382,7 @@ fn parse_xorb_metadata(
                 .try_into()
                 .map_err(|_| corrupt("bad uncompressed_len"))?,
         );
+        validate_chunk_size(uncompressed_len)?;
         cursor += 4;
 
         let scheme_byte = metadata[cursor];
@@ -403,6 +417,7 @@ fn parse_xorb_metadata(
 }
 
 fn decompress_chunk_data(meta: &ChunkMeta, compressed: &[u8]) -> Result<Chunk> {
+    validate_chunk_size(meta.uncompressed_len)?;
     let decompressed = meta
         .scheme
         .decompress_from_slice(compressed)
@@ -413,6 +428,14 @@ fn decompress_chunk_data(meta: &ChunkMeta, compressed: &[u8]) -> Result<Chunk> {
 
     let chunk = Chunk::new(Bytes::from(decompressed.into_owned()));
 
+    if chunk.data.len() != meta.uncompressed_len as usize {
+        return Err(corrupt(format!(
+            "decompressed chunk length {} does not match metadata length {}",
+            chunk.data.len(),
+            meta.uncompressed_len
+        )));
+    }
+
     if chunk.hash != meta.hash {
         return Err(XetError::CorruptObject {
             path: format!("chunk at offset {}", meta.offset),
@@ -421,6 +444,16 @@ fn decompress_chunk_data(meta: &ChunkMeta, compressed: &[u8]) -> Result<Chunk> {
     }
 
     Ok(chunk)
+}
+
+fn validate_chunk_size(uncompressed_len: u32) -> Result<()> {
+    if u64::from(uncompressed_len) <= MAX_XORB_SIZE as u64 {
+        return Ok(());
+    }
+    Err(corrupt(format!(
+        "chunk is {uncompressed_len} bytes; maximum is {} bytes",
+        MAX_XORB_SIZE
+    )))
 }
 
 fn decompress_chunk_bytes(meta: &ChunkMeta, compressed: Bytes) -> Result<Chunk> {
@@ -444,10 +477,10 @@ fn decompress_chunk_bytes(meta: &ChunkMeta, compressed: Bytes) -> Result<Chunk> 
     Ok(chunk)
 }
 
-fn corrupt(reason: &str) -> XetError {
+fn corrupt(reason: impl AsRef<str>) -> XetError {
     XetError::CorruptObject {
         path: "xorb".to_string(),
-        reason: reason.to_string(),
+        reason: reason.as_ref().to_string(),
     }
 }
 
@@ -659,6 +692,42 @@ mod tests {
         let mut bad = vec![0u8; FOOTER_SIZE];
         bad[FOOTER_SIZE - 4..].copy_from_slice(b"NOPE");
         assert!(XorbParser::parse(Bytes::from(bad)).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_chunk_count_beyond_xet_limit_before_allocating_metadata() {
+        let num_chunks = *MAX_XORB_CHUNKS + 1;
+        let metadata_len = num_chunks * CHUNK_META_ENTRY_SIZE;
+        let mut body = vec![0u8; metadata_len + FOOTER_SIZE];
+        body[metadata_len..metadata_len + 4].copy_from_slice(&(num_chunks as u32).to_le_bytes());
+        body[metadata_len + 4..metadata_len + 12].copy_from_slice(&0u64.to_le_bytes());
+        let footer_start = body.len() - FOOTER_SIZE;
+        body[footer_start + FOOTER_SIZE - 4..].copy_from_slice(XORB_MAGIC);
+
+        let error = match XorbParser::parse(Bytes::from(body)) {
+            Ok(_) => panic!("oversized chunk count must be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("maximum is"));
+    }
+
+    #[test]
+    fn parse_rejects_uncompressed_chunk_larger_than_xorb_limit() {
+        let metadata_len = CHUNK_META_ENTRY_SIZE;
+        let mut body = vec![0u8; metadata_len + FOOTER_SIZE];
+        let oversized = (MAX_XORB_SIZE + 1) as u32;
+        body[40..44].copy_from_slice(&oversized.to_le_bytes());
+        body[metadata_len..metadata_len + 4].copy_from_slice(&1u32.to_le_bytes());
+        body[metadata_len + 4..metadata_len + 12].copy_from_slice(&0u64.to_le_bytes());
+        let footer_start = body.len() - FOOTER_SIZE;
+        body[footer_start + FOOTER_SIZE - 4..].copy_from_slice(XORB_MAGIC);
+
+        let error = match XorbParser::parse(Bytes::from(body)) {
+            Ok(_) => panic!("oversized chunk must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("chunk is"));
     }
 
     #[test]

--- a/packages/web/content/docs/cli/automation/workflow-pipelines.mdx
+++ b/packages/web/content/docs/cli/automation/workflow-pipelines.mdx
@@ -42,6 +42,10 @@ is needed.
 
 If no local cache entries exist (`.crab/cache/` is absent), the command
 reports zero entries and exits successfully.
+If any discovered entry is unreadable, invalid, or cannot be uploaded, the
+summary reports the partial counts and the command exits nonzero. Invoking the
+command from a repository subdirectory still resolves the worktree root before
+scanning `.crab/cache/stages/`.
 
 ## Options
 

--- a/packages/web/content/docs/cli/diagnostics/metadata-database.mdx
+++ b/packages/web/content/docs/cli/diagnostics/metadata-database.mdx
@@ -26,17 +26,17 @@ The file index is per-repository. The chunk index is shared globally across all 
 
 A two-tier local cache sits in front of the remote chunk index:
 - **In-memory LRU** — fastest lookups for hot chunks
-- **SQLite file** — persistent on-disk cache at `~/.cache/crab/{bucket}/{repo-hash}/chunk-index.sqlite`
+- **SQLite file** — persistent bucket-scoped cache at `~/.cache/crab/buckets/{bucket-hash}/chunk-index.sqlite`
 
 ## Diagnosing Issues
 
 ### Check database health
 
 ```bash
-crab metadb diagnose
+crab metadb diagnose --deep
 ```
 
-Read-only health snapshot — reports open state, format version, epoch, and path for each database. Safe to run concurrently with pushes.
+Read-only health snapshot — reports open state, format version, epoch, and path for each database. Add `--deep` to scan every metadata row and enumerate the backing object store. Deep diagnosis validates committed/receipt namespaces and flags malformed compacted-SST names as warnings; it never deletes remote objects. Safe to run concurrently with pushes.
 
 ```bash
 crab metadb diagnose --db chunk_index
@@ -49,7 +49,9 @@ crab metadb diagnose --db file_index --json
 crab metadb cache stats
 ```
 
-Shows the SQLite file path, on-disk size, entry count, installed shard count, and GC generation cursor.
+Shows the SQLite path, combined database/WAL/shared-memory size, entry count,
+installed shard count, and GC generation cursor. The read-only inspection does
+not create, migrate, repair, or load the cache into memory.
 
 ### Run a durable Git index owner
 
@@ -76,7 +78,19 @@ crab metadb rebuild --db file_index
 crab metadb rebuild --db both
 ```
 
-Rebuild is idempotent — every write is content-addressed, so running it multiple times produces the same result. An interrupted run can be restarted without cleanup.
+Rebuild is idempotent — every write is content-addressed, so running it multiple times produces the same result. An interrupted run can be restarted without cleanup. Any manifest-named shard, xorb-placement, or Git-pack validation failure exits non-zero and prevents generation-receipt publication.
+
+## Compacting the Databases
+
+```bash
+crab metadb compact --db both
+```
+
+This acquires a renewable repository maintenance lease and runs SlateDB's
+size-tiered compactor until the current scheduler work drains. File and chunk
+indexes run sequentially. Cancellation, an existing active compaction, or a new
+compaction failure exits non-zero; a database with no eligible work is reported
+as already policy-satisfied.
 
 ### When to rebuild
 
@@ -94,7 +108,9 @@ Rebuild is not a migration tool. Fresh repositories never need it — `Db::open`
 crab metadb cache clear
 ```
 
-Forces a cold re-warm on the next operation. Useful when the cache is suspected of drift or corruption, or for benchmarking. The remote state is untouched.
+Transactionally removes cached chunk and shard rows, forcing a cold re-warm on
+the next operation. The remote state is untouched, and the local SQLite file,
+schema, and GC cursor remain intact for live shared handles.
 
 ## Troubleshooting
 
@@ -123,6 +139,10 @@ cache_gc_grace = 3
 ```
 
 All settings can be overridden with `CRAB_METADB_*` environment variables (e.g., `CRAB_METADB_CHUNK_INDEX_IN_MEMORY_CEILING_BYTES`).
+The shipped `wal_flush_size` key controls SlateDB's L0 SST target size; Crab
+flushes WAL durability explicitly at commit boundaries. File-index and
+chunk-index values are applied independently, and all three database tunables
+must be non-zero.
 
 ## Command Help
 

--- a/packages/web/content/docs/cli/reference/crab-cache.mdx
+++ b/packages/web/content/docs/cli/reference/crab-cache.mdx
@@ -15,6 +15,7 @@ Manage the local chunk cache.
 
 ```bash
 crab cache stats
+crab cache verify
 crab cache clean
 ```
 
@@ -30,7 +31,10 @@ For conceptual background, see [Local Cache](/docs/cli/storage/local-cache).
 
 ### stats
 
-Show cache size, hit rate, and entry count.
+Show the configured size limit, resident bytes, and entry count for the xet
+range cache, plus a size and object-count breakdown for Crab's local object
+cache. Range-cache entries are streamed on a blocking worker, so a large cache
+does not retain its complete file inventory or block the async runtime.
 
 ```bash
 crab cache stats
@@ -46,6 +50,13 @@ crab cache clean
 
 The current cache subcommands do not add command-specific selection flags;
 use `crab cache <command> --help` for global logging options.
+
+### verify
+
+Validate content-addressed chunks, shards, and xorbs plus xet range filenames,
+lengths, offset headers, and CRCs, then evict corrupt entries. Range entries are
+verified as they are scanned. I/O failures fail the command. For a non-mutating
+cleanup preview, use `crab optimize cache clean --dry-run`.
 
 ## Remote Cache Service
 

--- a/packages/web/content/docs/cli/reference/crab-compact.mdx
+++ b/packages/web/content/docs/cli/reference/crab-compact.mdx
@@ -19,9 +19,14 @@ crab compact [OPTIONS] --repo <REPO> --bucket <BUCKET>
 
 ## Description
 
-`crab compact` is a remote storage maintenance command. It merges small
-shards under the selected bucket and repository prefix. It does not replace
-`crab metadb compact`, which compacts local metadata databases.
+`crab compact` is the legacy top-level entry for `crab optimize shards`. It
+merges the Xet metadata shards selected by the repository's canonical manifest.
+Downloads and output are hash-verified, publication is fail-closed, and source
+shards remain immutable until garbage collection. Before downloading, Crab
+HEAD-checks the selected shards and requires workspace capacity for twice their
+combined size plus a 512 MiB reserve. Temporary files live under the configured
+Crab cache's maintenance directory. It does not replace `crab metadb compact`,
+which maintains the metadata databases themselves.
 
 For conceptual background, see [Compacting Data](/docs/cli/storage/compacting-data).
 
@@ -32,13 +37,14 @@ For conceptual background, see [Compacting Data](/docs/cli/storage/compacting-da
 | `--repo <REPO>` | required | Repository prefix, such as `org/models` |
 | `--bucket <BUCKET>` | required | S3 bucket containing the repository |
 | `--dry-run` | `false` | Report the plan without mutating remote storage |
-| `--max-shard-size <SIZE>` | `100MiB` | Maximum compacted shard size |
+| `--max-shard-size <SIZE>` | `100MiB` | Maximum compacted shard size; greater than zero and at most `100MiB` |
 
 ## Examples
 
 ```bash
 crab compact --repo org/models --bucket my-bucket --dry-run
 crab compact --repo org/models --bucket my-bucket
+crab optimize shards --repo org/models --bucket my-bucket --max-shard-size 50MiB
 ```
 
 Start with `--dry-run` and record the proposed shard count and size. Apply the

--- a/packages/web/content/docs/cli/reference/crab-fetch.mdx
+++ b/packages/web/content/docs/cli/reference/crab-fetch.mdx
@@ -34,7 +34,7 @@ also need remote Git ref and pack updates.
 | `--include <PATTERN>` | None | Include matching file/object patterns; repeat as needed |
 | `--exclude <PATTERN>` | None | Exclude matching patterns; repeat as needed |
 | `--all` | Disabled | Fetch objects for all refs rather than only HEAD |
-| `--dry-run` | Disabled | Report the intended source and filters without downloading |
+| `--dry-run` | Disabled | Resolve and report selected files without credentials, network access, or cache writes |
 | `--no-sync-chunk-index` | Disabled | Skip post-fetch local chunk-index warming |
 | `--json` | Disabled | Emit one terminal JSON envelope |
 | `--jsonl` | Disabled | Stream JSONL progress and a terminal result |
@@ -66,6 +66,13 @@ crab fetch --include '*.safetensors' --exclude 'archive/**'
 ```bash
 crab fetch --dry-run --json
 ```
+
+Fetch uses Git pointer blobs as the live inventory. It batch-checks blob sizes,
+deduplicates identical file hashes across refs, then reconstructs selected files
+into a discard sink through the same replica, file-index, shard, and xet-core
+range-cache path used by hydrate. Reconstructed bytes are hash- and size-checked;
+peak memory does not scale with logical file size. `--all` means every local ref,
+so run `git fetch origin` first when remote refs must be current.
 
 ## Related
 

--- a/packages/web/content/docs/cli/reference/crab-metadb.mdx
+++ b/packages/web/content/docs/cli/reference/crab-metadb.mdx
@@ -23,14 +23,24 @@ crab metadb <SUBCOMMAND> [OPTIONS]
 | Command | Purpose |
 | --- | --- |
 | `diagnose` | Print `sys:*` key snapshots for one or both databases |
-| `rebuild` | Rebuild databases from durable shards under `.crab/shards/` |
+| `rebuild` | Validate manifest-named shards and packs, then rebuild generation-bound index evidence |
 | `owner` | Continuously publish Git locator checkpoints and visibility proofs |
-| `compact` | Request immediate database compaction |
-| `cache` | Inspect or wipe the local chunk-index cache |
+| `compact` | Run SlateDB's size-tiered compactor until current eligible work drains |
+| `cache` | Inspect or transactionally clear the local chunk-index cache |
 
 Use the subcommand's `--help` output for database selectors and cache-specific
-options. Rebuild and cache-wipe operations can be expensive; run diagnostics
+options. Rebuild and cache-clear operations can be expensive; run diagnostics
 first and keep a backup of the durable remote data.
+
+`compact` holds a renewable repository maintenance lease and exits non-zero on
+cancellation, an already-active compaction, or a new SlateDB compaction failure.
+`cache stats` is read-only; `cache clear` preserves the SQLite file, schema, and
+GC cursor while removing cached chunk and shard rows.
+
+`rebuild` streams each manifest-named Xet shard through a temporary maintenance
+file, verifies its content hash, and parses only the selected index sections.
+This keeps full shard bodies out of the rebuild process heap; selecting one
+database also avoids decoding the other index.
 
 ```bash
 crab metadb diagnose

--- a/packages/web/content/docs/cli/reference/crab-optimize.mdx
+++ b/packages/web/content/docs/cli/reference/crab-optimize.mdx
@@ -23,8 +23,8 @@ crab optimize [OPTIONS] <COMMAND>
 |------------|---------|
 | `plan` | Build a combined cost optimization plan |
 | `apply` | Apply the combined cost optimization workflow |
-| `xorbs` | Rewrite content-addressed xorbs to a target size, grouping, compression, and storage-class profile |
-| `packs` | Consolidate remote Git pack files; grouped home for `crab repack` |
+| `xorbs` | Consolidate the repository's live content-addressed xorbs to a target size and Xet compression profile |
+| `packs` | Consolidate the canonical Git pack inventory with full graph and generation-evidence validation; grouped home for `crab repack` |
 | `shards` | Compact metadata shards; grouped home for `crab compact` |
 | `tiers` | Plan, apply, or roll back lifecycle tiering rules; grouped home for `crab tier` |
 | `cache` | Inspect, verify, prune, clean, or warm the local object cache |
@@ -44,16 +44,66 @@ crab optimize packs --dry-run
 crab optimize shards --repo org/models --bucket my-bucket --dry-run
 crab optimize tiers plan
 crab optimize cache prune
+crab optimize cache clean --dry-run
+crab optimize cache warm --include '*.safetensors' --dry-run
 crab optimize indexes diagnose --deep
+crab optimize indexes compact --db both
 crab optimize lfs dedup
+crab optimize workflow-cache push --all
 crab optimize workflow-cache journal-gc
 crab optimize replicas status
 crab optimize repo --json
 ```
 
+`--profile` is valid only with `--include-xorbs`. Crab validates the named
+Xorb profile before inventory or mutation begins, so an unknown profile fails
+without touching remote storage.
+
 `crab optimize repo` and `crab doctor --cost` require a configured Crab remote
 and currently use live inventory. The explicit provider-report source is
 reserved until report discovery and freshness metadata are wired.
+
+The `tiers` group preserves lifecycle-provider safety: plan and dry-run remain
+available, while apply and rollback require a qualified conditional-write
+adapter. The current S3 lifecycle API has no conditional write; GCS and Azure
+also fail closed until their prefix-preserving adapters are qualified.
+
+Index rebuild and compaction acquire renewable maintenance leases. Rebuild
+fails closed on incomplete shard, xorb, or pack proof; compaction waits for
+SlateDB's current size-tiered scheduler work to drain. Local index statistics
+are non-mutating, and cache clear preserves the SQLite schema and GC cursor.
+
+LFS optimization verifies content before deduplication or deletion. Conversion
+streams large objects, preserves index modes, writes an atomic rollback
+manifest, automatically rolls back a failed operation, and scans large Git
+indexes in fixed-size batches. Deduplication and prune stream Git object
+discovery and reject large non-pointer blobs before reading their contents.
+Prune protects staged pointers and recent or unpushed objects, honors
+`lfs.storage`, and uses bounded remote verification; `--force` skips
+confirmation but does not weaken recent-object protection. Optimize-owned LFS,
+cache-clean, and journal-GC work honors Ctrl-C between bounded scan, verify, and
+mutation units; failed conversions always run their rollback manifest cleanup.
+
+Xorb source-shard inventory is disk-backed: each canonical Xet shard is
+downloaded to a bounded maintenance workspace, hash-verified, and parsed
+through its file-info stream before the temporary file is removed. This keeps
+large-repository planning from retaining several full metadata shards in heap
+memory at once.
+
+For Xet-backed large files, use both storage layers when needed: `shards`
+compacts the metadata that maps file/chunk identities to storage, while
+`xorbs` rewrites the content-addressed chunk containers to the selected size
+and compression profile. There is no separate whole-file rewrite because a
+file's durable representation is its canonical shard metadata plus the
+referenced xorbs; the same path covers datasets, models, and other large Xet
+objects. `indexes rebuild|compact` repairs or compacts the acceleration layer
+without changing canonical shard or xorb bytes.
+
+`crab optimize workflow-cache push --all` exits nonzero when any local entry
+cannot be validated or uploaded. Journal GC never removes in-flight or
+symlinked run directories and reports partial deletion failures. Combined
+`optimize apply` is serialized per repository, stops at the first failed step,
+and keeps child-process output memory bounded for large reports.
 
 ## Related Commands
 

--- a/packages/web/content/docs/cli/reference/crab-repack.mdx
+++ b/packages/web/content/docs/cli/reference/crab-repack.mdx
@@ -27,6 +27,12 @@ to retain old packs by default, so repack first optimizes active reads. To
 reclaim superseded storage, explicitly prune older recovery generations and
 then run repository GC.
 
+Apply mode validates the complete source and replacement Git object graphs,
+uses the repository maintenance lease, and does not report success until Git
+visibility, locator coverage, and the generation receipt are durable. Dry-run
+does not download packs; structured output retains the current byte count in
+`bytes_after` rather than presenting it as an estimated replacement size.
+
 For conceptual background, see [Repacking Objects](/docs/cli/storage/repacking-objects).
 
 ## Options

--- a/packages/web/content/docs/cli/reference/crab-tier.mdx
+++ b/packages/web/content/docs/cli/reference/crab-tier.mdx
@@ -19,9 +19,17 @@ crab tier [OPTIONS] <COMMAND>
 
 ## Description
 
-`crab tier` manages bucket lifecycle rules. It currently exposes `plan` to
-generate a lifecycle plan and `rollback` to restore a prior configuration from
-a backup file.
+`crab tier` manages bucket lifecycle rules. `plan` produces a human summary or
+explicit XML, JSON, or YAML output; `--apply --dry-run` remains read-only.
+Lifecycle mutation requires a provider conditional-write guard and verified
+read-back. The S3 lifecycle API has no conditional write, so the CLI fails
+closed before an S3 mutation; GCS and Azure also fail closed until their safe
+prefix-preserving adapters are wired. `rollback` rejects provider or policy
+drift, restores the previous configuration, and deletes the lifecycle when
+none existed before apply. The prior policy backup is stored in the
+repository's shared `.crab/tier/backups` directory and synced before provider
+mutation, including when the command starts in a subdirectory. Invalid Crab
+configuration fails closed.
 
 For conceptual background, see [Storage Tiers](/docs/cli/storage/storage-tiers).
 

--- a/packages/web/content/docs/cli/storage/compacting-data.mdx
+++ b/packages/web/content/docs/cli/storage/compacting-data.mdx
@@ -21,15 +21,17 @@ flowchart LR
 
 ## How Compaction Works
 
-1. Reads the repository's shard-list to discover all current shards.
-2. Downloads all shards to a temporary directory.
-3. Merges them using xet-core's shard merging algorithm, respecting the maximum shard size limit.
-4. Strips unreferenced xorb-info entries — in global-dedup layouts, merged shards may carry metadata from other repositories.
-5. Uploads compacted shards to the remote store.
-6. Atomically updates the shard-list, then conservatively CAS-unions its
-   committed roots into the partitioned ref-registry. Exact stale-root removal
-   is reserved for exclusive registry repair so a concurrent push cannot lose
-   its pre-registered roots.
+1. Pins the repository's current shard inventory and validates its size and
+   entry bounds.
+2. Downloads shards with bounded concurrency into a temporary maintenance
+   workspace, verifying each content hash before parsing.
+3. Merges the complete set with xet-core's shard merging algorithm, respecting
+   the maximum shard size limit.
+4. Uploads hash-verified replacement shards and the new immutable shard index.
+5. Atomically updates the shard-list with compare-and-swap and publishes
+   candidate roots before the new list is visible.
+6. Reconciles the partitioned ref registry without dropping roots registered by
+   a concurrent push.
 
 Source shards are left in place for garbage collection to clean up later.
 
@@ -55,7 +57,7 @@ crab compact --repo org/models --bucket my-crab-bucket
 crab compact --repo org/models --bucket my-crab-bucket --max-shard-size 50MiB
 ```
 
-Smaller compacted shards trade fewer total shards for lower per-shard download latency — useful when shard sync latency matters more than minimizing shard count.
+Smaller compacted shards trade fewer total shards for lower per-shard download latency — useful when shard sync latency matters more than minimizing shard count. The value must be greater than zero and cannot exceed Xet's native 100 MiB shard cap.
 
 ## When to Compact
 
@@ -67,7 +69,11 @@ Smaller compacted shards trade fewer total shards for lower per-shard download l
 
 ## Concurrency Safety
 
-Compaction is safe to run concurrently with pushes — the CAS update ensures atomicity. However, two concurrent compactions on the same repository may cause one to fail with a CAS conflict. Retrying is safe.
+Compaction holds a renewable repository maintenance lease and is safe to retry.
+Pushes may continue: immutable candidate objects are safe before publication,
+the manifest compare-and-swap prevents stale commits, and registry
+reconciliation preserves concurrent push roots. Cancellation is checked between
+bounded download, parse, and publish units.
 
 ## Compaction vs. Repacking
 

--- a/packages/web/content/docs/cli/storage/local-cache.mdx
+++ b/packages/web/content/docs/cli/storage/local-cache.mdx
@@ -34,8 +34,8 @@ The cache is a content-addressed store — chunks are identified by their blake3
 | Priority | Source | Default Path |
 |----------|--------|-------------|
 | 1 | `$CRAB_CACHE_DIR` environment variable | Custom path |
-| 2 | `.crab/config.toml` `cache.dir` setting | Custom path |
-| 3 | Platform default | `~/.cache/crab/` |
+| 2 | `[cache].chunk_cache_dir` | Custom xet range-cache path |
+| 3 | Platform default | `~/.cache/crab/` (range cache under `chunks/`) |
 
 To use a fast NVMe drive for the cache:
 
@@ -47,11 +47,9 @@ export CRAB_CACHE_DIR=/mnt/nvme/crab-cache
 
 The cache grows as you hydrate files. You can set a maximum size:
 
-```toml
-# .crab/config.toml
-[cache]
-max_size = "50GB"
-```
+The xet range-cache byte ceiling uses Crab's `chunk_cache_bytes` configuration;
+the shard object cache uses `shard_cache_bytes` when configured. `crab prune`
+applies those byte budgets.
 
 When the cache exceeds this limit, least-recently-used chunks are evicted. Eviction is lazy — it happens during the next cache write, not in the background.
 
@@ -61,7 +59,8 @@ When the cache exceeds this limit, least-recently-used chunks are evicted. Evict
 crab cache stats
 ```
 
-Shows total size, number of objects, hit rate, and cache directory path.
+Shows the read-only xet range-cache snapshot and the Crab object-cache counts
+and bytes. Stats never initializes, repairs, or deletes cache entries.
 
 ## Cleaning the Cache
 

--- a/packages/web/content/docs/cli/storage/optimizing-xorbs.mdx
+++ b/packages/web/content/docs/cli/storage/optimizing-xorbs.mdx
@@ -9,7 +9,10 @@ meta:
 
 ## Optimizing Xorb Layout
 
-Crab stores file content as content-addressed xorbs. Xorb size and grouping affect storage cost, object count, and access performance. `crab optimize xorbs` rewrites xorbs to match a target profile: larger xorbs for ML models, medium xorbs for datasets, and smaller xorbs for code or random-access workloads.
+Crab stores file content as content-addressed xorbs. Xorb size and grouping
+affect storage cost, object count, and access performance. `crab optimize
+xorbs` rewrites the xorbs referenced by the repository's canonical metadata
+into a target size profile.
 
 This is different from `crab optimize packs`, which consolidates Git pack files. Xorb optimization operates on the content-addressed data layer.
 
@@ -27,7 +30,12 @@ flowchart TD
 | `dataset` | 64 MiB | unlimited | Directory | Training datasets, parquet files |
 | `code` | 16 MiB | unlimited | Hash | Source code, configs, small assets |
 
-When you omit `--profile`, Crab scans the file index and selects based on median file size:
+Built-in profiles retain their public Zstd level descriptions; the current
+Xet xorb encoder maps that config to its supported LZ4 chunk scheme. Custom
+profiles may select `zstd:N`, `lz4`, or `none`.
+
+When you omit `--profile`, Crab scans the canonical file index and selects a
+target from the median file size:
 
 - p50 > 100 MiB: `ml`
 - p50 >= 1 MiB: `dataset`
@@ -41,8 +49,9 @@ Dry-run first:
 crab optimize xorbs --profile ml --dry-run
 ```
 
-Dry-run is the supported optimization path today. It lists live source xorbs,
-reads their sizes and storage classes, and performs no writes.
+Dry-run reads the canonical shard set and live xorb metadata. It performs no
+writes. Source-shard scanning is disk-backed and hash-verified, so planning
+does not retain several complete metadata shards in memory at once.
 
 Apply the rewrite:
 
@@ -50,9 +59,11 @@ Apply the rewrite:
 crab optimize xorbs --profile ml --apply
 ```
 
-Apply currently fails closed. The executor can create destination xorbs, but
-the file-index/shard manifest reconciliation required for readers to resolve
-them is not implemented yet.
+Apply consolidates bounded batches of source xorbs, verifies every source and
+destination size/hash, rebuilds affected Xet shards, publishes candidate
+indexes, and advances the canonical manifest with compare-and-swap. A
+repository maintenance lease prevents overlapping destructive maintenance;
+old xorbs remain immutable until a later GC proves them unreferenced.
 
 Resume or abort an interrupted run:
 
@@ -70,7 +81,7 @@ Define profiles in `.crab/config.toml`:
 target_xorb_bytes = 134217728   # 128 MiB
 max_xorbs_per_file = 8
 group_by = "file"
-compression = "zstd:5"
+compression = "zstd:5"          # or "lz4" / "none"
 ```
 
 Custom profiles live under the same command namespace as `crab optimize xorbs`.
@@ -90,8 +101,9 @@ crab optimize xorbs --profile ml --apply --output-class=STANDARD_IA
 | Combination | Result |
 |-------------|--------|
 | Two `crab optimize xorbs` runs | Second fails with `CRAB-E0332` |
-| `crab gc` + `crab optimize xorbs` | Fails with `ConcurrentMaintenance [E0333]` |
+| `crab gc` + `crab optimize xorbs` | Repository maintenance lease admits only one operation |
 | `crab push` + `crab optimize xorbs --dry-run` | Safe; dry-run performs no writes |
+| `crab push` + `crab optimize xorbs --apply` | Manifest CAS reconciliation preserves current push roots |
 
 Old source xorbs become orphans and are reclaimed by the next `crab gc`.
 

--- a/packages/web/content/docs/cli/storage/repacking-objects.mdx
+++ b/packages/web/content/docs/cli/storage/repacking-objects.mdx
@@ -22,15 +22,16 @@ flowchart LR
 
 ## How Repacking Works
 
-1. Reads the pack list manifest from the remote store.
-2. Downloads all existing pack files.
-3. Runs `git repack --geometric=2 -d` to roll up only the packs needed to
-   restore a geometric progression.
-4. Validates every resulting pack together against the manifest refs.
-5. Uploads only newly generated pack, index, and reverse-index objects, and
-   repairs missing metadata sidecars.
+1. Pins the canonical manifest and segmented pack inventory.
+2. Downloads packs and indexes with bounded concurrency after a free-space
+   preflight.
+3. Verifies every source pair and the complete pinned ref graph, then runs
+   Git's geometric repack.
+4. Validates every replacement pack with strict Git checks.
+5. Uploads immutable replacement objects and repairs missing metadata sidecars.
 6. Atomically updates the manifest using compare-and-swap (CAS).
-7. Rebinds the existing Git visibility proof to the replacement pack inventory.
+7. Publishes the rebound visibility proof, exact locators, and generation
+   receipt before reporting success.
 
 Old pack files leave the active manifest after the update, but immutable
 recovery history continues to reference them. Repack therefore reduces the
@@ -41,11 +42,12 @@ an explicit history-retention boundary with `crab recover history prune
 ### Atomicity and Safety
 
 The manifest update uses CAS to prevent concurrent maintenance or push activity
-from corrupting state. If the manifest changes between read and write, repack
-fails without replacing the newer manifest; rerun the command against the new
-generation. The existing visibility proof is reused because repack changes the
-physical pack layout, not refs or reachable objects. Repack does not create a
-missing proof; `crab fsck` reports that pre-existing condition.
+from corrupting state. Apply mode holds the repository maintenance lease. If
+the manifest changes between repack and commit, the operation fails without
+replacing newer state; rerun against the new generation. Missing post-CAS
+evidence is repairable on a rerun without advancing an already consolidated
+generation. Dry-run reports current bytes; replacement size is unknown until
+Git performs the repack.
 
 ## Usage
 

--- a/packages/web/content/docs/cli/storage/storage-tiers.mdx
+++ b/packages/web/content/docs/cli/storage/storage-tiers.mdx
@@ -47,7 +47,12 @@ Read-only — probes the bucket and prints what Crab would apply. No write crede
 crab tier plan --apply
 ```
 
-Crab writes a backup of the current lifecycle configuration, then submits the new rules via CAS to prevent races.
+Crab requires a provider conditional-write guard before lifecycle mutation,
+writes a backup of the current configuration, submits the new rules, and
+requires an equivalent provider read-back before reporting success. The S3
+lifecycle API has no conditional write, and GCS/Azure safe prefix-preserving
+write paths are not wired, so the CLI currently renders plans but fails closed
+on lifecycle apply for all three providers.
 
 ### 3. Roll back if needed
 
@@ -133,13 +138,17 @@ Deleting an object before its minimum retention period incurs an early-deletion 
 
 ## Rollback and Safety
 
-Every `tier plan --apply` writes a backup before modifying the bucket:
+Every supported `tier plan --apply` writes a backup before modifying the bucket:
 
 ```text
 .crab/tier/backups/<RFC3339-ts>-pre-apply.json
 ```
 
-If the bucket's lifecycle has been modified since the backup was taken, the CAS guard detects the conflict and the rollback fails safely.
+New backups record both the previous and applied documents. Rollback validates
+the provider and fails if the current policy drifted, then restores the previous
+document or deletes the policy when none existed before apply. Providers
+without a conditional lifecycle write are rejected before a backup or
+mutation. Dry-run writes no backup.
 
 ## Common Workflow
 
@@ -153,7 +162,7 @@ crab tier plan
 # 3. Apply
 crab tier plan --apply
 
-# 4. Wait for provider evaluation (S3 ~24h, GCS ~24h, Azure up to 7d)
+# 4. Wait for S3 lifecycle evaluation (~24h)
 
 # 5. Compare costs
 crab doctor --cost --json > after.json


### PR DESCRIPTION
## Summary

- harden optimize workflows across xorb, shard, pack, cache, metadata, LFS, workflow, tier, replication, and cost paths
- bound object-store reads and metadata/cardinality, verify shard and xorb content hashes, cap reconciliation and journal reports, and preserve fail-closed cancellation/CAS behavior
- update CLI and documentation guidance for large-repository optimization

## Base

- rebased as one commit onto origin/main at 4747121d

## Validation

- cargo test -p crab --lib --locked --offline -- --test-threads=1 (3,719 passed; 2 ignored)
- cargo test -p crab-metadata --locked --offline (128 passed)
- cargo test -p crab-xet --locked --offline (122 passed)
- cargo fmt --all -- --check
- git diff --check
- web typecheck, lint (0 errors; existing warnings), tests (4 passed), and link checks