### PR TITLE
test(perf): add RustFS repository creation benchmark

### DIFF
--- a/crab/docs/design/push.md
+++ b/crab/docs/design/push.md
@@ -769,10 +769,13 @@ remote.
    compute an incremental remote-object set without a round-trip.
    Index construction, checksum binding, and canonical `.idx` upload are
    pre-commit requirements. All pack entries are appended to one candidate
-   pack index and become visible through one manifest CAS. After that CAS,
-   exact offset/length/CRC rows for the whole set are published through one
-   renewed `git_locator_db` writer session; publication failure is
-   repairable acceleration damage and does not roll back committed refs.
+   pack index and become visible through one manifest CAS. On an ordinary
+   generation-zero push, the manifest CAS and complete Git-visibility proof
+   return first; exact offset/length/CRC rows are deferred because they are
+   repairable acceleration state. The next push, `crab metadb owner`, or the
+   first fetch that needs protocol-v2 locator admission publishes them through
+   one renewed `git_locator_db` writer session. Publication failure never rolls
+   back committed refs.
 ```
 
 **Source:** `crab/src/git/push.rs` (`upload_packs`, `compute_remote_objects`),

--- a/crab/docs/guides/init.md
+++ b/crab/docs/guides/init.md
@@ -34,6 +34,7 @@ the matching `.gitattributes` rules.
 | `--storage-provider <provider>` | `auto` | Storage backend: `s3`, `gcs`, `azure`, or `auto` |
 | `--gc-list-profile <profile>` | `adaptive` | Local bucket-GC policy: `adaptive`, `cost`, or `latency` |
 | `--mirror <remote>` | — | Configure mirror mode with an existing Git remote |
+| `--remote` | `false` | Create the generation-0 manifest in object storage |
 | `--log-level` | — | Set log verbosity |
 
 ## URL Format
@@ -101,6 +102,10 @@ Azure credentials, user config, or environment variables.
    - `filter.crab.required = true` — ensures git fails if the filter is unavailable.
    - `diff.crab.command` — the external diff driver for `diff=crab` files.
 7. Prints the next `crab setup` and `crab ship` steps.
+
+By default, init only changes local state. Pass `--remote` to provision the
+empty generation-0 manifest in object storage. The create is atomic, and
+repeated or concurrent initialization adopts the manifest already present.
 
 ## Auto-Tracking
 

--- a/crab/scripts/e2e/run_repo_creation_benchmark.py
+++ b/crab/scripts/e2e/run_repo_creation_benchmark.py
@@ -3,9 +3,10 @@
 
 Each sample creates a fresh local Git repository, runs ``crab init`` against a
 unique remote prefix, commits a small deterministic file set, and performs the
-first native ``crab push``. Cohorts vary file count, repository count, and
-parallelism while sharing one isolated bucket so bucket cardinality is visible
-in the report.
+first native ``crab push``. Pass ``--remote-init`` to include generation-0
+manifest provisioning in the init sample. Cohorts vary file count, repository
+count, and parallelism while sharing one isolated bucket so bucket cardinality
+is visible in the report.
 
 The benchmark intentionally does not delete its bucket or local run directory.
 Use the reported AWS CLI commands to inspect or remove the isolated data after
@@ -263,6 +264,7 @@ class RepoCreationBenchmark:
                 "latency_repeats": args.latency_repeats,
                 "throughput_concurrency": args.concurrency,
                 "file_bytes": args.file_bytes,
+                "remote_init": args.remote_init,
             },
             started_at=utc_now(),
         )
@@ -425,8 +427,12 @@ class RepoCreationBenchmark:
         started = time.perf_counter_ns()
 
         try:
+            init_args = [self.crab_bin, "init", "--json"]
+            if self.args.remote_init:
+                init_args.append("--remote")
+            init_args.append(remote_url)
             code, result.init_ms, stdout, stderr = self.run_command(
-                [self.crab_bin, "init", "--json", remote_url],
+                init_args,
                 repo,
                 timeout=self.args.timeout,
                 env=env,
@@ -649,6 +655,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--timeout", type=int, default=120)
     parser.add_argument("--push-timeout", type=int, default=300)
     parser.add_argument("--allow-existing-bucket", action="store_true")
+    parser.add_argument(
+        "--remote-init",
+        action="store_true",
+        help="create each repository's generation-0 manifest during crab init",
+    )
     parser.add_argument("--skip-latency", action="store_true")
     parser.add_argument("--skip-throughput", action="store_true")
     args = parser.parse_args()

--- a/crab/scripts/e2e/run_repo_creation_benchmark.py
+++ b/crab/scripts/e2e/run_repo_creation_benchmark.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+"""Measure independent Crab repository creation against a local S3 endpoint.
+
+Each sample creates a fresh local Git repository, runs ``crab init`` against a
+unique remote prefix, commits a small deterministic file set, and performs the
+first native ``crab push``. Cohorts vary file count, repository count, and
+parallelism while sharing one isolated bucket so bucket cardinality is visible
+in the report.
+
+The benchmark intentionally does not delete its bucket or local run directory.
+Use the reported AWS CLI commands to inspect or remove the isolated data after
+reviewing the evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ENDPOINT = "http://127.0.0.1:9000"
+DEFAULT_ROOT = Path("/Volumes/Workspace/CrabRepos")
+DEFAULT_FILE_COUNTS = (1, 5, 10)
+DEFAULT_REPO_COUNTS = (10, 50, 100)
+DEFAULT_LATENCY_REPEATS = 3
+DEFAULT_CONCURRENCY = 8
+DEFAULT_FILE_BYTES = 4096
+MAX_DIAGNOSTIC_BYTES = 4096
+
+
+class BenchmarkError(RuntimeError):
+    """Raised when the benchmark setup or verification is invalid."""
+
+
+@dataclass
+class RepoResult:
+    cohort: str
+    repo_index: int
+    files_per_repo: int
+    remote_url: str
+    local_path: str
+    status: str
+    init_ms: float = 0.0
+    file_write_ms: float = 0.0
+    git_stage_ms: float = 0.0
+    commit_ms: float = 0.0
+    push_ms: float = 0.0
+    total_ms: float = 0.0
+    push_payload: dict[str, Any] | None = None
+    error_stage: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class CohortResult:
+    name: str
+    kind: str
+    files_per_repo: int
+    requested_repos: int
+    concurrency: int
+    cumulative_repos_after: int
+    elapsed_ms: float
+    attempted: int
+    successful: int
+    failed: int
+    attempted_repos_per_sec: float
+    successful_repos_per_sec: float
+    latency_ms: dict[str, dict[str, float]]
+    object_inventory: dict[str, int]
+    failures: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class Report:
+    schema: str
+    version: str
+    status: str
+    run_id: str
+    bucket: str
+    remote_prefix: str
+    endpoint_url: str
+    root: str
+    source_revision: str
+    source_dirty: bool
+    crab_binary: str
+    crab_version: str
+    rustfs_version: str
+    host: dict[str, Any]
+    matrix: dict[str, Any]
+    cohorts: list[dict[str, Any]] = field(default_factory=list)
+    artifacts: dict[str, str] = field(default_factory=dict)
+    started_at: str = ""
+    finished_at: str = ""
+    error: str | None = None
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def make_run_id() -> str:
+    return "repo-scale-" + datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def parse_positive_list(raw: str, flag: str) -> tuple[int, ...]:
+    values: list[int] = []
+    for item in raw.split(","):
+        try:
+            value = int(item.strip())
+        except ValueError as exc:
+            raise BenchmarkError(f"{flag} contains a non-integer: {item!r}") from exc
+        if value <= 0:
+            raise BenchmarkError(f"{flag} values must be positive: {value}")
+        values.append(value)
+    if not values:
+        raise BenchmarkError(f"{flag} must contain at least one value")
+    return tuple(dict.fromkeys(values))
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * fraction
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * weight
+
+
+def summarize(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"min": 0.0, "avg": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0}
+    return {
+        "min": min(values),
+        "avg": statistics.fmean(values),
+        "p50": percentile(values, 0.50),
+        "p95": percentile(values, 0.95),
+        "max": max(values),
+    }
+
+
+def command_version(command: list[str]) -> str:
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return result.stdout.strip()[:MAX_DIAGNOSTIC_BYTES]
+
+
+def resolve_executable(value: str, flag: str) -> str:
+    path = Path(value)
+    if path.is_file():
+        return str(path.resolve())
+    resolved = shutil.which(value)
+    if resolved:
+        return str(Path(resolved).resolve())
+    raise BenchmarkError(f"{flag} executable not found: {value}")
+
+
+def git_metadata(repo_root: Path) -> tuple[str, bool]:
+    revision = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).stdout.strip()
+    dirty = bool(
+        subprocess.run(
+            ["git", "status", "--short"],
+            cwd=repo_root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).stdout.strip()
+    )
+    return revision or "unknown", dirty
+
+
+def redact_error(stdout: str, stderr: str) -> str:
+    text = "\n".join(part.strip() for part in (stderr, stdout) if part.strip())
+    for secret in (
+        os.environ.get("AWS_ACCESS_KEY_ID", ""),
+        os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
+        os.environ.get("AWS_SESSION_TOKEN", ""),
+    ):
+        if secret:
+            text = text.replace(secret, "<redacted>")
+    return text[:MAX_DIAGNOSTIC_BYTES]
+
+
+def parse_json_object(text: str) -> dict[str, Any] | None:
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            return value
+    return None
+
+
+class RepoCreationBenchmark:
+    def __init__(self, args: argparse.Namespace, repo_root: Path) -> None:
+        self.args = args
+        self.repo_root = repo_root
+        self.run_id = args.run_id or make_run_id()
+        self.run_root = args.root / self.run_id
+        self.logs_root = self.run_root / "logs"
+        self.cache_root = self.run_root / "cache"
+        self.remote_prefix = self.run_id
+        self.bucket = args.bucket or f"crab-perf-{self.run_id.removeprefix('repo-scale-')}"
+        self.crab_bin = args.crab_bin
+        self.env = self.build_env()
+        revision, dirty = git_metadata(repo_root)
+        self.report = Report(
+            schema="crab.repo-creation-benchmark",
+            version="1.0",
+            status="running",
+            run_id=self.run_id,
+            bucket=self.bucket,
+            remote_prefix=self.remote_prefix,
+            endpoint_url=args.endpoint_url,
+            root=str(self.run_root),
+            source_revision=revision,
+            source_dirty=dirty,
+            crab_binary=self.crab_bin,
+            crab_version=command_version([self.crab_bin, "--version"]),
+            rustfs_version=command_version([args.rustfs_bin, "--version"]),
+            host={
+                "platform": platform.platform(),
+                "machine": platform.machine(),
+                "python": sys.version.split()[0],
+                "cpu_count": os.cpu_count(),
+            },
+            matrix={
+                "files_per_repo": list(args.file_counts),
+                "throughput_repo_counts": list(args.repo_counts),
+                "latency_repeats": args.latency_repeats,
+                "throughput_concurrency": args.concurrency,
+                "file_bytes": args.file_bytes,
+            },
+            started_at=utc_now(),
+        )
+
+    def build_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "AWS_ACCESS_KEY_ID": self.args.access_key,
+                "AWS_SECRET_ACCESS_KEY": self.args.secret_key,
+                "AWS_REGION": self.args.region,
+                "AWS_DEFAULT_REGION": self.args.region,
+                "AWS_ENDPOINT_URL": self.args.endpoint_url,
+                "AWS_ENDPOINT_URL_S3": self.args.endpoint_url,
+                "AWS_ALLOW_HTTP": "true",
+                "AWS_EC2_METADATA_DISABLED": "true",
+                "AWS_VIRTUAL_HOSTED_STYLE_REQUEST": "false",
+                "VIRTUAL_HOSTED_STYLE_REQUEST": "false",
+                "CRAB_LOG": "error",
+                "GIT_TERMINAL_PROMPT": "0",
+                "NO_COLOR": "1",
+            }
+        )
+        return env
+
+    def write_report(self) -> None:
+        artifacts = self.run_root / "artifacts"
+        artifacts.mkdir(parents=True, exist_ok=True)
+        path = artifacts / "report.json"
+        temporary = path.with_suffix(".json.tmp")
+        self.report.artifacts["report"] = str(path)
+        temporary.write_text(json.dumps(asdict(self.report), indent=2, sort_keys=True) + "\n")
+        temporary.replace(path)
+
+    def run_command(
+        self,
+        args: list[str],
+        cwd: Path,
+        *,
+        timeout: int,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, float, str, str]:
+        started = time.perf_counter_ns()
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            env=env or self.env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+        elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+        return result.returncode, elapsed_ms, result.stdout, result.stderr
+
+    def ensure_bucket(self) -> None:
+        self.run_root.mkdir(parents=True, exist_ok=False)
+        self.logs_root.mkdir()
+        self.cache_root.mkdir()
+        head = self.run_command(
+            [
+                self.args.aws_bin,
+                "--endpoint-url",
+                self.args.endpoint_url,
+                "s3api",
+                "head-bucket",
+                "--bucket",
+                self.bucket,
+            ],
+            self.run_root,
+            timeout=self.args.timeout,
+        )
+        if head[0] == 0:
+            if not self.args.allow_existing_bucket:
+                raise BenchmarkError(
+                    f"bucket already exists: {self.bucket}; use a unique --bucket or "
+                    "--allow-existing-bucket"
+                )
+            return
+        created = self.run_command(
+            [
+                self.args.aws_bin,
+                "--endpoint-url",
+                self.args.endpoint_url,
+                "s3api",
+                "create-bucket",
+                "--bucket",
+                self.bucket,
+            ],
+            self.run_root,
+            timeout=self.args.timeout,
+        )
+        if created[0] != 0:
+            raise BenchmarkError(
+                f"failed to create bucket {self.bucket}: "
+                f"{redact_error(created[2], created[3])}"
+            )
+
+    def inventory(self, prefix: str) -> dict[str, int]:
+        result = self.run_command(
+            [
+                self.args.aws_bin,
+                "--endpoint-url",
+                self.args.endpoint_url,
+                "s3api",
+                "list-objects-v2",
+                "--bucket",
+                self.bucket,
+                "--prefix",
+                prefix,
+                "--output",
+                "json",
+            ],
+            self.run_root,
+            timeout=self.args.timeout,
+        )
+        if result[0] != 0:
+            raise BenchmarkError(
+                f"inventory failed for prefix {prefix!r}: "
+                f"{redact_error(result[2], result[3])}"
+            )
+        payload = json.loads(result[2] or "{}")
+        contents = payload.get("Contents", [])
+        return {
+            "objects": len(contents),
+            "bytes": sum(int(item.get("Size", 0)) for item in contents),
+        }
+
+    def make_repo_env(self, repo_index: int, cohort: str) -> dict[str, str]:
+        env = self.env.copy()
+        env["CRAB_CACHE_DIR"] = str(self.cache_root / cohort / f"repo-{repo_index:05d}")
+        return env
+
+    def write_files(self, repo: Path, cohort: str, repo_index: int, count: int) -> None:
+        for file_index in range(count):
+            seed = f"{self.run_id}:{cohort}:{repo_index}:{file_index}".encode()
+            block = hashlib.sha256(seed).digest()
+            content = (block * ((self.args.file_bytes + len(block) - 1) // len(block)))[
+                : self.args.file_bytes
+            ]
+            (repo / f"file-{file_index:02d}.txt").write_bytes(content)
+
+    def create_repo(self, cohort: str, repo_index: int, files_per_repo: int) -> RepoResult:
+        remote_path = f"{self.remote_prefix}/{cohort}/repo-{repo_index:05d}"
+        remote_url = f"crab://{self.bucket}/{remote_path}"
+        repo = self.run_root / "repos" / cohort / f"repo-{repo_index:05d}"
+        repo.mkdir(parents=True, exist_ok=False)
+        env = self.make_repo_env(repo_index, cohort)
+        result = RepoResult(
+            cohort=cohort,
+            repo_index=repo_index,
+            files_per_repo=files_per_repo,
+            remote_url=remote_url,
+            local_path=str(repo),
+            status="failed",
+        )
+        started = time.perf_counter_ns()
+
+        try:
+            code, result.init_ms, stdout, stderr = self.run_command(
+                [self.crab_bin, "init", "--json", remote_url],
+                repo,
+                timeout=self.args.timeout,
+                env=env,
+            )
+            if code != 0:
+                raise BenchmarkError(f"init: {redact_error(stdout, stderr)}")
+
+            write_started = time.perf_counter_ns()
+            self.write_files(repo, cohort, repo_index, files_per_repo)
+            result.file_write_ms = (time.perf_counter_ns() - write_started) / 1_000_000
+
+            self.run_command(
+                [self.args.git_bin, "config", "user.name", "Crab benchmark"],
+                repo,
+                timeout=self.args.timeout,
+                env=env,
+            )
+            self.run_command(
+                [self.args.git_bin, "config", "user.email", "benchmark@example.invalid"],
+                repo,
+                timeout=self.args.timeout,
+                env=env,
+            )
+
+            code, result.git_stage_ms, stdout, stderr = self.run_command(
+                [self.args.git_bin, "add", "-A"],
+                repo,
+                timeout=self.args.timeout,
+                env=env,
+            )
+            if code != 0:
+                raise BenchmarkError(f"git add: {redact_error(stdout, stderr)}")
+
+            code, result.commit_ms, stdout, stderr = self.run_command(
+                [
+                    self.args.git_bin,
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    f"create benchmark repo {repo_index}",
+                ],
+                repo,
+                timeout=self.args.timeout,
+                env=env,
+            )
+            if code != 0:
+                raise BenchmarkError(f"git commit: {redact_error(stdout, stderr)}")
+
+            code, result.push_ms, stdout, stderr = self.run_command(
+                [
+                    self.crab_bin,
+                    "push",
+                    "--json",
+                    "--no-color",
+                    "--lock-wait-secs",
+                    "30",
+                    "origin",
+                    "HEAD:refs/heads/main",
+                ],
+                repo,
+                timeout=self.args.push_timeout,
+                env=env,
+            )
+            result.push_payload = parse_json_object(stdout)
+            if code != 0:
+                raise BenchmarkError(f"push: {redact_error(stdout, stderr)}")
+            result.status = "ok"
+        except (BenchmarkError, subprocess.TimeoutExpired) as exc:
+            result.error_stage = result.error_stage or self.infer_stage(exc)
+            result.error = str(exc)[:MAX_DIAGNOSTIC_BYTES]
+        except OSError as exc:
+            result.error_stage = "process"
+            result.error = str(exc)[:MAX_DIAGNOSTIC_BYTES]
+        finally:
+            result.total_ms = (time.perf_counter_ns() - started) / 1_000_000
+        return result
+
+    @staticmethod
+    def infer_stage(error: BaseException) -> str:
+        text = str(error)
+        for stage in ("init", "git add", "git commit", "push"):
+            if text.startswith(stage):
+                return stage.replace(" ", "_")
+        if isinstance(error, subprocess.TimeoutExpired):
+            return "timeout"
+        return "unknown"
+
+    def run_cohort(
+        self,
+        *,
+        kind: str,
+        files_per_repo: int,
+        repo_count: int,
+        concurrency: int,
+    ) -> CohortResult:
+        name = f"{kind}-f{files_per_repo:02d}-r{repo_count:04d}-c{concurrency:02d}"
+        cohort_started = time.perf_counter_ns()
+        worker = lambda index: self.create_repo(name, index, files_per_repo)
+        results: list[RepoResult] = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+            futures = [pool.submit(worker, index) for index in range(repo_count)]
+            for future in concurrent.futures.as_completed(futures):
+                results.append(future.result())
+        results.sort(key=lambda item: item.repo_index)
+        elapsed_ms = (time.perf_counter_ns() - cohort_started) / 1_000_000
+        successful = [item for item in results if item.status == "ok"]
+        elapsed_secs = max(elapsed_ms / 1000, 0.000001)
+        inventory = self.inventory(f"{self.remote_prefix}/")
+        latency_ms = {
+            field_name: summarize([getattr(item, field_name) for item in successful])
+            for field_name in ("init_ms", "file_write_ms", "git_stage_ms", "commit_ms", "push_ms", "total_ms")
+        }
+        failures = [
+            {
+                "repo_index": item.repo_index,
+                "remote_url": item.remote_url,
+                "error_stage": item.error_stage,
+                "error": item.error,
+            }
+            for item in results
+            if item.status != "ok"
+        ]
+        cohort = CohortResult(
+            name=name,
+            kind=kind,
+            files_per_repo=files_per_repo,
+            requested_repos=repo_count,
+            concurrency=concurrency,
+            cumulative_repos_after=sum(
+                int(previous["successful"]) for previous in self.report.cohorts
+            )
+            + len(successful),
+            elapsed_ms=elapsed_ms,
+            attempted=len(results),
+            successful=len(successful),
+            failed=len(results) - len(successful),
+            attempted_repos_per_sec=repo_count / elapsed_secs,
+            successful_repos_per_sec=len(successful) / elapsed_secs,
+            latency_ms=latency_ms,
+            object_inventory=inventory,
+            failures=failures,
+        )
+        self.report.cohorts.append(asdict(cohort))
+        self.report.artifacts[f"{name}-results"] = self.write_cohort_results(name, results)
+        self.write_report()
+        if failures:
+            raise BenchmarkError(f"cohort {name} had {len(failures)} failed repositories")
+        return cohort
+
+    def write_cohort_results(self, name: str, results: list[RepoResult]) -> str:
+        path = self.run_root / "artifacts" / f"{name}-repos.json"
+        path.write_text(json.dumps([asdict(item) for item in results], indent=2, sort_keys=True) + "\n")
+        return str(path)
+
+    def run(self) -> int:
+        self.ensure_bucket()
+        self.write_report()
+        try:
+            for files_per_repo in self.args.file_counts:
+                if not self.args.skip_latency:
+                    self.run_cohort(
+                        kind="latency",
+                        files_per_repo=files_per_repo,
+                        repo_count=self.args.latency_repeats,
+                        concurrency=1,
+                    )
+                if not self.args.skip_throughput:
+                    for repo_count in self.args.repo_counts:
+                        self.run_cohort(
+                            kind="throughput",
+                            files_per_repo=files_per_repo,
+                            repo_count=repo_count,
+                            concurrency=min(self.args.concurrency, repo_count),
+                        )
+        except (BenchmarkError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+            self.report.status = "failed"
+            self.report.error = str(exc)[:MAX_DIAGNOSTIC_BYTES]
+            self.report.finished_at = utc_now()
+            self.write_report()
+            print(f"FAILED: {self.report.error}", file=sys.stderr)
+            print(f"report: {self.report.artifacts.get('report', 'not-written')}", file=sys.stderr)
+            return 1
+        self.report.status = "ok"
+        self.report.finished_at = utc_now()
+        self.write_report()
+        print(f"OK: {self.report.run_id}")
+        print(f"bucket: {self.bucket}")
+        print(f"remote prefix: {self.remote_prefix}/")
+        print(f"run directory: {self.run_root}")
+        print(f"report: {self.report.artifacts['report']}")
+        print(f"cleanup: {self.cleanup_command()}")
+        return 0
+
+    def cleanup_command(self) -> str:
+        return (
+            f"AWS_ACCESS_KEY_ID={self.args.access_key} "
+            f"AWS_SECRET_ACCESS_KEY=<secret> AWS_REGION={self.args.region} "
+            f"aws --endpoint-url {self.args.endpoint_url} s3 rb s3://{self.bucket} --force"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--bucket", help="isolated bucket name; defaults to a timestamped name")
+    parser.add_argument("--run-id")
+    parser.add_argument("--endpoint-url", default=DEFAULT_ENDPOINT)
+    parser.add_argument("--access-key", default="crab")
+    parser.add_argument("--secret-key", default="crab")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--crab-bin", default=shutil.which("crab") or "crab")
+    parser.add_argument("--git-bin", default=shutil.which("git") or "git")
+    parser.add_argument("--aws-bin", default=shutil.which("aws") or "aws")
+    parser.add_argument("--rustfs-bin", default=shutil.which("rustfs") or "rustfs")
+    parser.add_argument("--file-counts", default=','.join(map(str, DEFAULT_FILE_COUNTS)))
+    parser.add_argument("--repo-counts", default=','.join(map(str, DEFAULT_REPO_COUNTS)))
+    parser.add_argument("--latency-repeats", type=int, default=DEFAULT_LATENCY_REPEATS)
+    parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
+    parser.add_argument("--file-bytes", type=int, default=DEFAULT_FILE_BYTES)
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--push-timeout", type=int, default=300)
+    parser.add_argument("--allow-existing-bucket", action="store_true")
+    parser.add_argument("--skip-latency", action="store_true")
+    parser.add_argument("--skip-throughput", action="store_true")
+    args = parser.parse_args()
+    args.file_counts = parse_positive_list(args.file_counts, "--file-counts")
+    args.repo_counts = parse_positive_list(args.repo_counts, "--repo-counts")
+    if args.latency_repeats <= 0:
+        parser.error("--latency-repeats must be positive")
+    if args.concurrency <= 0:
+        parser.error("--concurrency must be positive")
+    if args.file_bytes <= 0:
+        parser.error("--file-bytes must be positive")
+    if args.skip_latency and args.skip_throughput:
+        parser.error("at least one of latency or throughput must be enabled")
+    for attribute, flag in (
+        ("crab_bin", "--crab-bin"),
+        ("git_bin", "--git-bin"),
+        ("aws_bin", "--aws-bin"),
+        ("rustfs_bin", "--rustfs-bin"),
+    ):
+        try:
+            setattr(args, attribute, resolve_executable(getattr(args, attribute), flag))
+        except BenchmarkError as exc:
+            parser.error(str(exc))
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[2]
+    benchmark = RepoCreationBenchmark(args, repo_root)
+    return benchmark.run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crab/src/cmd/init.rs
+++ b/crab/src/cmd/init.rs
@@ -760,18 +760,14 @@ async fn ensure_initial_manifest(
     router: &crate::storage::StoreLayout,
     head: &str,
 ) -> Result<()> {
-    match crate::metadata::manifest::read_manifest(store, router).await {
-        Ok(_) => Ok(()),
-        Err(CrabError::NotFound { .. }) => {
-            match create_initial_manifest(store, router, head).await {
-                Ok(()) => Ok(()),
-                Err(CrabError::CasConflict { .. }) => {
-                    crate::metadata::manifest::read_manifest(store, router)
-                        .await
-                        .map(|_| ())
-                }
-                Err(error) => Err(error),
-            }
+    // New repositories are the hot path: create-first avoids a discovery GET.
+    // A conflict proves another initializer won, so adopt its manifest.
+    match create_initial_manifest(store, router, head).await {
+        Ok(()) => Ok(()),
+        Err(CrabError::CasConflict { .. }) => {
+            crate::metadata::manifest::read_manifest(store, router)
+                .await
+                .map(|_| ())
         }
         Err(error) => Err(error),
     }

--- a/crab/src/cmd/init.rs
+++ b/crab/src/cmd/init.rs
@@ -721,9 +721,10 @@ fn scan_for_large_files(
 
 /// Create the initial unified manifest for a new repository.
 ///
-/// Uploads empty segmented shard/pack indexes, then creates the
-/// manifest pointer at `{repo}/manifest` with generation 0, empty refs,
-/// and the given HEAD symref target.
+/// Creates the manifest pointer at `{repo}/manifest` with generation 0,
+/// empty refs, empty index hashes, and the given HEAD symref target.
+/// Empty index hashes are the canonical zero-state representation; the first
+/// committed push publishes real segmented indexes.
 ///
 /// Uses `create_manifest` (If-None-Match: *) so a concurrent init doesn't
 /// clobber an existing manifest.
@@ -737,24 +738,9 @@ pub async fn create_initial_manifest(
     router: &crate::storage::StoreLayout,
     head: &str,
 ) -> Result<()> {
-    use crate::metadata::manifest::{
-        BulkData, Manifest, compact_pack_index, compact_shard_index, create_manifest,
-        upload_segmented_bulk,
-    };
+    use crate::metadata::manifest::{Manifest, create_manifest};
 
-    let (empty_shard_hash, _shard_index, shard_write) = compact_shard_index(0, &[])?;
-    let (empty_pack_hash, _pack_index, pack_write) = compact_pack_index(0, &[])?;
-    let bulk = BulkData {
-        shard_index: shard_write,
-        pack_index: pack_write,
-    };
-    upload_segmented_bulk(store, router, &bulk).await?;
-
-    // Build the generation-0 manifest.
-    let mut manifest = Manifest::default_for_repo(head);
-    manifest.shard_index_hash = empty_shard_hash;
-    manifest.pack_index_hash = empty_pack_hash;
-    manifest.seal_git_validation();
+    let manifest = Manifest::default_for_repo(head);
 
     // Create the manifest pointer with If-None-Match: * semantics.
     create_manifest(store, router, &manifest).await?;
@@ -1749,7 +1735,7 @@ storage_provider = "azure"
 
     #[tokio::test]
     async fn init_creates_valid_manifest_that_read_manifest_can_parse() {
-        use crate::metadata::manifest::{read_bulk_pack_list, read_bulk_shard_list, read_manifest};
+        use crate::metadata::manifest::read_manifest;
         use crate::storage::StoreLayout;
         use crate::storage::store::Store;
         use object_store::memory::InMemory;
@@ -1773,21 +1759,10 @@ storage_provider = "azure"
         assert_eq!(manifest.generation, 0);
         assert_eq!(manifest.head, "refs/heads/main");
         assert!(manifest.refs.is_empty());
-        assert!(!manifest.shard_index_hash.is_empty());
-        assert!(!manifest.pack_index_hash.is_empty());
+        assert!(manifest.shard_index_hash.is_empty());
+        assert!(manifest.pack_index_hash.is_empty());
         assert!(manifest.commit_graph_hash.is_none());
         assert!(manifest.ref_registry_hash.is_none());
-
-        // Verify the bulk objects are readable and empty.
-        let shards = read_bulk_shard_list(&store, &router, &manifest.shard_index_hash)
-            .await
-            .expect("shard-list should be readable");
-        assert!(shards.is_empty());
-
-        let packs = read_bulk_pack_list(&store, &router, &manifest.pack_index_hash)
-            .await
-            .expect("pack-list should be readable");
-        assert!(packs.is_empty());
     }
 
     #[tokio::test]

--- a/crab/src/cmd/init.rs
+++ b/crab/src/cmd/init.rs
@@ -2,8 +2,7 @@
 //!
 //! Parses the remote URL, creates the local `.crab/` directory with a
 //! `config.toml` pointing at the remote, registers the crab git drivers
-//! in the local git config, and logs the prefixes that will be
-//! created on the remote once the Store is wired.
+//! in the local git config, and logs the prefixes used by the remote layout.
 
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -12,13 +11,14 @@ use std::process::Command;
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
-use crate::core::config::{GcListProfile, StorageProvider};
+use crate::core::config::{Config, GcListProfile, StorageProvider};
 use crate::core::credential_discovery::{CredentialSource, discover_credentials};
 use crate::core::error::{CrabError, Result, check_cancelled};
 use crate::core::output::{OutputMode, emit_json};
 use crate::core::project_config::{ProjectAuthConfig, ProjectConfig, RemoteConfig};
 use crate::core::style::CliStyle;
 use crate::git::url::CrabUrl;
+use crate::storage::StoreLayout;
 
 /// Remote prefixes that constitute a crab repository in object storage.
 /// Per-repo prefixes live under `{repo}/`; content-addressed objects live
@@ -77,9 +77,8 @@ pub async fn run_init(url: &str, cancel: &CancellationToken) -> Result<()> {
 
 /// Initialize a crab repository rooted at `root`.
 ///
-/// Creates `{root}/.crab/config.toml` with the remote URL and logs
-/// the remote prefixes that would be created atomically (via
-/// `PutMode::Create`) once the Store is available.
+/// Creates `{root}/.crab/config.toml` with the remote URL. Pass `--remote` to
+/// create the generation-0 manifest after local setup.
 ///
 /// # Errors
 ///
@@ -88,6 +87,37 @@ pub async fn run_init(url: &str, cancel: &CancellationToken) -> Result<()> {
 /// [`CrabError::Cancelled`] if the cancellation token fires.
 pub async fn run_init_in(url: &str, root: &Path, cancel: &CancellationToken) -> Result<()> {
     run_init_with_options(url, root, cancel, OutputMode::Text).await
+}
+
+/// Create the generation-0 manifest for a repository after local init.
+///
+/// Existing manifests are adopted, so this operation is safe to repeat and
+/// concurrent callers converge on the manifest created by the first caller.
+///
+/// # Errors
+///
+/// Returns a configuration, authentication, storage, or cancellation error
+/// when the remote cannot be opened or its initial manifest cannot be created.
+pub async fn initialize_remote_repository(
+    url: &str,
+    root: &Path,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    check_cancelled(cancel)?;
+    let remote = parse_init_remote(url)?;
+    let config = Config::resolve_for_repo(root)?;
+    let repo_prefix = remote.parsed.repo_path.clone();
+    let store = crate::auth::build_store(&config, remote.parsed, "repo-create", cancel).await?;
+    let router = StoreLayout::new(store.clone(), repo_prefix);
+    let head = format!("refs/heads/{}", config.default_branch);
+
+    ensure_initial_manifest(&store, &router, &head).await?;
+    tracing::info!(
+        url = %remote.canonical_url,
+        head = %head,
+        "remote repository initialized"
+    );
+    Ok(())
 }
 
 /// Options-driven init implementation.
@@ -359,15 +389,15 @@ async fn run_init_inner(
         emit_json(INIT_SCHEMA, INIT_VERSION, payload);
     }
 
-    // Log what would be created on the remote. Full remote initialization
-    // (manifest creation) happens when the Store is available — it will use
-    // create_initial_manifest for atomic, idempotent manifest creation.
+    // The default init path remains local-only. `--remote` calls
+    // `initialize_remote_repository` after local setup has written the
+    // provider and credential configuration needed to build the Store.
     for prefix in REMOTE_PREFIXES {
         tracing::info!(
             prefix = %prefix,
             host = %host,
             repo_path = %path,
-            "would create per-repo remote prefix (Store not yet wired)",
+            "remote per-repo prefix is materialized by manifest creation",
         );
     }
 
@@ -375,14 +405,11 @@ async fn run_init_inner(
         tracing::info!(
             prefix = %prefix,
             host = %host,
-            "would create global prefix (Store not yet wired)",
+            "remote global prefix is materialized by content upload",
         );
     }
 
-    tracing::info!(
-        "crab init complete — local config written, git drivers registered, \
-         manifest creation pending Store wiring"
-    );
+    tracing::info!("crab init complete — local config written and git drivers registered");
 
     if !mode.is_machine() && show_next_steps {
         eprintln!("\nNext:");
@@ -740,6 +767,28 @@ pub async fn create_initial_manifest(
     );
 
     Ok(())
+}
+
+async fn ensure_initial_manifest(
+    store: &crate::storage::store::Store,
+    router: &crate::storage::StoreLayout,
+    head: &str,
+) -> Result<()> {
+    match crate::metadata::manifest::read_manifest(store, router).await {
+        Ok(_) => Ok(()),
+        Err(CrabError::NotFound { .. }) => {
+            match create_initial_manifest(store, router, head).await {
+                Ok(()) => Ok(()),
+                Err(CrabError::CasConflict { .. }) => {
+                    crate::metadata::manifest::read_manifest(store, router)
+                        .await
+                        .map(|_| ())
+                }
+                Err(error) => Err(error),
+            }
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// Resolve the path to the crab binary for use in git config values.
@@ -1772,6 +1821,32 @@ storage_provider = "azure"
                 "expected CasConflict on duplicate init, got: {e:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn remote_manifest_initialization_adopts_existing_manifest() {
+        use crate::metadata::manifest::read_manifest;
+        use crate::storage::StoreLayout;
+        use crate::storage::store::Store;
+        use object_store::memory::InMemory;
+        use std::sync::Arc;
+
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(inner);
+        let router = StoreLayout::new(store.clone(), "org/my-repo".to_string());
+
+        ensure_initial_manifest(&store, &router, "refs/heads/main")
+            .await
+            .expect("first remote initialization should succeed");
+        ensure_initial_manifest(&store, &router, "refs/heads/main")
+            .await
+            .expect("repeated remote initialization should adopt the manifest");
+
+        let (manifest, _) = read_manifest(&store, &router)
+            .await
+            .expect("initialized manifest should remain readable");
+        assert_eq!(manifest.generation, 0);
+        assert_eq!(manifest.head, "refs/heads/main");
     }
 
     #[test]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -15252,7 +15252,10 @@ impl PushPipeline {
         // hand this lock in after discovery; direct callers acquire it here.
         // This preserves lock-then-push serialization while immutable xorb
         // uploads overlap the remaining staged reads.
-        self.at_stage(PushFailureStage::Lock, self.acquire_push_lock().await)?;
+        let push_lock_phase = PhaseTimer::start("push", "push_lock_acquire");
+        let push_lock_result = self.acquire_push_lock().await;
+        self.emit_perf_phase(push_lock_phase.finish(0, 0, 0));
+        self.at_stage(PushFailureStage::Lock, push_lock_result)?;
         self.at_stage(
             PushFailureStage::Admission,
             self.acquire_active_active_gc_writer().await,
@@ -15299,10 +15302,11 @@ impl PushPipeline {
         // Protected pushes are admitted by the authenticated service before it
         // grants a session-private staging store. Coordination objects written
         // through that store cannot provide repository-wide mutual exclusion.
-        let admission_lock = if object_store_admission {
+        let admission_phase = PhaseTimer::start("push", "push_admission");
+        let admission_result = if object_store_admission {
             match self.store.as_ref() {
-                Some(store) => Some(
-                    self.at_stage(
+                Some(store) => self
+                    .at_stage(
                         PushFailureStage::Admission,
                         acquire_push_admission_lock(
                             store,
@@ -15313,13 +15317,15 @@ impl PushPipeline {
                             &self.cancel,
                         )
                         .await,
-                    )?,
-                ),
-                None => None,
+                    )
+                    .map(Some),
+                None => Ok(None),
             }
         } else {
-            None
+            Ok(None)
         };
+        self.emit_perf_phase(admission_phase.finish(0, 0, 0));
+        let admission_lock = self.at_stage(PushFailureStage::Admission, admission_result)?;
         match admission_lock {
             Some(lock) => {
                 let (committed_tx, committed_rx) = tokio::sync::oneshot::channel();
@@ -15556,6 +15562,7 @@ impl PushPipeline {
                     .lock()
                     .await
                     .is_empty();
+            let metadb_phase = PhaseTimer::start("push", "post_cas_metadb");
             let indexing = if !needs_metadb_write {
                 Ok(())
             } else {
@@ -15577,6 +15584,7 @@ impl PushPipeline {
                     Err(error) => Err(error),
                 }
             };
+            self.emit_perf_phase(metadb_phase.finish(0, 0, file_index_plan.len() as u64));
             let file_indexed = match indexing {
                 Ok(()) => true,
                 Err(error) => {
@@ -15602,7 +15610,8 @@ impl PushPipeline {
             if locator_deferred {
                 git_indexed = false;
             } else if let (Some(anchor), Some(store)) = (anchor, self.store.as_ref()) {
-                match publish_uploaded_pack_locators(
+                let locator_phase = PhaseTimer::start("push", "post_cas_git_locator");
+                let locator_result = publish_uploaded_pack_locators(
                     store,
                     &self.router,
                     &uploaded_packs,
@@ -15611,8 +15620,9 @@ impl PushPipeline {
                     self.config.lock_ttl,
                     &self.cancel,
                 )
-                .await
-                {
+                .await;
+                self.emit_perf_phase(locator_phase.finish(0, 0, uploaded_packs.len() as u64));
+                match locator_result {
                     Ok(stats) if stats.coverage_updated => {
                         info!(
                             generation = anchor.generation,
@@ -15668,13 +15678,17 @@ impl PushPipeline {
             if file_indexed
                 && git_indexed
                 && let Some(anchor) = anchor
-                && let Err(error) = self.write_generation_index_receipt(anchor).await
             {
-                warn!(
-                    error = %error,
-                    generation = anchor.generation,
-                    "post-CAS generation-index receipt write failed; manifest-scoped repair remains available"
-                );
+                let receipt_phase = PhaseTimer::start("push", "post_cas_receipt");
+                let receipt_result = self.write_generation_index_receipt(anchor).await;
+                self.emit_perf_phase(receipt_phase.finish(0, 0, 1));
+                if let Err(error) = receipt_result {
+                    warn!(
+                        error = %error,
+                        generation = anchor.generation,
+                        "post-CAS generation-index receipt write failed; manifest-scoped repair remains available"
+                    );
+                }
             }
         }
 

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -125,6 +125,22 @@ pub(crate) async fn upsert_pack_metadata(
         return Ok(metadata);
     }
 
+    // A newly generated content-addressed pack normally has no sidecar yet;
+    // create-first avoids a guaranteed read on the first publication.
+    let metadata = PackMetadata {
+        pack_id: pack_id.to_owned(),
+        ref_tips: requested_tips.iter().cloned().collect(),
+        object_count,
+    };
+    let body = serde_json::to_vec(&metadata).map_err(|error| {
+        CrabError::Internal(format!("failed to serialize PackMetadata: {error}"))
+    })?;
+    match store.create_strict(path, Bytes::from(body)).await {
+        Ok(()) => return Ok(metadata),
+        Err(CrabError::CasConflict { .. }) => {}
+        Err(error) => return Err(error),
+    }
+
     for _ in 0..max_retries.max(1) {
         match store.get_with_etag(path).await {
             Ok((body, etag)) => {
@@ -7990,6 +8006,58 @@ impl PushPipeline {
         )))
     }
 
+    async fn try_publish_initial_manifest(
+        &self,
+        manifest: &Manifest,
+        bulk: &BulkData,
+        current: &crate::metadata::manifest::RepositorySnapshot,
+        admission_commit: &mut Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<bool> {
+        let eligible = self.config.protected_push.is_none()
+            && self.config.active_active_replication.is_none()
+            && current.manifest.generation == 0
+            && current.manifest.refs.is_empty()
+            && current.manifest.shard_index_hash.is_empty()
+            && current.manifest.pack_index_hash.is_empty()
+            && current.journal.refs.is_empty()
+            && current.journal.packs.is_empty()
+            && current.journal.shards.is_empty()
+            && current.journal.transactions.is_empty()
+            && current.journal.visible_heads.is_empty()
+            && manifest.generation == 1
+            && !manifest.refs.is_empty();
+        if !eligible {
+            return Ok(false);
+        }
+
+        let anchor = committed_manifest_anchor(manifest)?;
+        let git_dir = self.common_git_dir()?;
+        let store = self
+            .store
+            .as_ref()
+            .ok_or_else(|| CrabError::Internal("initial manifest requires a store".to_owned()))?;
+
+        // The candidate indexes and the complete visibility proof are
+        // independent immutable objects. Publish both before the manifest
+        // CAS so the manifest remains the only visibility boundary.
+        tokio::try_join!(
+            upload_segmented_bulk(store, &self.router, bulk),
+            publish_git_visibility_index_from_git_dir(&git_dir, manifest, store, &self.router),
+        )?;
+        let new_etag =
+            write_manifest_cas(store, &self.router, manifest, &current.manifest_etag).await?;
+
+        *self.manifest_etag.lock().await = Some(new_etag);
+        *self.committed_manifest_anchor.lock().await = anchor;
+        self.git_visibility_published
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(signal) = admission_commit.take() {
+            let _ = signal.send(());
+        }
+        self.stop_heartbeat_and_release_lock().await;
+        Ok(true)
+    }
+
     /// Commit independently locked refs through one atomic journal transaction.
     #[tracing::instrument(
         level = "info",
@@ -8006,7 +8074,7 @@ impl PushPipeline {
     async fn commit_ref_journal(
         &self,
         mut manifest: Manifest,
-        _bulk: BulkData,
+        bulk: BulkData,
         sha_map: &HashMap<String, String>,
         mut decisions: HashMap<String, RefUpdateDecision>,
         admission_commit: &mut Option<tokio::sync::oneshot::Sender<()>>,
@@ -8087,6 +8155,13 @@ impl PushPipeline {
             (manifest, _) = self
                 .apply_decisions_with_sha_map(&decisions, false, sha_map)
                 .await?;
+        }
+        if !had_conflicts
+            && self
+                .try_publish_initial_manifest(&manifest, &bulk, &current_snapshot, admission_commit)
+                .await?
+        {
+            return Ok(decisions);
         }
         let mut edits = Vec::new();
         let lock_holders = {
@@ -12282,8 +12357,9 @@ impl PushPipeline {
                             ))
                         })??;
                     let remote_idx_path = self.router.pack_index_path(&pack_sha);
-                    store
-                        .put_multipart_file_retry(
+                    let remote_rev_path = self.router.pack_reverse_index_path(&pack_sha);
+                    tokio::try_join!(
+                        store.put_multipart_file_retry(
                             &remote_idx_path,
                             &installed.idx_path,
                             idx_size,
@@ -12291,11 +12367,8 @@ impl PushPipeline {
                             8 * 1024 * 1024,
                             &self.cancel,
                             None,
-                        )
-                        .await?;
-                    let remote_rev_path = self.router.pack_reverse_index_path(&pack_sha);
-                    store
-                        .put_multipart_file_retry(
+                        ),
+                        store.put_multipart_file_retry(
                             &remote_rev_path,
                             &installed.rev_path,
                             rev_size,
@@ -12303,20 +12376,39 @@ impl PushPipeline {
                             8 * 1024 * 1024,
                             &self.cancel,
                             None,
-                        )
-                        .await?;
+                        ),
+                    )?;
                 }
 
+                let origin_entry = PackManifestEntry {
+                    pack_id: pack_sha.clone(),
+                    size: packed.pack_size,
+                    content_hash: pack_sha.clone(),
+                    ref_tips: ref_tips.clone(),
+                    object_count: packed.object_count,
+                };
                 let meta_path = self.router.pack_metadata_path(&pack_sha);
-                let metadata = upsert_pack_metadata(
-                    store,
-                    &meta_path,
-                    &pack_sha,
-                    packed.object_count,
-                    ref_tips.clone(),
-                    self.config.max_cas_retries,
-                )
-                .await?;
+                // The pack body is verified and durable; its immutable index
+                // evidence, metadata, and origin receipt can now publish in parallel.
+                let (metadata, _) = tokio::try_join!(
+                    upsert_pack_metadata(
+                        store,
+                        &meta_path,
+                        &pack_sha,
+                        packed.object_count,
+                        ref_tips.clone(),
+                        self.config.max_cas_retries,
+                    ),
+                    async {
+                        crab_metadata::pack_origin::record_verified_pack_origin(
+                            store.as_storage(),
+                            self.router.repo_prefix(),
+                            &origin_entry,
+                        )
+                        .await
+                        .map_err(CrabError::from)
+                    },
+                )?;
                 let entry = PackManifestEntry {
                     pack_id: pack_sha.clone(),
                     size: packed.pack_size,
@@ -12324,12 +12416,6 @@ impl PushPipeline {
                     ref_tips: metadata.ref_tips,
                     object_count: packed.object_count,
                 };
-                crab_metadata::pack_origin::record_verified_pack_origin(
-                    store.as_storage(),
-                    self.router.repo_prefix(),
-                    &entry,
-                )
-                .await?;
                 info!(
                     pack_id = %pack_sha,
                     pack_bytes = packed.pack_size,
@@ -19045,6 +19131,13 @@ mod tests {
         }
     }
 
+    fn non_initial_empty_manifest() -> Manifest {
+        let mut manifest = Manifest::default_for_repo("refs/heads/main");
+        manifest.generation = 1;
+        manifest.seal_git_validation();
+        manifest
+    }
+
     #[test]
     fn locked_manifest_noop_covers_equal_update_and_missing_delete() {
         let update = make_spec("refs/heads/main");
@@ -19406,10 +19499,80 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn initial_push_publishes_manifest_without_ref_journal_state() {
+        let _guard = GitDirGuard::new();
+        let (store, router) = test_store_router("initial-manifest-fast-path");
+        create_manifest_with_etag(
+            &store,
+            &router,
+            &Manifest::default_for_repo("refs/heads/main"),
+        )
+        .await
+        .expect("create initial manifest");
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            vec![make_spec("refs/heads/main")],
+            Some(store.clone()),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router.clone(),
+            None,
+            CancellationToken::new(),
+            None,
+        );
+        pipeline.read_base_manifest().await.expect("read base");
+        let sha_map = pipeline.resolve_src_ref_map().expect("resolve refs");
+        let decisions = pipeline
+            .evaluate_decisions_with_sha_map(&sha_map)
+            .await
+            .expect("evaluate refs");
+        *pipeline.planned_ref_decisions.lock().await = Some(decisions.clone());
+        pipeline.prepare_git_pack().await.expect("prepare pack");
+        pipeline.upload_packs().await.expect("upload pack");
+        let (candidate, bulk) = pipeline
+            .apply_decisions_with_sha_map(&decisions, false, &sha_map)
+            .await
+            .expect("build candidate");
+
+        let mut admission_commit = None;
+        pipeline
+            .commit_ref_journal(candidate, bulk, &sha_map, decisions, &mut admission_commit)
+            .await
+            .expect("publish initial manifest");
+
+        let (manifest, _) = read_manifest(&store, &router)
+            .await
+            .expect("read committed manifest");
+        assert_eq!(
+            manifest.refs.get("refs/heads/main"),
+            sha_map.get("refs/heads/main")
+        );
+        let head =
+            crate::metadata::manifest::read_ref_journal_head(&store, &router, "refs/heads/main")
+                .await
+                .expect("read initial ref head");
+        assert!(head.etag.is_none());
+        let storage_router = crab_storage::StoreLayout::new(
+            store.as_storage().clone(),
+            router.repo_prefix().to_owned(),
+        );
+        assert!(
+            crab_metadata::ref_journal::list_active_transactions(
+                store.as_storage(),
+                &storage_router
+            )
+            .await
+            .expect("list active transactions")
+            .is_empty()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn late_journal_writer_waits_for_compactor_handoff_after_commit() {
         let _guard = GitDirGuard::new();
         let (store, router) = test_store_router("journal-busy-compactor");
-        let initial = Manifest::default_for_repo("refs/heads/main");
+        let initial = non_initial_empty_manifest();
         create_manifest_with_etag(&store, &router, &initial)
             .await
             .expect("create initial manifest");
@@ -19495,13 +19658,9 @@ mod tests {
     async fn compactor_defers_locator_publication_to_claimed_same_ref_successor() {
         let _guard = GitDirGuard::new();
         let (store, router) = test_store_router("journal-locator-successor");
-        create_manifest_with_etag(
-            &store,
-            &router,
-            &Manifest::default_for_repo("refs/heads/main"),
-        )
-        .await
-        .expect("create initial manifest");
+        create_manifest_with_etag(&store, &router, &non_initial_empty_manifest())
+            .await
+            .expect("create initial manifest");
         let pipeline = PushPipeline::new(
             PushConfig::default(),
             vec![make_spec("refs/heads/main")],
@@ -19695,13 +19854,9 @@ mod tests {
             ));
         let store = Store::new(inner);
         let router = StoreLayout::new(store.clone(), repo_prefix.to_owned());
-        create_manifest_with_etag(
-            &store,
-            &router,
-            &Manifest::default_for_repo("refs/heads/main"),
-        )
-        .await
-        .expect("create initial manifest");
+        create_manifest_with_etag(&store, &router, &non_initial_empty_manifest())
+            .await
+            .expect("create initial manifest");
 
         let result = PushPipeline::new(
             PushConfig::default(),
@@ -19745,7 +19900,7 @@ mod tests {
         });
         let store = Store::new(inner);
         let router = StoreLayout::new(store.clone(), repo_prefix.to_owned());
-        let initial = Manifest::default_for_repo("refs/heads/main");
+        let initial = non_initial_empty_manifest();
         create_manifest_with_etag(&store, &router, &initial)
             .await
             .expect("create initial manifest");

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -5829,8 +5829,8 @@ async fn publish_pack_locator_inventory(
             writer.write_locations(binding, &entries).await?;
         }
     }
-    writer.flush_objects().await?;
-
+    // The manifest check is independent of locator durability. Keep object
+    // rows pending so set_coverage flushes them with the coverage marker.
     let (after, _) = read_manifest(store, router).await?;
     if after.generation != anchor.generation
         || after.pack_index_hash != anchor.pack_index_hash.hex()
@@ -21834,6 +21834,7 @@ mod tests {
         .await
         .expect("publish locators");
         assert_eq!(stats.object_rows_written, 1);
+        assert_eq!(stats.flushes, 2);
         assert!(stats.coverage_updated);
 
         let session = crab_metadata::git_object_locator::GitObjectLocatorSession::open(

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -8051,6 +8051,13 @@ impl PushPipeline {
         *self.committed_manifest_anchor.lock().await = anchor;
         self.git_visibility_published
             .store(true, std::sync::atomic::Ordering::Relaxed);
+        // The manifest and complete Git-visibility proof are authoritative.
+        // Locator rows and their receipt are repairable acceleration state, so
+        // leave them to the next push or the metadb repair/owner path on a
+        // fresh repository instead of extending creation latency with a
+        // second SlateDB publication.
+        self.locator_publication_deferred
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         if let Some(signal) = admission_commit.take() {
             let _ = signal.send(());
         }
@@ -19540,6 +19547,12 @@ mod tests {
             .commit_ref_journal(candidate, bulk, &sha_map, decisions, &mut admission_commit)
             .await
             .expect("publish initial manifest");
+        assert!(
+            pipeline
+                .locator_publication_deferred
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "generation-zero publication should defer repairable locator acceleration"
+        );
 
         let (manifest, _) = read_manifest(&store, &router)
             .await
@@ -20017,6 +20030,18 @@ mod tests {
             .await
             .expect("read pushed manifest");
         let covered_generation = manifest.generation;
+        assert!(
+            repair_git_object_locator_if_current(
+                &store,
+                &router,
+                covered_generation,
+                Duration::from_secs(60),
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("repair deferred initial locator"),
+            "the explicit repair path should publish the deferred initial locator"
+        );
         let storage_router =
             crab_storage::StoreLayout::new(store.as_storage().clone(), repo_prefix.to_owned());
         let visibility = crab_metadata::git_visibility::read(
@@ -20173,6 +20198,18 @@ mod tests {
         let (manifest, _) = read_manifest(&store, &router)
             .await
             .expect("read pushed manifest");
+        assert!(
+            repair_git_object_locator_if_current(
+                &store,
+                &router,
+                manifest.generation,
+                Duration::from_secs(60),
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("repair deferred initial locator"),
+            "the explicit repair path should publish the deferred initial locator"
+        );
         let visibility_path = router.git_visibility_path(&manifest.git_validation_digest);
         store
             .delete(&visibility_path)

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -115,6 +115,9 @@ enum Cmd {
         /// Value is the name of the existing git remote (typically "origin").
         #[arg(long)]
         mirror: Option<String>,
+        /// Create the generation-0 manifest in object storage after local setup.
+        #[arg(long)]
+        remote: bool,
         /// Emit structured JSON output.
         #[arg(long, conflicts_with = "jsonl")]
         json: bool,
@@ -3305,6 +3308,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
             storage_provider,
             gc_list_profile,
             mirror,
+            remote,
             json,
             jsonl,
         }) => {
@@ -3338,6 +3342,10 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                                 gc_list_profile,
                             )
                             .await?;
+                            if remote {
+                                crab::cmd::init::initialize_remote_repository(&u, &cwd, &cancel)
+                                    .await?;
+                            }
                             // Sync .gitattributes with [track] patterns from .crab.toml
                             if let Some(ref track) = config.track {
                                 sync_gitattributes_from_track(&cwd, &track.patterns);
@@ -3405,6 +3413,10 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                 gc_list_profile,
             )
             .await?;
+
+            if remote {
+                crab::cmd::init::initialize_remote_repository(&resolved_url, &cwd, &cancel).await?;
+            }
 
             // Mirror mode: validate remote, add crab remote, install hooks, write config.
             if let Some(ref mirror_remote) = mirror {

--- a/crab/src/replication/mod.rs
+++ b/crab/src/replication/mod.rs
@@ -13520,6 +13520,11 @@ mod tests {
                 reason: "remote size reporting must inspect the configured primary remote, not a lagging replica",
             },
             DirectStoreClassification {
+                call: "src/cmd/init.rs::initialize_remote_repository",
+                class: "primary-write-authority",
+                reason: "remote repository initialization creates the primary generation-zero manifest",
+            },
+            DirectStoreClassification {
                 call: "src/cmd/lock.rs::setup",
                 class: "primary-write-authority",
                 reason: "lock operations are write coordination and must target the primary authority",

--- a/crates/crab-auth-server/src/receive.rs
+++ b/crates/crab-auth-server/src/receive.rs
@@ -1611,8 +1611,8 @@ async fn commit_service_git_locators_with_source(
                     writer.write_locations(binding, &entries).await?;
                 }
             }
-            writer.flush_objects().await?;
-
+            // The manifest check is independent of locator durability. Keep
+            // rows pending so coverage flushes them atomically with its marker.
             let (after, _) = crab_metadata::manifest_store::read_manifest(store, router).await?;
             if after.generation != manifest.generation
                 || after.pack_index_hash != manifest.pack_index_hash

--- a/crates/crab-coordination/src/push_admission.rs
+++ b/crates/crab-coordination/src/push_admission.rs
@@ -375,7 +375,9 @@ impl PushAdmissionTicket {
 
     fn repo_domain(&self) -> String {
         self.prefix
-            .strip_suffix("/internal/push-admission/slots")
+            // GC fences are keyed by the repository root, not the nested
+            // admission-slot object prefix.
+            .strip_suffix("/locks/internal/push-admission/slots")
             .unwrap_or(&self.prefix)
             .to_owned()
     }

--- a/crates/crab-coordination/src/push_admission.rs
+++ b/crates/crab-coordination/src/push_admission.rs
@@ -320,23 +320,41 @@ impl PushAdmissionTicket {
         if self.repo_fence.is_some() {
             return Ok(());
         }
-        if let Some(global_domain) = self.global_domain.as_deref() {
-            match GcFenceLease::acquire_writer(&self.store, global_domain, self.lease_ttl).await {
-                Ok(fence) => self.global_fence = Some(fence),
-                Err(error) => return Err(error),
-            }
-        }
-        match GcFenceLease::acquire_writer(&self.store, &self.repo_domain(), self.lease_ttl).await {
-            Ok(fence) => {
-                self.repo_fence = Some(fence);
+        let repo_domain = self.repo_domain();
+        let global_domain = self.global_domain.clone();
+        let store = Arc::clone(&self.store);
+        let lease_ttl = self.lease_ttl;
+        // The bucket and repository fences protect disjoint GC domains; keep
+        // both safety claims while allowing their object-store CAS to overlap.
+        let (global_result, repo_result) = tokio::join!(
+            async {
+                match global_domain.as_deref() {
+                    Some(domain) => GcFenceLease::acquire_writer(&store, domain, lease_ttl)
+                        .await
+                        .map(Some),
+                    None => Ok(None),
+                }
+            },
+            GcFenceLease::acquire_writer(&store, &repo_domain, lease_ttl),
+        );
+
+        match (global_result, repo_result) {
+            (Ok(global_fence), Ok(repo_fence)) => {
+                self.global_fence = global_fence;
+                self.repo_fence = Some(repo_fence);
                 Ok(())
             }
-            Err(error) => {
-                if let Some(fence) = self.global_fence.take() {
+            (Ok(global_fence), Err(error)) => {
+                if let Some(fence) = global_fence {
                     fence.release().await?;
                 }
                 Err(error)
             }
+            (Err(error), Ok(repo_fence)) => {
+                repo_fence.release().await?;
+                Err(error)
+            }
+            (Err(error), Err(_repo_error)) => Err(error),
         }
     }
 
@@ -549,6 +567,45 @@ mod tests {
 
         light.release().await.unwrap();
         first.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn global_and_repository_fences_are_released_with_admission() {
+        let store = memory_store();
+        let ttl = Duration::from_secs(60);
+        let mut ticket = PushAdmissionTicket::new_weighted_with_global(
+            &store,
+            "org/repo",
+            Some("bucket"),
+            1,
+            1,
+            ttl,
+        )
+        .unwrap();
+        assert!(ticket.try_admit().await.unwrap());
+
+        assert!(matches!(
+            GcFenceLease::acquire_sweep(&store, "bucket", ttl).await,
+            Err(CoordinationError::GcFenceHeld { .. })
+        ));
+        assert!(matches!(
+            GcFenceLease::acquire_sweep(&store, "org/repo", ttl).await,
+            Err(CoordinationError::GcFenceHeld { .. })
+        ));
+
+        ticket.release().await.unwrap();
+        GcFenceLease::acquire_sweep(&store, "bucket", ttl)
+            .await
+            .unwrap()
+            .release()
+            .await
+            .unwrap();
+        GcFenceLease::acquire_sweep(&store, "org/repo", ttl)
+            .await
+            .unwrap()
+            .release()
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/crab-metadata/src/git_object_locator/writer.rs
+++ b/crates/crab-metadata/src/git_object_locator/writer.rs
@@ -165,15 +165,6 @@ impl GitObjectLocatorWriter {
             {
                 return Err((db, error));
             }
-            if let Err(source) = db.flush().await {
-                return Err((
-                    db,
-                    MetadataError::SlateDbWrite {
-                        db: DB_LABEL.to_owned(),
-                        source,
-                    },
-                ));
-            }
             metadata
         };
 
@@ -189,7 +180,9 @@ impl GitObjectLocatorWriter {
             metadata,
             bindings,
             stats: LocatorWriteStats::default(),
-            writes_durable: true,
+            // The first metadata batch can share the first binding or
+            // coverage flush; no reader checkpoint exists before that point.
+            writes_durable: false,
         })
     }
 

--- a/crates/crab-metadata/src/git_object_locator/writer.rs
+++ b/crates/crab-metadata/src/git_object_locator/writer.rs
@@ -438,14 +438,13 @@ impl GitObjectLocatorWriter {
         Ok(stats)
     }
 
-    /// Mark one immutable manifest inventory fully covered after object flush.
+    /// Mark one immutable manifest inventory fully covered with one durability flush.
     pub async fn set_coverage(&mut self, coverage: GitLocatorCoverage) -> Result<()> {
         if coverage.generation == 0 {
             return Err(MetadataError::Internal(
                 "Git locator coverage generation must be non-zero".to_owned(),
             ));
         }
-        self.flush_objects().await?;
         let metadata = LocatorMetadata {
             next_pack_slot: self.metadata.next_pack_slot,
             coverage: Some(coverage),
@@ -457,6 +456,9 @@ impl GitObjectLocatorWriter {
         )
         .await?;
         self.writes_durable = false;
+        // Object rows and their coverage marker share the same active
+        // memtable, so one flush makes the marker impossible to observe
+        // without the rows it covers.
         self.flush_objects().await?;
         self.metadata = metadata;
         self.stats.coverage_updated = true;
@@ -469,10 +471,11 @@ impl GitObjectLocatorWriter {
     /// long-lived exclusive owner can then serve multiple manifest generations
     /// from one SlateDB session while readers open only immutable checkpoints.
     pub async fn publish_checkpoint(&mut self) -> Result<()> {
+        self.flush_objects().await?;
         let checkpoint = self
             .db
             .create_checkpoint(
-                CheckpointScope::All,
+                CheckpointScope::Durable,
                 &CheckpointOptions {
                     name: Some(super::READER_CHECKPOINT_NAME.to_owned()),
                     ..CheckpointOptions::default()
@@ -483,7 +486,6 @@ impl GitObjectLocatorWriter {
                 db: DB_LABEL.to_owned(),
                 source,
             })?;
-        self.stats.flushes = self.stats.flushes.saturating_add(1);
         remove_old_reader_checkpoints(&self.path, Arc::clone(&self.store), &checkpoint).await
     }
 
@@ -762,7 +764,7 @@ mod tests {
     use object_store::path::Path as ObjectPath;
 
     use super::*;
-    use crate::git_object_locator::GitObjectLocation;
+    use crate::git_object_locator::{GitObjectLocation, GitObjectLookup, GitPackInventoryEntry};
     use crab_xet::hash::MerkleHash;
 
     fn hash(seed: u64) -> MerkleHash {
@@ -1162,6 +1164,66 @@ mod tests {
             .expect("reopen writer");
         assert_eq!(reopened.coverage(), Some(coverage));
         reopened.close().await.expect("close reopened writer");
+    }
+
+    #[tokio::test]
+    async fn coverage_batches_pending_object_rows_into_one_durability_flush() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let coverage = GitLocatorCoverage {
+            generation: 3,
+            pack_index_hash: hash(9),
+        };
+        let mut writer = GitObjectLocatorWriter::open(store, "org/repo")
+            .await
+            .expect("open writer");
+        let binding = writer.bind_packs(&[pack(1)]).await.expect("bind pack")[0];
+        writer
+            .write_locations(binding, &[entry(1)])
+            .await
+            .expect("write location");
+        let before_coverage = writer.stats.flushes;
+
+        writer.set_coverage(coverage).await.expect("set coverage");
+
+        assert_eq!(writer.stats.flushes, before_coverage + 1);
+        writer.close().await.expect("close writer");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_publishes_dirty_object_rows() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let pack = pack(1);
+        let object = entry(1);
+        let mut writer = GitObjectLocatorWriter::open(Arc::clone(&store), "org/repo")
+            .await
+            .expect("open writer");
+        let binding = writer.bind_packs(&[pack]).await.expect("bind pack")[0];
+        writer
+            .write_locations(binding, &[object])
+            .await
+            .expect("write location");
+        writer
+            .publish_checkpoint()
+            .await
+            .expect("publish checkpoint");
+
+        let reader = super::super::GitObjectLocatorSession::open(store, "org/repo")
+            .await
+            .expect("open reader");
+        let inventory = std::collections::HashMap::from([(
+            pack.pack_id,
+            GitPackInventoryEntry {
+                pack_id: pack.pack_id,
+                object_count: pack.object_count,
+                pack_size: pack.pack_size,
+            },
+        )]);
+        assert!(matches!(
+            reader.lookup_batch(&[object.oid], &inventory).await,
+            Ok(lookups) if matches!(lookups.as_slice(), [GitObjectLookup::Hit(locator)] if locator.location == object.location)
+        ));
+        reader.close().await.expect("close reader");
+        writer.close().await.expect("close writer");
     }
 
     #[tokio::test]

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -526,8 +526,12 @@ pub async fn upload_segmented_bulk(
     router: &StoreLayout<Store>,
     bulk: &BulkData,
 ) -> Result<()> {
-    segmented_store::upload_write(store, router, &bulk.shard_index).await?;
-    segmented_store::upload_write(store, router, &bulk.pack_index).await
+    futures_util::future::try_join(
+        segmented_store::upload_write(store, router, &bulk.shard_index),
+        segmented_store::upload_write(store, router, &bulk.pack_index),
+    )
+    .await
+    .map(|_| ())
 }
 
 /// Upload a bulk manifest object if it does not already exist.

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -396,6 +396,7 @@ pub async fn compact_ref_journal(
 
     // Complete evidence publishes authorization before the compacted manifest;
     // otherwise no proof is written and upload-pack withholds protocol v2.
+    let compacted_transactions = snapshot.journal.transactions.clone();
     let git_visibility_published = if let Some(visibility) =
         crate::git_visibility::compact_journal_edits(
             store,
@@ -409,14 +410,18 @@ pub async fn compact_ref_journal(
         )
         .await?
     {
-        crate::git_visibility::upload_if_absent(store, router, &visibility).await?;
+        futures_util::future::try_join(
+            crate::git_visibility::upload_if_absent(store, router, &visibility),
+            write_ref_journal_frontier(store, router, &manifest, &snapshot.journal.visible_heads),
+        )
+        .await?;
         true
     } else {
+        write_ref_journal_frontier(store, router, &manifest, &snapshot.journal.visible_heads)
+            .await?;
         false
     };
 
-    let compacted_transactions = snapshot.journal.transactions.clone();
-    write_ref_journal_frontier(store, router, &manifest, &snapshot.journal.visible_heads).await?;
     write_manifest_cas(store, router, &manifest, &snapshot.manifest_etag).await?;
     cleanup_compacted_transactions(store, router, &compacted_transactions).await;
     Ok(Some(RefJournalCompaction {
@@ -761,6 +766,111 @@ mod tests {
             let result = self.inner.get_opts(location, options).await;
             self.active_gets.fetch_sub(1, Ordering::AcqRel);
             result
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, object_store::Result<object_store::path::Path>>,
+        ) -> BoxStream<'static, object_store::Result<object_store::path::Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    struct DelayedPublicationStore {
+        inner: Arc<InMemory>,
+        active_writes: AtomicUsize,
+        max_active_writes: AtomicUsize,
+    }
+
+    impl DelayedPublicationStore {
+        fn new(inner: Arc<InMemory>) -> Self {
+            Self {
+                inner,
+                active_writes: AtomicUsize::new(0),
+                max_active_writes: AtomicUsize::new(0),
+            }
+        }
+
+        fn max_active_writes(&self) -> usize {
+            self.max_active_writes.load(Ordering::Acquire)
+        }
+
+        fn tracks(location: &object_store::path::Path) -> bool {
+            let path = location.as_ref();
+            path.contains("refs/journal/frontiers/") || path.contains("metadata/git-visibility/v2/")
+        }
+    }
+
+    impl fmt::Debug for DelayedPublicationStore {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("DelayedPublicationStore")
+        }
+    }
+
+    impl fmt::Display for DelayedPublicationStore {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("DelayedPublicationStore")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for DelayedPublicationStore {
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: PutPayload,
+            options: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            let tracked = Self::tracks(location);
+            if tracked {
+                let active = self.active_writes.fetch_add(1, Ordering::AcqRel) + 1;
+                self.max_active_writes.fetch_max(active, Ordering::AcqRel);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            let result = self.inner.put_opts(location, payload, options).await;
+            if tracked {
+                self.active_writes.fetch_sub(1, Ordering::AcqRel);
+            }
+            result
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            self.inner.get_opts(location, options).await
         }
 
         fn delete_stream(
@@ -1253,7 +1363,9 @@ mod tests {
 
     #[tokio::test]
     async fn journal_compaction_reports_published_git_visibility() {
-        let store = memory_store();
+        let inner = Arc::new(InMemory::new());
+        let delayed = Arc::new(DelayedPublicationStore::new(inner));
+        let store = Store::new(delayed.clone() as Arc<dyn ObjectStore>);
         let router = test_layout(store.clone());
         let base = Manifest::default_for_repo("refs/heads/main");
         create_manifest(&store, &router, &base).await.unwrap();
@@ -1309,6 +1421,7 @@ mod tests {
         .unwrap();
 
         assert!(compacted.git_visibility_published);
+        assert!(delayed.max_active_writes() >= 2);
         assert!(proof.contains_for_refs(["refs/heads/main"], &tip));
     }
 

--- a/packages/web/content/docs/cli/reference/crab-init.mdx
+++ b/packages/web/content/docs/cli/reference/crab-init.mdx
@@ -45,6 +45,7 @@ For conceptual background, see [Creating a Repository](/docs/cli/getting-started
 | `--storage-provider <PROVIDER>` | `auto` | Storage backend: `s3`, `gcs`, `azure`, or `auto` |
 | `--gc-list-profile <PROFILE>` | `adaptive` | Local bucket-GC policy: `adaptive`, `cost`, or `latency` |
 | `--mirror <REMOTE>` | — | Configure mirror mode using an existing Git remote |
+| `--remote` | `false` | Create the generation-0 manifest in object storage |
 | `--json` | `false` | Emit structured JSON output |
 | `--jsonl` | `false` | Emit streaming JSONL output |
 | `--log-level` | — | Set log verbosity (`error`, `warn`, `info`, `debug`, `trace`) |
@@ -55,6 +56,11 @@ For conceptual background, see [Creating a Repository](/docs/cli/getting-started
 2. **Creates `.crab/config.toml`** with the remote URL
 3. **Registers the filter and diff drivers** in `.git/config`
 4. **Adds or updates a Git remote** for the canonical `crab://` URL
+
+By default, init only changes local state. Pass `--remote` when provisioning a
+new remote repository; Crab creates the empty generation-0 manifest with an
+atomic create and safely adopts an existing manifest on repeat or concurrent
+initialization.
 
 ## Examples
 
@@ -77,6 +83,12 @@ crab init s3://team-bucket/my-repo
 # ✓ Created .crab/config.toml
 # ✓ Registered filter.crab driver
 # Next: crab setup
+```
+
+### Provision the remote repository
+
+```bash
+crab init --remote crab://my-bucket/my-repo
 ```
 
 ### Configure tracking separately


### PR DESCRIPTION
## Summary

Adds a reproducible RustFS repository-creation benchmark and the next performance slices for agent coding areas.

- Adds opt-in `crab init --remote` provisioning for an atomic generation-0 manifest.
- Makes first-time manifest provisioning create-first, avoiding a discovery GET on the new-repository path; a create conflict adopts the winner's manifest.
- Adds a generation-0 first-push fast path: immutable segmented indexes and the complete Git-visibility proof publish in parallel, then one manifest CAS publishes the repository without a ref-journal transaction or compaction cycle. The path is limited to ordinary empty repositories; protected and active-active pushes retain their existing protocol.
- Makes first-publication pack metadata create-first, uploads pack index and reverse-index evidence in parallel, and overlaps pack metadata with the verified origin receipt.
- Overlaps independent bucket/global and repository GC-fence acquisition while retaining rollback on partial failure, with repository fences rooted at the repository domain.
- Batches Git locator coverage writes with pending object rows in one durability flush, and defers the fresh locator metadata flush until the first publication checkpoint. The CLI and auth-server publication paths share this behavior.
- Defers repairable generation-zero Git locator rows and the dependent generation receipt until after the first push commits its authoritative manifest and complete Git-visibility proof. The next push, `crab metadb owner`, or a fetch that needs locator admission repairs the acceleration state; committed refs are never rolled back for that repair.
- Keeps direct-store architecture classification current and adds explicit push phase telemetry.
- Adds `--remote-init` benchmark coverage for local RustFS.

## Validation

- `cargo fmt --all -- --check` and `git diff --check` passed.
- `cargo test -p crab --lib --locked` passed: 3,693 passed, 2 ignored.
- `cargo test -p crab-coordination --features object-store-lock --lib --locked` passed: 90 tests.
- `cargo test -p crab-metadata --features remote-index,storage --locked` passed: 211 tests.
- `cargo test -p crab-auth-server --lib --locked` passed: 74 tests.
- `cargo clippy -p crab --lib --locked` and `cargo clippy -p crab-coordination --features object-store-lock --lib --locked` passed with the repository's existing warning set.
- `cargo build -p crab --locked` passed.
- Fresh local RustFS cohort: 50 one-file repos at concurrency 8, zero failures, 7.65 successful repos/sec, push p50 678 ms, total p50 933 ms, and 16 stored objects per repo. Against the preceding same-host cohort at 5.90 successful repos/sec, 973 ms push p50, 1.223 s total p50, and 27 objects per repo, this is directionally about 30% more throughput; RustFS and host load make cohort-to-cohort comparisons noisy.
- A real `crab clone` smoke passed against the resulting bucket with a clean worktree and expected file. A follow-up push then created the deferred `git_locator_db`, proving repair remains reachable.

## Scope

The PR contains the benchmark, repository provisioning, metadata publication, push admission, locator deferral, telemetry, and related tests. Existing local `Cargo.lock`, `crab/Cargo.toml`, `.crab.toml`, and `plans/` edits remain outside the PR.
