### PR TITLE
docs(web): enrich blog guides with interactive visuals

### DIFF
--- a/packages/web/components/blog/blog-detail-diagrams.tsx
+++ b/packages/web/components/blog/blog-detail-diagrams.tsx
@@ -12,6 +12,130 @@ const CHANGED = {
 
 const VERSION_A = ["header", "weights 1", "weights 2", "optimizer", "footer"]
 const VERSION_B = ["header", "weights 1", "new weights", "optimizer", "footer"]
+const CHECKPOINTS = ["v1", "v2", "v3", "v4"]
+
+export function BinaryHistoryGrowthDiagram() {
+  const heading = {
+    fill: "var(--foreground)",
+    fontFamily: "Inter, ui-sans-serif, system-ui",
+    fontSize: 14,
+    fontWeight: 650,
+    textAnchor: "middle",
+  } as const
+  const detail = {
+    fill: "var(--muted-foreground)",
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 10,
+    textAnchor: "middle",
+  } as const
+
+  return (
+    <DiagramFrame
+      title="Four checkpoints: full objects or unique chunks"
+      caption="Illustrative model: each 8 GB checkpoint preserves 7.5 GB of encoded bytes from the previous version. The totals exclude compression and metadata overhead."
+    >
+      <svg
+        viewBox="0 0 760 228"
+        className="h-auto w-full min-w-[40rem]"
+        role="img"
+        aria-label="Four 8 gigabyte Git blobs total 32 gigabytes, while compact pointers and reusable chunks add 9.5 gigabytes of unique data to object storage"
+      >
+        <line
+          x1="380"
+          y1="18"
+          x2="380"
+          y2="210"
+          stroke="var(--border)"
+          strokeDasharray="4 5"
+        />
+        <text x="190" y="30" {...heading}>
+          Ordinary Git blobs
+        </text>
+        <text x="570" y="30" {...heading}>
+          Crab pointer path
+        </text>
+
+        {CHECKPOINTS.map((version, index) => {
+          const gitX = 36 + index * 80
+          const pointerX = 430 + index * 82
+          return (
+            <g key={version}>
+              <rect
+                x={gitX}
+                y="60"
+                width="66"
+                height="66"
+                rx="9"
+                fill="color-mix(in srgb, #f97316 10%, var(--card))"
+                stroke="#f97316"
+                strokeWidth="1.5"
+              />
+              <text x={gitX + 33} y="87" {...heading} fontSize="12">
+                {version}
+              </text>
+              <text x={gitX + 33} y="106" {...detail}>
+                8 GB
+              </text>
+              <rect
+                x={pointerX}
+                y="60"
+                width="58"
+                height="36"
+                rx="7"
+                fill="color-mix(in srgb, #f97316 10%, var(--card))"
+                stroke="#f97316"
+                strokeWidth="1.5"
+              />
+              <text x={pointerX + 29} y="83" {...heading} fontSize="11">
+                {version}
+              </text>
+            </g>
+          )
+        })}
+
+        <text x="190" y="162" {...heading} fontSize="15" fontWeight="700">
+          32 GB reachable history
+        </text>
+        <text x="190" y="182" {...detail}>
+          every version remains a complete Git object
+        </text>
+
+        <rect
+          x="430"
+          y="126"
+          width="235"
+          height="44"
+          rx="8"
+          fill="color-mix(in srgb, #06b6d4 12%, var(--card))"
+          stroke="#06b6d4"
+          strokeWidth="1.5"
+        />
+        <text x="547.5" y="152" {...heading} fontSize="12">
+          8 GB reusable base
+        </text>
+        {[0, 1, 2].map((index) => (
+          <rect
+            key={index}
+            x={671 + index * 18}
+            y="126"
+            width="14"
+            height="44"
+            rx="4"
+            fill="color-mix(in srgb, #f59e0b 12%, var(--card))"
+            stroke="#f59e0b"
+            strokeWidth="1.5"
+          />
+        ))}
+        <text x="570" y="194" {...heading} fontSize="13" fontWeight="700">
+          9.5 GB unique data + compact Git pointers
+        </text>
+        <text x="570" y="212" {...detail}>
+          8 GB base + 3 × 0.5 GB new content
+        </text>
+      </svg>
+    </DiagramFrame>
+  )
+}
 
 export function ChunkReuseDiagram() {
   const startX = 126

--- a/packages/web/components/blog/cache-visuals.tsx
+++ b/packages/web/components/blog/cache-visuals.tsx
@@ -1,0 +1,578 @@
+"use client"
+
+import {
+  ArrowDown,
+  ArrowRight,
+  Check,
+  Cloud,
+  Database,
+  HardDrive,
+  Server,
+  ShieldCheck,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type RouteStep = {
+  id: "local" | "shared" | "origin"
+  label: string
+  note: string
+  outcome: "hit" | "miss" | "skip"
+}
+
+type RouteScenario = {
+  id: string
+  label: string
+  title: string
+  result: string
+  explanation: string
+  steps: RouteStep[]
+}
+
+const ROUTE_SCENARIOS: RouteScenario[] = [
+  {
+    id: "cold",
+    label: "First read",
+    title: "Nothing nearby has the bytes yet",
+    result: "ORIGIN",
+    explanation:
+      "The verified origin response fills the local cache for the next read.",
+    steps: [
+      { id: "local", label: "Local disk", note: "empty", outcome: "miss" },
+      {
+        id: "shared",
+        label: "Team cache",
+        note: "not configured or empty",
+        outcome: "miss",
+      },
+      {
+        id: "origin",
+        label: "Object storage",
+        note: "canonical bytes",
+        outcome: "hit",
+      },
+    ],
+  },
+  {
+    id: "warm",
+    label: "Repeat read",
+    title: "The same machine already has verified bytes",
+    result: "LOCAL",
+    explanation: "The request stops at local disk. No network read is needed.",
+    steps: [
+      {
+        id: "local",
+        label: "Local disk",
+        note: "verified entry",
+        outcome: "hit",
+      },
+      {
+        id: "shared",
+        label: "Team cache",
+        note: "not contacted",
+        outcome: "skip",
+      },
+      {
+        id: "origin",
+        label: "Object storage",
+        note: "not contacted",
+        outcome: "skip",
+      },
+    ],
+  },
+  {
+    id: "teammate",
+    label: "Teammate",
+    title: "This machine is cold; the team cache is warm",
+    result: "TEAM",
+    explanation:
+      "The shared response is verified, then written to this machine's local cache.",
+    steps: [
+      { id: "local", label: "Local disk", note: "empty", outcome: "miss" },
+      {
+        id: "shared",
+        label: "Team cache",
+        note: "verified response",
+        outcome: "hit",
+      },
+      {
+        id: "origin",
+        label: "Object storage",
+        note: "not contacted",
+        outcome: "skip",
+      },
+    ],
+  },
+  {
+    id: "outage",
+    label: "Cache offline",
+    title: "Acceleration failed; correctness did not",
+    result: "ORIGIN",
+    explanation:
+      "An unavailable team cache is bypassed. Canonical object storage still serves the read.",
+    steps: [
+      { id: "local", label: "Local disk", note: "empty", outcome: "miss" },
+      {
+        id: "shared",
+        label: "Team cache",
+        note: "unavailable",
+        outcome: "miss",
+      },
+      {
+        id: "origin",
+        label: "Object storage",
+        note: "canonical bytes",
+        outcome: "hit",
+      },
+    ],
+  },
+]
+
+const ROUTE_ICONS = {
+  local: HardDrive,
+  shared: Server,
+  origin: Cloud,
+}
+
+export function CacheRouteTicket() {
+  const [scenarioId, setScenarioId] = useState("cold")
+  const scenario =
+    ROUTE_SCENARIOS.find((item) => item.id === scenarioId) ?? ROUTE_SCENARIOS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] bg-[#071d2b] text-[#eaf9ff] shadow-[0_18px_60px_rgba(7,29,43,0.2)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#34505f] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-bold tracking-[0.2em] text-[#7edcf2]">
+            READ DISPATCH / ONE IMMUTABLE OBJECT
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.03em] text-white sm:text-3xl">
+            How far does this read travel?
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-2" aria-label="Read scenario">
+          {ROUTE_SCENARIOS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={scenario.id === item.id}
+              onClick={() => setScenarioId(item.id)}
+              className={cn(
+                "rounded-full border px-3 py-1.5 font-mono text-[10px] font-bold transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#7edcf2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#071d2b]",
+                scenario.id === item.id
+                  ? "border-[#7edcf2] bg-[#7edcf2] text-[#071d2b]"
+                  : "border-[#496572] text-[#b8ced7] hover:border-[#7edcf2] hover:text-white"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[minmax(0,1fr)_17rem]">
+        <div className="p-5 sm:p-7">
+          <div className="grid gap-3 sm:grid-cols-[1fr_auto_1fr_auto_1fr] sm:items-center">
+            {scenario.steps.map((step, index) => {
+              const Icon = ROUTE_ICONS[step.id]
+              return (
+                <div key={step.id} className="contents">
+                  <div
+                    className={cn(
+                      "relative min-h-36 rounded-2xl border p-4 transition-colors duration-300 motion-reduce:transition-none",
+                      step.outcome === "hit" &&
+                        "border-[#7edcf2] bg-[#103b49] shadow-[inset_0_0_0_1px_#7edcf2]",
+                      step.outcome === "miss" &&
+                        "border-[#d8a449] bg-[#282b2b]",
+                      step.outcome === "skip" &&
+                        "border-[#34505f] bg-[#0b2533] opacity-55"
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <Icon className="size-5" aria-hidden="true" />
+                      <span
+                        className={cn(
+                          "rounded-full px-2 py-1 font-mono text-[9px] font-black",
+                          step.outcome === "hit" &&
+                            "bg-[#7edcf2] text-[#071d2b]",
+                          step.outcome === "miss" &&
+                            "bg-[#d8a449] text-[#241b0b]",
+                          step.outcome === "skip" &&
+                            "bg-[#29424e] text-[#91aab5]"
+                        )}
+                      >
+                        {step.outcome.toUpperCase()}
+                      </span>
+                    </div>
+                    <p className="m-0 mt-7 text-base font-black text-white">
+                      {step.label}
+                    </p>
+                    <p className="m-0 mt-1 text-xs leading-5 text-[#a9c1cb]">
+                      {step.note}
+                    </p>
+                  </div>
+                  {index < scenario.steps.length - 1 ? (
+                    <div className="flex justify-center text-[#68828e] sm:block">
+                      <ArrowDown
+                        className="size-5 sm:hidden"
+                        aria-hidden="true"
+                      />
+                      <ArrowRight
+                        className="hidden size-5 sm:block"
+                        aria-hidden="true"
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        <aside
+          className="relative border-t border-dashed border-[#5c7681] bg-[#e9f8fc] p-6 text-[#071d2b] lg:border-t-0 lg:border-l"
+          aria-live="polite"
+        >
+          <div className="absolute top-0 left-0 hidden h-full w-3 -translate-x-1/2 bg-[radial-gradient(circle,#071d2b_4px,transparent_5px)] bg-[length:12px_24px] lg:block" />
+          <p className="m-0 font-mono text-[9px] font-black tracking-[0.18em] text-[#4d6671]">
+            SERVED BY
+          </p>
+          <p className="m-0 mt-2 font-mono text-5xl leading-none font-black tracking-[-0.07em] text-[#0b7189]">
+            {scenario.result}
+          </p>
+          <h4 className="m-0 mt-7 text-lg leading-6 font-black">
+            {scenario.title}
+          </h4>
+          <p className="m-0 mt-2 text-sm leading-6 text-[#4d6671]">
+            {scenario.explanation}
+          </p>
+          <div className="mt-7 border-t border-[#aac7d0] pt-4 font-mono text-[9px] font-bold text-[#4d6671]">
+            CONTENT ID CHECKED
+            <Check
+              className="ml-2 inline size-4 text-[#0b8c6e]"
+              aria-hidden="true"
+            />
+          </div>
+        </aside>
+      </div>
+    </figure>
+  )
+}
+
+type RangePattern = {
+  id: string
+  label: string
+  title: string
+  required: number[]
+  groups: number[][]
+  exactBytes: number
+  plannedBytes: number
+  note: string
+}
+
+const RANGE_PATTERNS: RangePattern[] = [
+  {
+    id: "adjacent",
+    label: "Adjacent",
+    title: "Three neighboring chunks",
+    required: [1, 2, 3],
+    groups: [[1, 2, 3]],
+    exactBytes: 24,
+    plannedBytes: 24,
+    note: "One contiguous range replaces three small requests with no extra bytes.",
+  },
+  {
+    id: "small-gap",
+    label: "Small gap",
+    title: "Useful chunks around one gap",
+    required: [1, 3, 4],
+    groups: [[1, 2, 3, 4]],
+    exactBytes: 24,
+    plannedBytes: 32,
+    note: "One wider read spends 8 MiB to remove two request round trips.",
+  },
+  {
+    id: "sparse",
+    label: "Sparse",
+    title: "Two distant chunks",
+    required: [0, 6],
+    groups: [[0], [6]],
+    exactBytes: 16,
+    plannedBytes: 16,
+    note: "The gap is too wide. Two narrow ranges avoid downloading unused bytes.",
+  },
+]
+
+export function RangePlanningTape() {
+  const [patternId, setPatternId] = useState("adjacent")
+  const pattern =
+    RANGE_PATTERNS.find((item) => item.id === patternId) ?? RANGE_PATTERNS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden border border-[#263a4a] bg-[#f4f7f8] shadow-[0_12px_40px_rgba(38,58,74,0.14)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="flex flex-wrap items-end justify-between gap-5 border-b border-[#aab9c0] bg-white px-5 py-5 sm:px-7">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.18em] text-[#6b7e87]">
+            RANGE PLANNING TAPE / ILLUSTRATIVE SCALE
+          </p>
+          <h3 className="m-0 mt-1 text-2xl font-black tracking-[-0.03em] text-[#172934]">
+            Fewer requests can mean more bytes.
+          </h3>
+        </div>
+        <div className="flex border border-[#263a4a] bg-[#edf2f4] p-1">
+          {RANGE_PATTERNS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={pattern.id === item.id}
+              onClick={() => setPatternId(item.id)}
+              className={cn(
+                "px-3 py-1.5 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#137d89]",
+                pattern.id === item.id
+                  ? "bg-[#172934] text-white"
+                  : "text-[#5f727b] hover:bg-white"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="p-5 sm:p-7">
+        <div className="flex items-center justify-between gap-4">
+          <h4 className="m-0 text-lg font-black text-[#172934]">
+            {pattern.title}
+          </h4>
+          <span className="font-mono text-[10px] font-bold text-[#6b7e87]">
+            ONE XORB →
+          </span>
+        </div>
+
+        <div
+          className="mt-5 grid grid-cols-8 gap-1"
+          aria-label="Toy xorb ranges"
+        >
+          {Array.from({ length: 8 }, (_, index) => {
+            const required = pattern.required.includes(index)
+            const fetched = pattern.groups.some((group) =>
+              group.includes(index)
+            )
+            return (
+              <div
+                key={index}
+                className={cn(
+                  "relative flex h-24 items-end justify-center border pb-3 font-mono text-[10px] font-black transition-colors duration-300 motion-reduce:transition-none",
+                  required && "border-[#087f76] bg-[#65d6c6] text-[#073d3a]",
+                  !required &&
+                    fetched &&
+                    "border-[#d6962d] bg-[repeating-linear-gradient(135deg,#f7c96e_0,#f7c96e_6px,#ffe2a6_6px,#ffe2a6_12px)] text-[#6b4300]",
+                  !fetched && "border-[#bac6cb] bg-white text-[#8b9ba2]"
+                )}
+              >
+                <span>{index}</span>
+                {required ? (
+                  <span className="absolute top-2 left-1/2 -translate-x-1/2 text-[8px]">
+                    NEED
+                  </span>
+                ) : null}
+                {!required && fetched ? (
+                  <span className="absolute top-2 left-1/2 -translate-x-1/2 text-[8px]">
+                    GAP
+                  </span>
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="mt-6 grid gap-px overflow-hidden border border-[#263a4a] bg-[#263a4a] sm:grid-cols-2">
+          <div className="bg-white p-5">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#6b7e87]">
+              ONE REQUEST PER NEEDED CHUNK
+            </p>
+            <div className="mt-4 flex items-end justify-between gap-4">
+              <div>
+                <p className="m-0 text-4xl font-black text-[#172934]">
+                  {pattern.required.length}
+                </p>
+                <p className="m-0 text-xs text-[#6b7e87]">requests</p>
+              </div>
+              <div className="text-right">
+                <p className="m-0 text-2xl font-black text-[#172934]">
+                  {pattern.exactBytes} MiB
+                </p>
+                <p className="m-0 text-xs text-[#6b7e87]">transferred</p>
+              </div>
+            </div>
+          </div>
+          <div className="bg-[#e8f7f4] p-5">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#47726d]">
+              PLANNED CONTIGUOUS RANGES
+            </p>
+            <div className="mt-4 flex items-end justify-between gap-4">
+              <div>
+                <p className="m-0 text-4xl font-black text-[#087f76]">
+                  {pattern.groups.length}
+                </p>
+                <p className="m-0 text-xs text-[#47726d]">requests</p>
+              </div>
+              <div className="text-right">
+                <p className="m-0 text-2xl font-black text-[#087f76]">
+                  {pattern.plannedBytes} MiB
+                </p>
+                <p className="m-0 text-xs text-[#47726d]">transferred</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p
+          className="m-0 mt-5 border-l-4 border-[#d6962d] pl-4 text-sm leading-6 text-[#52666f]"
+          aria-live="polite"
+        >
+          {pattern.note}
+        </p>
+      </div>
+    </figure>
+  )
+}
+
+type ObjectPassport = {
+  id: string
+  label: string
+  object: string
+  identity: string
+  changes: string
+  route: string
+  stamp: string
+  cacheable: boolean
+  note: string
+}
+
+const OBJECT_PASSPORTS: ObjectPassport[] = [
+  {
+    id: "xorb",
+    label: "Xorb",
+    object: "Packed chunk bytes",
+    identity: "Content hash",
+    changes: "Never under the same identity",
+    route: "Local → team → origin",
+    stamp: "CACHEABLE",
+    cacheable: true,
+    note: "Wrong bytes fail verification and the client repairs from origin.",
+  },
+  {
+    id: "shard",
+    label: "Shard",
+    object: "Chunk placement metadata",
+    identity: "Content-addressed path",
+    changes: "New content gets a new object",
+    route: "Local → team → origin",
+    stamp: "CACHEABLE",
+    cacheable: true,
+    note: "Cached metadata can locate immutable bytes without changing repository state.",
+  },
+  {
+    id: "ref",
+    label: "Ref",
+    object: "Visible branch position",
+    identity: "Mutable repository name",
+    changes: "Moves when a push publishes",
+    route: "Origin directly",
+    stamp: "BYPASS",
+    cacheable: false,
+    note: "A cached ref could hide a newer commit, so authority stays at origin.",
+  },
+]
+
+export function CacheObjectPassport() {
+  const [passportId, setPassportId] = useState("xorb")
+  const passport =
+    OBJECT_PASSPORTS.find((item) => item.id === passportId) ??
+    OBJECT_PASSPORTS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(58rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-3xl border border-[#d1c9bb] bg-[#f2eee5] p-3 shadow-[0_15px_45px_rgba(55,43,28,0.13)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(58rem,calc(100vw-2rem))] lg:w-[min(58rem,calc(100vw-24.5rem))]">
+      <div className="rounded-[1.1rem] border border-[#9e9587] bg-[#fffdf8] p-5 sm:p-7">
+        <header className="flex flex-wrap items-start justify-between gap-5 border-b border-dashed border-[#aaa091] pb-5">
+          <div>
+            <p className="m-0 font-mono text-[10px] font-black tracking-[0.18em] text-[#786e61]">
+              CACHE ADMISSION PASSPORT
+            </p>
+            <h3 className="m-0 mt-1 text-2xl font-black tracking-[-0.03em] text-[#2d2923]">
+              Immutable bytes travel. Mutable truth does not.
+            </h3>
+          </div>
+          <div className="flex gap-1 rounded-full border border-[#9e9587] p-1">
+            {OBJECT_PASSPORTS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                aria-pressed={passport.id === item.id}
+                onClick={() => setPassportId(item.id)}
+                className={cn(
+                  "rounded-full px-3 py-1.5 font-mono text-[10px] font-black outline-none focus-visible:ring-2 focus-visible:ring-[#176c86]",
+                  passport.id === item.id
+                    ? "bg-[#2d2923] text-white"
+                    : "text-[#786e61] hover:bg-[#eee8dd]"
+                )}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        <div className="grid gap-7 pt-6 sm:grid-cols-[minmax(0,1fr)_13rem] sm:items-stretch">
+          <dl className="m-0 grid gap-px overflow-hidden border border-[#c7bdad] bg-[#c7bdad] sm:grid-cols-2">
+            {[
+              ["OBJECT", passport.object],
+              ["IDENTITY", passport.identity],
+              ["CAN IT CHANGE?", passport.changes],
+              ["READ ROUTE", passport.route],
+            ].map(([label, value]) => (
+              <div key={label} className="bg-[#fffdf8] p-4">
+                <dt className="font-mono text-[9px] font-black tracking-[0.15em] text-[#84796b]">
+                  {label}
+                </dt>
+                <dd className="m-0 mt-2 text-sm leading-5 font-bold text-[#2d2923]">
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          <div
+            className={cn(
+              "flex min-h-44 rotate-[-2deg] flex-col items-center justify-center border-4 p-4 text-center",
+              passport.cacheable
+                ? "border-[#16785f] bg-[#e6f4e9] text-[#16785f]"
+                : "border-[#b44d3a] bg-[#fae8e2] text-[#b44d3a]"
+            )}
+          >
+            {passport.cacheable ? (
+              <ShieldCheck className="size-9" aria-hidden="true" />
+            ) : (
+              <Database className="size-9" aria-hidden="true" />
+            )}
+            <p className="m-0 mt-3 font-mono text-2xl font-black tracking-[-0.05em]">
+              {passport.stamp}
+            </p>
+            <p className="m-0 mt-1 font-mono text-[9px] font-black tracking-[0.12em]">
+              {passport.cacheable ? "VERIFY ON READ" : "ASK THE AUTHORITY"}
+            </p>
+          </div>
+        </div>
+
+        <p
+          className="m-0 mt-6 border-t border-dashed border-[#aaa091] pt-4 text-sm leading-6 text-[#655c50]"
+          aria-live="polite"
+        >
+          {passport.note}
+        </p>
+      </div>
+    </figure>
+  )
+}

--- a/packages/web/components/blog/consistency-visuals.tsx
+++ b/packages/web/components/blog/consistency-visuals.tsx
@@ -1,0 +1,576 @@
+"use client"
+
+import {
+  ArrowRight,
+  Check,
+  CircleStop,
+  Clock3,
+  GitBranch,
+  LockKeyhole,
+  RadioTower,
+  UnlockKeyhole,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type RaceStep = {
+  label: string
+  tone: "work" | "wait" | "pass" | "fail"
+}
+
+type RaceScenario = {
+  id: string
+  label: string
+  title: string
+  aliceRef: string
+  bobRef: string
+  alice: RaceStep[]
+  bob: RaceStep[]
+  result: string
+  resultNote: string
+}
+
+const RACE_SCENARIOS: RaceScenario[] = [
+  {
+    id: "alice-wins",
+    label: "Alice wins",
+    title: "Both plans start from main at A",
+    aliceRef: "main: A → B",
+    bobRef: "main: A → C",
+    alice: [
+      { label: "acquire main", tone: "work" },
+      { label: "upload B", tone: "work" },
+      { label: "expect A = A", tone: "pass" },
+      { label: "publish B", tone: "pass" },
+    ],
+    bob: [
+      { label: "main held", tone: "wait" },
+      { label: "acquire main", tone: "work" },
+      { label: "expect A ≠ B", tone: "fail" },
+      { label: "fetch + rebase", tone: "wait" },
+    ],
+    result: "main → B",
+    resultNote:
+      "Bob's prepared objects may remain, but his stale ref edit is rejected.",
+  },
+  {
+    id: "lease-expires",
+    label: "Alice stalls",
+    title: "Alice pauses after preparing B",
+    aliceRef: "main: A → B",
+    bobRef: "main: A → C",
+    alice: [
+      { label: "acquire main", tone: "work" },
+      { label: "pause past TTL", tone: "wait" },
+      { label: "resume stale", tone: "work" },
+      { label: "expect A ≠ C", tone: "fail" },
+    ],
+    bob: [
+      { label: "reclaim lease", tone: "work" },
+      { label: "expect A = A", tone: "pass" },
+      { label: "publish C", tone: "pass" },
+      { label: "release main", tone: "pass" },
+    ],
+    result: "main → C",
+    resultNote:
+      "Lease expiry restores progress; expected-old stops Alice's resumed stale plan.",
+  },
+  {
+    id: "different-refs",
+    label: "Different refs",
+    title: "The writers target independent mutable keys",
+    aliceRef: "main: A → B",
+    bobRef: "release: R → S",
+    alice: [
+      { label: "acquire main", tone: "work" },
+      { label: "upload B", tone: "work" },
+      { label: "expect A = A", tone: "pass" },
+      { label: "publish B", tone: "pass" },
+    ],
+    bob: [
+      { label: "acquire release", tone: "work" },
+      { label: "upload S", tone: "work" },
+      { label: "expect R = R", tone: "pass" },
+      { label: "publish S", tone: "pass" },
+    ],
+    result: "both publish",
+    resultNote:
+      "Ref-scoped leases preserve parallelism between unrelated branches.",
+  },
+]
+
+const STEP_TONES = {
+  work: "border-[#7190a5] bg-[#dfeaf0] text-[#17324d]",
+  wait: "border-[#d59a2e] bg-[#fff0c8] text-[#6e4a06]",
+  pass: "border-[#2f8f68] bg-[#dcf0e6] text-[#1f684c]",
+  fail: "border-[#c34a4a] bg-[#f7dddd] text-[#913333]",
+}
+
+export function ConcurrentPushRaceBoard() {
+  const [scenarioId, setScenarioId] = useState("alice-wins")
+  const scenario =
+    RACE_SCENARIOS.find((item) => item.id === scenarioId) ?? RACE_SCENARIOS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-lg border-4 border-[#17324d] bg-[#d8e0e5] shadow-[0_18px_55px_rgba(23,50,77,0.2)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b-4 border-[#17324d] bg-[#f5f7f8] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#60798b]">
+            REF SIGNAL BOX / INTERACTIVE RACE
+          </p>
+          <h3 className="m-0 mt-1 text-2xl font-black tracking-[-0.03em] text-[#17324d] sm:text-3xl">
+            Two writers enter. One current ref edit leaves.
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-1 rounded-md border-2 border-[#17324d] bg-white p-1">
+          {RACE_SCENARIOS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={scenario.id === item.id}
+              onClick={() => setScenarioId(item.id)}
+              className={cn(
+                "rounded px-3 py-1.5 font-mono text-[9px] font-black outline-none focus-visible:ring-2 focus-visible:ring-[#f2b544]",
+                scenario.id === item.id
+                  ? "bg-[#17324d] text-white"
+                  : "text-[#5f7280] hover:bg-[#eaf0f3]"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="p-4 sm:p-6">
+        <div className="flex items-center justify-between gap-4 border-b-2 border-dashed border-[#8295a1] pb-4">
+          <p className="m-0 text-lg font-black text-[#17324d]">
+            {scenario.title}
+          </p>
+          <span className="font-mono text-[9px] font-black text-[#60798b]">
+            TIME →
+          </span>
+        </div>
+
+        <RaceLane
+          writer="ALICE"
+          refPlan={scenario.aliceRef}
+          steps={scenario.alice}
+          accent="bg-[#6ca8cf]"
+        />
+        <div className="my-3 h-1 bg-[repeating-linear-gradient(90deg,#8b9da8_0,#8b9da8_10px,transparent_10px,transparent_18px)]" />
+        <RaceLane
+          writer="BOB"
+          refPlan={scenario.bobRef}
+          steps={scenario.bob}
+          accent="bg-[#d58bb6]"
+        />
+      </div>
+
+      <figcaption
+        className="grid gap-3 border-t-4 border-[#17324d] bg-[#17324d] px-5 py-4 text-white sm:grid-cols-[auto_1fr] sm:items-center sm:px-7"
+        aria-live="polite"
+      >
+        <span className="inline-flex w-fit items-center gap-2 rounded-full bg-[#f2b544] px-3 py-1 font-mono text-[10px] font-black text-[#3f2c08]">
+          <RadioTower className="size-4" aria-hidden="true" /> {scenario.result}
+        </span>
+        <span className="text-sm leading-5 text-[#c9d9e3]">
+          {scenario.resultNote}
+        </span>
+      </figcaption>
+    </figure>
+  )
+}
+
+function RaceLane({
+  writer,
+  refPlan,
+  steps,
+  accent,
+}: {
+  writer: string
+  refPlan: string
+  steps: RaceStep[]
+  accent: string
+}) {
+  return (
+    <div className="grid gap-3 py-4 lg:grid-cols-[7.5rem_minmax(0,1fr)] lg:items-center">
+      <div>
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "size-3 rounded-full border border-[#17324d]",
+              accent
+            )}
+          />
+          <strong className="font-mono text-xs text-[#17324d]">{writer}</strong>
+        </div>
+        <p className="m-0 mt-1 font-mono text-[9px] font-bold text-[#617680]">
+          {refPlan}
+        </p>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-4">
+        {steps.map((step, index) => (
+          <div
+            key={`${step.label}-${index}`}
+            className="relative flex items-center gap-2 sm:block"
+          >
+            <div
+              className={cn(
+                "flex min-h-16 flex-1 items-center justify-center rounded border-2 px-2 py-3 text-center font-mono text-[9px] font-black",
+                STEP_TONES[step.tone]
+              )}
+            >
+              {step.label}
+            </div>
+            {index < steps.length - 1 ? (
+              <ArrowRight
+                className="size-4 shrink-0 text-[#6b7f8a] sm:absolute sm:top-1/2 sm:-right-[13px] sm:-translate-y-1/2"
+                aria-hidden="true"
+              />
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+type LeaseMoment = {
+  id: string
+  label: string
+  clock: string
+  holder: string
+  expires: number
+  leaseSecs: number
+  state: "live" | "expired" | "reacquired"
+  action: string
+  note: string
+}
+
+const LEASE_MOMENTS: LeaseMoment[] = [
+  {
+    id: "acquire",
+    label: "Acquire",
+    clock: "T+0",
+    holder: "alice-7f3a",
+    expires: 1700000300,
+    leaseSecs: 300,
+    state: "live",
+    action: "Alice owns refs/heads/main",
+    note: "A conditional object-store write creates the ref-scoped claim.",
+  },
+  {
+    id: "renew",
+    label: "Renew",
+    clock: "T+240",
+    holder: "alice-7f3a",
+    expires: 1700000540,
+    leaseSecs: 300,
+    state: "live",
+    action: "Alice extends the same claim",
+    note: "Renewal checks the holder and current object version before extending the lease.",
+  },
+  {
+    id: "expire",
+    label: "Expire",
+    clock: "T+541",
+    holder: "alice-7f3a",
+    expires: 1700000540,
+    leaseSecs: 300,
+    state: "expired",
+    action: "The slot can be reclaimed",
+    note: "Backend-authored object time determines lease age; expiry restores progress after a crash.",
+  },
+  {
+    id: "reacquire",
+    label: "Bob acquires",
+    clock: "T+542",
+    holder: "bob-b921",
+    expires: 1700000842,
+    leaseSecs: 300,
+    state: "reacquired",
+    action: "Bob now owns refs/heads/main",
+    note: "Alice's late release cannot clear Bob's claim because release checks the holder identity.",
+  },
+]
+
+export function LeaseClockInspector() {
+  const [momentId, setMomentId] = useState("acquire")
+  const moment =
+    LEASE_MOMENTS.find((item) => item.id === momentId) ?? LEASE_MOMENTS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(58rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[2rem] bg-[#f2b544] p-3 shadow-[0_16px_45px_rgba(85,59,7,0.18)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(58rem,calc(100vw-2rem))] lg:w-[min(58rem,calc(100vw-24.5rem))]">
+      <div className="overflow-hidden rounded-[1.25rem] border-2 border-[#513c12] bg-[#fff9e8]">
+        <header className="flex flex-wrap items-end justify-between gap-5 border-b-2 border-[#513c12] px-5 py-5 sm:px-7">
+          <div>
+            <p className="m-0 font-mono text-[10px] font-black tracking-[0.19em] text-[#806321]">
+              FIVE-MINUTE LEASE CLOCK
+            </p>
+            <h3 className="m-0 mt-1 text-2xl font-black tracking-[-0.03em] text-[#3c2d0d]">
+              Ownership is temporary—and holder checked.
+            </h3>
+          </div>
+          <Clock3 className="size-9 text-[#806321]" aria-hidden="true" />
+        </header>
+
+        <div className="grid lg:grid-cols-[minmax(0,1fr)_18rem]">
+          <div className="p-5 sm:p-7">
+            <div className="grid grid-cols-4 gap-1 border-b-2 border-[#513c12] pb-5">
+              {LEASE_MOMENTS.map((item, index) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  aria-pressed={moment.id === item.id}
+                  onClick={() => setMomentId(item.id)}
+                  className="group relative pt-5 font-mono text-[8px] font-black text-[#705719] outline-none focus-visible:ring-2 focus-visible:ring-[#17324d]"
+                >
+                  <span
+                    className={cn(
+                      "absolute top-0 left-1/2 size-4 -translate-x-1/2 rounded-full border-2 border-[#513c12] transition-colors",
+                      moment.id === item.id ? "bg-[#c34a4a]" : "bg-[#fff9e8]"
+                    )}
+                  />
+                  {item.label}
+                  {index < LEASE_MOMENTS.length - 1 ? (
+                    <span className="absolute top-[7px] left-[calc(50%+8px)] h-0.5 w-[calc(100%-16px)] bg-[#8e722f]" />
+                  ) : null}
+                </button>
+              ))}
+            </div>
+
+            <div className="mt-6 rounded-lg border-2 border-[#513c12] bg-[#17252e] p-5 text-[#dbe9ef] shadow-[inset_0_0_0_5px_#243944]">
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-mono text-[9px] font-bold text-[#8eb1c0]">
+                  locks/refs/heads/main/lock
+                </span>
+                <span
+                  className={cn(
+                    "rounded-full px-2 py-1 font-mono text-[8px] font-black",
+                    moment.state === "live" && "bg-[#2f8f68] text-white",
+                    moment.state === "expired" && "bg-[#c34a4a] text-white",
+                    moment.state === "reacquired" &&
+                      "bg-[#6ca8cf] text-[#102c3d]"
+                  )}
+                >
+                  {moment.state.toUpperCase()}
+                </span>
+              </div>
+              <pre className="m-0 mt-5 overflow-x-auto font-mono text-xs leading-7 text-[#eef7fa]">
+                {`{
+  "holder": "${moment.holder}",
+  "expires_at": ${moment.expires},
+  "lease_secs": ${moment.leaseSecs}
+}`}
+              </pre>
+            </div>
+          </div>
+
+          <aside
+            className="border-t-2 border-[#513c12] bg-white p-6 lg:border-t-0 lg:border-l-2"
+            aria-live="polite"
+          >
+            <p className="m-0 font-mono text-5xl font-black tracking-[-0.08em] text-[#c34a4a]">
+              {moment.clock}
+            </p>
+            <h4 className="m-0 mt-5 text-lg leading-6 font-black text-[#3c2d0d]">
+              {moment.action}
+            </h4>
+            <p className="m-0 mt-2 text-sm leading-6 text-[#6d624b]">
+              {moment.note}
+            </p>
+            <div className="mt-6 border-t border-dashed border-[#b9aa87] pt-4">
+              {moment.state === "expired" ? (
+                <UnlockKeyhole
+                  className="size-7 text-[#c34a4a]"
+                  aria-hidden="true"
+                />
+              ) : (
+                <LockKeyhole
+                  className="size-7 text-[#2f8f68]"
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </figure>
+  )
+}
+
+type VisibilityStage = {
+  id: string
+  label: string
+  writerState: string
+  readerTip: "A" | "B"
+  dependencies: "old" | "prepared" | "complete"
+  signal: "hold" | "proceed"
+  note: string
+}
+
+const VISIBILITY_STAGES: VisibilityStage[] = [
+  {
+    id: "upload",
+    label: "Objects uploaded",
+    writerState: "immutable B data exists",
+    readerTip: "A",
+    dependencies: "prepared",
+    signal: "hold",
+    note: "Uploaded packs, xorbs, and shards are not branch visibility.",
+  },
+  {
+    id: "closure",
+    label: "Closure proved",
+    writerState: "every B dependency is durable",
+    readerTip: "A",
+    dependencies: "complete",
+    signal: "hold",
+    note: "B is complete, but readers still follow the committed ref state at A.",
+  },
+  {
+    id: "prepared",
+    label: "Heads prepared",
+    writerState: "ref head points at invisible prepared state",
+    readerTip: "A",
+    dependencies: "complete",
+    signal: "hold",
+    note: "Prepared ref heads stay invisible until the transaction marker exists.",
+  },
+  {
+    id: "marker",
+    label: "Marker committed",
+    writerState: "one immutable transaction becomes visible",
+    readerTip: "B",
+    dependencies: "complete",
+    signal: "proceed",
+    note: "The active marker is the atomic visibility boundary. Readers can now resolve B and its closure.",
+  },
+  {
+    id: "compact",
+    label: "Compacted",
+    writerState: "derived manifest catches up",
+    readerTip: "B",
+    dependencies: "complete",
+    signal: "proceed",
+    note: "Compaction is cleanup after visibility; failure here does not roll B back to A.",
+  },
+]
+
+export function RefVisibilitySignal() {
+  const [stageId, setStageId] = useState("upload")
+  const stage =
+    VISIBILITY_STAGES.find((item) => item.id === stageId) ??
+    VISIBILITY_STAGES[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(62rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden border-2 border-[#1d2d39] bg-[#eef2f4] shadow-[7px_7px_0_#aebac1] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(62rem,calc(100vw-2rem))] lg:w-[min(62rem,calc(100vw-24.5rem))]">
+      <header className="border-b-2 border-[#1d2d39] bg-white px-5 py-5 sm:px-7">
+        <p className="m-0 font-mono text-[10px] font-black tracking-[0.19em] text-[#637886]">
+          READER VISIBILITY SIGNAL
+        </p>
+        <h3 className="m-0 mt-1 text-2xl font-black tracking-[-0.03em] text-[#17324d]">
+          Data can exist before the branch points to it.
+        </h3>
+      </header>
+
+      <div className="grid lg:grid-cols-[13rem_minmax(0,1fr)]">
+        <div className="border-b-2 border-[#1d2d39] bg-[#17324d] p-4 lg:border-r-2 lg:border-b-0">
+          <div className="grid gap-1">
+            {VISIBILITY_STAGES.map((item, index) => (
+              <button
+                key={item.id}
+                type="button"
+                aria-pressed={stage.id === item.id}
+                onClick={() => setStageId(item.id)}
+                className={cn(
+                  "grid grid-cols-[1.5rem_1fr] items-center gap-2 border px-3 py-2 text-left font-mono text-[9px] font-black outline-none focus-visible:ring-2 focus-visible:ring-[#f2b544]",
+                  stage.id === item.id
+                    ? "border-[#f2b544] bg-[#f2b544] text-[#3c2b08]"
+                    : "border-[#4d6678] text-[#c0d1dc] hover:border-[#8ba7b8]"
+                )}
+              >
+                <span>{String(index + 1).padStart(2, "0")}</span>
+                <span>{item.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="p-5 sm:p-7">
+          <div className="grid gap-5 sm:grid-cols-[minmax(0,1fr)_10rem] sm:items-stretch">
+            <div>
+              <div className="grid gap-px overflow-hidden border border-[#8797a5] bg-[#8797a5] sm:grid-cols-2">
+                <SignalFact label="WRITER STATE" value={stage.writerState} />
+                <SignalFact
+                  label="DEPENDENCIES"
+                  value={
+                    stage.dependencies === "complete"
+                      ? "closure complete"
+                      : stage.dependencies === "prepared"
+                        ? "durable but unreachable"
+                        : "old closure"
+                  }
+                />
+              </div>
+
+              <div className="mt-5 rounded-md border-2 border-[#17324d] bg-white p-5">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="font-mono text-[9px] font-black tracking-[0.14em] text-[#667c89]">
+                    READERS RESOLVE
+                  </span>
+                  <GitBranch
+                    className="size-5 text-[#60798b]"
+                    aria-hidden="true"
+                  />
+                </div>
+                <p className="m-0 mt-3 text-4xl font-black tracking-[-0.06em] text-[#17324d]">
+                  main → {stage.readerTip}
+                </p>
+                <p
+                  className="m-0 mt-3 text-sm leading-6 text-[#5e707a]"
+                  aria-live="polite"
+                >
+                  {stage.note}
+                </p>
+              </div>
+            </div>
+
+            <div
+              className={cn(
+                "flex min-h-56 flex-col items-center justify-center rounded-full border-8 p-4 text-center shadow-[inset_0_0_0_5px_#1d2d39]",
+                stage.signal === "proceed"
+                  ? "border-[#2f8f68] bg-[#d9f1e5] text-[#1f684c]"
+                  : "border-[#c34a4a] bg-[#f7dddd] text-[#913333]"
+              )}
+            >
+              {stage.signal === "proceed" ? (
+                <Check className="size-12" aria-hidden="true" />
+              ) : (
+                <CircleStop className="size-12" aria-hidden="true" />
+              )}
+              <span className="mt-2 font-mono text-sm font-black">
+                {stage.signal === "proceed" ? "VISIBLE" : "HOLD A"}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </figure>
+  )
+}
+
+function SignalFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-white p-4">
+      <p className="m-0 font-mono text-[8px] font-black tracking-[0.14em] text-[#70838e]">
+        {label}
+      </p>
+      <p className="m-0 mt-2 text-sm leading-5 font-black text-[#263b49]">
+        {value}
+      </p>
+    </div>
+  )
+}

--- a/packages/web/components/blog/cost-ledger-visual.tsx
+++ b/packages/web/components/blog/cost-ledger-visual.tsx
@@ -1,0 +1,272 @@
+"use client"
+
+import {
+  ArrowDown,
+  Cloud,
+  Coins,
+  Database,
+  Gauge,
+  ReceiptText,
+  RotateCcw,
+  Wifi,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type CostScenario = {
+  id: "standard" | "measured" | "cached" | "overarchive"
+  label: string
+  title: string
+  availability: string
+  note: string
+  tiers: { label: string; gb: number; color: string }[]
+  lines: { label: string; value: number; icon: typeof Cloud }[]
+}
+
+const COST_SCENARIOS: CostScenario[] = [
+  {
+    id: "standard",
+    label: "All Standard",
+    title: "Simple and immediately readable",
+    availability: "DIRECT READ",
+    note: "This is the baseline. Transfer, not storage, is already the largest line item.",
+    tiers: [{ label: "Standard", gb: 10_000, color: "bg-[#4c3f91]" }],
+    lines: [
+      { label: "Storage", value: 230, icon: Database },
+      { label: "Requests", value: 4, icon: Gauge },
+      { label: "Retrieval", value: 0, icon: RotateCcw },
+      { label: "Transfer", value: 180, icon: Wifi },
+      { label: "Early deletion", value: 0, icon: Coins },
+    ],
+  },
+  {
+    id: "measured",
+    label: "Measured tiers",
+    title: "Keep the active 10% hot",
+    availability: "MIXED LATENCY",
+    note: "Tiering lowers storage, but recurring origin reads still dominate the bill.",
+    tiers: [
+      { label: "Hot", gb: 1_000, color: "bg-[#4c3f91]" },
+      { label: "IA", gb: 3_000, color: "bg-[#43b3ae]" },
+      { label: "Glacier IR", gb: 6_000, color: "bg-[#c7d66d]" },
+    ],
+    lines: [
+      { label: "Storage", value: 84.5, icon: Database },
+      { label: "Requests", value: 7, icon: Gauge },
+      { label: "Retrieval", value: 12, icon: RotateCcw },
+      { label: "Transfer", value: 180, icon: Wifi },
+      { label: "Early deletion", value: 0, icon: Coins },
+    ],
+  },
+  {
+    id: "cached",
+    label: "Tiers + cache",
+    title: "Serve repeat reads before origin",
+    availability: "FAST WHEN WARM",
+    note: "The cache does not reduce origin storage. It cuts repeated retrieval and transfer.",
+    tiers: [
+      { label: "Hot", gb: 1_000, color: "bg-[#4c3f91]" },
+      { label: "IA", gb: 3_000, color: "bg-[#43b3ae]" },
+      { label: "Glacier IR", gb: 6_000, color: "bg-[#c7d66d]" },
+    ],
+    lines: [
+      { label: "Storage", value: 84.5, icon: Database },
+      { label: "Requests", value: 5, icon: Gauge },
+      { label: "Retrieval", value: 4, icon: RotateCcw },
+      { label: "Transfer", value: 54, icon: Wifi },
+      { label: "Early deletion", value: 0, icon: Coins },
+    ],
+  },
+  {
+    id: "overarchive",
+    label: "Archive too early",
+    title: "The lowest storage rate loses",
+    availability: "RESTORE REQUIRED",
+    note: "Retrieval, delay, and one early-deletion event erase most of the storage win.",
+    tiers: [
+      { label: "Hot", gb: 1_000, color: "bg-[#4c3f91]" },
+      { label: "IA", gb: 1_000, color: "bg-[#43b3ae]" },
+      { label: "Deep Archive", gb: 8_000, color: "bg-[#e56b6f]" },
+    ],
+    lines: [
+      { label: "Storage", value: 43.42, icon: Database },
+      { label: "Requests", value: 12, icon: Gauge },
+      { label: "Retrieval", value: 40, icon: RotateCcw },
+      { label: "Transfer", value: 180, icon: Wifi },
+      { label: "Early deletion", value: 60, icon: Coins },
+    ],
+  },
+]
+
+export function CostReceiptMixer() {
+  const [scenarioId, setScenarioId] = useState<CostScenario["id"]>("standard")
+  const selected =
+    COST_SCENARIOS.find((item) => item.id === scenarioId) ?? COST_SCENARIOS[0]
+  const total = selected.lines.reduce((sum, line) => sum + line.value, 0)
+  const baseline = COST_SCENARIOS[0].lines.reduce(
+    (sum, line) => sum + line.value,
+    0
+  )
+  const measured = COST_SCENARIOS[1].lines.reduce(
+    (sum, line) => sum + line.value,
+    0
+  )
+  const difference = baseline - total
+  const archiveOverage = total - measured
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] border border-[#a9b3ad] bg-[#dce7e4] text-[#18212a] shadow-[0_20px_60px_rgba(24,33,42,0.16)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#a9b3ad] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#4c3f91]">
+            MONTHLY COST RECEIPT / 10,000 GB / 2,000 GB READ
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.04em] sm:text-3xl">
+            Which line item did the policy move?
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-2" aria-label="Cost scenario">
+          {COST_SCENARIOS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={selected.id === item.id}
+              onClick={() => setScenarioId(item.id)}
+              className={cn(
+                "min-h-11 rounded-full border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#4c3f91] focus-visible:ring-offset-2 focus-visible:ring-offset-[#dce7e4]",
+                selected.id === item.id
+                  ? "border-[#18212a] bg-[#18212a] text-white"
+                  : "border-[#87958e] bg-[#f7f8f0] text-[#52615b] hover:border-[#18212a] hover:text-[#18212a]"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[1fr_22rem]" aria-live="polite">
+        <section className="border-b border-[#a9b3ad] p-5 sm:p-7 lg:border-r lg:border-b-0">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#60716a]">
+                REPOSITORY PLACEMENT
+              </p>
+              <h4 className="m-0 mt-1 text-xl font-black sm:text-2xl">
+                {selected.title}
+              </h4>
+            </div>
+            <span className="rounded-full bg-[#f7f8f0] px-3 py-2 font-mono text-[9px] font-black text-[#4c3f91]">
+              {selected.availability}
+            </span>
+          </div>
+
+          <div className="mt-6 overflow-hidden rounded-2xl border-2 border-[#18212a] bg-[#f7f8f0] p-1">
+            <div className="flex h-24 gap-1">
+              {selected.tiers.map((tier) => (
+                <div
+                  key={tier.label}
+                  className={cn(
+                    "flex min-w-16 flex-col justify-end rounded-xl p-3 text-white",
+                    tier.color
+                  )}
+                  style={{ width: `${(tier.gb / 10_000) * 100}%` }}
+                >
+                  <p className="m-0 text-xs font-black">{tier.label}</p>
+                  <p className="m-0 mt-1 font-mono text-[9px] text-white/80">
+                    {tier.gb.toLocaleString()} GB
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            {selected.lines.map((line) => {
+              const Icon = line.icon
+              return (
+                <div
+                  key={line.label}
+                  className="rounded-xl border border-[#b5bfba] bg-[#f7f8f0] p-3"
+                >
+                  <Icon className="size-4 text-[#4c3f91]" aria-hidden="true" />
+                  <p className="m-0 mt-4 text-xs font-black">{line.label}</p>
+                  <p className="m-0 mt-1 font-mono text-[11px] text-[#60716a]">
+                    ${line.value.toFixed(2)}
+                  </p>
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="mt-6 flex gap-3 rounded-xl border border-dashed border-[#87958e] bg-[#edf2ee] p-4">
+            <ArrowDown
+              className="mt-0.5 size-5 shrink-0 text-[#e56b6f]"
+              aria-hidden="true"
+            />
+            <p className="m-0 text-sm leading-6 text-[#52615b]">
+              {selected.note}
+            </p>
+          </div>
+        </section>
+
+        <aside className="relative bg-[#f7f8f0] p-6 font-mono sm:p-7">
+          <div className="absolute top-0 left-0 hidden h-full w-3 -translate-x-1/2 bg-[radial-gradient(circle,#18212a_4px,transparent_5px)] bg-[length:12px_24px] lg:block" />
+          <div className="flex items-center justify-between gap-3 border-b border-dashed border-[#87958e] pb-4">
+            <div>
+              <p className="m-0 text-[9px] font-black tracking-[0.16em] text-[#60716a]">
+                ESTIMATE
+              </p>
+              <p className="m-0 mt-1 text-sm font-black">crab / monthly</p>
+            </div>
+            <ReceiptText className="size-6 text-[#4c3f91]" aria-hidden="true" />
+          </div>
+
+          <div className="mt-5 space-y-3 text-[10px]">
+            {selected.lines.map((line) => (
+              <div
+                key={line.label}
+                className="flex items-center justify-between gap-4"
+              >
+                <span className="text-[#52615b]">{line.label}</span>
+                <span>${line.value.toFixed(2)}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-5 border-y-2 border-[#18212a] py-4">
+            <div className="flex items-end justify-between gap-4">
+              <span className="text-xs font-black">TOTAL</span>
+              <span className="text-4xl font-black tracking-[-0.08em]">
+                ${total.toFixed(2)}
+              </span>
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "mt-5 rounded-xl p-4 text-xs font-black",
+              selected.id === "overarchive"
+                ? "bg-[#f6dddd] text-[#7b3038]"
+                : difference > 0
+                  ? "bg-[#e6edc5] text-[#435116]"
+                  : "bg-[#ece9f7] text-[#4c3f91]"
+            )}
+          >
+            {selected.id === "overarchive"
+              ? `$${archiveOverage.toFixed(2)} above measured tiers`
+              : difference > 0
+                ? `$${difference.toFixed(2)} below baseline`
+                : "baseline"}
+          </div>
+
+          <p className="m-0 mt-6 text-[9px] leading-4 text-[#60716a]">
+            Illustration uses Crab’s embedded S3 us-east-1 rate table. Replace
+            with your region or contract rates.
+          </p>
+        </aside>
+      </div>
+    </figure>
+  )
+}

--- a/packages/web/components/blog/deduplication-visuals.tsx
+++ b/packages/web/components/blog/deduplication-visuals.tsx
@@ -1,0 +1,568 @@
+"use client"
+
+import {
+  ArrowRight,
+  Check,
+  Database,
+  Fingerprint,
+  MapPin,
+  Package,
+  ShieldCheck,
+  X,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type Chunk = {
+  id: string
+  size: number
+  reused: boolean
+}
+
+type EditScenario = {
+  id: string
+  label: string
+  title: string
+  note: string
+  reuse: string
+  reusedBytes: string
+  newBytes: string
+  chunks: Chunk[]
+}
+
+const ORIGINAL_CHUNKS: Chunk[] = [
+  { id: "A", size: 18, reused: true },
+  { id: "B", size: 22, reused: true },
+  { id: "C", size: 17, reused: true },
+  { id: "D", size: 25, reused: true },
+  { id: "E", size: 18, reused: true },
+]
+
+const EDIT_SCENARIOS: EditScenario[] = [
+  {
+    id: "replace",
+    label: "Replace",
+    title: "A fixed-size replacement disturbs one region",
+    note: "The byte length stays stable, so the next content boundary can recover quickly.",
+    reuse: "80%",
+    reusedBytes: "8 GiB",
+    newBytes: "2 GiB",
+    chunks: [
+      { id: "A", size: 18, reused: true },
+      { id: "N", size: 22, reused: false },
+      { id: "C", size: 17, reused: true },
+      { id: "D", size: 25, reused: true },
+      { id: "E", size: 18, reused: true },
+    ],
+  },
+  {
+    id: "insert",
+    label: "Insert",
+    title: "An insertion shifts boundaries, then resynchronizes",
+    note: "Nearby chunks change. Stable content later in the stream finds familiar boundaries again.",
+    reuse: "60%",
+    reusedBytes: "6 GiB",
+    newBytes: "4 GiB",
+    chunks: [
+      { id: "A", size: 17, reused: true },
+      { id: "N", size: 13, reused: false },
+      { id: "O", size: 18, reused: false },
+      { id: "D", size: 28, reused: true },
+      { id: "E", size: 24, reused: true },
+    ],
+  },
+  {
+    id: "append",
+    label: "Append",
+    title: "An append preserves every earlier boundary",
+    note: "Existing chunks keep their identities. Only the new tail needs storage.",
+    reuse: "83%",
+    reusedBytes: "10 GiB",
+    newBytes: "2 GiB",
+    chunks: [...ORIGINAL_CHUNKS, { id: "N", size: 20, reused: false }],
+  },
+  {
+    id: "recompress",
+    label: "Recompress",
+    title: "A new encoded stream can erase physical overlap",
+    note: "The logical data may be similar, but changed compressed bytes produce new chunk identities.",
+    reuse: "0%",
+    reusedBytes: "0 GiB",
+    newBytes: "10 GiB",
+    chunks: [
+      { id: "N", size: 15, reused: false },
+      { id: "O", size: 21, reused: false },
+      { id: "P", size: 18, reused: false },
+      { id: "Q", size: 24, reused: false },
+      { id: "R", size: 22, reused: false },
+    ],
+  },
+]
+
+export function DedupBoundaryLab() {
+  const [scenarioId, setScenarioId] = useState("replace")
+  const scenario =
+    EDIT_SCENARIOS.find((item) => item.id === scenarioId) ?? EDIT_SCENARIOS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden border-2 border-[#18201f] bg-[#f5f0df] shadow-[7px_7px_0_#18201f] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="flex flex-wrap items-end justify-between gap-4 border-b-2 border-[#18201f] bg-[#fffdf6] px-4 py-4 sm:px-6">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.18em] text-[#5f6966]">
+            CONTENT-DEFINED CUTTING MAT
+          </p>
+          <h3 className="m-0 mt-1 text-xl font-black tracking-tight text-[#18201f] sm:text-2xl">
+            Change the edit. Watch boundaries recover.
+          </h3>
+        </div>
+        <div className="flex flex-wrap border-2 border-[#18201f] bg-white p-1">
+          {EDIT_SCENARIOS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={scenario.id === item.id}
+              onClick={() => setScenarioId(item.id)}
+              className={cn(
+                "px-3 py-1.5 font-mono text-[10px] font-black uppercase transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#2447a8]",
+                scenario.id === item.id
+                  ? "bg-[#18201f] text-white"
+                  : "text-[#5f6966] hover:bg-[#ebe5d1]"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[minmax(0,1fr)_15rem]">
+        <div className="border-b-2 border-[#18201f] p-4 sm:p-6 lg:border-r-2 lg:border-b-0">
+          <ChunkRow label="VERSION 1" chunks={ORIGINAL_CHUNKS} original />
+          <div className="my-4 flex items-center gap-3">
+            <div className="h-px flex-1 bg-[#929b97]" />
+            <span className="border border-[#18201f] bg-[#f2c14e] px-2 py-1 font-mono text-[9px] font-black uppercase">
+              {scenario.label} bytes
+            </span>
+            <div className="h-px flex-1 bg-[#929b97]" />
+          </div>
+          <ChunkRow label="VERSION 2" chunks={scenario.chunks} />
+
+          <div
+            className="mt-6 border-t-2 border-[#18201f] pt-4"
+            aria-live="polite"
+          >
+            <h4 className="m-0 text-lg font-black text-[#18201f]">
+              {scenario.title}
+            </h4>
+            <p className="m-0 mt-1 max-w-2xl text-sm leading-6 text-[#5f6966]">
+              {scenario.note}
+            </p>
+          </div>
+        </div>
+
+        <aside className="flex flex-col justify-between bg-[#2447a8] p-5 text-white sm:p-6">
+          <div>
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#bdcaf1]">
+              TOY REUSE MODEL
+            </p>
+            <p className="m-0 mt-2 font-mono text-6xl leading-none font-black tracking-[-0.08em]">
+              {scenario.reuse}
+            </p>
+            <p className="m-0 mt-2 text-sm font-bold text-[#dce4ff]">
+              source bytes reused
+            </p>
+          </div>
+          <div className="mt-8 grid gap-2 border-t border-[#8fa3df] pt-4 font-mono text-[10px]">
+            <div className="flex justify-between gap-3">
+              <span className="text-[#bdcaf1]">REUSED</span>
+              <strong>{scenario.reusedBytes}</strong>
+            </div>
+            <div className="flex justify-between gap-3">
+              <span className="text-[#bdcaf1]">NEW</span>
+              <strong>{scenario.newBytes}</strong>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <figcaption className="border-t-2 border-[#18201f] bg-[#18201f] px-4 py-3 text-xs leading-5 text-[#dce5e1] sm:px-6">
+        Illustrative chunks, not measured boundaries. Crab uses a gearhash
+        chunker with a 64 KiB target.
+      </figcaption>
+    </figure>
+  )
+}
+
+function ChunkRow({
+  label,
+  chunks,
+  original = false,
+}: {
+  label: string
+  chunks: Chunk[]
+  original?: boolean
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between font-mono text-[9px] font-black tracking-[0.15em] text-[#5f6966]">
+        <span>{label}</span>
+        <span>BYTE STREAM →</span>
+      </div>
+      <div className="flex min-w-0 gap-1.5">
+        {chunks.map((chunk, index) => (
+          <div
+            key={`${chunk.id}-${index}`}
+            className={cn(
+              "flex h-20 min-w-10 flex-col justify-between border-2 p-2 transition-[flex-grow,background-color] duration-300 motion-reduce:transition-none",
+              original || chunk.reused
+                ? "border-[#16745a] bg-[#dcefe4] text-[#125c48]"
+                : "border-[#e5533d] bg-[#f9ded8] text-[#9e3021]"
+            )}
+            style={{ flexGrow: chunk.size, flexBasis: 0 }}
+          >
+            <span className="font-mono text-base font-black">{chunk.id}</span>
+            <span className="font-mono text-[8px] font-bold uppercase">
+              {original ? "original" : chunk.reused ? "reused" : "new"}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+type EvidenceLevel = {
+  id: string
+  label: string
+  structure: string
+  authority: string
+  saves: string
+  canSkipUpload: boolean
+}
+
+const EVIDENCE_LEVELS: EvidenceLevel[] = [
+  {
+    id: "session",
+    label: "Session hit",
+    structure: "in-memory chunk map",
+    authority: "This process has seen the bytes.",
+    saves: "Repeated hashing or local reads",
+    canSkipUpload: false,
+  },
+  {
+    id: "staging",
+    label: "Staging hit",
+    structure: "FilePushPlan + PlannedXorb",
+    authority: "This client can reconstruct or upload the chunk.",
+    saves: "Rechunking and xorb preparation",
+    canSkipUpload: false,
+  },
+  {
+    id: "canonical",
+    label: "Origin proof",
+    structure: "ChunkPlacement + OriginReceipt",
+    authority: "A remote reader can locate durable bytes.",
+    saves: "The chunk upload itself",
+    canSkipUpload: true,
+  },
+]
+
+export function DedupEvidenceLadder() {
+  const [activeId, setActiveId] = useState("session")
+  const active =
+    EVIDENCE_LEVELS.find((item) => item.id === activeId) ?? EVIDENCE_LEVELS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(62rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden border border-[#d6d9dd] bg-white min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(62rem,calc(100vw-2rem))] lg:w-[min(62rem,calc(100vw-24.5rem))]">
+      <div className="grid md:grid-cols-[1fr_1.1fr]">
+        <div className="border-b border-[#d6d9dd] bg-[#f3f5f7] p-4 sm:p-6 md:border-r md:border-b-0">
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.17em] text-[#687078]">
+            PROOF LADDER · SELECT EVIDENCE
+          </p>
+          <h3 className="m-0 mt-1 text-xl font-black text-[#18201f]">
+            A hash match is not yet upload permission
+          </h3>
+
+          <div className="relative mt-6 grid gap-3 before:absolute before:top-5 before:bottom-5 before:left-[1.15rem] before:w-0.5 before:bg-[#aeb6bd]">
+            {EVIDENCE_LEVELS.map((item, index) => (
+              <button
+                key={item.id}
+                type="button"
+                aria-pressed={active.id === item.id}
+                onClick={() => setActiveId(item.id)}
+                className={cn(
+                  "relative z-10 grid grid-cols-[2.25rem_1fr] items-center border p-2 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#2447a8]",
+                  active.id === item.id
+                    ? "border-[#2447a8] bg-white shadow-[3px_3px_0_#2447a8]"
+                    : "border-[#c7cdd2] bg-[#f9fafb] hover:bg-white"
+                )}
+              >
+                <span className="flex size-7 items-center justify-center rounded-full border-2 border-[#18201f] bg-[#f2c14e] font-mono text-[10px] font-black">
+                  {index + 1}
+                </span>
+                <span>
+                  <span className="block text-sm font-black text-[#18201f]">
+                    {item.label}
+                  </span>
+                  <code className="mt-0.5 block text-[9px] font-bold text-[#687078]">
+                    {item.structure}
+                  </code>
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div
+          className="flex flex-col justify-between p-5 sm:p-7"
+          aria-live="polite"
+        >
+          <div>
+            <div className="flex size-10 items-center justify-center border-2 border-[#18201f] bg-[#f2c14e]">
+              <ShieldCheck size={19} aria-hidden="true" />
+            </div>
+            <p className="m-0 mt-5 font-mono text-[9px] font-black tracking-[0.16em] text-[#687078]">
+              AUTHORITY AT THIS LEVEL
+            </p>
+            <h4 className="m-0 mt-1 text-2xl font-black tracking-tight text-[#18201f]">
+              {active.authority}
+            </h4>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              <EvidenceFact
+                label="WORK AVOIDED"
+                value={active.saves}
+                icon={Check}
+              />
+              <EvidenceFact
+                label="SKIP REMOTE UPLOAD"
+                value={
+                  active.canSkipUpload
+                    ? "Yes—proof is canonical"
+                    : "No—durability unproven"
+                }
+                icon={active.canSkipUpload ? Check : X}
+                positive={active.canSkipUpload}
+              />
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "mt-7 border-2 px-4 py-3 font-mono text-sm font-black tracking-[0.08em]",
+              active.canSkipUpload
+                ? "border-[#16745a] bg-[#dcefe4] text-[#125c48]"
+                : "border-[#e5533d] bg-[#f9ded8] text-[#9e3021]"
+            )}
+          >
+            {active.canSkipUpload ? "UPLOAD MAY BE OMITTED" : "KEEP PROVING"}
+          </div>
+        </div>
+      </div>
+      <figcaption className="border-t border-[#d6d9dd] px-4 py-3 text-xs leading-5 text-[#687078] sm:px-6">
+        Local evidence can save work. Only canonical placement and origin
+        evidence can prove another client can read the bytes.
+      </figcaption>
+    </figure>
+  )
+}
+
+function EvidenceFact({
+  label,
+  value,
+  icon: Icon,
+  positive = true,
+}: {
+  label: string
+  value: string
+  icon: typeof Check
+  positive?: boolean
+}) {
+  return (
+    <div className="border border-[#c7cdd2] bg-[#f9fafb] p-3">
+      <Icon
+        size={16}
+        className={positive ? "text-[#16745a]" : "text-[#e5533d]"}
+        aria-hidden="true"
+      />
+      <p className="m-0 mt-3 font-mono text-[8px] font-black tracking-[0.13em] text-[#687078]">
+        {label}
+      </p>
+      <p className="m-0 mt-1 text-xs leading-5 font-bold text-[#18201f]">
+        {value}
+      </p>
+    </div>
+  )
+}
+
+type AddressChunk = {
+  id: "A" | "B" | "C"
+  hash: string
+  xorb: string
+  index: number
+  bytes: string
+  positions: number[]
+}
+
+const ADDRESS_CHUNKS: AddressChunk[] = [
+  {
+    id: "A",
+    hash: "8f21…a1",
+    xorb: "xorb-31",
+    index: 0,
+    bytes: "64 KiB",
+    positions: [1, 3],
+  },
+  {
+    id: "B",
+    hash: "d902…7c",
+    xorb: "xorb-31",
+    index: 1,
+    bytes: "61 KiB",
+    positions: [2],
+  },
+  {
+    id: "C",
+    hash: "4ab7…e9",
+    xorb: "xorb-88",
+    index: 4,
+    bytes: "67 KiB",
+    positions: [4],
+  },
+]
+
+const RECIPE = ["A", "B", "A", "C"] as const
+
+export function ChunkAddressMap() {
+  const [selectedId, setSelectedId] = useState<AddressChunk["id"]>("A")
+  const selected =
+    ADDRESS_CHUNKS.find((chunk) => chunk.id === selectedId) ?? ADDRESS_CHUNKS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(62rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden border-2 border-[#18201f] bg-[#edf2ee] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(62rem,calc(100vw-2rem))] lg:w-[min(62rem,calc(100vw-24.5rem))]">
+      <header className="border-b-2 border-[#18201f] bg-[#18201f] px-4 py-4 text-white sm:px-6">
+        <p className="m-0 font-mono text-[10px] font-black tracking-[0.18em] text-[#9fb0a8]">
+          CHUNK ADDRESS MAP · SELECT A RECIPE TERM
+        </p>
+        <h3 className="m-0 mt-1 text-xl font-black tracking-tight">
+          Identity stays stable while location can move
+        </h3>
+      </header>
+
+      <div className="grid gap-0 lg:grid-cols-[1fr_2rem_1fr_2rem_1fr]">
+        <AddressColumn title="1 · FILE RECIPE" icon={Fingerprint}>
+          <p className="m-0 text-xs leading-5 text-[#5f6966]">
+            Ordered identities define the file.
+          </p>
+          <div className="mt-4 grid grid-cols-4 gap-1.5">
+            {RECIPE.map((id, index) => (
+              <button
+                key={`${id}-${index}`}
+                type="button"
+                aria-pressed={selected.id === id}
+                onClick={() => setSelectedId(id)}
+                className={cn(
+                  "flex h-16 flex-col justify-between border-2 p-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-[#2447a8]",
+                  selected.id === id
+                    ? "border-[#2447a8] bg-[#dfe6fb] text-[#2447a8]"
+                    : "border-[#9eaaa4] bg-white text-[#5f6966]"
+                )}
+              >
+                <span className="font-mono text-[8px] font-bold">
+                  {index + 1}
+                </span>
+                <strong className="font-mono text-base">{id}</strong>
+              </button>
+            ))}
+          </div>
+          <code className="mt-4 block border border-[#9eaaa4] bg-white p-2 text-[10px] font-bold text-[#18201f]">
+            chunk_hash: {selected.hash}
+          </code>
+        </AddressColumn>
+
+        <AddressArrow />
+
+        <AddressColumn title="2 · CHUNK PLACEMENT" icon={MapPin}>
+          <p className="m-0 text-xs leading-5 text-[#5f6966]">
+            Canonical metadata maps identity to storage.
+          </p>
+          <div className="mt-4 border-2 border-[#16745a] bg-[#dcefe4] p-3 font-mono text-[10px] leading-6 text-[#125c48]">
+            <div>chunk_hash: {selected.hash}</div>
+            <div>xorb_hash: {selected.xorb}</div>
+            <div>chunk_index: {selected.index}</div>
+            <div>uncompressed_size: {selected.bytes}</div>
+          </div>
+          <p className="m-0 mt-3 text-xs font-bold text-[#18201f]">
+            Recipe positions: {selected.positions.join(", ")}
+          </p>
+        </AddressColumn>
+
+        <AddressArrow />
+
+        <AddressColumn title="3 · XORB OBJECT" icon={Package}>
+          <p className="m-0 text-xs leading-5 text-[#5f6966]">
+            Packed bytes remain immutable and range-readable.
+          </p>
+          <div className="mt-5 border-2 border-[#18201f] bg-white p-2">
+            <div className="flex h-20 gap-1">
+              {[0, 1, 2, 3, 4].map((index) => {
+                const active = selected.index === index
+                return (
+                  <div
+                    key={index}
+                    className={cn(
+                      "flex flex-1 items-center justify-center border font-mono text-[10px] font-black",
+                      active
+                        ? "border-[#e5533d] bg-[#f9ded8] text-[#9e3021]"
+                        : "border-[#c7cfc9] bg-[#edf2ee] text-[#7b8881]"
+                    )}
+                  >
+                    {index}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+          <div className="mt-3 flex items-center gap-2 font-mono text-[10px] font-black text-[#18201f]">
+            <Database size={14} className="text-[#e5533d]" aria-hidden="true" />
+            {selected.xorb} · index {selected.index}
+          </div>
+        </AddressColumn>
+      </div>
+
+      <figcaption className="border-t-2 border-[#18201f] bg-[#fffdf6] px-4 py-3 text-xs leading-5 text-[#5f6966] sm:px-6">
+        Chunk A appears twice in the recipe but needs one stored identity.
+        Repacking may change its placement without changing the recipe hash.
+      </figcaption>
+    </figure>
+  )
+}
+
+function AddressColumn({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string
+  icon: typeof Fingerprint
+  children: React.ReactNode
+}) {
+  return (
+    <section className="min-w-0 p-4 sm:p-5">
+      <div className="flex items-center gap-2 font-mono text-[10px] font-black tracking-[0.12em] text-[#18201f]">
+        <Icon size={15} aria-hidden="true" />
+        {title}
+      </div>
+      <div className="mt-4">{children}</div>
+    </section>
+  )
+}
+
+function AddressArrow() {
+  return (
+    <div className="hidden items-center justify-center border-x border-[#c7cfc9] bg-[#fffdf6] lg:flex">
+      <ArrowRight size={16} className="text-[#5f6966]" aria-hidden="true" />
+    </div>
+  )
+}

--- a/packages/web/components/blog/gc-run-permit.tsx
+++ b/packages/web/components/blog/gc-run-permit.tsx
@@ -1,0 +1,223 @@
+"use client"
+
+import {
+  ArchiveRestore,
+  Check,
+  FileClock,
+  LockKeyhole,
+  PackageOpen,
+  Timer,
+  X,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type PermitCase = {
+  id: "preview" | "apply" | "bucket" | "force"
+  label: string
+  title: string
+  command: string
+  status: "PREVIEW" | "READY" | "REFUSED" | "CAUTION"
+  checks: { label: string; ok: boolean; note: string }[]
+  action: string
+}
+
+const PERMIT_CASES: PermitCase[] = [
+  {
+    id: "preview",
+    label: "Repo preview",
+    title: "Review the proof without deleting",
+    command: "crab gc --scope repo --dry-run --json",
+    status: "PREVIEW",
+    checks: [
+      { label: "Repository scope", ok: true, note: "normal boundary" },
+      { label: "Root walk complete", ok: true, note: "no unknown proof" },
+      { label: "Dry run", ok: true, note: "zero deletes" },
+      { label: "Candidate inventory", ok: true, note: "save for review" },
+    ],
+    action:
+      "Record candidate counts, bytes, policy, and the exact repository identity.",
+  },
+  {
+    id: "apply",
+    label: "Repo apply",
+    title: "Apply the reviewed repository plan",
+    command: "crab gc --scope repo",
+    status: "READY",
+    checks: [
+      { label: "Dry run reviewed", ok: true, note: "same scope + policy" },
+      { label: "Roots readable", ok: true, note: "mark proof complete" },
+      { label: "Sweep fence", ok: true, note: "writer epoch sealed" },
+      { label: "Post-check planned", ok: true, note: "run crab fsck" },
+    ],
+    action: "Apply, preserve the outcome, then run integrity verification.",
+  },
+  {
+    id: "bucket",
+    label: "Bucket incomplete",
+    title: "Bucket scope cannot prove shared reachability",
+    command: "crab gc --scope bucket --bucket team-data",
+    status: "REFUSED",
+    checks: [
+      { label: "Bucket named", ok: true, note: "team-data" },
+      { label: "Registry complete", ok: false, note: "repo/labs missing" },
+      { label: "Shared marks complete", ok: false, note: "blind spot" },
+      { label: "Coordinator proof", ok: true, note: "still insufficient" },
+    ],
+    action: "Repair registry coverage before attempting destructive bucket GC.",
+  },
+  {
+    id: "force",
+    label: "Force recent",
+    title: "Force removes only the age key",
+    command: "crab gc --scope repo --force",
+    status: "CAUTION",
+    checks: [
+      { label: "Age protection", ok: false, note: "bypassed" },
+      { label: "Reachability proof", ok: true, note: "still required" },
+      { label: "Writer fence", ok: true, note: "still required" },
+      { label: "Confirmation", ok: true, note: "interactive or --yes" },
+    ],
+    action:
+      "Use only with a documented maintenance reason and current coordination evidence.",
+  },
+]
+
+const PERMIT_STYLE = {
+  PREVIEW: "bg-[#dcecf4] text-[#285b79]",
+  READY: "bg-[#dcece6] text-[#205743]",
+  REFUSED: "bg-[#f7d9d5] text-[#7a2923]",
+  CAUTION: "bg-[#fff0c9] text-[#714d12]",
+}
+
+export function GcRunPermit() {
+  const [caseId, setCaseId] = useState<PermitCase["id"]>("preview")
+  const selected =
+    PERMIT_CASES.find((item) => item.id === caseId) ?? PERMIT_CASES[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] border border-[#aebdc1] bg-[#eef4f3] text-[#20313a] shadow-[0_20px_60px_rgba(19,42,58,0.14)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#aebdc1] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#2e6f95]">
+            DELETION PERMIT / TRY AN OPERATION
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.04em] sm:text-3xl">
+            Does this run have enough proof?
+          </h3>
+        </div>
+        <FileClock
+          className="hidden size-8 text-[#c64e44] lg:block"
+          aria-hidden="true"
+        />
+      </header>
+
+      <div className="grid lg:grid-cols-[17rem_1fr]">
+        <nav
+          className="border-b border-[#aebdc1] p-5 sm:p-7 lg:border-r lg:border-b-0"
+          aria-label="GC operation"
+        >
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
+            {PERMIT_CASES.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                aria-pressed={selected.id === item.id}
+                onClick={() => setCaseId(item.id)}
+                className={cn(
+                  "min-h-11 rounded-xl border px-4 py-3 text-left text-sm font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#2e6f95] focus-visible:ring-offset-2",
+                  selected.id === item.id
+                    ? "border-[#132a3a] bg-[#132a3a] text-white"
+                    : "border-[#aebdc1] bg-white text-[#536871] hover:border-[#132a3a] hover:text-[#132a3a]"
+                )}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </nav>
+
+        <section className="bg-white p-5 sm:p-7" aria-live="polite">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#667a83]">
+                OPERATOR DECISION
+              </p>
+              <h4 className="m-0 mt-1 text-xl font-black sm:text-2xl">
+                {selected.title}
+              </h4>
+            </div>
+            <span
+              className={cn(
+                "rounded-full px-3 py-2 font-mono text-[10px] font-black",
+                PERMIT_STYLE[selected.status]
+              )}
+            >
+              {selected.status}
+            </span>
+          </div>
+
+          <code className="mt-5 block overflow-x-auto rounded-xl bg-[#132a3a] px-4 py-3 font-mono text-[11px] text-[#f6c85f]">
+            {selected.command}
+          </code>
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-2">
+            {selected.checks.map((check) => (
+              <div
+                key={check.label}
+                className="rounded-xl border border-[#aebdc1] bg-[#eef4f3] p-4"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className="m-0 text-sm font-black">{check.label}</p>
+                  {check.ok ? (
+                    <Check
+                      className="size-5 text-[#2f7d63]"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <X className="size-5 text-[#c64e44]" aria-hidden="true" />
+                  )}
+                </div>
+                <p className="m-0 mt-2 font-mono text-[9px] text-[#667a83]">
+                  {check.note}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-5 flex gap-3 rounded-xl border border-dashed border-[#8fa4aa] bg-[#f7f9f8] p-4">
+            {selected.status === "READY" ? (
+              <PackageOpen
+                className="mt-0.5 size-5 shrink-0 text-[#2f7d63]"
+                aria-hidden="true"
+              />
+            ) : selected.status === "REFUSED" ? (
+              <LockKeyhole
+                className="mt-0.5 size-5 shrink-0 text-[#c64e44]"
+                aria-hidden="true"
+              />
+            ) : selected.status === "CAUTION" ? (
+              <Timer
+                className="mt-0.5 size-5 shrink-0 text-[#d99a27]"
+                aria-hidden="true"
+              />
+            ) : (
+              <ArchiveRestore
+                className="mt-0.5 size-5 shrink-0 text-[#2e6f95]"
+                aria-hidden="true"
+              />
+            )}
+            <p className="m-0 text-sm leading-6 text-[#536871]">
+              {selected.action}
+            </p>
+          </div>
+        </section>
+      </div>
+      <figcaption className="border-t border-[#aebdc1] px-5 py-3 font-mono text-[10px] text-[#667a83] sm:px-7">
+        Force bypasses age protection only. Unknown reachability always blocks
+        deletion.
+      </figcaption>
+    </figure>
+  )
+}

--- a/packages/web/components/blog/gc-visuals.tsx
+++ b/packages/web/components/blog/gc-visuals.tsx
@@ -1,0 +1,552 @@
+"use client"
+
+import {
+  ArrowRight,
+  GitBranch,
+  History,
+  LockKeyhole,
+  ShieldCheck,
+  Trash2,
+  X,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type ObjectCase = {
+  id: "main" | "history" | "recent" | "candidate" | "shared"
+  label: string
+  object: string
+  size: string
+  age: string
+  path: string
+  roots: { label: string; kind: "live" | "retained" | "none" }[]
+  unreachable: boolean
+  oldEnough: boolean
+  verdict: "RETAIN" | "PROTECTED" | "CANDIDATE"
+  reason: string
+  structures: string[]
+}
+
+const OBJECT_CASES: ObjectCase[] = [
+  {
+    id: "main",
+    label: "On main",
+    object: "xorb 19e2…",
+    size: "12 GB",
+    age: "90 days",
+    path: "models/current/model.safetensors",
+    roots: [
+      { label: "refs/heads/main", kind: "live" },
+      { label: "pointer → recipe", kind: "live" },
+      { label: "recipe → xorb 19e2", kind: "live" },
+    ],
+    unreachable: false,
+    oldEnough: true,
+    verdict: "RETAIN",
+    reason: "Age cannot override a live path from main.",
+    structures: ["root set", "pointer map", "mark set"],
+  },
+  {
+    id: "history",
+    label: "Deleted branch",
+    object: "xorb a840…",
+    size: "6.4 GB",
+    age: "41 days",
+    path: "experiments/branch-17/output.bin",
+    roots: [
+      { label: "feature branch deleted", kind: "none" },
+      { label: "recovery generation 184", kind: "retained" },
+      { label: "recipe → xorb a840", kind: "retained" },
+    ],
+    unreachable: false,
+    oldEnough: true,
+    verdict: "RETAIN",
+    reason: "Recovery history still reaches the object.",
+    structures: ["history root", "generation", "mark set"],
+  },
+  {
+    id: "recent",
+    label: "Interrupted push",
+    object: "xorb 6cb1…",
+    size: "800 MB",
+    age: "18 minutes",
+    path: "staging/push-7/xorb-6cb1",
+    roots: [{ label: "no published root", kind: "none" }],
+    unreachable: true,
+    oldEnough: false,
+    verdict: "PROTECTED",
+    reason: "It is unreachable, but still inside the 24-hour grace window.",
+    structures: ["object metadata", "snapshot time", "grace cutoff"],
+  },
+  {
+    id: "candidate",
+    label: "Old orphan",
+    object: "xorb d77c…",
+    size: "4.2 GB",
+    age: "3 days",
+    path: "xorbs/d7/d77c…",
+    roots: [{ label: "no retained root", kind: "none" }],
+    unreachable: true,
+    oldEnough: true,
+    verdict: "CANDIDATE",
+    reason: "Both deletion proofs pass. Dry run may list this object.",
+    structures: ["unmarked listing", "candidate batch", "ETag + size"],
+  },
+  {
+    id: "shared",
+    label: "Shared xorb",
+    object: "xorb f093…",
+    size: "9.8 GB",
+    age: "120 days",
+    path: "xorbs/f0/f093…",
+    roots: [
+      { label: "repo/vision: unreferenced", kind: "none" },
+      { label: "repo/labs: recipe → xorb", kind: "live" },
+    ],
+    unreachable: false,
+    oldEnough: true,
+    verdict: "RETAIN",
+    reason:
+      "Bucket scope keeps an object reached by any registered repository.",
+    structures: ["repository registry", "union of marks", "shared xorb"],
+  },
+]
+
+const VERDICT_STYLE = {
+  RETAIN: "border-[#2f7d63] bg-[#dcece6] text-[#205743]",
+  PROTECTED: "border-[#d99a27] bg-[#fff0c9] text-[#714d12]",
+  CANDIDATE: "border-[#c64e44] bg-[#f7d9d5] text-[#7a2923]",
+}
+
+export function GcObjectEvidenceLab() {
+  const [caseId, setCaseId] = useState<ObjectCase["id"]>("main")
+  const selected =
+    OBJECT_CASES.find((item) => item.id === caseId) ?? OBJECT_CASES[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] border border-[#617785] bg-[#eef4f3] text-[#20313a] shadow-[0_20px_60px_rgba(19,42,58,0.16)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="border-b border-[#aebdc1] bg-[#132a3a] px-5 py-5 text-white sm:px-7">
+        <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#f6c85f]">
+          OBJECT EVIDENCE LAB / SELECT A SPECIMEN
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2" aria-label="Object example">
+          {OBJECT_CASES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={selected.id === item.id}
+              onClick={() => setCaseId(item.id)}
+              className={cn(
+                "min-h-11 rounded-full border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#f6c85f] focus-visible:ring-offset-2 focus-visible:ring-offset-[#132a3a]",
+                selected.id === item.id
+                  ? "border-[#f6c85f] bg-[#f6c85f] text-[#132a3a]"
+                  : "border-[#617785] text-[#c6d5d9] hover:border-[#f6c85f] hover:text-white"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[1.1fr_0.9fr]" aria-live="polite">
+        <section className="border-b border-[#aebdc1] p-5 sm:p-7 lg:border-r lg:border-b-0">
+          <div className="grid gap-4 sm:grid-cols-[1fr_auto] sm:items-start">
+            <div>
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#667a83]">
+                STORAGE OBJECT
+              </p>
+              <h3 className="m-0 mt-1 font-mono text-3xl font-black tracking-[-0.06em] text-[#2e6f95]">
+                {selected.object}
+              </h3>
+              <p className="m-0 mt-2 font-mono text-[10px] break-all text-[#667a83]">
+                {selected.path}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-right font-mono text-[10px]">
+              <div className="rounded-xl border border-[#aebdc1] bg-white p-3">
+                <span className="block text-[#667a83]">SIZE</span>
+                <strong className="mt-1 block text-sm">{selected.size}</strong>
+              </div>
+              <div className="rounded-xl border border-[#aebdc1] bg-white p-3">
+                <span className="block text-[#667a83]">AGE</span>
+                <strong className="mt-1 block text-sm">{selected.age}</strong>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-6 rounded-2xl border border-[#8fa4aa] bg-white p-4">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#667a83]">
+              ROOT TRACE
+            </p>
+            <div className="mt-4 grid gap-2">
+              {selected.roots.map((root, index) => (
+                <div key={root.label} className="contents">
+                  <div
+                    className={cn(
+                      "flex min-h-12 items-center gap-3 rounded-xl border px-4 py-3 font-mono text-[10px] font-bold",
+                      root.kind === "live" &&
+                        "border-[#6ca58e] bg-[#e6f2ed] text-[#205743]",
+                      root.kind === "retained" &&
+                        "border-[#759cb5] bg-[#e6eff4] text-[#285b79]",
+                      root.kind === "none" &&
+                        "border-dashed border-[#aebdc1] bg-[#f4f6f5] text-[#77868b]"
+                    )}
+                  >
+                    {root.kind === "none" ? (
+                      <X className="size-4 shrink-0" aria-hidden="true" />
+                    ) : root.kind === "retained" ? (
+                      <History className="size-4 shrink-0" aria-hidden="true" />
+                    ) : (
+                      <GitBranch
+                        className="size-4 shrink-0"
+                        aria-hidden="true"
+                      />
+                    )}
+                    {root.label}
+                  </div>
+                  {index < selected.roots.length - 1 ? (
+                    <ArrowRight
+                      className="mx-auto size-4 rotate-90 text-[#8fa4aa]"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-white p-5 sm:p-7">
+          <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#667a83]">
+            TWO-KEY DELETION PERMIT
+          </p>
+          <div className="mt-4 grid gap-3">
+            <ProofKey
+              label="Unreachable from every retained root"
+              passes={selected.unreachable}
+              passLabel="CLEAR"
+              failLabel="BLOCKED"
+            />
+            <ProofKey
+              label="Older than the 24-hour grace window"
+              passes={selected.oldEnough}
+              passLabel="CLEAR"
+              failLabel="BLOCKED"
+            />
+          </div>
+
+          <div
+            className={cn(
+              "mt-5 rounded-2xl border-2 p-5",
+              VERDICT_STYLE[selected.verdict]
+            )}
+          >
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] opacity-75">
+              CLASSIFICATION
+            </p>
+            <p className="m-0 mt-1 font-mono text-4xl font-black tracking-[-0.06em]">
+              {selected.verdict}
+            </p>
+            <p className="m-0 mt-3 text-sm leading-6">{selected.reason}</p>
+          </div>
+
+          <div className="mt-5 border-t border-dashed border-[#aebdc1] pt-4">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#667a83]">
+              EVIDENCE STRUCTURES
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {selected.structures.map((structure) => (
+                <span
+                  key={structure}
+                  className="rounded-full border border-[#aebdc1] bg-[#eef4f3] px-3 py-1.5 font-mono text-[10px] text-[#4e626b]"
+                >
+                  {structure}
+                </span>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+    </figure>
+  )
+}
+
+function ProofKey({
+  label,
+  passes,
+  passLabel,
+  failLabel,
+}: {
+  label: string
+  passes: boolean
+  passLabel: string
+  failLabel: string
+}) {
+  return (
+    <div className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-xl border border-[#aebdc1] bg-[#eef4f3] p-3">
+      <LockKeyhole
+        className={cn("size-5", passes ? "text-[#2f7d63]" : "text-[#c64e44]")}
+        aria-hidden="true"
+      />
+      <p className="m-0 text-xs leading-5 font-bold">{label}</p>
+      <span
+        className={cn(
+          "rounded-full px-2 py-1 font-mono text-[9px] font-black",
+          passes ? "bg-[#dcece6] text-[#205743]" : "bg-[#f7d9d5] text-[#7a2923]"
+        )}
+      >
+        {passes ? passLabel : failLabel}
+      </span>
+    </div>
+  )
+}
+
+type RaceCase = {
+  id: "publishes" | "abandoned" | "crossing"
+  label: string
+  title: string
+  result: string
+  resultTone: "keep" | "delete" | "stop"
+  summary: string
+  stateBefore: string
+  stateAfter: string
+  stages: {
+    time: string
+    label: string
+    detail: string
+    tone: "gc" | "writer" | "safe" | "stop"
+  }[]
+}
+
+const RACE_CASES: RaceCase[] = [
+  {
+    id: "publishes",
+    label: "Push publishes",
+    title: "A fresh upload looks orphaned only briefly",
+    result: "KEEP",
+    resultTone: "keep",
+    summary:
+      "Grace protects the upload now; the published ref marks it live on the next run.",
+    stateBefore: "roots: none",
+    stateAfter: "roots: main → xorb",
+    stages: [
+      {
+        time: "T0",
+        label: "GC snapshots roots",
+        detail: "xorb not present",
+        tone: "gc",
+      },
+      {
+        time: "+2m",
+        label: "Writer uploads xorb",
+        detail: "not published yet",
+        tone: "writer",
+      },
+      {
+        time: "+8m",
+        label: "GC sees object",
+        detail: "inside 24h grace",
+        tone: "safe",
+      },
+      {
+        time: "+11m",
+        label: "Writer publishes ref",
+        detail: "reachable next run",
+        tone: "writer",
+      },
+    ],
+  },
+  {
+    id: "abandoned",
+    label: "Push abandoned",
+    title: "An abandoned upload ages into a candidate",
+    result: "CANDIDATE",
+    resultTone: "delete",
+    summary:
+      "No retained root appears. After 24 hours, both deletion proofs can pass.",
+    stateBefore: "age: 18 min",
+    stateAfter: "age: 30 hours",
+    stages: [
+      {
+        time: "T-30h",
+        label: "Writer uploads xorb",
+        detail: "push interrupted",
+        tone: "writer",
+      },
+      {
+        time: "T0",
+        label: "GC snapshots roots",
+        detail: "no publication",
+        tone: "gc",
+      },
+      {
+        time: "+4m",
+        label: "Mark walk ends",
+        detail: "xorb unmarked",
+        tone: "gc",
+      },
+      {
+        time: "+6m",
+        label: "Age check passes",
+        detail: "older than 24h",
+        tone: "stop",
+      },
+    ],
+  },
+  {
+    id: "crossing",
+    label: "Writer crosses batches",
+    title: "A new writer invalidates the sealed sweep",
+    result: "STOP",
+    resultTone: "stop",
+    summary:
+      "The writer epoch changes. GC fails closed before deleting another batch.",
+    stateBefore: "writer_epoch 42",
+    stateAfter: "writer_epoch 43",
+    stages: [
+      {
+        time: "T0",
+        label: "GC seals root snapshot",
+        detail: "epoch 42",
+        tone: "gc",
+      },
+      {
+        time: "+5m",
+        label: "Batch 1 completes",
+        detail: "512 candidates",
+        tone: "gc",
+      },
+      {
+        time: "+6m",
+        label: "Writer admitted",
+        detail: "epoch advances",
+        tone: "writer",
+      },
+      {
+        time: "+7m",
+        label: "Next fence check",
+        detail: "epoch mismatch",
+        tone: "stop",
+      },
+    ],
+  },
+]
+
+const RACE_TONE = {
+  gc: "border-[#7896a5] bg-[#1d3a4b]",
+  writer: "border-[#f6c85f] bg-[#4a432d]",
+  safe: "border-[#68a58d] bg-[#21483e]",
+  stop: "border-[#d17269] bg-[#4d2e31]",
+}
+
+export function GcRaceReplay() {
+  const [caseId, setCaseId] = useState<RaceCase["id"]>("publishes")
+  const selected =
+    RACE_CASES.find((item) => item.id === caseId) ?? RACE_CASES[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] bg-[#132a3a] text-white shadow-[0_20px_60px_rgba(19,42,58,0.22)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#526c79] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#f6c85f]">
+            CONCURRENCY REPLAY / MOVE THE WRITER
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.04em] sm:text-3xl">
+            What happens around the snapshot?
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-2" aria-label="Concurrency example">
+          {RACE_CASES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={selected.id === item.id}
+              onClick={() => setCaseId(item.id)}
+              className={cn(
+                "min-h-11 rounded-lg border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#f6c85f] focus-visible:ring-offset-2 focus-visible:ring-offset-[#132a3a]",
+                selected.id === item.id
+                  ? "border-[#f6c85f] bg-[#f6c85f] text-[#132a3a]"
+                  : "border-[#617785] text-[#c6d5d9] hover:border-[#f6c85f] hover:text-white"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="p-5 sm:p-7" aria-live="polite">
+        <div className="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-start">
+          <div>
+            <h4 className="m-0 text-xl font-black sm:text-2xl">
+              {selected.title}
+            </h4>
+            <p className="m-0 mt-2 max-w-2xl text-sm leading-6 text-[#c6d5d9]">
+              {selected.summary}
+            </p>
+          </div>
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-xl border border-[#526c79] bg-[#1d3a4b] px-4 py-3 font-mono text-[10px] font-black">
+            <span className="text-[#a9bdc5]">{selected.stateBefore}</span>
+            <ArrowRight className="size-4 text-[#f6c85f]" aria-hidden="true" />
+            <span className="text-right">{selected.stateAfter}</span>
+          </div>
+        </div>
+
+        <div className="mt-7 grid gap-2 lg:grid-cols-[1fr_auto_1fr_auto_1fr_auto_1fr] lg:items-stretch">
+          {selected.stages.map((stage, index) => (
+            <div key={`${selected.id}-${stage.time}`} className="contents">
+              <div
+                className={cn(
+                  "min-h-36 rounded-2xl border p-4",
+                  RACE_TONE[stage.tone]
+                )}
+              >
+                <p className="m-0 font-mono text-[10px] font-black text-[#f6c85f]">
+                  {stage.time}
+                </p>
+                <p className="m-0 mt-7 text-sm font-black">{stage.label}</p>
+                <p className="m-0 mt-1 font-mono text-[9px] leading-4 text-[#c6d5d9]">
+                  {stage.detail}
+                </p>
+              </div>
+              {index < selected.stages.length - 1 ? (
+                <div className="flex items-center justify-center text-[#7896a5]">
+                  <ArrowRight
+                    className="size-4 rotate-90 lg:rotate-0"
+                    aria-hidden="true"
+                  />
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center justify-between gap-4 border-t border-dashed border-[#617785] pt-5">
+          <div className="flex items-center gap-3">
+            {selected.resultTone === "keep" ? (
+              <ShieldCheck
+                className="size-6 text-[#68a58d]"
+                aria-hidden="true"
+              />
+            ) : selected.resultTone === "delete" ? (
+              <Trash2 className="size-6 text-[#d17269]" aria-hidden="true" />
+            ) : (
+              <LockKeyhole
+                className="size-6 text-[#f6c85f]"
+                aria-hidden="true"
+              />
+            )}
+            <span className="font-mono text-2xl font-black tracking-[-0.05em]">
+              {selected.result}
+            </span>
+          </div>
+          <p className="m-0 font-mono text-[9px] font-bold text-[#91a8b2]">
+            STATE: root set · object age · writer epoch
+          </p>
+        </div>
+      </div>
+    </figure>
+  )
+}

--- a/packages/web/components/blog/lazy-checkout-visuals.tsx
+++ b/packages/web/components/blog/lazy-checkout-visuals.tsx
@@ -1,0 +1,639 @@
+"use client"
+
+import {
+  ArrowRight,
+  Box,
+  Cloud,
+  Database,
+  FileArchive,
+  FileCode2,
+  FolderTree,
+  HardDrive,
+  Laptop,
+  MousePointerClick,
+  PackageCheck,
+  PencilLine,
+  ScanSearch,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type MaterializationMode = {
+  id: "pointers" | "hydrate" | "mount"
+  label: string
+  local: string
+  headline: string
+  bestFor: string
+  command: string
+  packed: { label: string; size: string; color: string }[]
+  remote: { label: string; size: string }[]
+}
+
+const MATERIALIZATION_MODES: MaterializationMode[] = [
+  {
+    id: "pointers",
+    label: "Pointers",
+    local: "180 MB",
+    headline: "Carry identity, not payloads",
+    bestFor: "Review code, inspect branches, run metadata-only jobs",
+    command: "crab clone crab://team-data/vision-search",
+    packed: [
+      { label: "Git + source", size: "120 MB", color: "bg-[#2f6478]" },
+      { label: "Pointers", size: "60 MB", color: "bg-[#e18c4f]" },
+    ],
+    remote: [
+      { label: "Models", size: "820 GB" },
+      { label: "Datasets", size: "3.1 TB" },
+    ],
+  },
+  {
+    id: "hydrate",
+    label: "Hydrate set",
+    local: "84 GB",
+    headline: "Pack the known working set",
+    bestFor: "Training, CI, or any job with a stable input list",
+    command: "crab hydrate --manifest-ref HEAD:.crab/manifests/training.txt",
+    packed: [
+      { label: "Git + pointers", size: "180 MB", color: "bg-[#2f6478]" },
+      { label: "Model", size: "12 GB", color: "bg-[#e18c4f]" },
+      { label: "Training data", size: "72 GB", color: "bg-[#67a58b]" },
+    ],
+    remote: [
+      { label: "Other models", size: "808 GB" },
+      { label: "Other data", size: "3.0 TB" },
+    ],
+  },
+  {
+    id: "mount",
+    label: "Mount",
+    local: "9 GB →",
+    headline: "Fetch as the application explores",
+    bestFor: "Asset browsers, analysis tools, and unpredictable reads",
+    command:
+      "crab mount -r crab://team-data/vision-search -m /mnt/vision --read-only",
+    packed: [
+      { label: "Snapshot", size: "180 MB", color: "bg-[#2f6478]" },
+      { label: "Read cache", size: "grows", color: "bg-[#e18c4f]" },
+    ],
+    remote: [
+      { label: "Unread content", size: "stays remote" },
+      { label: "Read ranges", size: "arrive on demand" },
+    ],
+  },
+]
+
+export function MaterializationPackingDesk() {
+  const [modeId, setModeId] = useState<MaterializationMode["id"]>("pointers")
+  const mode =
+    MATERIALIZATION_MODES.find((item) => item.id === modeId) ??
+    MATERIALIZATION_MODES[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] border border-[#a6afa8] bg-[#f3f0e7] text-[#192a33] shadow-[0_20px_60px_rgba(25,42,51,0.13)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#b9b7ac] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#2f6478]">
+            MATERIALIZATION DESK / 4 TB REPO / 256 GB LAPTOP
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.04em] sm:text-3xl">
+            What actually goes in the laptop?
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-2" aria-label="Materialization mode">
+          {MATERIALIZATION_MODES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={mode.id === item.id}
+              onClick={() => setModeId(item.id)}
+              className={cn(
+                "min-h-11 rounded-full border px-3 py-1.5 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#2f6478] focus-visible:ring-offset-2 focus-visible:ring-offset-[#f3f0e7]",
+                mode.id === item.id
+                  ? "border-[#192a33] bg-[#192a33] text-white"
+                  : "border-[#9ba39c] bg-white/60 text-[#53626a] hover:border-[#192a33] hover:text-[#192a33]"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[1fr_1.15fr]">
+        <section className="border-b border-[#b9b7ac] p-5 sm:p-7 lg:border-r lg:border-b-0">
+          <div className="flex items-center gap-3">
+            <Cloud className="size-6 text-[#2f6478]" aria-hidden="true" />
+            <div>
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#708087]">
+                OBJECT STORAGE
+              </p>
+              <p className="m-0 text-lg font-black">The 4 TB source of truth</p>
+            </div>
+          </div>
+          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+            {mode.remote.map((item) => (
+              <div
+                key={item.label}
+                className="rounded-2xl border border-dashed border-[#8ea0a6] bg-[#dce8e8] p-4"
+              >
+                <FileArchive
+                  className="size-5 text-[#2f6478]"
+                  aria-hidden="true"
+                />
+                <p className="m-0 mt-5 text-sm font-black">{item.label}</p>
+                <p className="m-0 mt-1 font-mono text-xs text-[#53626a]">
+                  {item.size}
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-5 flex items-center gap-3 font-mono text-[10px] font-bold text-[#53626a]">
+            <span className="h-px flex-1 border-t border-dashed border-[#8ea0a6]" />
+            {mode.id === "mount"
+              ? "RANGES CROSS WHEN READ"
+              : "ONLY THE SELECTION CROSSES"}
+            <ArrowRight className="size-4" aria-hidden="true" />
+          </div>
+        </section>
+
+        <section className="bg-[#fbfaf5] p-5 sm:p-7" aria-live="polite">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#708087]">
+                LOCAL DISK / 256 GB
+              </p>
+              <h4 className="m-0 mt-1 text-xl font-black">{mode.headline}</h4>
+            </div>
+            <div className="shrink-0 rounded-xl bg-[#192a33] px-3 py-2 text-right text-white">
+              <p className="m-0 font-mono text-[9px] text-[#bdc8cb]">
+                STARTS AT
+              </p>
+              <p className="m-0 font-mono text-xl font-black">{mode.local}</p>
+            </div>
+          </div>
+
+          <div className="relative mt-6 overflow-hidden rounded-[1.35rem] border-2 border-[#192a33] bg-[#e8e1d2] p-3 pt-7">
+            <div className="absolute top-0 left-1/2 h-3 w-20 -translate-x-1/2 rounded-b-lg border-x-2 border-b-2 border-[#192a33] bg-[#fbfaf5]" />
+            <div className="grid min-h-32 gap-2 sm:grid-cols-3">
+              {mode.packed.map((item) => (
+                <div
+                  key={item.label}
+                  className={cn(
+                    "flex min-h-24 flex-col justify-between rounded-xl p-3 text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.25)]",
+                    item.color
+                  )}
+                >
+                  <Box className="size-4" aria-hidden="true" />
+                  <div>
+                    <p className="m-0 text-xs font-black">{item.label}</p>
+                    <p className="m-0 mt-1 font-mono text-[10px] text-white/80">
+                      {item.size}
+                    </p>
+                  </div>
+                </div>
+              ))}
+              <div className="flex min-h-24 items-center justify-center rounded-xl border border-dashed border-[#9f998e] font-mono text-[10px] font-black text-[#777166]">
+                HEADROOM
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
+            <p className="m-0 text-sm leading-6 text-[#53626a]">
+              <span className="font-black text-[#192a33]">Best for:</span>{" "}
+              {mode.bestFor}
+            </p>
+            <Laptop
+              className="hidden size-6 text-[#e18c4f] sm:block"
+              aria-hidden="true"
+            />
+          </div>
+          <code className="mt-4 block overflow-x-auto rounded-xl bg-[#192a33] px-4 py-3 font-mono text-[11px] text-[#f8d6b9]">
+            {mode.command}
+          </code>
+        </section>
+      </div>
+      <figcaption className="border-t border-[#b9b7ac] px-5 py-3 font-mono text-[10px] text-[#657279] sm:px-7">
+        Illustrative sizes. The committed file identities stay the same in every
+        mode.
+      </figcaption>
+    </figure>
+  )
+}
+
+type ReadScene = {
+  id: "list" | "cold" | "warm" | "write"
+  label: string
+  title: string
+  note: string
+  before: string
+  after: string
+  structures: string[]
+  steps: {
+    icon: typeof FolderTree
+    label: string
+    detail: string
+    active?: boolean
+  }[]
+}
+
+const READ_SCENES: ReadScene[] = [
+  {
+    id: "list",
+    label: "List folder",
+    title: "Names arrive without large-file bytes",
+    note: "The resolver merges the base snapshot with overlay entries, then returns directory names.",
+    before: "cache 0 MB",
+    after: "cache 0 MB",
+    structures: ["snapshot row", "overlay entry", "directory page"],
+    steps: [
+      { icon: FolderTree, label: "readdir()", detail: "models/" },
+      {
+        icon: Database,
+        label: "Snapshot + overlay",
+        detail: "merge children",
+        active: true,
+      },
+      { icon: Laptop, label: "Application", detail: "names + types" },
+    ],
+  },
+  {
+    id: "cold",
+    label: "First read",
+    title: "Only the requested window is reconstructed",
+    note: "A pointer maps the byte range to verified remote content. The completed window is cached locally.",
+    before: "cache 0 MB",
+    after: "cache 8 MB",
+    structures: ["pointer", "file recipe", "xorb range", "read window"],
+    steps: [
+      {
+        icon: MousePointerClick,
+        label: "read(64 KiB)",
+        detail: "offset 32 MiB",
+      },
+      { icon: FileCode2, label: "Pointer", detail: "hash + size" },
+      {
+        icon: Cloud,
+        label: "Xorb ranges",
+        detail: "verified bytes",
+        active: true,
+      },
+      { icon: HardDrive, label: "Read cache", detail: "8 MiB window" },
+      { icon: Laptop, label: "Application", detail: "exact 64 KiB" },
+    ],
+  },
+  {
+    id: "warm",
+    label: "Repeat read",
+    title: "The request stops at the local window",
+    note: "The same file hash and window key find complete cached bytes, so object storage is not contacted.",
+    before: "cache 8 MB",
+    after: "network 0 B",
+    structures: ["file hash", "window key", "verified cache file"],
+    steps: [
+      { icon: MousePointerClick, label: "read(64 KiB)", detail: "same offset" },
+      { icon: FileCode2, label: "Pointer", detail: "same identity" },
+      {
+        icon: HardDrive,
+        label: "Read cache",
+        detail: "complete hit",
+        active: true,
+      },
+      { icon: Laptop, label: "Application", detail: "exact 64 KiB" },
+    ],
+  },
+  {
+    id: "write",
+    label: "First write",
+    title: "The base file is promoted into the overlay",
+    note: "A writable mount reconstructs the full base file into local overlay backing before applying the edit.",
+    before: "overlay 0 GB",
+    after: "overlay +12 GB",
+    structures: [
+      "base pointer",
+      "temp backing file",
+      "overlay row",
+      "source OID",
+    ],
+    steps: [
+      { icon: PencilLine, label: "write()", detail: "writable mount" },
+      { icon: FileCode2, label: "Base pointer", detail: "12 GB file" },
+      {
+        icon: PackageCheck,
+        label: "Full promotion",
+        detail: "temp → atomic rename",
+        active: true,
+      },
+      { icon: HardDrive, label: "Overlay backing", detail: "local copy" },
+      { icon: Laptop, label: "Application", detail: "read-after-write" },
+    ],
+  },
+]
+
+export function MountedReadCutaway() {
+  const [sceneId, setSceneId] = useState<ReadScene["id"]>("cold")
+  const scene =
+    READ_SCENES.find((item) => item.id === sceneId) ?? READ_SCENES[1]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] bg-[#172830] text-[#f7f3e9] shadow-[0_20px_60px_rgba(23,40,48,0.2)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="border-b border-[#49606a] px-5 py-5 sm:px-7">
+        <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#efad72]">
+          MOUNT CUTAWAY / SELECT AN OS OPERATION
+        </p>
+        <div
+          className="mt-3 flex flex-wrap gap-2"
+          aria-label="Filesystem operation"
+        >
+          {READ_SCENES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={scene.id === item.id}
+              onClick={() => setSceneId(item.id)}
+              className={cn(
+                "min-h-11 rounded-lg border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#efad72] focus-visible:ring-offset-2 focus-visible:ring-offset-[#172830]",
+                scene.id === item.id
+                  ? "border-[#efad72] bg-[#efad72] text-[#172830]"
+                  : "border-[#5d737c] text-[#b9c8cd] hover:border-[#efad72] hover:text-white"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="p-5 sm:p-7" aria-live="polite">
+        <div className="grid gap-5 lg:grid-cols-[1fr_auto] lg:items-start">
+          <div>
+            <h3 className="m-0 text-2xl font-black tracking-[-0.035em] sm:text-3xl">
+              {scene.title}
+            </h3>
+            <p className="m-0 mt-2 max-w-2xl text-sm leading-6 text-[#b9c8cd]">
+              {scene.note}
+            </p>
+          </div>
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-xl border border-[#49606a] bg-[#203841] px-4 py-3 font-mono text-[10px] font-black">
+            <span className="text-[#b9c8cd]">{scene.before}</span>
+            <ArrowRight className="size-4 text-[#efad72]" aria-hidden="true" />
+            <span className="text-right text-white">{scene.after}</span>
+          </div>
+        </div>
+
+        <div className="mt-7 flex flex-col gap-2 lg:flex-row lg:items-stretch">
+          {scene.steps.map((step, index) => {
+            const Icon = step.icon
+            return (
+              <div key={`${scene.id}-${step.label}`} className="contents">
+                <div
+                  className={cn(
+                    "min-w-0 flex-1 rounded-2xl border p-4 transition-colors duration-300 motion-reduce:transition-none",
+                    step.active
+                      ? "border-[#efad72] bg-[#5a392b] shadow-[inset_0_0_0_1px_#efad72]"
+                      : "border-[#49606a] bg-[#203841]"
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <Icon
+                      className="size-5 text-[#efad72]"
+                      aria-hidden="true"
+                    />
+                    <span className="font-mono text-[9px] font-black text-[#78909a]">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                  </div>
+                  <p className="m-0 mt-5 text-sm font-black text-white">
+                    {step.label}
+                  </p>
+                  <p className="m-0 mt-1 font-mono text-[9px] leading-4 text-[#b9c8cd]">
+                    {step.detail}
+                  </p>
+                </div>
+                {index < scene.steps.length - 1 ? (
+                  <div className="flex items-center justify-center text-[#78909a]">
+                    <ArrowRight
+                      className="size-4 rotate-90 lg:rotate-0"
+                      aria-hidden="true"
+                    />
+                  </div>
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="mt-6 border-t border-dashed border-[#5d737c] pt-4">
+          <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#78909a]">
+            KEY DATA STRUCTURES
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {scene.structures.map((structure) => (
+              <span
+                key={structure}
+                className="rounded-full border border-[#5d737c] bg-[#203841] px-3 py-1.5 font-mono text-[10px] text-[#d6e0e2]"
+              >
+                {structure}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </figure>
+  )
+}
+
+type BudgetScenario = {
+  id: "browse" | "training" | "writable" | "overflow"
+  label: string
+  status: "roomy" | "tight" | "over"
+  advice: string
+  parts: { label: string; value: number; color: string }[]
+}
+
+const BUDGET_SCENARIOS: BudgetScenario[] = [
+  {
+    id: "browse",
+    label: "Browse assets",
+    status: "roomy",
+    advice:
+      "A read-only mount leaves 150 GB for new windows and normal laptop use.",
+    parts: [
+      { label: "Hydrated", value: 0, color: "bg-[#2f6478]" },
+      { label: "Cache", value: 18, color: "bg-[#e18c4f]" },
+      { label: "Overlay", value: 0, color: "bg-[#a66b7b]" },
+      { label: "App scratch", value: 24, color: "bg-[#67a58b]" },
+      { label: "System reserve", value: 64, color: "bg-[#7d8588]" },
+    ],
+  },
+  {
+    id: "training",
+    label: "Train model",
+    status: "tight",
+    advice:
+      "Only 16 GB remains. Narrow the manifest or reduce scratch/cache before starting.",
+    parts: [
+      { label: "Hydrated", value: 96, color: "bg-[#2f6478]" },
+      { label: "Cache", value: 32, color: "bg-[#e18c4f]" },
+      { label: "Overlay", value: 0, color: "bg-[#a66b7b]" },
+      { label: "App scratch", value: 48, color: "bg-[#67a58b]" },
+      { label: "System reserve", value: 64, color: "bg-[#7d8588]" },
+    ],
+  },
+  {
+    id: "writable",
+    label: "Edit 118 GB file",
+    status: "tight",
+    advice:
+      "First write promotes the full file. Export or commit the overlay before it crowds the disk.",
+    parts: [
+      { label: "Hydrated", value: 0, color: "bg-[#2f6478]" },
+      { label: "Cache", value: 22, color: "bg-[#e18c4f]" },
+      { label: "Overlay", value: 118, color: "bg-[#a66b7b]" },
+      { label: "App scratch", value: 24, color: "bg-[#67a58b]" },
+      { label: "System reserve", value: 64, color: "bg-[#7d8588]" },
+    ],
+  },
+  {
+    id: "overflow",
+    label: "Hydrate too much",
+    status: "over",
+    advice:
+      "This plan exceeds the disk by 80 GB. A broad glob is not a safe working set.",
+    parts: [
+      { label: "Hydrated", value: 160, color: "bg-[#2f6478]" },
+      { label: "Cache", value: 48, color: "bg-[#e18c4f]" },
+      { label: "Overlay", value: 0, color: "bg-[#a66b7b]" },
+      { label: "App scratch", value: 64, color: "bg-[#67a58b]" },
+      { label: "System reserve", value: 64, color: "bg-[#7d8588]" },
+    ],
+  },
+]
+
+export function DiskBudgetWorkbench() {
+  const [scenarioId, setScenarioId] = useState<BudgetScenario["id"]>("browse")
+  const scenario =
+    BUDGET_SCENARIOS.find((item) => item.id === scenarioId) ??
+    BUDGET_SCENARIOS[0]
+  const used = scenario.parts.reduce((total, part) => total + part.value, 0)
+  const free = 256 - used
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] border border-[#b9b7ac] bg-[#fbfaf5] text-[#192a33] shadow-[0_20px_60px_rgba(25,42,51,0.12)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#b9b7ac] bg-[#f3f0e7] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#2f6478]">
+            CAPACITY BENCH / 256 GB DISK
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.04em] sm:text-3xl">
+            Four stores compete for the same space
+          </h3>
+        </div>
+        <ScanSearch
+          className="hidden size-8 text-[#e18c4f] lg:block"
+          aria-hidden="true"
+        />
+      </header>
+
+      <div className="grid lg:grid-cols-[17rem_1fr]">
+        <div className="border-b border-[#b9b7ac] p-5 sm:p-7 lg:border-r lg:border-b-0">
+          <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#708087]">
+            TRY A WORKLOAD
+          </p>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
+            {BUDGET_SCENARIOS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                aria-pressed={scenario.id === item.id}
+                onClick={() => setScenarioId(item.id)}
+                className={cn(
+                  "rounded-xl border px-4 py-3 text-left text-sm font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#2f6478] focus-visible:ring-offset-2",
+                  scenario.id === item.id
+                    ? "border-[#192a33] bg-[#192a33] text-white"
+                    : "border-[#c6c4ba] bg-white text-[#53626a] hover:border-[#192a33] hover:text-[#192a33]"
+                )}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="p-5 sm:p-7" aria-live="polite">
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#708087]">
+                PLANNED LOCAL FOOTPRINT
+              </p>
+              <p className="m-0 mt-1 font-mono text-4xl font-black tracking-[-0.07em]">
+                {used} GB
+              </p>
+            </div>
+            <div
+              className={cn(
+                "rounded-full px-3 py-1.5 font-mono text-[10px] font-black",
+                scenario.status === "roomy" && "bg-[#dcecdf] text-[#24563b]",
+                scenario.status === "tight" && "bg-[#fae0bd] text-[#73451e]",
+                scenario.status === "over" && "bg-[#f7c9c2] text-[#7c2f2a]"
+              )}
+            >
+              {free >= 0 ? `${free} GB FREE` : `${Math.abs(free)} GB OVER`}
+            </div>
+          </div>
+
+          <div className="mt-6 overflow-hidden rounded-xl border-2 border-[#192a33] bg-[#e8e1d2] p-1">
+            <div
+              className="flex h-16 min-w-full gap-1"
+              style={{ width: `${Math.max(100, (used / 256) * 100)}%` }}
+            >
+              {scenario.parts
+                .filter((part) => part.value > 0)
+                .map((part) => (
+                  <div
+                    key={part.label}
+                    className={cn("min-w-2 rounded-md", part.color)}
+                    style={{ width: `${(part.value / used) * 100}%` }}
+                    title={`${part.label}: ${part.value} GB`}
+                  />
+                ))}
+            </div>
+          </div>
+          <div className="mt-2 flex justify-between font-mono text-[9px] font-bold text-[#708087]">
+            <span>0 GB</span>
+            <span>DISK LIMIT 256 GB</span>
+          </div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            {scenario.parts.map((part) => (
+              <div
+                key={part.label}
+                className="rounded-xl border border-[#d0cdc1] bg-[#f3f0e7] p-3"
+              >
+                <div className={cn("h-2 w-8 rounded-full", part.color)} />
+                <p className="m-0 mt-3 text-xs font-black">{part.label}</p>
+                <p className="m-0 mt-1 font-mono text-[10px] text-[#708087]">
+                  {part.value} GB
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6 flex gap-3 rounded-xl border border-[#d0cdc1] bg-[#f3f0e7] p-4">
+            <HardDrive
+              className="mt-0.5 size-5 shrink-0 text-[#e18c4f]"
+              aria-hidden="true"
+            />
+            <p className="m-0 text-sm leading-6 text-[#53626a]">
+              {scenario.advice}
+            </p>
+          </div>
+        </div>
+      </div>
+      <figcaption className="border-t border-[#b9b7ac] px-5 py-3 font-mono text-[10px] text-[#657279] sm:px-7">
+        Example budgets include a 64 GB reserve for the OS and ordinary work.
+      </figcaption>
+    </figure>
+  )
+}

--- a/packages/web/components/blog/lfs-compatibility-visuals.tsx
+++ b/packages/web/components/blog/lfs-compatibility-visuals.tsx
@@ -1,0 +1,517 @@
+"use client"
+
+import {
+  ArrowDown,
+  ArrowRight,
+  Check,
+  CircleAlert,
+  Fingerprint,
+  GitBranch,
+  HardDrive,
+  Route,
+  ShieldCheck,
+  X,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type MigrationPath = "existing" | "bridge" | "native"
+
+const PATHS = {
+  existing: {
+    label: "Existing LFS",
+    title: "Git LFS owns the transfer route",
+    commit: "8f31c4d",
+    commitState: "UNCHANGED",
+    pointer: [
+      "version https://git-lfs.github.com/spec/v1",
+      "oid sha256:91ae…b72c",
+      "size 8589934592",
+    ],
+    pointerLabel: "LFS POINTER",
+    route: "Git LFS → LFS endpoint",
+    storage: "one 8 GB LFS object",
+    rollback: "current configuration",
+    changed: ["Nothing"],
+  },
+  bridge: {
+    label: "Crab bridge",
+    title: "Crab takes the transfer call",
+    commit: "8f31c4d",
+    commitState: "UNCHANGED",
+    pointer: [
+      "version https://git-lfs.github.com/spec/v1",
+      "oid sha256:91ae…b72c",
+      "size 8589934592",
+    ],
+    pointerLabel: "SAME LFS POINTER",
+    route: "Git LFS → Crab transfer agent → bucket",
+    storage: "whole-file LFS semantics",
+    rollback: "restore prior LFS endpoint",
+    changed: ["transfer route", "Git config", "pre-push hook"],
+  },
+  native: {
+    label: "Native Crab",
+    title: "Pointer and history become Crab-native",
+    commit: "c972e8a",
+    commitState: "NEW ID",
+    pointer: [
+      "version https://crab.dev/spec/v1",
+      "file-hash 4cb9…731a",
+      "size 8589934592",
+    ],
+    pointerLabel: "CRAB POINTER",
+    route: "Crab filter + remote helper → bucket",
+    storage: "chunks → xorbs + shards",
+    rollback: "restore preserved old refs",
+    changed: ["pointer", "commit IDs", "tracking rule", "storage layout"],
+  },
+} as const
+
+export function LfsIdentityLab() {
+  const [path, setPath] = useState<MigrationPath>("existing")
+  const selected = PATHS[path]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.5rem] border border-[#7d8da4] bg-[#eef1f4] text-[#17233b] shadow-[0_24px_70px_rgba(23,35,59,0.18)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#aab5c3] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#49617d]">
+            IDENTITY LAB / 8 GB MODEL / SELECT A PATH
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.04em] sm:text-3xl">
+            What actually changes?
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-2" aria-label="Migration path">
+          {(Object.keys(PATHS) as MigrationPath[]).map((id) => (
+            <button
+              key={id}
+              type="button"
+              aria-pressed={path === id}
+              onClick={() => setPath(id)}
+              className={cn(
+                "min-h-11 rounded-lg border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#e56b5d] focus-visible:ring-offset-2 focus-visible:ring-offset-[#eef1f4]",
+                path === id
+                  ? "border-[#17233b] bg-[#17233b] text-white"
+                  : "border-[#9aa8b9] bg-white text-[#49617d] hover:border-[#17233b] hover:text-[#17233b]"
+              )}
+            >
+              {PATHS[id].label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[1fr_18rem]" aria-live="polite">
+        <section className="border-b border-[#aab5c3] p-5 sm:p-7 lg:border-r lg:border-b-0">
+          <p className="m-0 text-xl font-black">{selected.title}</p>
+          <div className="mt-5 grid gap-3 md:grid-cols-[1fr_auto_1fr] md:items-stretch">
+            <div className="rounded-2xl bg-[#17233b] p-5 text-white">
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-mono text-[9px] font-black tracking-[0.16em] text-[#9db1ca]">
+                  GIT BLOB
+                </span>
+                <span className="rounded-full bg-white/10 px-2 py-1 font-mono text-[9px] font-black text-[#39a9db]">
+                  {selected.pointerLabel}
+                </span>
+              </div>
+              <pre className="m-0 mt-7 overflow-x-auto font-mono text-[10px] leading-6 whitespace-pre-wrap text-[#dce7f3]">
+                {selected.pointer.join("\n")}
+              </pre>
+            </div>
+
+            <ArrowRight
+              className="mx-auto size-5 rotate-90 self-center text-[#7d8da4] md:rotate-0"
+              aria-hidden="true"
+            />
+
+            <div className="rounded-2xl border-2 border-[#17233b] bg-white p-5">
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#61738a]">
+                COMMIT IDENTITY
+              </p>
+              <div className="mt-6 flex items-center gap-3">
+                <Fingerprint
+                  className="size-7 text-[#e56b5d]"
+                  aria-hidden="true"
+                />
+                <span className="font-mono text-2xl font-black">
+                  {selected.commit}
+                </span>
+              </div>
+              <span
+                className={cn(
+                  "mt-4 inline-flex rounded-full px-3 py-1.5 font-mono text-[9px] font-black",
+                  path === "native"
+                    ? "bg-[#fff0d5] text-[#76500e]"
+                    : "bg-[#dcefe4] text-[#245c3a]"
+                )}
+              >
+                {selected.commitState}
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <StateCard
+              icon={Route}
+              label="Transfer route"
+              value={selected.route}
+            />
+            <StateCard
+              icon={HardDrive}
+              label="Storage shape"
+              value={selected.storage}
+            />
+          </div>
+        </section>
+
+        <aside className="bg-white p-5 sm:p-7">
+          <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#61738a]">
+            CHANGE SEAL
+          </p>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {selected.changed.map((change) => (
+              <span
+                key={change}
+                className={cn(
+                  "rounded-md border px-2.5 py-2 font-mono text-[10px] font-black",
+                  change === "Nothing"
+                    ? "border-[#71b48d] bg-[#e5f4ea] text-[#245c3a]"
+                    : "border-[#e8b04a] bg-[#fff4df] text-[#76500e]"
+                )}
+              >
+                {change}
+              </span>
+            ))}
+          </div>
+          <div className="mt-7 border-t border-dashed border-[#aab5c3] pt-5">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#61738a]">
+              ROLLBACK BOUNDARY
+            </p>
+            <p className="m-0 mt-2 text-sm leading-6 font-bold">
+              {selected.rollback}
+            </p>
+          </div>
+        </aside>
+      </div>
+    </figure>
+  )
+}
+
+function StateCard({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof Route
+  label: string
+  value: string
+}) {
+  return (
+    <div className="rounded-xl border border-[#aab5c3] bg-[#f8fafb] p-4">
+      <Icon className="size-4 text-[#39a9db]" aria-hidden="true" />
+      <p className="m-0 mt-4 font-mono text-[9px] font-black tracking-[0.14em] text-[#61738a]">
+        {label.toUpperCase()}
+      </p>
+      <p className="m-0 mt-1 text-sm leading-6 font-bold">{value}</p>
+    </div>
+  )
+}
+
+type RewriteScope = "bridge" | "main" | "all"
+
+const COMMITS = [
+  { id: "A", label: "source only" },
+  { id: "B", label: "model v1" },
+  { id: "C", label: "model v2" },
+  { id: "D", label: "release prep" },
+] as const
+
+const REWRITE_SCOPES = {
+  bridge: {
+    label: "Transfer bridge",
+    command: "crab lfs install",
+    changed: [] as string[],
+    refs: "main and tags still point to the same commits",
+    verdict: "No history rewrite",
+  },
+  main: {
+    label: "Convert main",
+    command: "crab lfs migrate export --include '*.safetensors' main --to-crab",
+    changed: ["B", "C", "D"],
+    refs: "main moves; excluded refs can still name old history",
+    verdict: "B and every selected descendant get new IDs",
+  },
+  all: {
+    label: "Convert selected history",
+    command:
+      "crab lfs migrate export --include '*.safetensors' --to-crab --everything --object-map ../lfs-to-crab.csv",
+    changed: ["B", "C", "D"],
+    refs: "all selected branches and tags need mapped destinations",
+    verdict: "The object map becomes cutover evidence",
+  },
+} as const
+
+export function LfsRewriteMap() {
+  const [scope, setScope] = useState<RewriteScope>("bridge")
+  const selected = REWRITE_SCOPES[scope]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.5rem] bg-[#17233b] text-white shadow-[0_24px_70px_rgba(23,35,59,0.2)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="border-b border-[#42536d] px-5 py-5 sm:px-7">
+        <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#39a9db]">
+          DESCENDANT MAP / MODEL FIRST APPEARS AT B
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2" aria-label="Rewrite scope">
+          {(Object.keys(REWRITE_SCOPES) as RewriteScope[]).map((id) => (
+            <button
+              key={id}
+              type="button"
+              aria-pressed={scope === id}
+              onClick={() => setScope(id)}
+              className={cn(
+                "min-h-11 rounded-full border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#e8b04a] focus-visible:ring-offset-2 focus-visible:ring-offset-[#17233b]",
+                scope === id
+                  ? "border-[#e8b04a] bg-[#e8b04a] text-[#17233b]"
+                  : "border-[#526580] text-[#c8d3e2] hover:border-[#e8b04a] hover:text-white"
+              )}
+            >
+              {REWRITE_SCOPES[id].label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div
+        className="grid gap-6 p-5 sm:p-7 lg:grid-cols-[1fr_20rem]"
+        aria-live="polite"
+      >
+        <section>
+          <div className="overflow-x-auto pb-2">
+            <div className="flex min-w-[34rem] items-center">
+              {COMMITS.map((commit, index) => {
+                const changed = (
+                  selected.changed as readonly string[]
+                ).includes(commit.id)
+                return (
+                  <div key={commit.id} className="contents">
+                    <div className="w-28 shrink-0 text-center">
+                      <div
+                        className={cn(
+                          "mx-auto flex size-16 items-center justify-center rounded-full border-2 font-mono text-xl font-black",
+                          changed
+                            ? "border-[#e8b04a] bg-[#fff0d5] text-[#76500e]"
+                            : "border-[#71b48d] bg-[#24483a] text-[#a8dfba]"
+                        )}
+                      >
+                        {changed ? `${commit.id}′` : commit.id}
+                      </div>
+                      <p className="m-0 mt-3 font-mono text-[9px] text-[#aab9cb]">
+                        {commit.label}
+                      </p>
+                    </div>
+                    {index < COMMITS.length - 1 ? (
+                      <div className="h-0.5 flex-1 bg-[#526580]" />
+                    ) : null}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="mt-6 rounded-xl border border-[#526580] bg-[#202e47] p-4">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.14em] text-[#8da2bc]">
+              COMMAND
+            </p>
+            <code className="mt-2 block overflow-x-auto font-mono text-[11px] leading-6 whitespace-pre-wrap text-white">
+              {selected.command}
+            </code>
+          </div>
+        </section>
+
+        <aside className="rounded-2xl bg-[#eef1f4] p-5 text-[#17233b]">
+          <GitBranch className="size-6 text-[#e56b5d]" aria-hidden="true" />
+          <p className="m-0 mt-5 text-lg leading-6 font-black">
+            {selected.verdict}
+          </p>
+          <p className="m-0 mt-3 text-sm leading-6 text-[#52637a]">
+            {selected.refs}
+          </p>
+          <div className="mt-5 border-t border-dashed border-[#aab5c3] pt-4">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.14em] text-[#61738a]">
+              KEY STRUCTURES
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {["Git blob", "commit graph", "refs", "object-map.csv"].map(
+                (item) => (
+                  <span
+                    key={item}
+                    className="rounded-md border border-[#aab5c3] bg-white px-2 py-1.5 font-mono text-[9px] font-bold"
+                  >
+                    {item}
+                  </span>
+                )
+              )}
+            </div>
+          </div>
+        </aside>
+      </div>
+    </figure>
+  )
+}
+
+type RehearsalCase = "healthy" | "missing" | "mixed" | "rewrite"
+
+const REHEARSAL_CASES = {
+  healthy: {
+    label: "Bridge passes",
+    title: "New writes and cold reads both work",
+    result: "READY FOR A LIMITED BRIDGE",
+    pass: true,
+    steps: [
+      ["Inventory", "LFS objects available", true],
+      ["Upload", "new object reaches Crab storage", true],
+      ["Cold clone", "empty cache fetches the object", true],
+      ["Integrity", "crab lfs fsck passes", true],
+    ],
+    action: "Keep the old endpoint during the evidence window.",
+  },
+  missing: {
+    label: "Old tag fails",
+    title: "A historical pointer has no source bytes",
+    result: "STOP: REPAIR SOURCE CLOSURE",
+    pass: false,
+    steps: [
+      ["Inventory", "release/v1 pointer found", true],
+      ["Resolve", "OID absent locally and remotely", false],
+      ["Convert", "cannot manufacture missing bytes", false],
+      ["Publish", "blocked before ref changes", false],
+    ],
+    action: "Recover that OID or remove the ref from the supported scope.",
+  },
+  mixed: {
+    label: "Plain client",
+    title: "A client lacks Crab transfer configuration",
+    result: "DEFINE THE MIXED-CLIENT POLICY",
+    pass: false,
+    steps: [
+      ["Clone", "Git history arrives", true],
+      ["Smudge", "LFS pointer is recognized", true],
+      ["Transfer", "Crab agent is unavailable", false],
+      ["Checkout", "large file stays unresolved", false],
+    ],
+    action:
+      "Install Crab in bootstrap and CI, or retain a supported LFS route.",
+  },
+  rewrite: {
+    label: "Native passes",
+    title: "A fresh clone proves the rewritten repository",
+    result: "READY FOR COORDINATED CUTOVER",
+    pass: true,
+    steps: [
+      ["Map", "old and new commit IDs recorded", true],
+      ["Hydrate", "model bytes match before hash", true],
+      ["Topology", "selected refs close correctly", true],
+      ["Workload", "build passes from empty cache", true],
+    ],
+    action:
+      "Freeze writes, publish mapped refs, then test one independent client.",
+  },
+} as const
+
+export function LfsRehearsalConsole() {
+  const [caseId, setCaseId] = useState<RehearsalCase>("healthy")
+  const selected = REHEARSAL_CASES[caseId]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.5rem] border-2 border-[#17233b] bg-white text-[#17233b] shadow-[0_24px_70px_rgba(23,35,59,0.15)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="bg-[#eef1f4] px-5 py-5 sm:px-7">
+        <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#49617d]">
+          CUTOVER REHEARSAL / CHOOSE A FAILURE OR SUCCESS
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2" aria-label="Rehearsal case">
+          {(Object.keys(REHEARSAL_CASES) as RehearsalCase[]).map((id) => (
+            <button
+              key={id}
+              type="button"
+              aria-pressed={caseId === id}
+              onClick={() => setCaseId(id)}
+              className={cn(
+                "min-h-11 rounded-lg border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#39a9db] focus-visible:ring-offset-2 focus-visible:ring-offset-[#eef1f4]",
+                caseId === id
+                  ? "border-[#17233b] bg-[#17233b] text-white"
+                  : "border-[#9aa8b9] bg-white text-[#49617d] hover:border-[#17233b]"
+              )}
+            >
+              {REHEARSAL_CASES[id].label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[1fr_19rem]" aria-live="polite">
+        <section className="border-b border-[#aab5c3] p-5 sm:p-7 lg:border-r lg:border-b-0">
+          <h3 className="m-0 text-xl font-black tracking-[-0.03em] sm:text-2xl">
+            {selected.title}
+          </h3>
+          <div className="mt-6 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+            {selected.steps.map(([label, detail, passed], index) => (
+              <div key={label} className="contents">
+                <div
+                  className={cn(
+                    "relative rounded-xl border p-4",
+                    passed
+                      ? "border-[#71b48d] bg-[#edf8f1]"
+                      : "border-[#e56b5d] bg-[#fff0ed]"
+                  )}
+                >
+                  {passed ? (
+                    <Check
+                      className="size-5 text-[#2f7449]"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <X className="size-5 text-[#a23d33]" aria-hidden="true" />
+                  )}
+                  <p className="m-0 mt-5 font-mono text-[10px] font-black">
+                    {label}
+                  </p>
+                  <p className="m-0 mt-2 text-xs leading-5 text-[#52637a]">
+                    {detail}
+                  </p>
+                  {index < selected.steps.length - 1 ? (
+                    <ArrowDown
+                      className="absolute -bottom-5 left-1/2 z-10 size-4 -translate-x-1/2 text-[#7d8da4] sm:hidden"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <aside
+          className={cn(
+            "p-5 sm:p-7",
+            selected.pass ? "bg-[#dcefe4]" : "bg-[#fff0d5]"
+          )}
+        >
+          {selected.pass ? (
+            <ShieldCheck className="size-7 text-[#2f7449]" aria-hidden="true" />
+          ) : (
+            <CircleAlert className="size-7 text-[#a86913]" aria-hidden="true" />
+          )}
+          <p className="m-0 mt-5 font-mono text-[10px] leading-5 font-black tracking-[0.12em]">
+            {selected.result}
+          </p>
+          <p className="m-0 mt-3 text-sm leading-6 font-bold">
+            {selected.action}
+          </p>
+        </aside>
+      </div>
+    </figure>
+  )
+}

--- a/packages/web/components/blog/push-pipeline-visuals.tsx
+++ b/packages/web/components/blog/push-pipeline-visuals.tsx
@@ -1,0 +1,882 @@
+"use client"
+
+import {
+  AlertTriangle,
+  ArrowRight,
+  Check,
+  Cloud,
+  GitBranch,
+  PackageCheck,
+  ShieldCheck,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type PhaseName = "Plan" | "Upload" | "Prove" | "Publish"
+
+type PipelineStage = {
+  number: number
+  phase: PhaseName
+  title: string
+  action: string
+  evidence: string
+  structure: string
+  fields: string[]
+  before: string
+  after: string
+}
+
+const PHASES: Array<{
+  name: PhaseName
+  range: string
+  color: string
+  width: string
+}> = [
+  { name: "Plan", range: "01–04", color: "#6557c8", width: "28.57%" },
+  { name: "Upload", range: "05–10", color: "#087f73", width: "42.86%" },
+  { name: "Prove", range: "11–12", color: "#bd642e", width: "14.29%" },
+  { name: "Publish", range: "13–14", color: "#d3423f", width: "14.29%" },
+]
+
+const PHASE_COLOR = Object.fromEntries(
+  PHASES.map((phase) => [phase.name, phase.color])
+) as Record<PhaseName, string>
+
+const PIPELINE_STAGES: PipelineStage[] = [
+  {
+    number: 1,
+    phase: "Plan",
+    title: "Parse refspec",
+    action: "Resolve the source and destination ref.",
+    evidence: "Intended ref edit",
+    structure: "PushSpec",
+    fields: ["src", "dst", "force"],
+    before: "main:main",
+    after: "validated ref edit",
+  },
+  {
+    number: 2,
+    phase: "Plan",
+    title: "Read destination",
+    action: "Record the current tip of main.",
+    evidence: "Expected-old A",
+    structure: "RefJournalHeadSnapshot",
+    fields: ["head", "etag", "visible_transaction"],
+    before: "remote tip unknown",
+    after: "expected-old = A",
+  },
+  {
+    number: 3,
+    phase: "Plan",
+    title: "Acquire lock",
+    action: "Serialize work for this destination ref.",
+    evidence: "Writer lease",
+    structure: "PushLockLease",
+    fields: ["lock", "heartbeat"],
+    before: "main unlocked",
+    after: "lease held",
+  },
+  {
+    number: 4,
+    phase: "Plan",
+    title: "Discover closure",
+    action: "Walk Git objects and every Crab pointer.",
+    evidence: "Dependency plan",
+    structure: "PushDependencyPlan",
+    fields: ["ref_edits", "file_dependencies", "unique_chunks"],
+    before: "commit roots",
+    after: "complete dependency set",
+  },
+  {
+    number: 5,
+    phase: "Upload",
+    title: "Classify chunks",
+    action: "Separate proven chunks from new content.",
+    evidence: "Upload set",
+    structure: "FilePushPlan",
+    fields: ["chunks", "existing", "prepared_xorbs"],
+    before: "chunks unclassified",
+    after: "reuse + upload sets",
+  },
+  {
+    number: 6,
+    phase: "Upload",
+    title: "Build Git pack",
+    action: "Pack commits, trees, blobs, and pointers.",
+    evidence: "Git transport object",
+    structure: "PreparedGitPack",
+    fields: ["refs", "exact_missing_objects", "all_candidates_proven"],
+    before: "reachable Git objects",
+    after: "pack candidate",
+  },
+  {
+    number: 7,
+    phase: "Upload",
+    title: "Build xorbs",
+    action: "Compress new chunks into immutable objects.",
+    evidence: "Xorb objects",
+    structure: "PackedXorb",
+    fields: ["hash", "placements", "payload"],
+    before: "new chunk stream",
+    after: "content-addressed xorbs",
+  },
+  {
+    number: 8,
+    phase: "Upload",
+    title: "Upload xorbs",
+    action: "Flush staging and store new chunk bytes.",
+    evidence: "Durable large-file data",
+    structure: "UploadedXorb",
+    fields: ["hash", "len", "payload"],
+    before: "local xorb payload",
+    after: "durable origin object",
+  },
+  {
+    number: 9,
+    phase: "Upload",
+    title: "Upload Git pack",
+    action: "Store the standard Git representation.",
+    evidence: "Durable Git objects",
+    structure: "UploadedGitPack",
+    fields: ["entry", "idx_path", "git_sha1"],
+    before: "local pack candidate",
+    after: "durable pack entry",
+  },
+  {
+    number: 10,
+    phase: "Upload",
+    title: "Publish shards",
+    action: "Store complete file reconstruction terms.",
+    evidence: "Durable file map",
+    structure: "PushShardSession",
+    fields: ["writers", "current", "current_hashes"],
+    before: "file recipes in memory",
+    after: "uploaded shard hashes",
+  },
+  {
+    number: 11,
+    phase: "Prove",
+    title: "Verify Git",
+    action: "Prove the proposed commit graph is complete.",
+    evidence: "Git closure",
+    structure: "GitObjectSetProof",
+    fields: ["count", "digest"],
+    before: "candidate pack inventory",
+    after: "Git closure proven",
+  },
+  {
+    number: 12,
+    phase: "Prove",
+    title: "Verify pointers",
+    action: "Prove every pointer reaches durable bytes.",
+    evidence: "Pointer closure",
+    structure: "PushCommitReceipt",
+    fields: ["file_recipe_set_digest", "xorb_proof_digest", "plan_digest"],
+    before: "candidate placements",
+    after: "pointer closure proven",
+  },
+  {
+    number: 13,
+    phase: "Publish",
+    title: "Compare tip",
+    action: "Confirm main still equals expected-old A.",
+    evidence: "Freshness decision",
+    structure: "RefUpdateDecision",
+    fields: ["Proceed { etag }", "Reject(reason)"],
+    before: "expected A · current ?",
+    after: "proceed or reject",
+  },
+  {
+    number: 14,
+    phase: "Publish",
+    title: "Commit ref",
+    action: "Append the transaction that moves main to B.",
+    evidence: "Visible ref B",
+    structure: "RefJournalTransaction",
+    fields: ["parents", "edits", "packs", "shards"],
+    before: "committed head = A",
+    after: "committed head = B",
+  },
+]
+
+export function PushPipelineBoard() {
+  const [activeNumber, setActiveNumber] = useState(1)
+  const active = PIPELINE_STAGES[activeNumber - 1]
+  const published = active.number === 14
+  const color = PHASE_COLOR[active.phase]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden border-2 border-[#17231e] bg-[#edf4f1] shadow-[7px_7px_0_#17231e] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="flex flex-wrap items-end justify-between gap-4 border-b-2 border-[#17231e] bg-[#fbfcf9] px-4 py-4 sm:px-6">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-bold tracking-[0.2em] text-[#52615a]">
+            PUSH CONTROL SHEET · CLICK ANY STAGE
+          </p>
+          <h3 className="m-0 mt-1 text-xl font-black tracking-[-0.035em] text-[#17231e] sm:text-2xl">
+            Fourteen checks. One visible change.
+          </h3>
+        </div>
+        <div className="flex items-center gap-2 font-mono text-[11px] font-bold text-[#17231e]">
+          <span className="size-2 bg-[#d3423f]" aria-hidden="true" />
+          REF MOVES AT 14
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[minmax(0,1fr)_19rem]">
+        <div className="min-w-0 border-b-2 border-[#17231e] lg:border-r-2 lg:border-b-0">
+          <div className="overflow-x-auto p-4 sm:p-6">
+            <div className="min-w-[47rem]">
+              <div className="mb-2 flex gap-1">
+                {PHASES.map((phase) => (
+                  <div
+                    key={phase.name}
+                    style={{ width: phase.width, backgroundColor: phase.color }}
+                    className="flex items-center justify-between px-2 py-2 font-mono text-[10px] font-black tracking-[0.12em] text-white uppercase"
+                  >
+                    <span>{phase.name}</span>
+                    <span className="opacity-70">{phase.range}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="grid grid-cols-[repeat(14,minmax(46px,1fr))] border-t-2 border-l-2 border-[#17231e] bg-[#fbfcf9]">
+                {PIPELINE_STAGES.map((stage) => {
+                  const selected = stage.number === active.number
+                  const complete = stage.number < active.number
+                  const stageColor = PHASE_COLOR[stage.phase]
+                  return (
+                    <button
+                      key={stage.number}
+                      type="button"
+                      aria-pressed={selected}
+                      aria-label={`Stage ${stage.number}: ${stage.title}`}
+                      onClick={() => setActiveNumber(stage.number)}
+                      className={cn(
+                        "group relative flex h-28 flex-col justify-between border-r-2 border-b-2 border-[#17231e] p-2 text-left transition-[background-color,color,transform] duration-150 outline-none focus-visible:z-10 focus-visible:ring-4 focus-visible:ring-[#17231e]/25",
+                        selected
+                          ? "-translate-y-1 text-white"
+                          : "bg-[#fbfcf9] text-[#17231e] hover:bg-white"
+                      )}
+                      style={
+                        selected ? { backgroundColor: stageColor } : undefined
+                      }
+                    >
+                      <span className="font-mono text-xs font-black">
+                        {String(stage.number).padStart(2, "0")}
+                      </span>
+                      <span className="text-[9px] leading-tight font-bold tracking-[0.04em] uppercase [writing-mode:vertical-rl] sm:text-[10px]">
+                        {stage.title}
+                      </span>
+                      <span
+                        className={cn(
+                          "size-2 border border-[#17231e]",
+                          complete && "bg-[#17231e]",
+                          selected && "border-white bg-white"
+                        )}
+                        aria-hidden="true"
+                      />
+                    </button>
+                  )
+                })}
+              </div>
+
+              <div className="mt-4 flex items-center gap-3">
+                <span className="font-mono text-[10px] font-bold text-[#52615a]">
+                  START
+                </span>
+                <div className="h-2 flex-1 border border-[#17231e] bg-[#dce8e3]">
+                  <div
+                    className="h-full bg-[#17231e] transition-[width] duration-300 motion-reduce:transition-none"
+                    style={{ width: `${(active.number / 14) * 100}%` }}
+                  />
+                </div>
+                <span className="font-mono text-[10px] font-bold text-[#52615a]">
+                  VISIBLE
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="px-4 pb-4 sm:px-6 sm:pb-6" aria-live="polite">
+            <div className="grid border-2 border-[#17231e] bg-[#fbfcf9] sm:grid-cols-[1.15fr_1fr]">
+              <div className="border-r-2 border-[#17231e] p-4">
+                <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#6d7d75]">
+                  KEY DATA STRUCTURE
+                </p>
+                <code className="mt-2 block text-xl font-black tracking-tight text-[#17231e]">
+                  {active.structure}
+                </code>
+                <div className="mt-3 grid grid-cols-2 gap-1.5">
+                  {active.fields.map((field, index) => (
+                    <div
+                      key={field}
+                      className="flex min-w-0 items-center gap-2 border border-[#97aaa1] bg-[#edf4f1] px-2 py-2"
+                    >
+                      <span
+                        className="size-2 shrink-0"
+                        style={{ backgroundColor: color }}
+                        aria-hidden="true"
+                      />
+                      <code className="min-w-0 text-[9px] font-bold break-all text-[#52615a]">
+                        {field}
+                      </code>
+                      <span className="ml-auto font-mono text-[8px] text-[#97aaa1]">
+                        {String(index + 1).padStart(2, "0")}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="p-4">
+                <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#6d7d75]">
+                  STATE CHANGE
+                </p>
+                <div className="mt-3 grid grid-cols-[minmax(0,1fr)_1.5rem_minmax(0,1fr)] items-stretch">
+                  <div className="flex min-h-20 flex-col justify-between border border-[#97aaa1] bg-white p-2.5">
+                    <span className="font-mono text-[8px] font-black tracking-[0.12em] text-[#97aaa1]">
+                      BEFORE
+                    </span>
+                    <span className="font-mono text-[10px] leading-4 font-bold text-[#52615a]">
+                      {active.before}
+                    </span>
+                  </div>
+                  <div
+                    className="flex items-center justify-center text-base font-black text-[#17231e]"
+                    aria-hidden="true"
+                  >
+                    →
+                  </div>
+                  <div
+                    className="flex min-h-20 flex-col justify-between border-2 p-2.5"
+                    style={{
+                      borderColor: color,
+                      backgroundColor: `${color}18`,
+                    }}
+                  >
+                    <span
+                      className="font-mono text-[8px] font-black tracking-[0.12em]"
+                      style={{ color }}
+                    >
+                      AFTER
+                    </span>
+                    <span className="font-mono text-[10px] leading-4 font-black text-[#17231e]">
+                      {active.after}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col bg-[#fbfcf9]">
+          <div className="flex flex-1 flex-col p-5 sm:p-6" aria-live="polite">
+            <div className="flex items-start justify-between gap-4">
+              <span
+                className="font-mono text-5xl leading-none font-black"
+                style={{ color }}
+              >
+                {String(active.number).padStart(2, "0")}
+              </span>
+              <span
+                className="px-2 py-1 font-mono text-[10px] font-black tracking-[0.14em] text-white uppercase"
+                style={{ backgroundColor: color }}
+              >
+                {active.phase}
+              </span>
+            </div>
+            <h4 className="m-0 mt-5 text-xl font-black tracking-tight text-[#17231e]">
+              {active.title}
+            </h4>
+            <p className="m-0 mt-2 text-sm leading-6 text-[#52615a]">
+              {active.action}
+            </p>
+
+            <div className="mt-6 border-t border-dashed border-[#97aaa1] pt-4">
+              <p className="m-0 font-mono text-[9px] font-bold tracking-[0.16em] text-[#6d7d75]">
+                GUARANTEE ADDED
+              </p>
+              <p className="m-0 mt-1 text-sm font-bold text-[#17231e]">
+                {active.evidence}
+              </p>
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "m-4 flex items-center justify-between border-2 border-[#17231e] px-4 py-3 transition-colors duration-300 motion-reduce:transition-none sm:m-5",
+              published ? "bg-[#dff3d8]" : "bg-[#fff0c7]"
+            )}
+          >
+            <div>
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.15em] text-[#52615a]">
+                READERS SEE
+              </p>
+              <p className="m-0 mt-0.5 text-sm font-black text-[#17231e]">
+                main → {published ? "B" : "A"}
+              </p>
+            </div>
+            <div
+              className={cn(
+                "-rotate-3 border-2 px-2 py-1 font-mono text-xs font-black tracking-wider",
+                published
+                  ? "border-[#267236] text-[#267236]"
+                  : "border-[#9a6416] text-[#9a6416]"
+              )}
+            >
+              {published ? "PUBLISHED" : "UNCHANGED"}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <figcaption className="border-t-2 border-[#17231e] bg-[#17231e] px-4 py-3 text-xs leading-5 text-[#dce8e3] sm:px-6">
+        Stages 1–13 prepare evidence. Select stage 14 to cross the visibility
+        boundary.
+      </figcaption>
+    </figure>
+  )
+}
+
+type LaneFocus = "both" | "git" | "crab"
+
+export function PushDataLanesDiagram() {
+  const [focus, setFocus] = useState<LaneFocus>("both")
+  const gitActive = focus !== "crab"
+  const crabActive = focus !== "git"
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(62rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden border border-[#ccd7df] bg-white min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(62rem,calc(100vw-2rem))] lg:w-[min(62rem,calc(100vw-24.5rem))]">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[#ccd7df] px-4 py-4 sm:px-6">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-bold tracking-[0.18em] text-[#687987]">
+            DUAL-LANE ROUTE MAP
+          </p>
+          <h3 className="m-0 mt-1 text-lg font-bold tracking-tight text-[#152532]">
+            Two object types arrive at one gate
+          </h3>
+        </div>
+        <div
+          className="flex border border-[#9eacb7] p-1"
+          aria-label="Highlight a push data lane"
+        >
+          {(["both", "git", "crab"] as const).map((option) => (
+            <button
+              key={option}
+              type="button"
+              aria-pressed={focus === option}
+              onClick={() => setFocus(option)}
+              className={cn(
+                "px-3 py-1.5 font-mono text-[10px] font-bold uppercase transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#152532]",
+                focus === option
+                  ? "bg-[#152532] text-white"
+                  : "text-[#687987] hover:bg-[#edf2f5]"
+              )}
+            >
+              {option === "both" ? "Both lanes" : option}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto bg-[#f4f7f8] px-4 py-6 sm:px-6">
+        <svg
+          viewBox="0 0 900 330"
+          role="img"
+          aria-label="Git objects and Crab chunks travel in parallel to durable storage, pass separate closure proofs, and meet at one ref gate."
+          className="min-w-[48rem]"
+        >
+          <defs>
+            <pattern
+              id="push-map-grid"
+              width="24"
+              height="24"
+              patternUnits="userSpaceOnUse"
+            >
+              <path
+                d="M24 0H0V24"
+                fill="none"
+                stroke="#dce4e8"
+                strokeWidth="1"
+              />
+            </pattern>
+            <marker
+              id="push-arrow-git"
+              markerWidth="8"
+              markerHeight="8"
+              refX="7"
+              refY="4"
+              orient="auto"
+            >
+              <path d="M0 0L8 4L0 8Z" fill="#e46b32" />
+            </marker>
+            <marker
+              id="push-arrow-crab"
+              markerWidth="8"
+              markerHeight="8"
+              refX="7"
+              refY="4"
+              orient="auto"
+            >
+              <path d="M0 0L8 4L0 8Z" fill="#008f83" />
+            </marker>
+          </defs>
+          <rect width="900" height="330" fill="url(#push-map-grid)" />
+
+          <g
+            opacity={gitActive ? 1 : 0.18}
+            className="transition-opacity duration-200 motion-reduce:transition-none"
+          >
+            <path
+              d="M118 105H700"
+              fill="none"
+              stroke="#e46b32"
+              strokeWidth="10"
+              markerEnd="url(#push-arrow-git)"
+            />
+            <text
+              x="30"
+              y="76"
+              fill="#a64219"
+              fontSize="12"
+              fontWeight="800"
+              letterSpacing="1.2"
+            >
+              GIT LANE
+            </text>
+            <RailStop
+              x={118}
+              y={105}
+              color="#e46b32"
+              number="06"
+              title="Build pack"
+            />
+            <RailStop
+              x={338}
+              y={105}
+              color="#e46b32"
+              number="09"
+              title="Upload pack"
+            />
+            <RailStop
+              x={560}
+              y={105}
+              color="#e46b32"
+              number="11"
+              title="Prove Git"
+            />
+          </g>
+
+          <g
+            opacity={crabActive ? 1 : 0.18}
+            className="transition-opacity duration-200 motion-reduce:transition-none"
+          >
+            <path
+              d="M118 230H700"
+              fill="none"
+              stroke="#008f83"
+              strokeWidth="10"
+              markerEnd="url(#push-arrow-crab)"
+            />
+            <text
+              x="30"
+              y="201"
+              fill="#00675f"
+              fontSize="12"
+              fontWeight="800"
+              letterSpacing="1.2"
+            >
+              CRAB LANE
+            </text>
+            <RailStop
+              x={118}
+              y={230}
+              color="#008f83"
+              number="07"
+              title="Build xorbs"
+            />
+            <RailStop
+              x={338}
+              y={230}
+              color="#008f83"
+              number="08–10"
+              title="Data + shards"
+            />
+            <RailStop
+              x={560}
+              y={230}
+              color="#008f83"
+              number="12"
+              title="Prove pointers"
+            />
+          </g>
+
+          <path
+            d="M704 105C755 105 750 165 780 165M704 230C755 230 750 165 780 165"
+            fill="none"
+            stroke="#152532"
+            strokeWidth="3"
+            strokeDasharray="6 5"
+          />
+          <rect x="778" y="117" width="98" height="96" fill="#152532" />
+          <text
+            x="827"
+            y="145"
+            fill="#a9bac5"
+            fontSize="10"
+            fontWeight="700"
+            textAnchor="middle"
+            letterSpacing="1"
+          >
+            REF GATE
+          </text>
+          <text
+            x="827"
+            y="176"
+            fill="white"
+            fontSize="24"
+            fontWeight="900"
+            textAnchor="middle"
+          >
+            13 → 14
+          </text>
+          <text
+            x="827"
+            y="197"
+            fill="#a9bac5"
+            fontSize="10"
+            textAnchor="middle"
+          >
+            COMPARE · COMMIT
+          </text>
+        </svg>
+      </div>
+
+      <figcaption className="flex items-start gap-2 border-t border-[#ccd7df] px-4 py-3 text-xs leading-5 text-[#526674] sm:px-6">
+        <PackageCheck
+          size={15}
+          className="mt-0.5 shrink-0 text-[#008f83]"
+          aria-hidden="true"
+        />
+        The lanes upload independently, but neither can publish alone. Both
+        proofs must reach the ref gate.
+      </figcaption>
+    </figure>
+  )
+}
+
+function RailStop({
+  x,
+  y,
+  color,
+  number,
+  title,
+}: {
+  x: number
+  y: number
+  color: string
+  number: string
+  title: string
+}) {
+  return (
+    <g>
+      <circle
+        cx={x}
+        cy={y}
+        r="18"
+        fill="white"
+        stroke={color}
+        strokeWidth="6"
+      />
+      <text
+        x={x}
+        y={y + 4}
+        textAnchor="middle"
+        fill="#152532"
+        fontSize="10"
+        fontWeight="900"
+      >
+        {number}
+      </text>
+      <text
+        x={x}
+        y={y + 38}
+        textAnchor="middle"
+        fill="#526674"
+        fontSize="11"
+        fontWeight="700"
+      >
+        {title}
+      </text>
+    </g>
+  )
+}
+
+type VisibilityCase = {
+  label: string
+  title: string
+  visible: "A" | "B" | "C"
+  status: "unchanged" | "published" | "winner"
+  durable: string
+  next: string
+  summary: string
+  icon: typeof Cloud
+}
+
+const VISIBILITY_CASES: VisibilityCase[] = [
+  {
+    label: "Upload stops",
+    title: "Object upload is interrupted",
+    visible: "A",
+    status: "unchanged",
+    durable: "Some complete immutable objects",
+    next: "Retry and reuse completed uploads",
+    summary: "No closure proof, so the ref gate stays closed.",
+    icon: Cloud,
+  },
+  {
+    label: "Proof fails",
+    title: "A dependency cannot be proven",
+    visible: "A",
+    status: "unchanged",
+    durable: "An incomplete dependency set",
+    next: "Restore the missing object or metadata",
+    summary: "Canonical storage—not the local cache—must prove closure.",
+    icon: ShieldCheck,
+  },
+  {
+    label: "Alice wins",
+    title: "Expected-old A still matches",
+    visible: "B",
+    status: "published",
+    durable: "Complete Git and Crab closures",
+    next: "Release the lock and report success",
+    summary: "Stage 14 commits the ref transaction A → B.",
+    icon: Check,
+  },
+  {
+    label: "Bob is stale",
+    title: "Another writer already moved main",
+    visible: "C",
+    status: "winner",
+    durable: "Bob's uploaded objects remain safe",
+    next: "Fetch C, reconcile, and retry",
+    summary: "Expected-old rejects Bob instead of overwriting newer history.",
+    icon: GitBranch,
+  },
+  {
+    label: "Cleanup fails",
+    title: "The ref committed before cleanup failed",
+    visible: "B",
+    status: "published",
+    durable: "The complete published state",
+    next: "Finish cleanup; do not roll back",
+    summary: "Post-commit repair moves forward from valid durable state.",
+    icon: AlertTriangle,
+  },
+]
+
+export function PushVisibilityLab() {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const active = VISIBILITY_CASES[activeIndex]
+  const Icon = active.icon
+  const changed = active.visible !== "A"
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(62rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden bg-[#f3c94f] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(62rem,calc(100vw-2rem))] lg:w-[min(62rem,calc(100vw-24.5rem))]">
+      <div className="grid lg:grid-cols-[16rem_minmax(0,1fr)]">
+        <div className="border-b-2 border-[#191d1b] bg-[#191d1b] p-4 text-white sm:p-5 lg:border-r-2 lg:border-b-0">
+          <p className="m-0 font-mono text-[10px] font-bold tracking-[0.18em] text-[#f3c94f]">
+            INCIDENT SELECTOR
+          </p>
+          <h3 className="m-0 mt-1 text-xl font-black tracking-tight">
+            Where did the push stop?
+          </h3>
+          <div className="mt-5 grid gap-1.5 sm:grid-cols-2 lg:grid-cols-1">
+            {VISIBILITY_CASES.map((item, index) => (
+              <button
+                key={item.label}
+                type="button"
+                aria-pressed={index === activeIndex}
+                onClick={() => setActiveIndex(index)}
+                className={cn(
+                  "flex items-center justify-between gap-3 border px-3 py-2.5 text-left text-xs font-bold transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#f3c94f]",
+                  index === activeIndex
+                    ? "border-[#f3c94f] bg-[#f3c94f] text-[#191d1b]"
+                    : "border-[#4b504d] text-[#d7dcd9] hover:border-[#f3c94f]"
+                )}
+              >
+                {item.label}
+                <ArrowRight size={14} aria-hidden="true" />
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="p-4 sm:p-6 lg:p-8" aria-live="polite">
+          <div className="flex flex-wrap items-start justify-between gap-5 border-b-2 border-[#191d1b] pb-6">
+            <div className="max-w-lg">
+              <div className="flex size-10 items-center justify-center border-2 border-[#191d1b] bg-white">
+                <Icon size={19} aria-hidden="true" />
+              </div>
+              <h4 className="m-0 mt-4 text-2xl leading-tight font-black tracking-[-0.035em] text-[#191d1b] sm:text-3xl">
+                {active.title}
+              </h4>
+              <p className="m-0 mt-2 text-sm leading-6 text-[#4b4123]">
+                {active.summary}
+              </p>
+            </div>
+
+            <div className="min-w-40 border-2 border-[#191d1b] bg-white px-4 py-3 text-center shadow-[4px_4px_0_#191d1b]">
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#706744]">
+                READERS SEE
+              </p>
+              <p className="m-0 mt-1 text-5xl leading-none font-black text-[#191d1b]">
+                {active.visible}
+              </p>
+              <p className="m-0 mt-1 font-mono text-[9px] font-bold tracking-[0.12em] text-[#706744] uppercase">
+                {active.status}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 py-6 sm:grid-cols-2">
+            <div className="border-l-4 border-[#191d1b] pl-3">
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.15em] text-[#706744]">
+                MAY BE DURABLE
+              </p>
+              <p className="m-0 mt-1 text-sm font-bold text-[#191d1b]">
+                {active.durable}
+              </p>
+            </div>
+            <div className="border-l-4 border-[#191d1b] pl-3">
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.15em] text-[#706744]">
+                NEXT MOVE
+              </p>
+              <p className="m-0 mt-1 text-sm font-bold text-[#191d1b]">
+                {active.next}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 border-t-2 border-[#191d1b] pt-4 font-mono text-[10px] font-black tracking-[0.08em] text-[#191d1b]">
+            <span
+              className={cn(
+                "size-3 border-2 border-[#191d1b]",
+                changed ? "bg-[#e24e3f]" : "bg-white"
+              )}
+              aria-hidden="true"
+            />
+            REF GATE {changed ? "COMMITTED OR WON ELSEWHERE" : "DID NOT COMMIT"}
+          </div>
+        </div>
+      </div>
+      <figcaption className="border-t-2 border-[#191d1b] bg-[#fff4c8] px-4 py-3 text-xs leading-5 text-[#4b4123] sm:px-6">
+        Change the incident to see the only state readers can observe at each
+        boundary.
+      </figcaption>
+    </figure>
+  )
+}

--- a/packages/web/components/blog/reconstruction-visuals.tsx
+++ b/packages/web/components/blog/reconstruction-visuals.tsx
@@ -1,0 +1,570 @@
+"use client"
+
+import {
+  ArrowDown,
+  ArrowRight,
+  Check,
+  CircleX,
+  FileCheck2,
+  FileCode2,
+  Gauge,
+  PackageOpen,
+  RotateCcw,
+  ShieldCheck,
+  Wrench,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type RecipeTerm = {
+  position: number
+  chunk: string
+  xorb: string
+  range: string
+  bytes: string
+  source: "origin" | "cache" | "reused read"
+  color: string
+}
+
+const RECIPE: RecipeTerm[] = [
+  {
+    position: 1,
+    chunk: "A",
+    xorb: "xorb-17",
+    range: "chunks 0..1",
+    bytes: "72 KiB",
+    source: "origin",
+    color: "#77B6D1",
+  },
+  {
+    position: 2,
+    chunk: "B",
+    xorb: "xorb-42",
+    range: "chunks 3..4",
+    bytes: "64 KiB",
+    source: "origin",
+    color: "#F6C85F",
+  },
+  {
+    position: 3,
+    chunk: "C",
+    xorb: "xorb-17",
+    range: "chunks 1..2",
+    bytes: "81 KiB",
+    source: "origin",
+    color: "#A9D18E",
+  },
+  {
+    position: 4,
+    chunk: "D",
+    xorb: "xorb-99",
+    range: "chunks 8..9",
+    bytes: "59 KiB",
+    source: "cache",
+    color: "#D6A5CF",
+  },
+  {
+    position: 5,
+    chunk: "B",
+    xorb: "xorb-42",
+    range: "chunks 3..4",
+    bytes: "64 KiB",
+    source: "reused read",
+    color: "#F6C85F",
+  },
+]
+
+export function ReconstructionWorkbench() {
+  const [selectedPosition, setSelectedPosition] = useState(1)
+  const selected =
+    RECIPE.find((term) => term.position === selectedPosition) ?? RECIPE[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-xl border-4 border-[#203948] bg-[#d8e1e4] shadow-[0_18px_50px_rgba(32,57,72,0.18)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="flex flex-wrap items-end justify-between gap-5 border-b-4 border-[#203948] bg-[#234e70] px-5 py-5 text-white sm:px-7">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#b9d7e5]">
+            FILE RECONSTRUCTION BENCH / TOY RECIPE
+          </p>
+          <h3 className="m-0 mt-1 text-2xl font-black tracking-[-0.03em] sm:text-3xl">
+            One stored chunk can fill two file positions.
+          </h3>
+        </div>
+        <div className="flex items-center gap-2 rounded-md border border-[#86a9bc] bg-[#17384f] px-3 py-2 font-mono text-[10px] font-bold text-[#d9edf5]">
+          <Wrench className="size-4" aria-hidden="true" />
+          SELECT AN OUTPUT SLOT
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[minmax(0,1fr)_17rem]">
+        <div className="p-4 sm:p-6">
+          <div className="rounded-lg border-2 border-[#203948] bg-[#f7f8f4] p-4 shadow-[inset_0_-8px_0_#e9ece8] sm:p-5">
+            <div className="flex items-center justify-between gap-4">
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.17em] text-[#66777d]">
+                LOGICAL FILE RECIPE
+              </p>
+              <span className="font-mono text-[9px] font-bold text-[#66777d]">
+                WRITE ORDER →
+              </span>
+            </div>
+            <div className="mt-3 grid grid-cols-5 gap-2">
+              {RECIPE.map((term) => (
+                <button
+                  key={term.position}
+                  type="button"
+                  aria-pressed={selected.position === term.position}
+                  aria-label={`Select file position ${term.position}, chunk ${term.chunk}`}
+                  onClick={() => setSelectedPosition(term.position)}
+                  className={cn(
+                    "group relative flex h-24 flex-col items-center justify-center rounded-md border-2 font-mono transition-transform outline-none hover:-translate-y-1 focus-visible:ring-3 focus-visible:ring-[#234e70] motion-reduce:transition-none",
+                    selected.position === term.position
+                      ? "-translate-y-1 border-[#203948] shadow-[0_5px_0_#203948]"
+                      : "border-[#87979d]"
+                  )}
+                  style={{ backgroundColor: term.color }}
+                >
+                  <span className="absolute top-1.5 left-2 text-[8px] font-black text-[#253840]">
+                    {String(term.position).padStart(2, "0")}
+                  </span>
+                  <span className="text-3xl font-black text-[#172a34]">
+                    {term.chunk}
+                  </span>
+                  {term.position === 5 ? (
+                    <span className="mt-1 rounded-full bg-[#6c5012] px-2 py-0.5 text-[7px] font-black text-white">
+                      REPEAT
+                    </span>
+                  ) : null}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="my-4 flex items-center gap-3 text-[#5f737b]">
+            <div className="h-px flex-1 bg-[#8fa0a7]" />
+            <ArrowDown className="size-5" aria-hidden="true" />
+            <span className="font-mono text-[9px] font-black">
+              RESOLVE PLACEMENT
+            </span>
+            <div className="h-px flex-1 bg-[#8fa0a7]" />
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              {
+                label: "XORB RACK 17",
+                chunks: ["A", "C", "E"],
+                color: "bg-[#d7eaf2]",
+              },
+              {
+                label: "XORB RACK 42",
+                chunks: ["F", "G", "H", "B"],
+                color: "bg-[#f9e8b6]",
+              },
+              {
+                label: "LOCAL CACHE",
+                chunks: ["D"],
+                color: "bg-[#ead9e7]",
+              },
+            ].map((rack) => (
+              <div
+                key={rack.label}
+                className="rounded-md border-2 border-[#52666f] bg-[#bec9cc] p-3"
+              >
+                <p className="m-0 font-mono text-[8px] font-black tracking-[0.14em] text-[#3e5159]">
+                  {rack.label}
+                </p>
+                <div className="mt-3 flex min-h-16 flex-wrap content-start gap-1.5">
+                  {rack.chunks.map((chunk) => {
+                    const active = selected.chunk === chunk
+                    return (
+                      <div
+                        key={chunk}
+                        className={cn(
+                          "flex size-10 items-center justify-center rounded border font-mono text-sm font-black transition-all motion-reduce:transition-none",
+                          rack.color,
+                          active
+                            ? "scale-110 border-[#203948] shadow-[0_3px_0_#203948]"
+                            : "border-[#82949b] text-[#52666f]"
+                        )}
+                      >
+                        {chunk}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <aside
+          className="border-t-4 border-[#203948] bg-[#f7f8f4] p-5 lg:border-t-0 lg:border-l-4"
+          aria-live="polite"
+        >
+          <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#6b7c82]">
+            SELECTED FILE TERM
+          </p>
+          <p className="m-0 mt-2 text-5xl font-black tracking-[-0.08em] text-[#234e70]">
+            {selected.chunk}
+            <span className="ml-2 text-base tracking-normal text-[#6b7c82]">
+              / {selected.position}
+            </span>
+          </p>
+          <dl className="m-0 mt-6 grid gap-4">
+            {[
+              ["PLACEMENT", selected.xorb],
+              ["CHUNK RANGE", selected.range],
+              ["UNPACKED", selected.bytes],
+              ["READ SOURCE", selected.source],
+            ].map(([label, value]) => (
+              <div key={label} className="border-b border-[#c1cbce] pb-3">
+                <dt className="font-mono text-[8px] font-black tracking-[0.14em] text-[#7b898e]">
+                  {label}
+                </dt>
+                <dd className="m-0 mt-1 text-sm font-black text-[#203948]">
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+          <p className="m-0 mt-5 text-xs leading-5 text-[#607077]">
+            File position {selected.position} keeps its own output slot even
+            when its bytes share a physical read.
+          </p>
+        </aside>
+      </div>
+
+      <figcaption className="border-t-4 border-[#203948] bg-[#f6c85f] px-5 py-3 font-mono text-[9px] font-bold text-[#3f330e] sm:px-7">
+        Illustrative hashes and sizes. The invariant is real: every recipe
+        position must have one valid placement.
+      </figcaption>
+    </figure>
+  )
+}
+
+type ArrivalScenario = {
+  id: string
+  label: string
+  arrival: string[]
+  note: string
+}
+
+const ARRIVAL_SCENARIOS: ArrivalScenario[] = [
+  {
+    id: "17-first",
+    label: "xorb-17 first",
+    arrival: ["A", "C", "B", "D"],
+    note: "A and C share one object read, but C still waits for output slot 3.",
+  },
+  {
+    id: "42-first",
+    label: "xorb-42 first",
+    arrival: ["B", "D", "A", "C"],
+    note: "B arrives first and fills two logical positions when assembly reaches them.",
+  },
+  {
+    id: "cache-first",
+    label: "cache first",
+    arrival: ["D", "A", "C", "B"],
+    note: "A local hit can finish immediately without moving D ahead of A, B, or C.",
+  },
+]
+
+const CHUNK_COLORS: Record<string, string> = {
+  A: "bg-[#77b6d1]",
+  B: "bg-[#f6c85f]",
+  C: "bg-[#a9d18e]",
+  D: "bg-[#d6a5cf]",
+}
+
+export function ReconstructionArrivalBoard() {
+  const [scenarioId, setScenarioId] = useState("17-first")
+  const scenario =
+    ARRIVAL_SCENARIOS.find((item) => item.id === scenarioId) ??
+    ARRIVAL_SCENARIOS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(60rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[2rem] bg-[#17252d] p-3 shadow-[0_18px_55px_rgba(23,37,45,0.2)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(60rem,calc(100vw-2rem))] lg:w-[min(60rem,calc(100vw-24.5rem))]">
+      <div className="rounded-[1.25rem] border border-[#57707b] bg-[#20343e] p-5 sm:p-7">
+        <header className="flex flex-wrap items-end justify-between gap-5">
+          <div>
+            <p className="m-0 font-mono text-[10px] font-black tracking-[0.18em] text-[#8db5c4]">
+              PARALLEL ARRIVAL BOARD
+            </p>
+            <h3 className="m-0 mt-1 text-2xl font-black tracking-[-0.03em] text-white">
+              Downloads may race. The recipe does not.
+            </h3>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {ARRIVAL_SCENARIOS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                aria-pressed={scenario.id === item.id}
+                onClick={() => setScenarioId(item.id)}
+                className={cn(
+                  "rounded-full border px-3 py-1.5 font-mono text-[9px] font-black outline-none focus-visible:ring-2 focus-visible:ring-[#f6c85f] focus-visible:ring-offset-2 focus-visible:ring-offset-[#20343e]",
+                  scenario.id === item.id
+                    ? "border-[#f6c85f] bg-[#f6c85f] text-[#30270c]"
+                    : "border-[#66808b] text-[#b9cdd4] hover:border-[#a6c8d5]"
+                )}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        <div className="mt-7 grid gap-5 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:items-center">
+          <div className="rounded-xl border border-[#57707b] bg-[#162830] p-4">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.15em] text-[#89a8b3]">
+              COMPLETION ORDER
+            </p>
+            <div className="mt-4 grid grid-cols-4 gap-2">
+              {scenario.arrival.map((chunk, index) => (
+                <div key={chunk} className="text-center">
+                  <div
+                    className={cn(
+                      "flex h-16 items-center justify-center rounded-md border border-white/30 font-mono text-xl font-black text-[#18252b]",
+                      CHUNK_COLORS[chunk]
+                    )}
+                  >
+                    {chunk}
+                  </div>
+                  <span className="mt-1 block font-mono text-[8px] font-bold text-[#829da8]">
+                    ARRIVAL {index + 1}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex justify-center text-[#f6c85f]">
+            <ArrowDown className="size-6 md:hidden" aria-hidden="true" />
+            <ArrowRight className="hidden size-6 md:block" aria-hidden="true" />
+          </div>
+
+          <div className="rounded-xl border-2 border-[#f6c85f] bg-[#f7f8f4] p-4">
+            <div className="flex items-center justify-between gap-3">
+              <p className="m-0 font-mono text-[9px] font-black tracking-[0.15em] text-[#5e6d73]">
+                FILE WRITE ORDER
+              </p>
+              <Gauge className="size-4 text-[#2f7d62]" aria-hidden="true" />
+            </div>
+            <div className="mt-4 grid grid-cols-5 gap-1.5">
+              {["A", "B", "C", "D", "B"].map((chunk, index) => (
+                <div
+                  key={`${chunk}-${index}`}
+                  className={cn(
+                    "flex h-16 items-center justify-center rounded border border-[#45575e] font-mono text-lg font-black text-[#18252b]",
+                    CHUNK_COLORS[chunk]
+                  )}
+                >
+                  {chunk}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <p
+          className="m-0 mt-6 border-t border-[#57707b] pt-4 text-sm leading-6 text-[#c1d2d8]"
+          aria-live="polite"
+        >
+          {scenario.note}
+        </p>
+      </div>
+    </figure>
+  )
+}
+
+type GateScenario = {
+  id: string
+  label: string
+  title: string
+  checks: Array<{ label: string; state: "pass" | "fail" | "waiting" }>
+  result: "published" | "blocked"
+  temp: string
+  reason: string
+}
+
+const GATE_SCENARIOS: GateScenario[] = [
+  {
+    id: "success",
+    label: "Valid file",
+    title: "Every proof agrees",
+    checks: [
+      { label: "5 / 5 recipe positions covered", state: "pass" },
+      { label: "Every chunk matches its hash", state: "pass" },
+      { label: "Size and full-file hash match", state: "pass" },
+    ],
+    result: "published",
+    temp: "renamed over pointer",
+    reason: "The sibling temporary file becomes the tracked file atomically.",
+  },
+  {
+    id: "missing",
+    label: "Missing term",
+    title: "The plan cannot cover the file",
+    checks: [
+      { label: "4 / 5 recipe positions covered", state: "fail" },
+      { label: "Chunk reads not started", state: "waiting" },
+      { label: "Final verification not started", state: "waiting" },
+    ],
+    result: "blocked",
+    temp: "not created",
+    reason:
+      "Coverage preflight stops before spending bandwidth on an incomplete plan.",
+  },
+  {
+    id: "chunk",
+    label: "Bad chunk",
+    title: "One fetched range has the wrong bytes",
+    checks: [
+      { label: "5 / 5 recipe positions covered", state: "pass" },
+      { label: "Chunk C hash mismatch", state: "fail" },
+      { label: "Final verification not reached", state: "waiting" },
+    ],
+    result: "blocked",
+    temp: "discarded",
+    reason:
+      "The bad range cannot enter the assembled file or local cache as valid content.",
+  },
+  {
+    id: "final",
+    label: "Wrong order",
+    title: "Chunks are valid; the whole file is not",
+    checks: [
+      { label: "5 / 5 recipe positions covered", state: "pass" },
+      { label: "Every chunk matches its hash", state: "pass" },
+      { label: "Full-file BLAKE3 mismatch", state: "fail" },
+    ],
+    result: "blocked",
+    temp: "discarded",
+    reason:
+      "Per-chunk checks cannot prove order. The final file hash closes that gap.",
+  },
+]
+
+export function HydrationSafetyGate() {
+  const [scenarioId, setScenarioId] = useState("success")
+  const scenario =
+    GATE_SCENARIOS.find((item) => item.id === scenarioId) ?? GATE_SCENARIOS[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(62rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden border-2 border-[#333b36] bg-[#f7f8f4] shadow-[8px_8px_0_#d5dbd5] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(62rem,calc(100vw-2rem))] lg:w-[min(62rem,calc(100vw-24.5rem))]">
+      <header className="flex flex-wrap items-end justify-between gap-5 border-b-2 border-[#333b36] px-5 py-5 sm:px-7">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.19em] text-[#637067]">
+            HYDRATION QUALITY GATE
+          </p>
+          <h3 className="m-0 mt-1 text-2xl font-black tracking-[-0.03em] text-[#202722]">
+            The pointer moves only after the proof passes.
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-1 border border-[#727d75] bg-white p-1">
+          {GATE_SCENARIOS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={scenario.id === item.id}
+              onClick={() => setScenarioId(item.id)}
+              className={cn(
+                "px-3 py-1.5 font-mono text-[9px] font-black outline-none focus-visible:ring-2 focus-visible:ring-[#234e70]",
+                scenario.id === item.id
+                  ? "bg-[#333b36] text-white"
+                  : "text-[#667069] hover:bg-[#edf0ec]"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div className="border-b-2 border-[#333b36] p-5 sm:p-7 lg:border-r-2 lg:border-b-0">
+          <h4 className="m-0 text-xl font-black text-[#202722]">
+            {scenario.title}
+          </h4>
+          <div className="mt-5 grid gap-2">
+            {scenario.checks.map((check, index) => (
+              <div
+                key={check.label}
+                className={cn(
+                  "grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 border p-3",
+                  check.state === "pass" && "border-[#83ab98] bg-[#e7f2eb]",
+                  check.state === "fail" && "border-[#d39189] bg-[#f8e8e5]",
+                  check.state === "waiting" &&
+                    "border-[#c3c9c4] bg-[#eff1ee] text-[#7b837d]"
+                )}
+              >
+                <span className="font-mono text-xs font-black">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="text-sm font-bold">{check.label}</span>
+                {check.state === "pass" ? (
+                  <Check
+                    className="size-5 text-[#2f7d62]"
+                    aria-label="Passed"
+                  />
+                ) : check.state === "fail" ? (
+                  <CircleX
+                    className="size-5 text-[#c84b45]"
+                    aria-label="Failed"
+                  />
+                ) : (
+                  <span className="font-mono text-[8px] font-black">WAIT</span>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-5 flex items-center gap-3 border-t border-dashed border-[#8a938c] pt-4">
+            <PackageOpen className="size-5 text-[#5e6a62]" aria-hidden="true" />
+            <p className="m-0 text-sm text-[#5e6a62]">
+              Temporary output: <strong>{scenario.temp}</strong>
+            </p>
+          </div>
+          <p className="m-0 mt-3 text-sm leading-6 text-[#5e6a62]">
+            {scenario.reason}
+          </p>
+        </div>
+
+        <aside
+          className={cn(
+            "flex flex-col justify-center p-6 text-center",
+            scenario.result === "published"
+              ? "bg-[#dff0e5] text-[#225e49]"
+              : "bg-[#f7dfdb] text-[#973b32]"
+          )}
+          aria-live="polite"
+        >
+          <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em]">
+            TRACKED PATH AFTER RUN
+          </p>
+          {scenario.result === "published" ? (
+            <FileCheck2 className="mx-auto mt-5 size-14" aria-hidden="true" />
+          ) : (
+            <FileCode2 className="mx-auto mt-5 size-14" aria-hidden="true" />
+          )}
+          <p className="m-0 mt-4 text-3xl font-black tracking-[-0.05em]">
+            {scenario.result === "published" ? "FULL FILE" : "POINTER"}
+          </p>
+          <div className="mt-5 border-t border-current/30 pt-4 font-mono text-[9px] font-black">
+            {scenario.result === "published" ? (
+              <span className="inline-flex items-center gap-2">
+                <ShieldCheck className="size-4" aria-hidden="true" /> VERIFIED
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-2">
+                <RotateCcw className="size-4" aria-hidden="true" /> UNCHANGED
+              </span>
+            )}
+          </div>
+        </aside>
+      </div>
+    </figure>
+  )
+}

--- a/packages/web/components/blog/tiering-visuals.tsx
+++ b/packages/web/components/blog/tiering-visuals.tsx
@@ -1,0 +1,406 @@
+"use client"
+
+import {
+  ArchiveRestore,
+  ArrowRight,
+  Check,
+  Clock3,
+  FileArchive,
+  FileCog,
+  Flame,
+  GitCommitHorizontal,
+  PackageOpen,
+  Snowflake,
+  X,
+} from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+type TierObject = {
+  id: "new-xorb" | "warm-xorb" | "cold-xorb" | "shard" | "ref" | "pack"
+  label: string
+  path: string
+  age: string
+  eligible: boolean
+  destination: string
+  reason: string
+  icon: typeof FileArchive
+  structures: string[]
+}
+
+const TIER_OBJECTS: TierObject[] = [
+  {
+    id: "new-xorb",
+    label: "10-day xorb",
+    path: ".crab/xorbs/a1/a1f4…",
+    age: "10 days",
+    eligible: true,
+    destination: "STANDARD",
+    reason:
+      "The object matches the xorb prefix but has not reached the 30-day transition.",
+    icon: Flame,
+    structures: ["object prefix", "last modified", "30-day rule"],
+  },
+  {
+    id: "warm-xorb",
+    label: "75-day xorb",
+    path: ".crab/xorbs/b7/b72c…",
+    age: "75 days",
+    eligible: true,
+    destination: "INFREQUENT ACCESS",
+    reason:
+      "It passed the 30-day warm transition but not the 180-day cold transition.",
+    icon: PackageOpen,
+    structures: ["xorb prefix", "transition rule", "storage class"],
+  },
+  {
+    id: "cold-xorb",
+    label: "240-day xorb",
+    path: ".crab/xorbs/c9/c90d…",
+    age: "240 days",
+    eligible: true,
+    destination: "DEEP COLD",
+    reason:
+      "It passed both default age thresholds. Access evidence must still justify the delay.",
+    icon: Snowflake,
+    structures: ["xorb prefix", "180-day rule", "restore policy"],
+  },
+  {
+    id: "shard",
+    label: "240-day shard",
+    path: ".crab/shards/3f/3f18…",
+    age: "240 days",
+    eligible: false,
+    destination: "KEEP READABLE",
+    reason:
+      "Shards map file and chunk identities to xorbs. Hydration planning needs them immediately.",
+    icon: FileCog,
+    structures: ["shard metadata", "file recipe", "range planning"],
+  },
+  {
+    id: "ref",
+    label: "Repository ref",
+    path: "repo/vision/refs/main",
+    age: "current",
+    eligible: false,
+    destination: "KEEP READABLE",
+    reason:
+      "Refs are mutable repository control data, not tier-eligible content objects.",
+    icon: GitCommitHorizontal,
+    structures: [
+      "ref transaction",
+      "current generation",
+      "repository discovery",
+    ],
+  },
+  {
+    id: "pack",
+    label: "Git pack",
+    path: "repo/vision/packs/pack-18.pack",
+    age: "210 days",
+    eligible: false,
+    destination: "KEEP READABLE",
+    reason: "Git packs remain outside Crab’s xorb-only lifecycle rule.",
+    icon: FileArchive,
+    structures: ["Git pack", "fetch path", "lifecycle prefix"],
+  },
+]
+
+export function TierEligibilitySorter() {
+  const [objectId, setObjectId] = useState<TierObject["id"]>("new-xorb")
+  const selected =
+    TIER_OBJECTS.find((item) => item.id === objectId) ?? TIER_OBJECTS[0]
+  const Icon = selected.icon
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] bg-[#18212a] text-white shadow-[0_20px_60px_rgba(24,33,42,0.2)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="border-b border-[#56626d] px-5 py-5 sm:px-7">
+        <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#c7d66d]">
+          LIFECYCLE SORTER / SELECT AN OBJECT
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2" aria-label="Storage object">
+          {TIER_OBJECTS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={selected.id === item.id}
+              onClick={() => setObjectId(item.id)}
+              className={cn(
+                "min-h-11 rounded-lg border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#c7d66d] focus-visible:ring-offset-2 focus-visible:ring-offset-[#18212a]",
+                selected.id === item.id
+                  ? "border-[#c7d66d] bg-[#c7d66d] text-[#18212a]"
+                  : "border-[#56626d] text-[#c5ced2] hover:border-[#c7d66d] hover:text-white"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="p-5 sm:p-7" aria-live="polite">
+        <div className="grid gap-3 lg:grid-cols-[1fr_auto_1fr_auto_1fr] lg:items-stretch">
+          <div className="rounded-2xl border border-[#56626d] bg-[#24313b] p-5">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#81919a]">
+              INVENTORY OBJECT
+            </p>
+            <Icon className="mt-6 size-7 text-[#43b3ae]" aria-hidden="true" />
+            <p className="m-0 mt-5 font-mono text-sm font-black break-all">
+              {selected.path}
+            </p>
+            <p className="m-0 mt-2 font-mono text-[10px] text-[#aab8be]">
+              age: {selected.age}
+            </p>
+          </div>
+
+          <ArrowRight
+            className="mx-auto size-5 rotate-90 self-center text-[#81919a] lg:rotate-0"
+            aria-hidden="true"
+          />
+
+          <div
+            className={cn(
+              "rounded-2xl border-2 p-5",
+              selected.eligible
+                ? "border-[#43b3ae] bg-[#20403f]"
+                : "border-[#e56b6f] bg-[#442d35]"
+            )}
+          >
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#aab8be]">
+              PREFIX GATE
+            </p>
+            <div className="mt-7 flex items-center gap-3">
+              {selected.eligible ? (
+                <Check className="size-7 text-[#43b3ae]" aria-hidden="true" />
+              ) : (
+                <X className="size-7 text-[#e56b6f]" aria-hidden="true" />
+              )}
+              <p className="m-0 text-xl font-black">
+                {selected.eligible ? "XORB ELIGIBLE" : "METADATA EXCLUDED"}
+              </p>
+            </div>
+            <p className="m-0 mt-3 font-mono text-[10px] text-[#c5ced2]">
+              rule: .crab/xorbs/ only
+            </p>
+          </div>
+
+          <ArrowRight
+            className="mx-auto size-5 rotate-90 self-center text-[#81919a] lg:rotate-0"
+            aria-hidden="true"
+          />
+
+          <div className="rounded-2xl border border-[#56626d] bg-[#f7f8f0] p-5 text-[#18212a]">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#60716a]">
+              DESTINATION
+            </p>
+            <p className="m-0 mt-7 font-mono text-2xl font-black tracking-[-0.05em] text-[#4c3f91]">
+              {selected.destination}
+            </p>
+            <p className="m-0 mt-3 text-sm leading-6 text-[#52615b]">
+              {selected.reason}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center gap-2 border-t border-dashed border-[#56626d] pt-5">
+          <span className="mr-2 font-mono text-[9px] font-black tracking-[0.16em] text-[#81919a]">
+            KEY EVIDENCE
+          </span>
+          {selected.structures.map((structure) => (
+            <span
+              key={structure}
+              className="rounded-full border border-[#56626d] bg-[#24313b] px-3 py-1.5 font-mono text-[10px] text-[#c5ced2]"
+            >
+              {structure}
+            </span>
+          ))}
+        </div>
+      </div>
+    </figure>
+  )
+}
+
+type RestoreCase = {
+  id: "warm" | "ci" | "nightly" | "incident"
+  label: string
+  title: string
+  storageClass: string
+  policy: string
+  command: string
+  result: string
+  timing: string
+  note: string
+  tone: "direct" | "blocked" | "wait" | "urgent"
+}
+
+const RESTORE_CASES: RestoreCase[] = [
+  {
+    id: "warm",
+    label: "Warm model",
+    title: "Read immediately",
+    storageClass: "Standard-IA",
+    policy: "direct read",
+    command: "crab hydrate 'models/current/**'",
+    result: "BYTES READABLE",
+    timing: "no restore step",
+    note: "Retrieval fees may apply, but the object does not need provider restore staging.",
+    tone: "direct",
+  },
+  {
+    id: "ci",
+    label: "CI fail-fast",
+    title: "Do not turn a test into a restore job",
+    storageClass: "Deep Archive",
+    policy: "restore disabled",
+    command: "crab hydrate --all --no-restore",
+    result: "FAIL WITH DIRECTION",
+    timing: "immediate decision",
+    note: "Use this when the job must fail rather than wait or create restore charges.",
+    tone: "blocked",
+  },
+  {
+    id: "nightly",
+    label: "Nightly batch",
+    title: "Trade time for a cheaper restore",
+    storageClass: "Glacier Flexible",
+    policy: "bulk restore",
+    command:
+      "crab hydrate --all --restore-tier=bulk --restore-duration-days=14",
+    result: "RESTORE + HYDRATE",
+    timing: "provider-dependent wait",
+    note: "The restored copy stays readable for 14 days, useful for a scheduled batch window.",
+    tone: "wait",
+  },
+  {
+    id: "incident",
+    label: "Incident recovery",
+    title: "Pay for the fastest supported path",
+    storageClass: "Glacier Flexible",
+    policy: "expedited restore",
+    command: "crab hydrate --all --restore-tier=expedited",
+    result: "URGENT RESTORE",
+    timing: "S3 example: 1–5 min",
+    note: "Run recovery drills before relying on this objective; provider capacity and class rules still apply.",
+    tone: "urgent",
+  },
+]
+
+const RESTORE_TONE = {
+  direct: "border-[#43b3ae] bg-[#d9efea] text-[#205a55]",
+  blocked: "border-[#e56b6f] bg-[#f6dddd] text-[#7b3038]",
+  wait: "border-[#4c3f91] bg-[#e8e4f5] text-[#4c3f91]",
+  urgent: "border-[#e8a933] bg-[#fff0c9] text-[#70500f]",
+}
+
+export function RestoreDispatchBoard() {
+  const [caseId, setCaseId] = useState<RestoreCase["id"]>("warm")
+  const selected =
+    RESTORE_CASES.find((item) => item.id === caseId) ?? RESTORE_CASES[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] border border-[#a9b3ad] bg-[#f7f8f0] text-[#18212a] shadow-[0_20px_60px_rgba(24,33,42,0.14)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#a9b3ad] px-5 py-5 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#4c3f91]">
+            RESTORE DISPATCH / SELECT A WORKLOAD
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.04em] sm:text-3xl">
+            What should happen when cold data is requested?
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-2" aria-label="Restore workload">
+          {RESTORE_CASES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={selected.id === item.id}
+              onClick={() => setCaseId(item.id)}
+              className={cn(
+                "min-h-11 rounded-full border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#4c3f91] focus-visible:ring-offset-2",
+                selected.id === item.id
+                  ? "border-[#4c3f91] bg-[#4c3f91] text-white"
+                  : "border-[#a9b3ad] bg-white text-[#52615b] hover:border-[#4c3f91] hover:text-[#4c3f91]"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="p-5 sm:p-7" aria-live="polite">
+        <div className="grid gap-3 lg:grid-cols-[1fr_auto_1fr_auto_1fr] lg:items-stretch">
+          <DispatchCard
+            icon={Snowflake}
+            label="STORAGE CLASS"
+            value={selected.storageClass}
+          />
+          <ArrowRight
+            className="mx-auto size-5 rotate-90 self-center text-[#87958e] lg:rotate-0"
+            aria-hidden="true"
+          />
+          <DispatchCard
+            icon={ArchiveRestore}
+            label="READ POLICY"
+            value={selected.policy}
+          />
+          <ArrowRight
+            className="mx-auto size-5 rotate-90 self-center text-[#87958e] lg:rotate-0"
+            aria-hidden="true"
+          />
+          <div
+            className={cn(
+              "rounded-2xl border-2 p-5",
+              RESTORE_TONE[selected.tone]
+            )}
+          >
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] opacity-75">
+              APPLICATION RESULT
+            </p>
+            <p className="m-0 mt-6 font-mono text-xl font-black">
+              {selected.result}
+            </p>
+            <p className="m-0 mt-2 font-mono text-[10px] opacity-80">
+              {selected.timing}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_18rem]">
+          <div>
+            <h4 className="m-0 text-xl font-black">{selected.title}</h4>
+            <p className="m-0 mt-2 text-sm leading-6 text-[#52615b]">
+              {selected.note}
+            </p>
+          </div>
+          <code className="block overflow-x-auto rounded-xl bg-[#18212a] px-4 py-3 font-mono text-[10px] leading-5 text-[#c7d66d]">
+            {selected.command}
+          </code>
+        </div>
+      </div>
+    </figure>
+  )
+}
+
+function DispatchCard({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof Clock3
+  label: string
+  value: string
+}) {
+  return (
+    <div className="rounded-2xl border border-[#a9b3ad] bg-[#edf2ee] p-5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="m-0 font-mono text-[9px] font-black tracking-[0.16em] text-[#60716a]">
+          {label}
+        </p>
+        <Icon className="size-5 text-[#4c3f91]" aria-hidden="true" />
+      </div>
+      <p className="m-0 mt-7 text-lg font-black">{value}</p>
+    </div>
+  )
+}

--- a/packages/web/content/blog/cost-optimization-s3-storage.mdx
+++ b/packages/web/content/blog/cost-optimization-s3-storage.mdx
@@ -19,220 +19,209 @@ meta:
   audience: "Repository operators responsible for cloud cost and access latency."
 ---
 
-A Crab storage bill has four main terms: bytes stored by class, object requests, cold-data retrieval, and network transfer. Deduplication, xorb packing, caching, garbage collection, and tiering each change a different term.
+A cheaper storage class does not guarantee a cheaper repository.
 
-<StorageTierDiagram />
-
-## Start with a formula, not a provider price table
-
-Provider prices vary by region, account, storage class, and date. Use the current calculator and contract for your bucket, then model the workload with this shape:
+Suppose a Crab repository stores **10 TB** and reads **2 TB** from origin each
+month. Storage is only one line on the bill:
 
 ```text
-monthly cost ≈
-  stored GB by class × storage rate
-  + write, list, and read requests × request rate
-  + restored or retrieved GB × retrieval rate
-  + transferred GB × network rate
-  + minimum-retention or early-deletion charges
+storage + requests + retrieval + transfer + early-deletion charges
 ```
 
-A cheaper storage class can cost more overall when each monthly workflow rereads the working set or deletes objects before the class minimum.
+Move the wrong 8 TB into archive and the storage line falls while restore
+delay and other charges rise.
 
-## Build one row per data temperature
+<CostReceiptMixer />
 
-Separate hot, warm, and archival xorbs instead of averaging the complete repository into one access rate. Each group has a different storage rate, read frequency, retrieval charge, and restore-time objective.
+The receipt uses Crab’s embedded S3 `us-east-1` rates as an illustration. Use
+your current region, negotiated contract, and provider calculator for a real
+decision.
 
-| Input | Hot set | Warm set | Archive set |
-| --- | --- | --- | --- |
-| Stored GB | `gb_hot` | `gb_warm` | `gb_archive` |
-| Monthly reads | `reads_hot` | `reads_warm` | `reads_archive` |
-| Retrieved GB | Direct-read bytes | Direct or metered bytes | Restored bytes |
-| Required latency | Interactive | Batch-compatible | Restore-compatible |
-| Minimum retention | Provider class rule | Provider class rule | Provider class rule |
+## Measure four inputs
 
-Multiply each set by its current regional prices, then add request and transfer terms. Separate rows expose a cold-tail policy that one storage total would hide.
-
-Run a sensitivity check as well. Double the archive read frequency, increase the hot set by one release cycle, and model an early-delete event. The policy should remain acceptable under plausible workload changes.
-
-## Build a workload worksheet before selecting controls
-
-Use one row for each workflow and one row for each retained data class. The worksheet should connect repository behavior to billable operations.
-
-| Workflow | Runs per month | Managed GB read | Managed GB written | Object requests | Restore-compatible |
-| --- | ---: | ---: | ---: | ---: | --- |
-| Developer hydration | `developer_runs` | `developer_read_gb` | 0 | `developer_requests` | No |
-| CI model test | `ci_runs` | `ci_read_gb` | 0 | `ci_requests` | No |
-| Training publish | `training_runs` | 0 | `training_write_gb` | `training_requests` | No |
-| Recovery drill | `recovery_runs` | `recovery_read_gb` | 0 | `recovery_requests` | Yes |
-| Repository GC | `gc_runs` | Metadata only | 0 | `gc_requests` | Not applicable |
-
-Populate the table from logs and Crab counters rather than estimates where possible. Multiply per-run values by frequency, then map reads and writes to the storage classes involved.
-
-Keep cache-served and origin-served bytes separate. Provider billing sees the origin path, while application latency sees both. A shared cache may trade object-store transfer for cache-service compute and network cost.
-
-## Work one tiering decision with concrete numbers
-
-Use a small calculation to test whether a lower storage rate pays for retrieval and transition work. The rates below illustrate the method; replace them with the current rates and minimum-retention rules for your provider.
-
-Assume access logs identify 6,000 GB of reachable xorbs that workflows read once per quarter. The proposed class lowers storage by `$0.014` per GB-month, charges `$0.02` per retrieved GB, and requires `$18` of one-time transition requests.
-
-| Term | Calculation | Effect |
-| --- | ---: | ---: |
-| Monthly storage reduction | `6,000 GB × $0.014` | `$84` saved |
-| Expected monthly retrieval | `200 GB × $0.02` | `$4` added |
-| Steady monthly savings | `$84 - $4` | `$80` saved |
-| Transition payback | `$18 ÷ $80` | `0.225 months` |
-
-The arithmetic supports the transition, but it does not prove the policy is safe. Confirm that quarterly restores meet the recovery-time objective and that early-deletion charges cannot erase the `$80` estimate.
-
-## Measure local and remote bytes
-
-Use Crab's inventory before changing policy:
+Start with repository inventory and Crab’s cost report:
 
 ```bash
-crab du
 crab du --remote
+crab doctor --cost --json > before.json
 crab optimize repo --json
 ```
 
-Record total remote bytes, object counts, age distribution, retrieval frequency, and the size of the active working set. Compare that baseline after each change.
+Then add evidence the object listing cannot provide:
 
-Provider billing and Crab inventory answer different questions. Billing shows charged usage. `crab du --remote` shows repository storage. Access logs and cache metrics show which bytes created requests and transfer.
+- Origin bytes read by workflow.
+- GET, PUT, LIST, and restore request counts.
+- Cache-served versus origin-served bytes.
+- Required time to first readable byte.
 
-Keep the observation window long enough to include releases, training cycles, and recovery drills. A quiet week can make active data look archival when the monthly workflow still needs it.
+Crab’s live inventory may infer Standard class when provider listings do not
+expose storage class consistently. Retrieval estimates are incomplete without
+access telemetry. Keep the pricing-table version from the report so the model
+is reproducible.
 
-Measure growth by cause. New unique chunks, retained historical roots, abandoned uploads inside the grace period, repacking overlap, and delayed provider deletion all add remote bytes for different reasons.
+Use at least one full release, training, and recovery cycle. A quiet week can
+make monthly data look archival.
 
-One inventory total cannot identify the failing cost term. Deduplication affects new unique data. Retention policy and GC affect unreachable data.
+## Match the control to the bill term
 
-Repacking affects object layout. Provider lifecycle affects the rate charged for reachable xorb bytes.
+| Bill term                          | First control to inspect          |
+| ---------------------------------- | --------------------------------- |
+| Stored GB keeps growing            | Deduplication, retained roots, GC |
+| Too many object operations         | Xorb packing and range coalescing |
+| Repeat origin reads                | Local or shared cache             |
+| Cold reachable bytes cost too much | Lifecycle tiering                 |
+| Retrieval charges rise             | Move the threshold later          |
+| Early-delete charges appear        | Respect class retention periods   |
 
-## Reduce unique bytes before moving them
+Do not change all controls together. The next bill will not show which change
+worked.
 
-Content-defined chunking prevents known chunks from uploading again. Garbage collection removes objects that are no longer protected by any retained root. These controls reduce the number of billable bytes.
+## Reduce bytes before moving bytes
 
-Packing and repacking target request economics. Larger well-formed xorbs let groups of chunks share object writes and coalesced range reads, which avoids a request per chunk.
+Use this order:
 
-Preview combined recommendations before applying layout changes:
+1. Measure unique chunk growth and deduplication.
+2. Review recovery roots and collect unreachable objects.
+3. Optimize the live xorb layout.
+4. Tier only the cold, reachable tail.
+5. Cache repeat reads close to the workload.
+
+Tiering first can archive objects GC would remove. Repacking first can rewrite
+objects that retention policy will release.
+
+Preview layout work before changing remote objects:
 
 ```bash
+crab gc --scope repo --dry-run
 crab optimize plan --include-xorbs --profile ml --json
 crab optimize xorbs --profile ml --dry-run
 ```
 
-Layout optimization can trade one term against another. Repacking may create temporary additional bytes while new objects upload. Larger xorbs can reduce requests but may increase extra range bytes for sparse reads.
+Larger xorbs can reduce requests, but sparse reads may fetch extra range bytes.
+Record both sides of that trade.
 
-Record both the steady-state estimate and migration cost. A policy that saves a small monthly amount may not repay its rewrite, transfer, and early-deletion charges within the repository's lifetime.
+## Tier xorbs, not repository metadata
 
-Apply controls in dependency order. Improve deterministic file production and measure chunk reuse first. Review retained roots and collect unreachable objects next.
+Crab lifecycle plans target `.crab/xorbs/` only. Refs, manifests, shards,
+file indexes, and Git packs stay directly readable.
 
-Optimize xorb layout after the live set is known. Tier the resulting cold reachable set last.
+Why? A 4 KiB shard may unlock a 40 GB model. Archiving that metadata saves
+almost nothing and can block every hydration plan that needs it.
 
-Reversing the order can archive bytes that GC would remove or repack objects that retention policy will release. It can also make migration traffic larger than the steady-state repository.
+The opt-in defaults transition xorbs to a warm class after 30 days and a
+deep-cold class after 180 days. Those numbers are starting points, not proof
+that the data is cold.
 
-Use a payback period for each layout or lifecycle change:
+<TierEligibilitySorter />
 
-```text
-payback months = one-time migration cost / expected monthly savings
-```
+Build separate age and access rows:
 
-Include temporary storage, requests, retrieval, transfer, and operator time in the numerator. Reject a change whose payback exceeds the expected repository or policy lifetime.
+| Set  | Example evidence                      | Starting policy              |
+| ---- | ------------------------------------- | ---------------------------- |
+| Hot  | Read daily by developers or CI        | Standard                     |
+| Warm | Read in a monthly model test          | Direct-read infrequent class |
+| Cold | Read only by quarterly recovery drill | Restore-compatible archive   |
 
-## Tier only immutable data objects
+Shared xorbs follow object age and lifecycle prefix, not the branch that first
+uploaded them. Confirm that every workflow using a shared object can tolerate
+the destination class.
 
-Crab lifecycle plans scope transitions to `.crab/xorbs/`. Refs, manifests, shards, file indexes, and Git packs remain in readable storage because repository discovery and hydration planning depend on them.
+## Plan now; do not assume apply is supported
 
-The default tier schedule is opt-in: warm-class transition after 30 days and deep-cold transition after 180 days. Treat those values as a starting point, then adjust them to measured access and provider retention rules.
+Generate the provider policy without mutation:
 
 ```bash
 crab tier plan
-crab tier plan --apply --merge
 ```
 
-`--merge` preserves unrelated lifecycle rules and replaces only Crab-managed rules. An apply writes a backup so the prior configuration can be restored.
+`crab tier plan --apply` currently fails closed for S3, GCS, and Azure because
+Crab does not yet have a qualified conditional, prefix-preserving lifecycle
+write path. S3’s lifecycle API has no conditional write.
 
-Keep metadata out of archive rules. A small metadata object can sit on the critical path for every ref list or hydration plan. Its storage savings are negligible compared with restore latency and request failure risk.
+That distinction matters: the plan is useful evidence, but it is not proof
+that Crab changed the bucket. Manage the reviewed lifecycle policy through
+your qualified infrastructure workflow until safe apply support exists.
 
-Review provider lifecycle precedence when the bucket already has infrastructure-managed rules. Merge mode protects unrelated rules, but overlapping prefixes or broader provider rules can still affect Crab objects.
+When a provider adapter becomes qualified, `--merge` will preserve unrelated
+rules and replace Crab-managed rules. Still inspect broader Terraform or
+bucket rules that overlap `.crab/xorbs/`.
 
-Test lifecycle changes in a non-production prefix with the same provider controls. Confirm which rule wins when object age, prefix, tags, and existing infrastructure policy overlap.
+## Treat restore time as a cost
 
-Keep the generated backup and the exact applied plan with the cost record. Restoring a previous lifecycle configuration changes future transitions, but it may not immediately restore objects already moved into an archive class.
+Some classes remain directly readable with a retrieval fee. Other archive
+classes require a provider restore before Crab can hydrate their xorbs.
 
-Metadata and ref objects should remain in an interactive class even when old data xorbs become archival. Their byte volume is small, while every repository discovery and hydration plan can depend on them.
+<RestoreDispatchBoard />
 
-## Include restore time in the policy
+Choose behavior per workload:
 
-Archive classes may require a restore before hydration can read an xorb. That changes both latency and retrieval cost.
+- CI can use `--no-restore` and fail instead of waiting.
+- Scheduled jobs can request a lower-cost bulk restore.
+- Incident recovery can request the fastest supported tier.
+- Warm data should stay directly readable.
 
-```bash
-crab hydrate --all --restore
-crab hydrate --all --no-restore
+Restored copies are temporary. Model restore-request charges, retrieved GB,
+the restored-copy duration, and the complete wait until hydration finishes.
+
+Run a recovery drill before relying on an archive objective. Record:
+
+1. Time to request all restores.
+2. Time until every xorb is readable.
+3. Retrieval and transfer bytes.
+4. Hydration duration after restore.
+
+A cheap class fails the policy if the release or incident cannot wait.
+
+## Watch minimum retention
+
+In Crab’s embedded S3 table, Standard-IA has a 30-day minimum, Glacier Instant
+and Flexible Retrieval have 90-day minimums, and Deep Archive has 180 days.
+Other providers differ.
+
+Deleting or rewriting earlier can create a charge for the remaining period.
+Class-aware `crab gc` blocks early deletion by default and estimates the
+penalty.
+
+Include migration cost in payback:
+
+```text
+payback months =
+  transition requests + temporary storage + retrieval + operator time
+  ------------------------------------------------------------------
+                    expected monthly savings
 ```
 
-Use `--no-restore` for jobs that should fail instead of waiting or incurring restore cost. Reserve archive tiers for data whose recovery-time objective can tolerate the provider's delay.
+Reject a migration whose payback exceeds the repository or policy lifetime.
 
-Model restores as events, not only GB. One recovery can request several xorbs with minimum billed retrieval units, restore-request charges, and a temporary restored-copy duration.
+## Cache the repeated path
 
-Run a scheduled recovery drill before committing to a deep-cold objective. Record time to request restore, time until every required range is readable, retrieval bytes, provider charges, and hydration duration after restoration.
+A local cache avoids repeat origin reads on one machine. A shared cache can do
+the same across developers and CI.
 
-The archive policy succeeds only when the complete workflow meets its recovery-time objective. A low storage rate is not useful if the release or incident process requires data sooner than the provider can restore it.
+Caching does not reduce origin storage. Count cache compute, disk, and
+cross-zone traffic, then subtract avoided origin retrieval and transfer.
 
-## Assign a request budget by workflow
+Use byte-weighted hit rate. A 95% object hit rate is weak evidence if the
+largest xorbs are the misses.
 
-Storage cost receives attention because it scales with total bytes, but request cost can dominate small-object layouts and repeated metadata scans.
+## Review one change per billing window
 
-Set budgets for common workflows:
+Keep a compact record:
 
-- **Push**: object checks, xorb writes, shard writes, Git-pack writes, and ref operations
-- **Lazy clone**: ref reads, Git-pack reads, and metadata synchronization
-- **Hydration**: shard reads, xorb range reads, restore requests, and verification work
-- **Garbage collection**: namespace listings, metadata reads, object deletes, and reconciliation
-- **Mount**: metadata lookup plus range reads driven by application access
+- Baseline dates and pricing-table version.
+- Workflow access and restore evidence.
+- One control changed.
+- Expected bill and availability effect.
+- Rollback or infrastructure revert path.
+- First complete billing window for review.
 
-Measure operations per completed workflow, not per command invocation. One hydration command can read several xorbs, and one xorb range can satisfy several chunks.
+End with one decision: keep the policy, adjust one measured threshold, or
+collect more evidence.
 
-Request batching and range coalescing should lower operations without downloading excessive unused bytes. Track both request count and transferred bytes to expose that tradeoff.
-
-Request budgets also expose unexpected metadata loops. A small hydration that performs repeated shard listings may cost little in bytes but add latency and operation charges. Compare requests per completed file and requests per hydrated GB.
-
-Segment provider error retries. A transient throttling event can multiply requests without increasing completed work. Backoff and bounded concurrency may lower both retry cost and tail latency.
-
-## Use caching for repeated reads
-
-A local cache removes repeat downloads on one machine. The optional shared cache service can remove repeat origin reads across developers and CI runners.
-
-Caching does not reduce stored origin bytes, and it introduces its own capacity and operations cost. Measure cache hit rate and transfer savings before treating it as a cost win.
-
-Calculate cache value from origin cost avoided minus cache cost added. Include service compute, local solid-state drive storage, cross-zone or cross-region transfer, and operational support.
-
-Prefer byte-weighted hit rate for large-file economics. An object-count hit rate can look healthy while the largest xorbs continue to miss and dominate transfer.
-
-## Review cost as a recurring repository operation
-
-Run a monthly review with repository inventory, provider billing, cache metrics, lifecycle transitions, restores, and garbage-collection results. Compare the same normalized workflow measures each month.
-
-Investigate changes by term. Growing unique bytes may reflect new data or expired deduplication assumptions. Growing reads may reflect a wider working set, cache eviction, or more workers. Growing retrieval charges may indicate that tier transitions happen too early.
-
-Document every applied lifecycle plan and retain its generated backup. Cost controls change availability behavior, so rollback evidence belongs beside the financial estimate.
-
-The review should end with one of three decisions: keep the policy, change a measured threshold, or collect more access evidence. Avoid changing several controls at once because the next bill will not reveal which control caused the result.
-
-Maintain an evidence table for each policy change:
-
-- **Baseline window**: dates and workflows included
-- **Control**: one deduplication, retention, packing, cache, or lifecycle change
-- **Expected effect**: the bill term and measured amount targeted
-- **Availability effect**: added restore delay, cache dependency, or maintenance work
-- **Rollback**: configuration or repository action that reverses the policy
-- **Review date**: the first complete billing window used to accept or revert it
-
-This discipline keeps cost work connected to repository behavior. It also makes provider-price changes easier to apply because workload measurements remain useful when rates change.
-
-<TakeawayBox title="Match the lever to the term">
-  Deduplication and GC reduce bytes. Packing reduces requests. Caching reduces
-  repeated reads. Tiering trades access latency and retrieval cost for a lower
+<TakeawayBox title="Move the expensive term, not just the bytes">
+  Deduplication and GC reduce stored bytes. Packing reduces requests. Caching
+  reduces repeat reads. Tiering trades retrieval cost and latency for a lower
   storage rate.
 </TakeawayBox>
 
-Review the [`crab tier`](/docs/cli/reference/crab-tier) and [`crab optimize`](/docs/cli/reference/crab-optimize) references before applying provider changes.
+Review the [`crab tier`](/docs/cli/reference/crab-tier), [`crab optimize`](/docs/cli/reference/crab-optimize), and [pricing tables](/docs/cli/reference/pricing-tables) before changing provider policy.

--- a/packages/web/content/blog/crab-vs-git-lfs.mdx
+++ b/packages/web/content/blog/crab-vs-git-lfs.mdx
@@ -1,156 +1,185 @@
 ---
 title: "Should you use Crab or Git LFS?"
-description: "Compare Crab and Git LFS by data path, infrastructure, deduplication, checkout behavior, and migration cost."
+description: "Compare Crab and Git LFS with one 8 GB model, a small second revision, selective checkout, and migration choices."
 date: "2026-05-15"
 author: "Crab Team"
 category: "product"
 tags: ["beginner", "comparison", "git-lfs"]
-excerpt: "Both keep large bytes out of normal Git blobs. The important difference is who serves the data and how versions reuse content."
+excerpt: "Both keep large bytes out of normal Git blobs. The important difference is what gets transferred and who owns the data path."
 level: "beginner"
 path: "start-here"
 order: 3
 concepts: ["Git LFS", "comparison", "serverless git"]
 prerequisites: ["What is Crab, and when should you use it?"]
 outcome: "Choose between Crab and Git LFS using repository and operations constraints."
-diagramType: "Comparison matrix"
+diagramType: "Comparison flow"
 meta:
   contentType: "Conceptual"
   goal: "Help readers choose a large-file architecture without treating either option as universally better."
   audience: "Teams evaluating or migrating large-file version control."
 ---
 
-Git LFS and Crab solve the same first problem: keep large-file bytes out of ordinary Git blobs while preserving a pointer in Git history. Git LFS usually sends each file object through an LFS service. Crab sends content-defined chunks directly to your object-storage bucket.
+Both tools keep an 8 GB model out of ordinary Git blobs. The difference starts after Git stores the pointer: **Git LFS transfers a complete file object through an LFS endpoint; Crab splits the file into reusable chunks and transfers them to your bucket.**
 
 <LfsComparisonDiagram />
 
-## The architecture determines the operating model
+## Compare one repository
 
-| Decision | Git LFS | Crab |
+Use a concrete project instead of a feature checklist:
+
+```text
+vision-search/
+├── README.md
+├── src/train.py
+└── models/encoder.safetensors  # 8 GB
+```
+
+The source files stay in normal Git. Only the model follows the large-file path.
+
+### Git LFS
+
+```bash
+git lfs install
+git lfs track '*.safetensors'
+git add .gitattributes models/encoder.safetensors
+git commit -m "Train encoder v1"
+git push
+```
+
+`git lfs track` writes the shared rule to `.gitattributes`. The commit contains an LFS pointer; the pre-push hook sends the 8 GB object to the configured LFS endpoint.
+
+### Crab
+
+In a configured Crab repository:
+
+```bash
+crab track '*.safetensors'
+crab ship . -m "Train encoder v1"
+```
+
+`crab track` also writes a shared `.gitattributes` rule. `crab ship` stages the files, creates the commit, and pushes new chunks through Crab's native pipeline.
+
+| After the first push | Git LFS | Crab |
 | --- | --- | --- |
-| Shared data service | Hosted or self-managed LFS endpoint | S3, GCS, or Azure bucket |
-| Stored unit | Whole file object identified by its content | Content-defined chunks packed into xorbs |
-| Reuse across changed versions | Depends on whole-file identity | Identical chunks can be reused |
-| Checkout model | LFS smudge or fetch workflow | Pointer checkout, selective hydration, or mount |
-| Operations owner | Forge provider or your LFS service team | Your bucket policies and client credentials |
-| Git integration | LFS filters and LFS API | Crab filters and a Git remote helper |
+| Git stores | LFS pointer | Crab pointer |
+| Large data stores | One 8 GB LFS object | Chunks packed into xorbs |
+| Data path owner | Forge or LFS service operator | Your object-storage account |
 
-Git LFS has the lowest adoption friction when a forge already provides enough storage, bandwidth, and reliability. Git clients and forge integrations understand its pointer format.
+## The second version is the useful test
 
-Crab is a better fit when large versions share substantial content, the team wants data in its own bucket, or selective hydration matters for repository scale.
+Now train version 2. It is still 8 GB, but 7.5 GB of encoded bytes are unchanged and 0.5 GB are new.
 
-## Choose Git LFS when service integration is the priority
+```bash
+# Git LFS
+git add models/encoder.safetensors
+git commit -m "Train encoder v2"
+git push
 
-Git LFS fits teams that want their forge to own the data endpoint and are comfortable with its quotas and transfer model. It also fits repositories whose large files change infrequently enough that whole-file storage is not a significant cost.
+# Crab
+crab ship models/encoder.safetensors -m "Train encoder v2"
+```
 
-A self-managed LFS service can provide more control, but then its availability, scaling, and maintenance become your responsibility.
+The [Git LFS pointer specification](https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md#the-pointer) gives the complete file one SHA-256 object ID and size. A changed file gets a new ID. The [LFS Batch API](https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md) requests that object by ID and size, and the standard [basic transfer](https://github.com/git-lfs/git-lfs/blob/main/docs/api/basic-transfers.md) uploads its raw bytes.
 
-## Choose Crab when data ownership and reuse are the priority
+Crab hashes chunks inside the file. Chunks already proven in the remote do not need another upload.
 
-Crab fits repositories with iterative models, datasets, media, or build artifacts where new versions reuse large byte regions. Its chunk index can recognize identical content across paths and revisions, so a push only needs to upload chunks that are new to the repository.
+<ChunkReuseDiagram />
 
-The bucket remains under your access, retention, and lifecycle policies. Clients talk to it directly, which removes a Crab data service but requires each working environment to have Crab and valid credentials.
+| Illustrative result | Git LFS | Crab |
+| --- | ---: | ---: |
+| Version 1 data | 8 GB | 8 GB |
+| New data for version 2 | 8 GB | about 0.5 GB |
+| Data after two versions | 16 GB | about 8.5 GB |
 
-## Daily Git work is similar, but maintenance is different
+These numbers show the storage unit, not a promised ratio. Recompression, encryption, or a format rewrite can change bytes across the whole file and leave little for Crab to reuse. Test the real files your team produces.
 
-Both systems use Git attributes and pointer blobs, so contributors still add, commit, switch branches, and merge through Git. The distinction becomes visible during setup, large-file transfer, troubleshooting, and repository maintenance.
+## Checkout: decide when the 8 GB becomes local
 
-With hosted Git LFS, the forge usually supplies the endpoint, authorization flow, storage quota, and usage reporting. Teams may need little infrastructure knowledge until they reach a quota or service limitation. With self-hosted LFS, the team owns the endpoint and its backing storage.
+Git LFS normally replaces pointers during checkout. You can skip that download and fetch a narrower path later:
 
-Crab removes the endpoint from the data path. Clients need direct access to the repository prefix, and operators use object-store inventory, lifecycle, access logs, and retention policy. Crab also adds native operations for hydration, dehydration, mounts, integrity checking, optimization, and garbage collection.
+```bash
+git lfs install --skip-smudge
+git lfs fetch --include='models/encoder.safetensors'
+git lfs checkout models/encoder.safetensors
+```
 
-Include repository operators in the comparison. A workflow that saves transfer but has no sustainable credential path is not a successful migration.
+Crab can keep managed files as pointers, hydrate a known working set, or expose files through a mount:
 
-## Changed-file behavior can dominate the comparison
+```bash
+crab config set checkout.lazy true
+crab hydrate models/encoder.safetensors
+```
 
-The stored unit matters most when large files change frequently. Git LFS identifies a complete file object with a SHA-256 object ID. If one byte changes, the new file has a new object identity and transfer is based on that complete object.
+<LazyCheckoutDiagram />
 
-Crab identifies chunks inside the file, then records their order in a native Crab recipe. A new version can reuse any chunk whose durable location is already proven. The benefit depends on physical byte overlap, not semantic similarity.
+The practical question is local disk, not clone speed alone. If a developer needs one checkpoint from a 500 GB repository, measure how clearly each workflow selects and removes that working set.
 
-| Update pattern | Expected implication |
-| --- | --- |
-| Rarely changed design export | Whole-file storage may be sufficient |
-| Iterative model checkpoints | Chunk reuse can reduce repeated upload |
-| Encrypted archive rebuilt each run | Both systems may store nearly all bytes again |
-| Dataset with appended partitions | Stable earlier regions can remain reusable |
-| Repeated copies of the same asset | Content identity can avoid duplicate native chunks |
+## Who handles a failed transfer?
 
-Measure with representative data before choosing. File extension and logical purpose do not reveal the stable-byte share between versions.
+| Question | Hosted Git LFS | Crab |
+| --- | --- | --- |
+| Who serves large data? | Forge's LFS service | Object-storage provider |
+| What does the client authenticate to? | LFS endpoint | Repository bucket or prefix |
+| Where do you inspect access? | Forge or LFS service logs | Bucket access logs and policy |
+| Who owns quotas and retention? | Forge plan and service policy | Your storage account and lifecycle rules |
 
-## Checkout behavior affects local capacity
+Self-hosting Git LFS changes the first column: you gain control and also own another service. Crab removes a Crab data server, but every developer machine and CI runner still needs Crab plus valid object-storage credentials.
 
-Git LFS commonly materializes files through smudge, fetch, pull, and checkout operations. Its include and exclude controls can narrow transfer, but the working model remains centered on LFS objects.
+Choose the boundary your team can operate at 2 a.m. A lower upload number does not rescue an unusable credential flow.
 
-Crab clones managed files as pointers by default. You can hydrate paths, use a committed manifest, hydrate everything, or mount a repository for on-demand reads. This range matters when the repository is larger than a developer machine or continuous integration runner.
+## Migration is a separate choice
 
-Both approaches require tooling on the client. A checkout without the required filter can leave pointer text in the working tree, so installation and diagnostic checks belong in developer setup and automation.
+Do not rewrite history just because a two-version pilot favors Crab.
 
-## Security follows the data path
+Crab's LFS compatibility path keeps existing LFS pointers and commit IDs while routing transfers through Crab:
 
-Git LFS clients authenticate to an LFS endpoint, which can translate forge identity into object access. That service becomes the policy and audit boundary for large-file transfers.
+```bash
+crab lfs install
+crab lfs fetch
+crab lfs checkout
+crab lfs fsck
+```
 
-Crab clients authenticate to object storage through the provider's credential flow. This can support short-lived roles, workload identity, prefix-scoped permissions, provider encryption controls, and storage access logs without a Crab credential database.
+A native conversion is different:
 
-Direct access also increases the importance of policy design. Clients should receive the operations required for their repository prefix, not broad bucket administration. Continuous integration should use short-lived workload credentials. Lifecycle and deletion permissions should remain separate from ordinary read and push roles when the provider supports that split.
+```bash
+crab lfs migrate export \
+  --include '*.safetensors' \
+  --to-crab \
+  --everything \
+  --object-map ../lfs-to-crab.csv
+```
 
-Compare revocation and incident response as well as initial login. Ask how long access revocation takes, which audit record identifies an object read, and who owns credential delivery on developer machines and runners.
+That command replaces selected LFS pointers with Crab pointers. Rewritten commits and their descendants get new Git IDs, so test it in an isolated clone and coordinate the cutover.
 
-## Compare control and recovery boundaries
-
-Hosted Git LFS delegates service availability, quotas, and retention behavior to the forge provider. Self-managed LFS gives you control but adds a service to deploy and recover.
-
-Crab delegates durability to your object-store provider and keeps repository coordination in stored metadata. Your team owns bucket access, lifecycle rules, retained recovery roots, and client credential delivery.
-
-The recovery question differs between the systems. Ask where large bytes live, who can restore them, how a deleted ref affects retention, and which logs prove a completed transfer.
-
-## Compare cost with version churn included
-
-Model stored bytes, requests, network transfer, retrieval, service charges, and operator time. Whole-file storage grows with each distinct file object. Native Crab storage grows with chunks that lack durable proof, plus recipe and shard metadata.
-
-The difference is workload-dependent. Two compressed or encrypted versions may share little physical content, so chunking cannot create savings from semantic similarity. Two checkpoints with stable byte regions may reuse most chunks even though the full-file hashes differ.
-
-Object-store request economics matter as well. Crab packs chunks into xorbs so hydration can coalesce ranges, but a sparse workload can still issue more requests than a single whole-file download. Hosted LFS bandwidth may include egress or enforce quotas, while a self-owned bucket exposes provider-specific transfer prices.
-
-Measure two versions, a cold clone, a warm read, and the expected retention period. Projecting cost from the first upload alone hides the version behavior that separates the systems.
-
-## Compatibility and migration are separate decisions
-
-Crab's `crab lfs` commands support an interoperability path for Git LFS workflows. This is useful when a repository must continue to work with existing LFS pointers or automation.
-
-A full native conversion is a different operation. `crab lfs migrate export --to-crab` rewrites selected LFS history into Crab-managed pointers, so it requires planning, coordination, and verification. Compatibility lets a team bridge systems; migration changes repository history.
+<LfsMigrationDiagram />
 
 ## Run a two-version pilot
 
-Test more than one initial upload. Choose a repository slice with ordinary source, one frequently changed binary, and one stable large asset.
+<FlowSteps
+  title="A comparison that exposes the real difference"
+  steps={[
+    "Push the same source tree and 8 GB model from an empty cache.",
+    "Clone from another machine and materialize only encoder.safetensors.",
+    "Create version 2 with the same training or export process used in production.",
+    "Push again; record uploaded bytes, requests, elapsed time, and local disk use.",
+    "Reconstruct both versions from a fresh client and compare their cryptographic hashes.",
+  ]}
+/>
 
-Evaluate both systems with the same sequence:
+Also record setup time, credential delivery, quota visibility, and recovery from an interrupted push. Those results often decide the system before raw transfer speed does.
 
-1. Publish the initial files from an empty client cache.
-2. Clone on another machine and materialize only the required paths.
-3. Change a representative region in the frequently updated file.
-4. Publish the second version and record uploaded bytes and requests.
-5. Reconstruct both versions and compare their cryptographic hashes.
-6. Simulate a stale push or interrupted transfer and record the recovery path.
+## Choose in 30 seconds
 
-Include operational effort in the result. A transfer saving does not compensate for a credential flow the team cannot maintain. A hosted workflow advantage may outweigh storage savings for a smaller repository.
+Choose **Git LFS** when your forge's LFS service is the easiest boundary to operate, existing tools require LFS pointers, and large files change infrequently.
 
-## Turn the pilot into a decision record
+Choose **Crab** when versions share substantial encoded bytes, the team wants data in its own bucket, or contributors should hydrate and mount only what they need.
 
-Record the result in terms that another reviewer can challenge. Include repository size, number of managed files, changed-byte pattern, measured upload and hydration bytes, request counts, local disk use, and the tested failure scenarios.
+Choose **a pilot** when files are compressed, encrypted, or regenerated. Their extensions cannot tell you how many bytes will survive between versions.
 
-Then document the non-performance constraints:
-
-- **Integration**: which forges, build systems, release tools, and developer environments must understand the pointer path
-- **Ownership**: who operates the endpoint or bucket policy and who responds to access failures
-- **Recovery**: which refs and historical objects remain recoverable after branch deletion
-- **Security**: how clients authenticate, how access is revoked, and where reads and writes are audited
-- **Migration**: whether existing commit identities and LFS pointers must remain stable
-
-A written record prevents one impressive transfer number from deciding the architecture. It also gives the team a baseline to revisit when repository churn, provider pricing, or forge limits change.
-
-<TakeawayBox title="Choose from constraints">
-  Use Git LFS when hosted integration and ecosystem compatibility dominate. Use
-  Crab when chunk reuse, direct bucket ownership, and selective hydration
-  dominate.
+<TakeawayBox title="Use the second version to decide">
+  The first 8 GB upload looks similar. The next realistic version reveals the
+  reuse, transfer, checkout, and operating model you will pay for every day.
 </TakeawayBox>
 
-If Crab matches your constraints, continue with [How do you set up a Crab repository?](/blog/getting-started-crab). If you already use LFS, read [How do you move a Git LFS repository to Crab?](/blog/git-lfs-compatibility-layer) before changing history.
+If Crab fits, continue with [How do you set up a Crab repository?](/blog/getting-started-crab). If you already use LFS, read [How do you move a Git LFS repository to Crab?](/blog/git-lfs-compatibility-layer) before changing history.

--- a/packages/web/content/blog/distributed-locking-consistency.mdx
+++ b/packages/web/content/blog/distributed-locking-consistency.mdx
@@ -1,211 +1,194 @@
 ---
 title: "How does Crab keep concurrent pushes consistent?"
-description: "See how ref-scoped leases, expected-old comparisons, immutable uploads, and journals prevent concurrent writers from losing history."
+description: "Follow two writers through ref leases, immutable uploads, expected-old checks, and one atomic visibility marker."
 date: "2026-07-17"
 author: "Crab Team"
 category: "architecture"
 tags: ["concurrency", "consistency", "locking", "push"]
-excerpt: "A lock reduces contested work, while the expected-old ref transaction provides the final lost-update protection."
+excerpt: "A ref lease reduces overlapping work. The expected-old transaction prevents stale writers from replacing newer history."
 level: "deep-dive"
 path: "advanced-operations"
 order: 1
 concepts: ["concurrency", "lease locks", "compare-and-swap", "journals"]
 prerequisites: ["What happens during a Crab push?"]
-outcome: "Explain which mechanism provides liveness, recovery, and final ref correctness."
-diagramType: "Interactive concurrent push trace"
+outcome: "Distinguish lock contention, stale-ref rejection, and the transaction that makes a complete push visible."
+diagramType: "Interactive concurrent push signal box"
 meta:
   contentType: "Conceptual"
-  goal: "Separate the roles of locking, immutable storage, journaling, and compare-and-swap."
-  audience: "Operators and developers reasoning about concurrent writers."
+  goal: "Explain consistency through one same-ref race instead of a catalog of coordination mechanisms."
+  audience: "Developers diagnosing waiting or rejected pushes."
 ---
 
-Without a central Git server, no permanent process serializes branch updates. Crab coordinates clients with a ref-scoped lease, immutable object uploads, a write journal, and an expected-old ref transaction.
+Alice and Bob both fetch `main` at commit `A`.
 
-<BlogProcessPlayer story="locking" />
+Alice creates `B`. Bob creates `C`. Both try to push.
 
-## The lock reduces wasted contention
+Crab must never silently let the last network request erase the first published commit.
 
-A push acquires a renewable lease for its destination ref. A second writer targeting the same ref waits instead of repeating all contested discovery and publication work at the same time.
+The core rule is:
 
-The scope matters. Writers targeting different refs can continue independently. Every acquired lease must be released on a normal exit, and expiration allows progress if a client disappears.
+> A lease decides who works now. An expected-old comparison decides whether that work is still current.
 
-The lease is not the final correctness proof. Networks pause, processes stall, and leases can expire. Ref correctness must survive those events.
+## Run the race
 
-Lease acquisition records a holder identity and expiration time at a ref-scoped location. The holder renews before expiration while it performs contested work. Other writers observe the lease and wait with bounded backoff.
+Choose who wins—or let Alice pause beyond her lease:
 
-The lease duration must cover normal renewal jitter without blocking recovery for an excessive period after a crash. A slow upload does not require one fixed lease that lasts for the complete push because the active holder can renew it.
+<ConcurrentPushRaceBoard />
 
-Every exit path attempts release, including discovery errors, upload failures, stale-ref rejection, and successful publication. Expiration remains the recovery path when the process cannot perform cleanup.
-
-## Renewal failure changes liveness before correctness
-
-A writer can lose the ability to renew while it still has local CPU and disk access. It may finish hashing or uploading immutable objects, but it can no longer assume exclusive access to the destination ref.
-
-The client should treat a lost lease as a signal to stop contested publication work or reacquire current coordination. Even if it continues reusable immutable preparation, the final ref edit still needs a current expected-old comparison.
-
-A process pause creates the same shape. The writer may wake after another client acquired the expired lease and published. Expected-old rejects the resumed stale plan.
-
-This separation keeps lease timing out of the permanent history contract. Clock skew, scheduler pauses, and delayed renew responses can reduce throughput without authorizing a lost update.
-
-## Same-ref and different-ref writers behave differently
-
-Alice and Bob can upload immutable data concurrently when they target different branches. Their ref transactions name separate keys, so neither branch decision needs to serialize the other.
-
-When both target `main`, the first lease holder performs the contested publication work. The second writer waits, then must observe the branch state after the first writer finishes.
-
-Shared immutable objects can still help both writers. If their files contain identical chunks, one writer's completed xorb upload may satisfy part of the other's later closure proof.
-
-Repository-wide maintenance can introduce a broader coordination boundary. Garbage collection and history maintenance need to avoid classifying objects while a push is preparing new reachability. Those operations use maintenance policy in addition to the per-ref writer lease.
-
-The narrower ref lock remains useful because ordinary branch writes should not serialize unrelated refs. A release branch and a feature branch can progress while sharing immutable content and canonical metadata.
-
-## Immutable uploads are safe before the decision
-
-Git packs, xorbs, and shards are immutable. A writer can upload them while readers continue to see the old branch tip.
-
-If the writer later loses the race, those objects do not corrupt history because no committed ref transaction names the rejected update. Another push may reuse them, or garbage collection may reclaim them after the protection window.
-
-This property narrows rollback. Crab does not need to delete every uploaded object when a ref conflict occurs. Immediate deletion could race with another writer that already reused the same immutable object.
-
-The safe response is to leave unreferenced preparation data in storage. Retained roots and the garbage-collection grace period decide when deletion becomes safe.
-
-Immutable identity also reduces coordination scope. Writers do not need one global lock to create a xorb or Git pack whose name derives from its content. They need coordination when updating mutable indexes, journals, and refs that expose relationships to those objects.
-
-When two writers upload the same immutable identity, provider preconditions and content verification ensure that neither can replace it with different meaning. The duplicate work costs requests, but it does not create two conflicting versions behind one key.
-
-## Expected-old prevents lost updates
-
-Each ref edit carries the value the writer observed when planning the push. At publication time, Crab compares the current branch value with that expected old object ID.
-
-If they differ, another writer changed the branch. Crab rejects the stale edit instead of silently replacing the newer tip. The writer must fetch, rebase or merge, and prepare a new update against current state.
-
-Compare-and-swap also handles lease loss. A paused writer may resume after its lease expired and another client published. Its expected-old value still names the earlier tip, so the final transaction rejects the stale plan.
-
-## Follow Alice and Bob through one race
-
-Alice and Bob both fetch `main` at commit `A`. Each creates a different commit and records `A` as the expected-old value.
-
-1. Alice acquires the `main` lease and prepares immutable dependencies for commit `B`.
-2. Bob waits for the same ref lease. He may prepare unrelated local staging, but he cannot publish `main`.
-3. Alice proves closure, compares `main` with `A`, and commits `A → B`.
-4. Alice releases the lease. Bob acquires it and rereads canonical branch state.
-5. Bob's plan still expects `A`, while `main` now names `B`. His update is rejected.
-6. Bob fetches `B`, rebases or merges his work, restages changed managed files, and creates a new expected-old plan.
-
-If Alice's lease expires before step 3 and Bob publishes first, the object IDs reverse but the result does not. The later stale expected-old comparison rejects whichever writer planned against the old tip.
-
-No silent overwrite occurs, and immutable data from the rejected plan can remain available for the reconciled retry.
-
-<TakeawayBox title="Correctness does not depend on the lease">
-  The lease narrows contention. The expected-old comparison prevents a stale
-  writer from overwriting a newer ref.
-</TakeawayBox>
-
-## The journal makes interruption legible
-
-A write journal records progress through the transaction. After an interruption, Crab can distinguish uploaded immutable dependencies from the uncommitted ref edit.
-
-A retry can reuse durable work and repeat incomplete steps. It still has to prove closure and compare against the current ref before publication.
-
-The journal cannot authorize publication by itself. It records what the client attempted and which immutable work completed. Current canonical state still decides whether each dependency exists and whether the ref comparison succeeds.
-
-Useful journal states distinguish planned work, completed immutable uploads, published metadata, successful closure, and committed ref outcome. A restart can resume from the last proven boundary while rechecking canonical storage.
-
-The journal must not record “published” before the ref transaction commits. Otherwise, a crashed writer could convert an intention into false history during recovery.
-
-Journal retention also needs policy. Active and recent records support retries and diagnosis. Old completed records can be compacted after their ref outcomes and recovery roots remain represented in canonical state.
-
-## Correctness comes from a chain of checks
-
-No single mechanism proves the complete push:
-
-| Mechanism | Protects | Does not prove |
-| --- | --- | --- |
-| Ref lease | Same-ref work is less likely to overlap | The writer still has current history |
-| Immutable identity | Retried uploads keep the same meaning | A ref reaches the object |
-| Write journal | Completed preparation can be recovered | The ref transaction committed |
-| Pointer closure | Managed dependencies are durable | The branch has not changed |
-| Expected-old comparison | The ref plan is current | Managed dependencies are complete |
-| Ref transaction | One complete state becomes visible | Later cleanup succeeded |
-
-The writer needs closure and freshness at the publication boundary. Removing either check creates a different failure: complete but stale history, or current history with missing bytes.
-
-## Readers observe complete states
-
-Readers resolve the committed ref journal, not a writer's temporary plan. The old tip remains visible until the transaction that names the new tip is committed.
-
-This creates a narrow state transition:
+When Alice publishes `A → B`, Bob's original plan does not become `B → C` automatically. It still says:
 
 ```text
-before: ref A -> complete Git and Crab dependencies
-after:  ref B -> complete Git and Crab dependencies
-never:  ref B -> missing xorb or shard dependency
+expected old: A
+new:          C
 ```
 
-Readers may begin before or after the transaction, but they resolve one committed ref state. They do not combine the old branch value with the new writer's temporary metadata.
+The current ref says `B`, so `A ≠ B`. Crab rejects Bob's stale edit.
 
-Object-store consistency and journal interpretation must preserve this rule. A reader that cannot prove a committed state returns an error instead of inventing a partial view.
+That rejection is success: the lost-update guard worked.
 
-Readers do not acquire the writer lease for ordinary ref discovery. They resolve committed state and immutable dependencies, which allows reads to continue while a writer prepares the next update.
+## The lease limits overlapping work
 
-After the ref transaction, a new reader can discover the new tip because closure already succeeded. A reader that began from the old tip can finish that operation against immutable objects without having its data replaced underneath it.
+The lock key is scoped to a full ref:
 
-## Common interruptions preserve the previous tip
+```text
+repo/locks/refs/heads/main/lock
+```
 
-| Interruption | Lock outcome | Ref outcome | Recovery |
-| --- | --- | --- | --- |
-| Client exits before upload | Lease releases or expires | Old tip remains | Restart discovery |
-| Network fails during xorb upload | Lease may expire | Old tip remains | Reuse durable objects and retry |
-| Client pauses past lease expiry | Another writer may proceed | Stale compare fails | Fetch and replan |
-| Ref changes before compare | Lease holder has stale input | Push is rejected | Rebase or merge |
-| Cleanup fails after commit | Lease may need expiry | New complete tip remains | Finish cleanup without ref rollback |
+Writers for `main` serialize. A writer for `release` can proceed independently because it owns a different mutable key.
 
-The table separates liveness from correctness. Lease cleanup determines how soon another writer can proceed. The committed ref transaction determines which history readers observe.
+The stored `PushLockPayload` contains three important fields:
 
-## Respond to a conflict as a Git conflict
+```json
+{
+  "holder": "alice-7f3a",
+  "expires_at": 1700000300,
+  "lease_secs": 300
+}
+```
 
-When a push reports a stale expected value, do not delete remote state or force the ref without understanding the newer commit. Fetch the current branch, reconcile history, and retry.
+The default lease is five minutes. The holder can renew it. If the process disappears, expiry lets another writer reclaim the slot.
 
-The immutable uploads from the rejected attempt are not evidence of a half-published branch. Visibility remains tied to the ref transaction.
+Inspect that state over time:
 
-Use this retry sequence:
+<LeaseClockInspector />
 
-1. Record the rejected destination and expected-old object ID.
-2. Fetch the destination ref and inspect the new commits.
-3. Rebase or merge the local source and pointer changes.
-4. Restage any managed files whose content changed during reconciliation.
-5. Push again and require a fresh pointer-closure proof.
+Renew and release operations check both the stored object version and holder identity. Alice cannot wake late and release a slot that Bob already reclaimed.
 
-Avoid an automatic unbounded retry loop. A repeated conflict can indicate an active writer, an expired credential flow, or a process that keeps planning from stale state.
+Crab uses backend-authored object time to judge current lease age. Client clock skew may hurt diagnostics, but it does not get to invent ownership.
 
-Do not delete the rejected writer's uploaded xorbs or packs as conflict cleanup. Another branch, another writer, or the reconciled retry may already reference the same immutable identities. Garbage collection has the complete retained-root view required to make that decision later.
+## Losing the lease is not losing history
 
-Force push remains a deliberate history operation. It can change ancestry rules when policy permits, but it still needs durable dependency closure and a current ref transaction. Force does not turn incomplete large-file data into a valid branch state.
+A paused writer may still have CPU, disk, and network access after its lease expires. It can finish useful immutable preparation, but it cannot assume it still owns `main`.
 
-## Bound contention instead of hiding it
+If another writer publishes first, expected-old catches the stale plan at the final boundary.
 
-Waiting writers should use bounded backoff and expose wait duration. Immediate tight retries add object-store traffic and can starve the current holder. Unbounded silent waits make a failed holder look like a hung Git command.
+This separation is deliberate:
 
-Set an operational timeout that reports the destination ref, observed lease age, and safe next action. The timeout should not delete the lease record unless the expiration contract proves it is no longer valid.
+| Mechanism       | Protects                       | Cannot prove                         |
+| --------------- | ------------------------------ | ------------------------------------ |
+| Ref lease       | less overlapping same-ref work | branch history is still current      |
+| Expected-old    | no stale ref replacement       | large-file dependencies are complete |
+| Pointer closure | every dependency is durable    | nobody changed the ref               |
 
-High same-ref contention can indicate workflow design rather than a locking defect. Automation that publishes every artifact to one branch may benefit from per-run refs followed by an explicit promotion step.
+A valid publication needs both closure and freshness.
 
-Different-ref parallelism should remain visible in metrics. A repository with active feature branches can have high total write throughput while `main` remains deliberately serialized at publication.
+## Immutable uploads can happen before the decision
 
-## Monitor leases without treating them as history
+Packs, xorbs, and shards are content-addressed and immutable. Alice can upload B's dependencies while readers still see A.
 
-Lease metrics should include acquisition time, wait duration, renewal failures, holder age, and release outcome. These values diagnose contention and abandoned work.
+If Alice later loses the race, those objects do not corrupt `main`. No committed ref transaction names them. A retry may reuse them, another branch may reference them, or garbage collection may remove them after its protection window.
 
-Ref metrics should separately include compare conflicts, committed transactions, rejected destinations, and recovery-journal resumes. Mixing the groups can make a healthy stale-write rejection look like lock corruption.
+Do not delete those uploads as conflict cleanup. Immediate deletion could race with another writer that already reused the same object.
 
-Alert on leases that remain past their expected renewal window and on repeated same-ref conflicts. Do not alert on every immutable orphan because interrupted preparation can create safe short-lived orphans by design.
+The safe visibility sequence is narrower than the complete push:
 
-Test the monitoring with controlled failures. Terminate a writer after lease acquisition, pause a writer past expiration, and start two writers from the same old tip. Confirm that dashboards separate wait time, lease recovery, stale-ref rejection, and published transactions.
+1. Upload immutable dependencies.
+2. Prove pointer and Git-object closure.
+3. Prepare ref heads against their observed versions.
+4. Publish one active transaction marker.
+5. Compact derived manifest state later.
 
-The expected outcome is not zero conflicts. A rejected stale writer is evidence that the final guard worked. The concerning outcomes are silent ref replacement, a lease that never becomes recoverable, or a visible ref whose dependencies fail closure.
+Move through the sequence below:
 
-Keep journal and ref evidence for repeated conflict incidents. The sequence should show which object ID each writer observed, which lease it held, which immutable work completed, and which expected-old comparison committed or failed.
+<RefVisibilitySignal />
 
-That evidence separates an application-level merge conflict from storage or coordination corruption. Two valid competing commits are normal. A ref transaction that cannot explain its previous value is not.
+The marker is the atomic visibility boundary. Before it exists, readers resolve A. After it exists, readers can resolve B and the complete dependency set recorded by the transaction.
+
+Head promotion and manifest compaction happen afterward. They make reads cheaper; they do not turn an already committed B back into A when cleanup fails.
+
+## The journal makes interruption understandable
+
+The ref journal separates prepared work from committed visibility.
+
+One transaction records:
+
+- parent transaction for each edited ref
+- `old_oid` and `new_oid`
+- new immutable Git packs
+- new shard identities
+- the lease holder that crossed the publication boundary
+
+On restart, Crab can tell whether objects were merely uploaded, heads were prepared, or the active marker committed.
+
+The journal cannot authorize a stale retry. Recovery still rereads canonical ref state and checks expected-old.
+
+## Readers see complete states
+
+Readers do not take the writer lease. They resolve committed ref-journal state and immutable dependencies.
+
+```text
+before marker: main → A → complete A closure
+after marker:  main → B → complete B closure
+never:         main → B → missing B xorb
+```
+
+A reader that started at A can finish against immutable A objects while Alice prepares B. New readers switch only at the committed marker.
+
+## Recover from a rejected push
+
+Treat a stale expected value like a normal Git conflict:
+
+```bash
+git fetch origin
+git rebase origin/main
+git push origin main
+```
+
+If reconciliation changes a Crab-managed file, restage its new content before retrying:
+
+```bash
+crab add models/encoder.safetensors
+git add models/encoder.safetensors
+git commit --amend --no-edit
+git push origin main
+```
+
+Do not force the ref just to silence the conflict. Force push can change ancestry policy when intentional, but it still needs current publication state and complete Crab dependencies.
+
+## Read failures by boundary
+
+| Signal                       | Meaning                                        | Safe response                              |
+| ---------------------------- | ---------------------------------------------- | ------------------------------------------ |
+| Lock held                    | another writer currently owns the ref slot     | wait with bounded backoff                  |
+| Lease renewal failed         | this writer may no longer own publication work | stop or reacquire current coordination     |
+| Expected-old mismatch        | the branch changed after planning              | fetch, rebase or merge, then retry         |
+| Closure failure              | a required pack, shard, or xorb is not durable | repair the dependency; do not move the ref |
+| Cleanup failure after commit | derived state needs repair                     | keep the new committed tip; finish cleanup |
+
+Do not collapse these into “push failed.” Lock waiting is liveness. Expected-old is freshness. Closure is completeness.
+
+## Monitor the two stories separately
+
+For leases, measure acquisition time, wait duration, renewal failure, holder age, and release outcome.
+
+For refs, measure expected-old conflicts, committed transactions, rejected destinations, and journal recovery.
+
+A stale push rejection can coexist with a healthy lock system. The concerning outcomes are a lease that never becomes reclaimable, a silent ref replacement, or a visible ref whose dependency closure fails.
+
+<TakeawayBox title="The lock is not the final guard">
+  The lease narrows contention. Closure proves the data. Expected-old prevents a
+  stale writer from replacing newer history. The transaction marker makes that
+  complete state visible.
+</TakeawayBox>
 
 Next, [choose how much repository content should become local](/blog/lazy-checkout-fuse).

--- a/packages/web/content/blog/first-crab-push.mdx
+++ b/packages/web/content/blog/first-crab-push.mdx
@@ -1,206 +1,159 @@
 ---
 title: "How do you verify your first Crab push?"
-description: "Trace one tracked file through the Git index, object storage, a fresh clone, hydration, and integrity checks."
+description: "Push one 64 MiB sample, inspect its Git pointer, confirm the remote ref, then hydrate and hash-check it from a fresh clone."
 date: "2026-05-29"
 author: "Crab Team"
 category: "tutorial"
 tags: ["beginner", "tutorial", "verification"]
-excerpt: "A hands-on push that proves the Git pointer and stored large-file data agree."
+excerpt: "Five visible checks prove that one tracked file reached the remote and came back byte-for-byte."
 level: "beginner"
 path: "first-workflow"
 order: 2
 concepts: ["push", "verification", "pointer", "hydration"]
 prerequisites: ["How do you set up a Crab repository?"]
 outcome: "Prove that one tracked file was filtered, uploaded, published, cloned, and reconstructed correctly."
-diagramType: "Push verification"
+diagramType: "Interactive push trace"
 meta:
   contentType: "Tutorial"
   goal: "Teach a source-to-result verification loop for a first Crab push."
   audience: "New Crab users who want evidence that each integration boundary works."
 ---
 
-A successful `crab push` has more than one visible result. Git must record a pointer, object storage must contain the referenced data, the remote ref must advance, and another checkout must reconstruct the original bytes.
+A progress bar only proves that Crab did some work. A verified push needs five visible results: **Git stores a pointer, Crab publishes the branch, a fresh clone finds that pointer, hydration rebuilds the file, and the rebuilt bytes match the original.**
 
 <FirstPushStateDiagram />
 
-## Establish the pre-push state
+## 1. Start from a clean test branch
 
-Begin from a clean branch whose remote tip you know. This makes the later ref result attributable to the test instead of an unrelated local change.
+Use a configured repository and keep this first test away from a shared production branch.
 
 ```bash
 git status --short
-git branch --show-current
-git rev-parse HEAD
-git ls-remote origin "refs/heads/$(git branch --show-current)"
 crab doctor
+export CRAB_VERIFY_REMOTE="$(git remote get-url origin)"
+git switch -c verify-crab-push
 ```
 
-The worktree should be clean before you create the sample file. The local and remote object IDs should agree when the branch already exists. If they differ, fetch and reconcile that history before using the push as a storage test.
+If `git status --short` prints anything, commit or stash it first. Fix any `crab doctor` failure before creating test data.
 
-Save the pre-push commit ID with the test evidence. It becomes the expected-old value that explains whether Crab advanced the intended branch state or rejected a stale writer.
+The `CRAB_VERIFY_REMOTE` variable keeps the same remote URL for the fresh-clone check later. Run the tutorial in one shell so the variable remains available.
 
-## Prepare a deterministic test file
+## 2. Create one file with a known hash
 
-Start in a configured repository with a tracked `*.bin` pattern. Create a file and record its BLAKE3 hash outside the repository so you can compare it after hydration.
+This sample is deliberately simple. It proves the storage path, not real-world deduplication performance.
 
 ```bash
 mkdir -p models
-dd if=/dev/zero of=models/checkpoint.bin bs=1m count=64
-b3sum models/checkpoint.bin > ../checkpoint.b3
-crab track '*.bin'
+dd if=/dev/zero of=models/checkpoint.bin bs=1048576 count=64
+git hash-object models/checkpoint.bin > ../checkpoint.git-hash
 ```
 
-If `b3sum` is unavailable, use another cryptographic hash tool consistently on both copies.
+`git hash-object` gives the file a repeatable content ID using Git's own hashing tool. Saving it outside the repository prevents the evidence file from entering the test commit.
 
-## Verify that Git uses the Crab filter
-
-Ask Git which attributes apply before staging the file:
+Now route `.bin` files through Crab:
 
 ```bash
-git check-attr filter diff merge -- models/checkpoint.bin
+crab track '*.bin'
+git add .gitattributes
+git check-attr filter -- models/checkpoint.bin
 ```
 
-The filter attribute should resolve to the Crab driver. Now stage the file through Crab and inspect the index object without changing the working-tree file.
+The last command should report `filter: crab`. If it does not, stop here and fix the tracking rule.
+
+## 3. Stage the file and inspect Git's copy
 
 ```bash
 crab add models/checkpoint.bin
 git show :models/checkpoint.bin
 ```
 
-The index output should be a compact pointer, not 64 MiB of zero bytes. Your working tree still contains the materialized file.
+The output should be a short text pointer with a version, `file-hash`, and `size`. Your working-tree file remains 64 MiB; only Git's staged representation is small.
 
-Inspect the pointer as data, not as an opaque success marker. It should record a supported pointer version, the expected file identity, and the decimal size. The full file hash must describe the working-tree bytes you staged.
+If `git show` emits binary data, do not commit it. The file missed the Crab filter.
 
-The pointer does not need to record every chunk location. Chunk placement can change through packing or repair while the committed file identity remains stable. Local staging connects this new pointer to its complete recipe until push makes that recipe durable for other clients.
+| Surface | What should exist now |
+| --- | --- |
+| Worktree | Complete 64 MiB file |
+| Git index | Compact Crab pointer |
+| Local Crab staging | Chunks and the reconstruction recipe |
+| Remote | Nothing from this new commit yet |
 
-If `git show :models/checkpoint.bin` emits the complete binary, stop before committing. The path did not take the Crab clean path, and a later push cannot retroactively turn that Git blob into a pointer.
-
-## Commit and push
-
-Commit the pointer and publish through Crab:
+## 4. Commit and publish
 
 ```bash
-git commit -m "Add checkpoint"
-crab push origin main
+git commit -m "Verify first Crab push"
+crab push
 ```
 
-The push stages and flushes large-file data before it publishes metadata and advances the branch ref. If the process fails before the ref update, readers continue to see the previous complete state.
+Step through the trace below. Crab uploads immutable Git and large-file data, verifies that the pointer can be reconstructed, and only then advances the branch.
 
-Capture the process exit status and the final ref result. Progress bars and uploaded-byte counts describe preparation, while the ref outcome describes publication. An interrupted command can upload reusable immutable objects without changing the branch.
+<GitArchitecturePlayer story="push" />
 
-After success, compare the new local commit with `git ls-remote`. Matching object IDs prove that remote discovery reports the new Git state. They do not yet prove that a different client can hydrate the managed file, which is why the fresh-clone step remains required.
+Check the two commit IDs:
 
-## Interpret the push as three proofs
+```bash
+git rev-parse HEAD
+git ls-remote origin refs/heads/verify-crab-push
+```
 
-The command output describes work, but the underlying result has three independent proofs. Git connectivity proves that the new commit, tree, and blobs exist at the origin. Pointer closure proves that every Crab pointer resolves to durable metadata and xorb data. The expected-old comparison proves that the branch still names the base commit you planned against.
+The hashes should match. That proves the remote branch names your commit—but not yet that another client can reconstruct the file.
 
-A successful upload without a ref update is not a published push. A visible Git commit without pointer closure would be unsafe, so Crab blocks that state. A stale expected-old value means another writer published first, even if your immutable uploads completed.
-
-Use the error boundary to choose the next action:
-
-- **Discovery error**: restage the tracked file so its pointer has a complete local recipe
-- **Object-store error**: restore credentials or connectivity, then retry the immutable upload
-- **Closure error**: run `crab fsck` and repair missing remote dependencies before publication
-- **Ref conflict**: fetch the current branch, reconcile Git history, and retry against the new tip
-
-Do not force a branch update to bypass a missing large-file dependency. Force changes ref ancestry rules, not pointer durability requirements.
-
-## Check the repository state
-
-Run local diagnostics after the push:
+Run the repository checks:
 
 ```bash
 crab status
-crab doctor
 crab fsck
 ```
 
-`crab status` reports tracked-file state. `crab doctor` checks configuration and access. `crab fsck` performs repository integrity checks against the stored metadata and data paths.
+`crab status` checks the tracked file's local state. `crab fsck` checks pointer, metadata, chunk, and remote-object relationships.
 
-These commands answer different questions. A clean `crab status` means the worktree agrees with its committed representation. A passing `crab doctor` means the current environment can reach its configured boundaries. A passing `crab fsck` tests repository relationships beyond the current working-tree file.
+## 5. Prove it from a fresh clone
 
-Keep the first failure from each command. Later errors may be consequences of the same missing credential, pointer recipe, shard, or object range.
-
-## Clone and reconstruct the file
-
-Use a separate directory so local caches cannot hide a remote-storage problem.
+Leave the writer repository. Clone the test branch lazily so the new worktree starts with the pointer:
 
 ```bash
 cd ..
-crab clone crab://team-data/vision-search vision-search-verify
+crab clone --branch verify-crab-push "$CRAB_VERIFY_REMOTE" vision-search-verify
 cd vision-search-verify
 crab status
-crab hydrate 'models/checkpoint.bin'
-b3sum --check ../checkpoint.b3
 ```
 
-The final hash check proves that hydration reconstructed the same bytes that entered the original repository.
-
-## Prove that the test did not use writer-only state
-
-A second directory on the same machine is better than the original worktree, but it may still share process caches, provider credentials, or a configured shared cache. For stronger evidence, use a clean container, runner, or another machine with its own Crab cache directory.
-
-The reader needs only the published repository state and authorized object access. It must not receive the writer's staging directory or temporary reconstruction output. If hydration works only after copying local Crab state, the remote repository is incomplete.
-
-Run one controlled negative check as well. Remove access from the isolated reader or point it at an unauthorized prefix, then confirm hydration fails without replacing the pointer with partial bytes. Restore the correct credentials and rerun the same hydration successfully.
-
-This check proves that errors stay visible at the data boundary. It also confirms that the test environment reads the configured origin instead of an unintended local copy.
-
-## Verify a changed version as well
-
-One file version proves transport. A second version proves that the repository can preserve history and reuse content without confusing file identities.
-
-Modify or replace part of the source file, then repeat the explicit workflow:
+`crab status` should mark `models/checkpoint.bin` as a pointer. Materialize only that file:
 
 ```bash
-crab add models/checkpoint.bin
-git commit -m "Update checkpoint"
-crab push origin main
-crab stat perf
+crab hydrate models/checkpoint.bin
+test "$(git hash-object models/checkpoint.bin)" = "$(cat ../checkpoint.git-hash)" \
+  && echo "hash matches"
 ```
 
-Save the second BLAKE3 hash under a different evidence file. A fresh clone should be able to hydrate either commit after checkout, subject to your retained-history policy.
+The final line should print `hash matches`. That is the end-to-end proof: the reader reconstructed the same bytes without the writer's staging directory.
 
-```bash
-git checkout HEAD~1
-crab hydrate 'models/checkpoint.bin'
-b3sum models/checkpoint.bin
+<HydrationPlanDiagram />
 
-git checkout main
-crab hydrate 'models/checkpoint.bin'
-b3sum models/checkpoint.bin
-```
+For stronger evidence, repeat the clone in a clean container, runner, or another machine. A second directory on the writer's machine may still share credentials or an optional cache.
 
-The two hashes should match the corresponding source versions. The amount uploaded for the second version may be lower when the physical bytes overlap.
+## When a check fails
 
-## Capture evidence suitable for automation
+| Failure | Next action |
+| --- | --- |
+| `git check-attr` does not report Crab | Run `crab track '*.bin'`, inspect `.gitattributes`, then check the path again |
+| The staged Git object is the full binary | Stop before committing; rerun `crab doctor` and restage after fixing the filter |
+| `crab push` reports credentials or storage access | Fix the boundary reported by `crab doctor`, then rerun `crab push` |
+| The local and remote commit IDs differ | Fetch and reconcile the branch; do not force past a stale ref |
+| Hydration fails or the hash differs | Run `crab fsck`; the repository is not verified |
 
-Manual inspection helps during setup, but automated environments need structured results. Crab commands that support `--json` or `--jsonl` can feed build logs and policy checks without parsing human prose.
-
-Record the commit object ID, destination ref, Crab command version, original file hash, hydration hash, and `crab fsck` result. Keep credentials and signed URLs out of the artifact.
-
-This evidence distinguishes a Git-only success from an end-to-end repository success. A green pipeline should mean another client can discover the commit and reconstruct its managed files.
-
-Use separate fields for source bytes, uploaded bytes, and hydrated bytes. Deduplication can make the upload smaller than the file, while a cold hydration still reads enough chunk ranges to reconstruct the complete output.
-
-Retain the destination repository identity and ref with the artifact. A hash without its repository and commit context proves byte equality, but it cannot show which published state produced those bytes.
-
-## Clean up without deleting shared proof
-
-After the verification, remove only disposable local clones and sample files that the test created. Do not delete bucket objects by path because xorbs may contain chunks reused by other file versions.
-
-If the tutorial used a dedicated repository prefix, apply repository-scoped retention and garbage collection after the evidence window. Keep the published commits when the test repository will become a fixture for future client or release checks.
+A failed upload may leave complete immutable objects that a retry can reuse. It must not advance the ref to a state with missing reachable data.
 
 ## Keep five pieces of evidence
 
 <ConceptChecklist
   items={[
-    "Git attributes route the path through the Crab filter.",
+    "Git attributes route checkpoint.bin through the Crab filter.",
     "The staged Git object is a compact pointer.",
-    "The push advances the intended remote ref without an integrity error.",
-    "A fresh clone can resolve and hydrate the pointer.",
-    "The hydrated file matches the original cryptographic hash."
+    "The remote branch points to the new commit.",
+    "A fresh clone can hydrate checkpoint.bin.",
+    "The hydrated file has the original Git content hash."
   ]}
 />
 
-This verification isolates the important boundaries. Once it passes, read [How does Crab connect to Git?](/blog/git-remote-helpers-filter-processes) to understand which Git protocols produced each result.
+Once all five pass, the repository has crossed the complete write-and-read path. Continue with [How does Crab connect to Git?](/blog/git-remote-helpers-filter-processes) to see which Git protocols produced each result.

--- a/packages/web/content/blog/garbage-collection-serverless.mdx
+++ b/packages/web/content/blog/garbage-collection-serverless.mdx
@@ -19,192 +19,202 @@ meta:
   audience: "Repository operators reclaiming object-storage capacity."
 ---
 
-Crab creates immutable Git packs, xorbs, and shards. Ref updates can make earlier objects unreachable, and interrupted pushes can leave unreferenced uploads. Garbage collection reclaims only objects that are outside every retained recovery boundary.
+Deleting a branch does **not** mean its 400 GB experiment disappears from
+object storage.
 
-<GarbageCollectionDiagram />
+The branch name may be gone while recovery history still reaches its commits,
+pointers, recipes, and shared xorbs. Crab deletes an object only when two keys
+turn:
 
-## Garbage collection has five explicit phases
+1. No retained root reaches it.
+2. It is older than the grace window.
 
-Repository garbage collection is easier to review as a proof pipeline:
+<GcObjectEvidenceLab />
 
-1. **Snapshot** the repository and maintenance boundary used for classification.
-2. **Enumerate roots** from refs, journals, workflows, and recovery policy.
-3. **Mark dependencies** by walking Git and Crab metadata to immutable objects.
-4. **Classify candidates** by subtracting the marked set and applying age and storage-class rules.
-5. **Delete and reconcile** the approved candidates, then verify repository state.
+## Start with one object
 
-Each phase can stop the operation without making the remaining objects less safe. A failed root read or incomplete listing blocks candidate proof. A partial delete reports progress and leaves the next run to reconcile current storage.
+Consider `xorb d77c…`, a 4.2 GB immutable object.
 
-Dry run executes the reasoning without the destructive phase. Treat its output as the review artifact for the later apply.
+Crab first builds a **root set** from current refs, the ref journal, workflow
+artifacts, and recovery history. It walks each pointer through its file recipe
+and marks every required xorb.
 
-## Mark starts from more than current branches
+Then it compares the complete storage listing with that mark set:
 
-The live set includes the current repository state, the ref journal, workflow artifact roots, and immutable recovery roots. Crab walks those roots through shards and file recipes to mark every referenced data object.
-
-Historical roots used by `crab recover history` are retained without a time or count limit by default. Deleting a branch therefore does not imply that all associated objects become immediate GC candidates.
-
-The walk follows both data lanes. Git roots reach commits, trees, packs, and pointer blobs. Each pointer reaches a file recipe, shard terms, and xorb ranges. A collector that marked only Git object IDs would miss the large-file closure behind those pointers.
-
-Shared chunks complicate intuition but not the rule. An xorb remains live when any retained recipe needs one of its chunks. The branch or file that first uploaded it does not own the complete object.
-
-<GarbageCollectionReachabilityDiagram />
-
-## Retained roots express recovery policy
-
-Current branches and tags describe active Git history. The ref journal records committed transitions. Recovery history preserves earlier states that operators may restore after an accidental ref change.
-
-Workflow artifact catalogs can protect data outside the current branch tree. Immutable recovery roots can also preserve objects required by repair and rollback operations.
-
-The collector must take the union of these roots. An xorb referenced by any retained file recipe remains live even if no current branch names the commit that first created it.
-
-## Classification is conservative
-
-An object becomes a candidate only when the complete mark walk cannot reach it. Missing metadata, failed listings, or incomplete repository registration block confident deletion rather than shrinking the live set by assumption.
-
-Repository-scoped collection is the normal operating boundary. Bucket-scoped collection reasons across registered repositories and requires broader coordination and evidence.
-
-Crab takes a snapshot boundary before it classifies objects. Data added after that boundary must not enter the unreachable set because a concurrent push may still be publishing its metadata.
-
-Listing failures also stop confident deletion. An incomplete object listing cannot prove that the mark walk examined the complete namespace.
-
-## The grace window protects concurrent work
-
-A candidate must also be older than the configured grace period. The `crab gc` command defaults to one hour and enforces a one-hour minimum unless force mode is used.
-
-The time check protects uploads created after the collector's snapshot and work that has not yet reached its ref transaction. A longer period can be appropriate for slow or intermittently connected workflows.
-
-Force mode bypasses the age check, but it does not convert unknown reachability into proof. Use it only within a documented maintenance plan with current repository coordination evidence.
-
-Storage classes may add minimum-retention charges. Class-aware garbage collection can retain or report objects whose early deletion would create a provider penalty.
-
-Consider a writer that uploads a xorb after GC takes its snapshot but before the writer publishes shard metadata. The snapshot cannot yet reach that object. The age rule prevents the collector from treating the new upload as an old orphan.
-
-On the next collection, the xorb will either be reachable through the committed writer state or remain an aged orphan after an abandoned push. Only the second case becomes eligible.
-
-Choose a grace period longer than the slowest expected preparation and recovery interval. A one-hour minimum protects the default path, while offline or archival workflows may require a wider policy.
-
-## Preview before deletion
-
-Start with a repository-scoped dry run:
-
-```bash
-crab fsck
-crab gc --scope repo --dry-run
+```text
+listed objects − marked objects = unreachable objects
 ```
 
-Review object counts, bytes, skipped recent objects, and any warning about incomplete proof. Then run the same scope without `--dry-run`:
+Unreachable does not yet mean deletable. Crab applies object age, storage-class
+rules, and current coordination evidence before creating a candidate batch.
 
-```bash
-crab gc --scope repo
-crab fsck
-```
+## Recovery history is still a root
 
-Successful deletions are idempotent. If some object deletion or reconciliation step fails, Crab exits nonzero and reports the partial outcome so rerunning the command is safe.
+Crab retains recovery-history roots without a time or count limit by default.
+That is why deleting `experiment/branch-17` may reclaim nothing.
 
-Before apply, compare the dry-run snapshot inputs with current activity. A long delay between preview and deletion can invalidate the operational review even when the collector will take a new safe snapshot.
+These are separate decisions:
 
-Record the repository identity, scope, grace period, root counts, candidate counts, candidate bytes, and storage-class skips. Approval should name the same scope and policy that the apply command uses.
+| Action                 | What it removes              |
+| ---------------------- | ---------------------------- |
+| Delete a branch        | An active ref name           |
+| Prune recovery history | Supported restore points     |
+| Run GC                 | Unreachable physical objects |
 
-## Read the dry-run result as a proof report
-
-Do not review only the byte total. Inspect how the collector reached that total.
-
-The report should distinguish these classes:
-
-- **Reachable**: protected by a current or retained root
-- **Recent orphan**: unreachable at the snapshot but still inside the grace period
-- **Deletion candidate**: unreachable and old enough for the selected policy
-- **Class-protected**: eligible by reachability but blocked by storage-class rules
-- **Unknown**: not safe to classify because listing or metadata proof failed
-
-A large recent-orphan count can follow an interrupted import or push. A growing reachable set can reflect unlimited recovery history. Unknown objects require investigation before another destructive run.
-
-Save structured dry-run output with the maintenance record. It provides the candidate inventory and policy inputs reviewed before deletion.
-
-## History retention is a separate decision
-
-If recovery history protects more data than your policy requires, preview an explicit retention boundary:
+If the recovery policy needs only the latest 20 generations, preview that
+change first:
 
 ```bash
 crab recover history prune --keep-last 20
 ```
 
-Apply the prune only after review, then run GC again:
+Apply it explicitly, then recalculate garbage:
 
 ```bash
 crab recover history prune --keep-last 20 --apply
 crab gc --scope repo --dry-run
 ```
 
-Pruning recovery roots changes what can be restored. It should be governed as a retention policy, not hidden inside routine storage cleanup.
+Pruning history does not delete xorbs. It removes roots; GC separately proves
+which objects became unreachable.
 
-Branch retention, recovery-history retention, and provider object retention answer different questions. A deleted branch removes an active name. Pruning recovery history removes a supported ref-restoration path. Garbage collection removes unreachable physical objects after proof.
+## Shared data has no single owner
 
-Perform the decisions in that order. Decide what history the product must recover, update retained roots, preview resulting candidates, and only then delete physical data.
+Suppose two repositories reuse chunks stored in `xorb f093…`. Repo `vision`
+can stop referencing it while repo `labs` still needs it.
 
-Signed releases, legal holds, experiment records, and workflow artifacts may need longer retention than ordinary branches. Express those requirements as explicit roots or supported repository policy instead of relying on an operator to remember object names.
+Repository GC stays inside its supported repository boundary. Bucket GC must
+take the union of every registered repository’s marks. Missing one repository
+creates a destructive blind spot, so incomplete registration blocks the run.
 
-## Schedule collection around repository activity
+Use repository scope for routine maintenance. Treat bucket scope as a separate,
+coordinated operation.
 
-Repository GC takes a renewable maintenance lease and cannot overlap conflicting history maintenance. Run it during a window that can tolerate object listings and deletes.
+## The default grace window is 24 hours
 
-Start with a dry run, review unexpected growth, then apply the same scope and policy. Run `crab fsck` afterward so deletion and reconciliation failures remain visible.
+New uploads can exist before their ref transaction publishes. During that gap,
+a storage listing sees the object but the root snapshot cannot reach it yet.
 
-Avoid routine bucket-scope collection unless the operator owns every registered repository in that bucket. Global deduplication means a bucket object may serve several repositories, so incomplete registration can create a destructive blind spot.
+Crab’s configured default grace period is **24 hours**. Non-force runs clamp a
+shorter value to at least one hour.
 
-Track reclaimed bytes, candidates skipped by grace, candidates blocked by storage class, failed deletes, and reconciliation outcome. Trends help distinguish healthy cleanup from a retention policy that never releases old roots.
+```bash
+crab gc --scope repo --grace-period 24h --dry-run
+```
 
-## Use a safety checklist before apply
+Choose a window longer than the slowest expected push or offline workflow.
 
-Confirm these conditions for every destructive run:
+<GcRaceReplay />
 
-- **Scope**: the command targets the intended repository, not an entire shared bucket
-- **Registration**: every repository that can reference shared objects is represented in the mark boundary
-- **Roots**: current refs, recovery history, workflows, and holds are readable
-- **Activity**: maintenance coordination protects current writers and history operations
-- **Age**: the grace period exceeds the in-flight preparation window
-- **Preview**: the reviewed dry run has no unknown classification
-- **Recovery**: operators know which history cannot be restored after deletion
+Two mechanisms protect concurrent work:
 
-Stop when any item is uncertain. Delayed reclamation costs storage. Incorrect reclamation can remove the only durable bytes behind a retained pointer.
+- **Grace:** a recent, unmarked upload stays protected.
+- **Fencing:** writers hold shared admission through publication; destructive
+  GC takes short exclusive sweep fences around reconciliation and delete
+  batches.
 
-## Treat deletion failures as partial progress
+If a writer enters between batches, the writer epoch changes. GC stops before
+another batch instead of trusting an outdated snapshot.
 
-Object stores can accept some deletes and reject others. Crab reports the successful and failed counts, then exits nonzero when repository-scope deletion or reconciliation is incomplete.
+`--force` bypasses the age key only. It does not bypass reachability, registry,
+closure, or coordinator proof.
 
-Do not restore already deleted unreferenced objects merely to make the batch appear atomic. Rerun the idempotent collection after fixing the provider or permission error.
+## Preview the exact repository first
 
-If reconciliation fails after successful deletes, preserve the command output and run integrity checks before the next maintenance action. The repository needs an accurate post-delete view even when every deleted object was a valid candidate.
+Start with integrity verification and structured dry-run output:
 
-Provider versioning or replication can make physical reclamation lag behind the logical delete. Billing inventory may therefore change after the Crab command completes. Measure provider-visible bytes over the lifecycle interval rather than assuming immediate capacity recovery.
+```bash
+crab fsck
+crab gc --scope repo --dry-run --json
+```
 
-Do not interpret a missing candidate on retry as unexplained drift. It may be one of the objects deleted successfully in the earlier partial batch. Reconciliation and structured output should connect that current absence to the completed action.
+A summary includes candidate counts and safety state:
 
-## Verify recovery assumptions after collection
+```json
+{
+  "packs_deleted": 3,
+  "xorbs_deleted": 12,
+  "shards_deleted": 4,
+  "bytes_reclaimed": 21743271936,
+  "dry_run": true,
+  "partial_enumeration": false,
+  "delete_failures": 0,
+  "reconciliation_failed": false
+}
+```
 
-Run `crab fsck` after the apply and hydrate representative current and retained historical files from an isolated client. Integrity checks cover repository relationships, while hydration proves that readable data still backs selected pointers.
+In dry-run mode, “deleted” fields mean **would delete**. Save the repository
+identity, scope, grace period, counts, and bytes with the review.
 
-Include a ref from the oldest supported recovery boundary. A successful default-branch checkout cannot prove that recovery roots retained every older xorb required by policy.
+Do not approve a preview with partial enumeration or unreadable roots. Missing
+evidence protects objects; it never shrinks the live set by assumption.
 
-Also confirm that a known deleted ref outside retention no longer appears as recoverable through the supported history interface. Storage reclamation and recovery behavior should match the policy reviewed before collection.
+## Apply the same policy
 
-Retain the dry run, apply result, integrity result, and provider deletion report as one maintenance record. This evidence connects candidate proof to the final repository state.
+After review, run the same scope without `--dry-run`:
 
-## Explain a dry run that reclaims little data
+```bash
+crab gc --scope repo
+crab fsck
+```
 
-A small candidate set does not mean the collector failed. Current branches may share most xorbs with deleted branches, recovery history may retain earlier commits, or recent interrupted uploads may still be inside the grace period.
+<GcRunPermit />
 
-Break the protected total down by root class and age. This shows whether storage remains because active history uses it, policy retains it, or time-based protection has not expired.
+Keep preview and apply close together. A long delay may change repository
+activity even though the apply run takes a fresh safe snapshot.
 
-Do not shorten the grace period to make one report look productive. Wait for the next safe window or change the documented recovery policy through its own review.
+Use force only for a documented exception:
 
-Provider storage can also remain after successful deletion because versioning, replication, or lifecycle retention preserves physical copies. Compare Crab's logical result with provider inventory after those controls have had time to apply.
+```bash
+crab gc --scope repo --force
+```
 
-The useful outcome is an explainable live set and candidate set. Reclaimed bytes are secondary to proving that every deletion respects repository history and recovery policy.
+The command asks for confirmation unless `--yes` is provided. Recent
+unreachable uploads lose age protection, so current coordination evidence is
+essential.
 
-<TakeawayBox title="Deletion requires two proofs">
-  The object is unreachable from every retained root, and it is older than the
-  protection window. Uncertainty keeps the object.
+## Read partial failure as progress, not success
+
+An object store can accept some deletes and reject others. Crab reports
+successful and failed counts and exits nonzero with `CRAB-E0322` when repository
+deletion or reconciliation is incomplete.
+
+Fix the provider or permission failure, preserve the output, and rerun GC.
+Successful deletes are idempotent; already removed candidates do not need to be
+restored.
+
+Provider versioning, replication, or lifecycle retention can also delay the
+billing change after Crab’s logical delete.
+
+## Why a dry run may reclaim little
+
+A small candidate set is often correct:
+
+- Current branches share most xorbs with deleted branches.
+- Recovery history still retains the old commits.
+- Interrupted uploads remain inside the grace window.
+- Storage-class minimum-retention policy protects early deletion.
+
+Do not shorten the grace window to make the report look productive. Change the
+recovery policy explicitly or wait for the next safe collection window.
+
+## Operator checklist
+
+Before apply, confirm:
+
+- Repository identity and scope are exact.
+- Current refs, journals, workflows, and recovery roots are readable.
+- The reviewed dry run has complete enumeration.
+- The grace window covers the longest expected publication delay.
+- Maintenance coordination can seal the sweep.
+- `crab fsck` is planned after deletion.
+
+If any answer is uncertain, stop. Extra storage is cheaper than deleting the
+only durable bytes behind a retained pointer.
+
+<TakeawayBox title="Deletion requires two keys">
+  The object is unreachable from every retained root, and it is old enough.
+  Unknown evidence keeps the object.
 </TakeawayBox>
 
-Next, [build a cost model before changing storage classes](/blog/cost-optimization-s3-storage).
+For exact flags and structured output, see the [`crab gc`](/docs/cli/reference/crab-gc) reference. Next, [build a cost model before changing storage classes](/blog/cost-optimization-s3-storage).

--- a/packages/web/content/blog/git-lfs-compatibility-layer.mdx
+++ b/packages/web/content/blog/git-lfs-compatibility-layer.mdx
@@ -1,43 +1,42 @@
 ---
 title: "How do you move a Git LFS repository to Crab?"
-description: "Choose between a compatible Crab transfer agent and a coordinated history rewrite from LFS pointers to native Crab pointers."
+description: "Keep existing LFS pointers with Crab's transfer agent, or rewrite selected history into native Crab pointers."
 date: "2026-08-14"
 author: "Crab Team"
 category: "architecture"
 tags: ["git-lfs", "migration", "compatibility", "history-rewrite"]
-excerpt: "Preserve LFS pointers first if you need a low-risk bridge; rewrite history only when the team is ready for new commit identities."
+excerpt: "Use the transfer bridge when commit identity must stay stable. Rewrite history only when native chunk reuse is worth a coordinated cutover."
 level: "intermediate"
 path: "advanced-operations"
 order: 5
 concepts: ["Git LFS", "custom transfer", "migration", ".gitattributes"]
-prerequisites: ["How do you control Crab object-storage cost?", "Should you use Crab or Git LFS?"]
-outcome: "Plan and verify either a compatible LFS transfer path or a native Crab history conversion."
-diagramType: "Migration decision flow"
+prerequisites:
+  [
+    "How do you control Crab object-storage cost?",
+    "Should you use Crab or Git LFS?",
+  ]
+outcome: "Choose, test, and verify either an LFS-compatible bridge or a native Crab conversion."
+diagramType: "Interactive migration lab"
 meta:
   contentType: "How-to"
-  goal: "Separate reversible transfer-agent adoption from coordinated history rewriting."
+  goal: "Show exactly which identities and data structures change on each migration path."
   audience: "Teams with existing Git LFS pointers, automation, and remote objects."
 ---
 
-Crab offers two different paths for an LFS repository. The compatibility path keeps LFS pointer format and commands while using Crab as Git LFS's custom transfer agent. The native path rewrites selected LFS history into Crab pointers backed by chunks, xorbs, and shards.
+Suppose `models/encoder.safetensors` is an 8 GB LFS file used by developers, CI, and old release tags.
 
-<LfsMigrationDiagram />
+Crab gives that repository two paths:
 
-## Separate pointer format, transfer path, and storage layout
+- **Bridge:** keep the LFS pointer and commit IDs; route LFS transfers through Crab.
+- **Convert:** replace selected LFS pointers with native Crab pointers; rewrite affected commits.
 
-Migration discussions can combine three independent choices:
+These are different migrations. Pick the boundary before picking the command.
 
-- **Pointer format**: the blob stored in Git history, either LFS or native Crab
-- **Transfer path**: the client integration that uploads and downloads managed objects
-- **Storage layout**: whole-file LFS objects or native chunk, xorb, and shard data
+<LfsIdentityLab />
 
-The transfer-agent path changes transfer routing while preserving LFS pointers and commit IDs. Native conversion changes the pointer and storage layout, which rewrites every affected commit and descendant.
+## First, prove the source is complete
 
-State the desired end condition before running a command. A team seeking direct bucket ownership may need only the compatibility bridge. A team seeking chunk reuse and native hydration needs conversion and the history coordination that follows.
-
-## Inventory pointers and tracking rules first
-
-Run the migration from a disposable clone with a clean working tree. Record current refs, remotes, `.gitattributes`, and pointer inventory before changing configuration.
+Use a disposable clone. Do not learn that an old object is missing halfway through a rewrite.
 
 ```bash
 git status --short
@@ -46,21 +45,26 @@ git lfs ls-files
 crab lfs migrate info --pointers only --everything
 ```
 
-Verify that every required LFS object is still available from its current remote. A history rewrite cannot recover bytes that no source can provide.
+Check four things:
 
-Save hashes for representative large files before changing transfer or history. The later compatibility and native checks should reconstruct those exact bytes.
+| Evidence                                    | Why it matters                                      |
+| ------------------------------------------- | --------------------------------------------------- |
+| LFS object exists locally or remotely       | A pointer cannot recreate missing bytes             |
+| Branch and tag inventory is complete        | An old tag may be the only user of an object        |
+| `.gitattributes` matches the intended paths | Filters decide which pointer format Git expects     |
+| CI and bootstrap scripts are known          | They may call `git lfs` even when developers do not |
 
-Inventory automation as well as repository data. Continuous integration images, developer bootstrap scripts, hooks, and deployment jobs may call `git lfs` directly even when contributors do not.
+Hash a few representative files now. After migration, a fresh client should produce the same bytes.
 
-Classify LFS objects by availability. Some may exist in the local clone, some only at the current LFS endpoint, and some may be missing from both. Record missing object IDs before choosing a migration scope.
+```bash
+shasum -a 256 models/encoder.safetensors
+```
 
-Inspect all selected refs, including annotated tags and release branches. A current checkout can appear healthy while an older tag points at an LFS object the server no longer retains.
+Signed commits and tags need a separate plan: rewritten Git objects get new IDs, so old signatures no longer describe them.
 
-Record signed commits and tags as well. Rewriting their object IDs invalidates existing signatures and requires an explicit signing and provenance plan.
+## Path 1: keep LFS semantics, change the route
 
-## Use the transfer agent for a compatible bridge
-
-Install Crab as the repository's LFS transfer agent:
+Install Crab as Git LFS’s custom transfer agent:
 
 ```bash
 crab lfs install
@@ -70,27 +74,38 @@ crab lfs checkout
 crab lfs fsck
 ```
 
-This path preserves LFS pointers and familiar LFS operations. It is useful when existing CI, clients, or downstream tools still require LFS semantics.
+`install` configures the transfer agent, LFS filters, and a pre-push gate. Git still commits the standard LFS pointer:
 
-The compatibility layer does not make an LFS pointer a native Crab pointer. Treat it as a stable bridge, not as evidence that chunk-level native storage has already replaced LFS object history.
+```text
+version https://git-lfs.github.com/spec/v1
+oid sha256:91ae…b72c
+size 8589934592
+```
 
-Git continues to store the LFS pointer format and invokes the configured custom transfer agent for object upload and download. Existing pointer object IDs and commit identities remain unchanged.
+That means:
 
-This path narrows cutover risk because clients can adopt the new transfer route without rewriting refs. It also preserves whole-file LFS object semantics, so changed versions do not automatically gain native Crab chunk reuse.
+- existing commits keep their IDs;
+- tools that require LFS pointers can keep using them;
+- rollback is a configuration change, not a ref rewrite;
+- the stored unit is still the whole LFS object.
 
-Keep a rollback record of the prior Git configuration. `crab lfs uninstall` removes Crab's transfer-agent entries, but the team still needs a working LFS endpoint before switching clients back.
+The last point matters. The bridge changes transport and ownership, but it does **not** turn an LFS object into Crab chunks. A slightly changed 8 GB model still has a new whole-file LFS object ID.
 
-Test upload and download separately. Publish one new LFS object through the transfer agent, remove the local LFS object cache in a disposable clone, and fetch it again through the configured path. Existing object download alone does not prove new writes use the intended destination.
+Test both directions. Push one new LFS object, then fetch it from a disposable clone with an empty local LFS cache. Reading old data alone does not prove that new writes use the Crab route.
 
-Confirm how non-Crab clients behave. A contributor without the custom transfer configuration may continue contacting the prior LFS endpoint or fail to materialize files. Decide whether that mixed-client period is supported and how bootstrap tooling enforces the configuration.
+Also test one machine without the Crab configuration. Decide whether that client should keep using the old endpoint or fail with a clear bootstrap instruction. An accidental mixed-client period is not a migration plan.
 
-During the bridge, monitor both systems. Existing historical objects may still come from the old endpoint while newly transferred objects use the Crab path. Keep retention on the old source until inventory proves the supported ref set no longer depends on it.
+To remove Crab’s transfer configuration later:
 
-## Use native conversion when chunk reuse matters
+```bash
+crab lfs uninstall
+```
 
-`crab lfs migrate export --to-crab` resolves selected LFS objects and rewrites their Git blobs as native Crab pointers. This changes commit IDs for rewritten commits and every descendant.
+Keep the previous LFS endpoint available until supported refs no longer depend on it.
 
-Test the exact scope in an isolated clone. Write an object map so old and new commit identities can be audited:
+## Path 2: convert to native Crab pointers
+
+Use native conversion when chunk reuse, native hydration, and Crab’s storage layout justify new Git identities.
 
 ```bash
 crab lfs migrate export \
@@ -100,119 +115,77 @@ crab lfs migrate export \
   --object-map ../lfs-to-crab.csv
 ```
 
-Do not publish rewritten refs until the converted repository passes verification and the team has agreed on a cutover window.
+For every matched LFS blob, Crab resolves the original bytes, creates native content and metadata, replaces the blob with a Crab pointer, updates tracking rules, and rewrites descendants.
 
-The converter must resolve each selected LFS object, create native Crab content and metadata, replace the Git blob, and rewrite descendant commit identities. Tags, branch protections, submodules, release references, and external build records may all name old object IDs.
+```text
+version https://crab.dev/spec/v1
+file-hash 4cb9…731a
+size 8589934592
+```
 
-Use the object map to connect old and new commits during review. Keep it outside the repository being rewritten so a reset or fresh clone cannot remove the evidence.
+The object map records old and new commit IDs. Keep it outside the rewritten clone so it survives a reset or replacement clone.
 
-Choose the rewrite scope explicitly. `--everything` can include branches and tags beyond the default path. Include and exclude patterns can limit file paths, but any rewritten blob still changes its containing commit and descendants.
+<LfsRewriteMap />
 
-Mixed pointer history is possible when conversion selects only some patterns or refs. That state requires both integration paths until the remaining LFS pointers leave the supported history. Prefer one documented boundary over an accidental mixture.
+A path pattern limits which blobs convert. Ref selection limits which history is rewritten. They solve different problems.
 
-Native conversion should preserve file bytes, executable modes, path names, authorship, messages, and parent relationships apart from the necessary new object IDs. The object map and fresh-clone validation supply evidence for those claims.
+If the model first appears in commit B, converting that blob changes B and every selected descendant—even commits that never touch the model again. Branch protections, release records, submodules, and open work may all name the old IDs.
 
-## Rehearse with the production ref shape
+Partial conversion is possible, but it leaves two pointer systems in supported history. Document exactly which paths and refs remain LFS-backed, or choose one clean boundary.
 
-A default-branch trial does not prove an all-history cutover. Rehearse the same branch and tag selection planned for production.
+## Rehearse the failure, not just the command
 
-The rehearsal should cover these phases:
+Use an isolated Crab destination and the same branch/tag scope planned for production.
 
-1. Freeze writes to the disposable source clone and fetch the selected refs.
-2. Confirm all LFS objects are available and hash representative files.
-3. Configure a separate Crab destination prefix for the rehearsal.
-4. Run the conversion and preserve the object map.
-5. Push rewritten refs to an isolated remote namespace.
-6. Clone from an empty client cache and hydrate representative files from several historical refs.
-7. Record duration, uploaded bytes, failed paths, new commit IDs, and integrity results.
+<LfsRehearsalConsole />
 
-Repeat the rehearsal after fixing any missing object or automation dependency. A successful retry from a partially populated destination also tests immutable-upload reuse.
+A useful rehearsal has observable gates:
 
-Use a destination that cannot be mistaken for production. Distinct bucket prefixes, remote names, and branch namespaces reduce the chance that rehearsal refs become contributor inputs.
+1. Fetch the selected refs and resolve every required LFS object.
+2. Run the bridge or conversion against a separate destination prefix.
+3. Push to an isolated remote namespace.
+4. Clone with an empty cache on another machine or runner.
+5. Materialize files from the default branch and an old release tag.
+6. Compare hashes, run the real workload, and record old/new commit IDs.
 
-Time each phase independently: source fetch, LFS object resolution, chunking and upload, Git rewrite, ref push, fresh clone, and hydration. This identifies whether the cutover window is limited by history computation, source bandwidth, or destination publication.
-
-Test the contributor reset procedure against the rehearsal remote. A migration is incomplete when the converted repository works only for the operator who performed the rewrite.
-
-## Verify content and repository closure
-
-After conversion, inspect attributes and pointer state, then push to a test location and hydrate from a fresh clone.
+For a native conversion, verify the repository as well as sample bytes:
 
 ```bash
-git status --short
 git log --all --oneline --decorate
 crab status
 crab fsck
 ```
 
-For representative files, compare cryptographic hashes before migration and after fresh hydration. Verify every branch and tag included in the cutover, not only the default branch.
+Check that every selected ref exists at its mapped ID, parent relationships preserve the intended topology, tracking rules match each historical pointer format, and every remaining LFS pointer still has a supported source.
 
-Inspect `.gitattributes` in rewritten historical commits, not only the current worktree. The path rules must agree with the pointer representation at each migrated state.
+Byte equality proves the migration copied data correctly. A build, training smoke test, or model load proves automation still finds it.
 
-Run source builds or model validation against the fresh clone. Byte equality proves migration integrity, while workload validation proves that automation still finds the expected paths and commands.
+## Cut over only after an independent client passes
 
-Compare more than sample file hashes:
+The bridge can roll out gradually if every supported client has the transfer configuration. A native rewrite needs a write freeze and one coordinated publication event.
 
-- **Ref coverage**: every selected branch and tag exists at its mapped new object ID
-- **Commit topology**: parent relationships preserve the intended history shape
-- **Attributes**: each historical path selects the pointer representation stored in that commit
-- **Large-file closure**: every native pointer resolves through durable Crab metadata
-- **Remaining LFS closure**: every intentionally retained LFS pointer still has a supported transfer source
-- **Signatures**: rewritten signed objects follow the approved replacement policy
+For native cutover:
 
-Save machine-readable inventories before and after conversion. Review count differences instead of relying on a successful default-branch checkout.
+1. Announce the freeze and preserve the final old refs.
+2. Run the rehearsed conversion from the final production state.
+3. Verify hashes, topology, attributes, and object closure.
+4. Publish mapped refs under the agreed protection exception.
+5. Update CI, release records, branch protections, and submodule references.
+6. Have an independent clean client hydrate and run the workload.
+7. Reopen writes only after that client passes.
 
-## Coordinate the history cutover
+Contributors with unpushed work need a backup ref and a deliberate rebase or cherry-pick onto mapped history. Avoid blanket “force pull” instructions: they can destroy unrelated work.
 
-A rewrite requires contributors to stop pushing, preserve or rebase unmerged work, and replace old local refs after the new history is published. Protected branches and CI references may need an explicit update.
+## Retire the old endpoint later
 
-Keep the old remote or backup refs read-only until the verification and rollback window closes. Document the object map and the date after which new work must use the rewritten history.
+A successful migration proves the new path. It does not authorize immediate deletion of the old LFS objects.
 
-The cutover sequence should name one owner for each action:
+Keep the old refs, object inventory, and commit map through the rollback window. Remove old storage only after supported tags, CI, releases, and contributor recovery no longer need it—and run that deletion through its own preview and approval.
 
-1. Announce the write freeze and confirm protected automation has stopped.
-2. Fetch the final production ref state into the migration clone.
-3. Verify LFS object availability and rerun the practiced conversion.
-4. Run content, topology, attribute, and closure checks.
-5. Publish rewritten refs under the agreed protection exception.
-6. Update build references, release metadata, and branch protections.
-7. Ask a clean client to follow the published reset procedure.
-8. Reopen writes only after the independent client passes.
-
-Record the final old and new default-branch object IDs in the announcement. Contributors can then detect whether a local branch still belongs to the old history.
-
-## Define rollback before the write freeze
-
-Compatibility rollback restores the prior LFS endpoint and transfer configuration because commit identities did not change. Native rollback is a ref cutover: restore the preserved old refs and direct clients back to the original object source.
-
-Do not delete the original LFS objects during the migration window. Native Crab verification may pass for sampled files while an untested historical ref still depends on an object you missed.
-
-Set a clear rollback deadline and retention period. After the deadline, archive the object map and migration evidence before applying the separate deletion policy for old LFS storage.
-
-## Publish a contributor reset procedure
-
-History rewrite changes the base of open work. Contributors need commands tailored to whether they have no local work, local commits, or uncommitted changes.
-
-The procedure should name the new canonical refs, the backup location, and the expected object IDs. It should also explain how to preserve local work before replacing old branches.
-
-Avoid a generic instruction to force-pull or delete every local branch. Those commands can destroy unrelated work. Test the reset procedure with representative contributor states during rehearsal.
-
-Provide separate paths for clean clones, local unpushed commits, and dirty worktrees. The clean case can replace the local canonical branch. The local-commit case needs a backup ref and a deliberate rebase or cherry-pick onto mapped history. The dirty case must save or commit work before any ref replacement.
-
-Include verification after reset. Contributors should confirm the new canonical object ID, inspect tracking attributes, hydrate one representative file, and run the repository's integrity check.
-
-## Retire the old LFS path only after the evidence window
-
-Removing old LFS objects is a separate destructive decision. Wait until supported refs, CI, releases, and contributor recovery no longer depend on the old endpoint.
-
-Keep the pre-migration ref snapshot, object inventory, and mapping through the rollback period. If policy requires longer provenance retention, archive those records even after the old object bytes become eligible for deletion.
-
-Apply the old-system deletion policy with its own preview and approval. A successful native migration proves the new repository; it does not authorize immediate removal of every historical LFS copy.
-
-<TakeawayBox title="Choose the smallest migration boundary">
-  Install the transfer agent when compatibility is enough. Rewrite history
-  only when native Crab pointers provide a measured benefit worth coordinating
-  new commit identities.
+<TakeawayBox title="Preserve identity until native storage pays for the rewrite">
+  Use the transfer bridge when LFS compatibility is the requirement. Convert
+  history only when measured chunk reuse or native hydration is worth changing
+  shared Git identities.
 </TakeawayBox>
 
-Use the [`crab lfs`](/docs/cli/reference/crab-lfs) reference for exact subcommand options during a migration rehearsal.
+See the [`crab lfs`](/docs/cli/reference/crab-lfs) reference for exact options before a rehearsal.

--- a/packages/web/content/blog/git-remote-helpers-filter-processes.mdx
+++ b/packages/web/content/blog/git-remote-helpers-filter-processes.mdx
@@ -1,11 +1,11 @@
 ---
 title: "How does Crab connect to Git?"
-description: "Understand how Crab combines a Git remote helper with clean and smudge filters to transport history and large-file data."
+description: "Follow one model through Git clean, a Crab pointer, git-remote-crab, fetch, smudge, and hydration."
 date: "2026-06-05"
 author: "Crab Team"
 category: "architecture"
 tags: ["git", "remote-helper", "filter-process", "integration"]
-excerpt: "Two standard Git extension points let Crab transform tracked files and use object storage as a remote."
+excerpt: "Git calls Crab at two extension points: a filter changes file representation, and a remote helper moves repository state."
 level: "deep-dive"
 path: "first-workflow"
 order: 3
@@ -19,354 +19,215 @@ meta:
   audience: "Developers who know Git basics and want to debug or extend Crab's integration."
 ---
 
-Crab connects to Git through two standard extension points. A long-running filter process transforms tracked file content during index and checkout operations. A remote helper transports Git objects, Crab data, metadata, and refs for `crab://` remotes.
+Crab does not patch Git. Git calls it through two standard extension points:
+
+- A **filter process** turns a tracked file into a pointer during add, then turns that pointer back into file bytes during checkout.
+- A **remote helper** handles fetch and push for `crab://` remotes.
 
 <BlogProcessPlayer story="integration" />
 
-## The filter owns file representation
+## Follow one model through Git
 
-A `.gitattributes` rule selects which paths Git sends to Crab:
+```text
+vision-search/
+├── src/train.py
+└── models/encoder.safetensors  # 8 GB
+```
+
+The Python file stays an ordinary Git blob. The model takes a second data path, but both paths still belong to one commit.
+
+| Command | Git invokes | Result |
+| --- | --- | --- |
+| `git add` | Filter `clean` | Git gets a pointer; Crab stages chunks |
+| `crab add` | Native parallel add path | The same pointer and staging result |
+| `git push` | `git-remote-crab` | Git and Crab dependencies become durable |
+| `crab push` | Native concurrent push path | The same durable repository outcome |
+| `git fetch` | `git-remote-crab` | Git receives commits, trees, and pointer blobs |
+| `git checkout` | Filter `smudge` | Worktree gets a pointer or verified file bytes |
+| `crab hydrate` | Crab reconstructor | A pointer becomes verified file bytes |
+
+## 1. Add calls the clean filter
+
+First, select the model path:
+
+```bash
+crab track '*.safetensors'
+git add .gitattributes
+git check-attr filter -- models/encoder.safetensors
+```
+
+`crab track` writes this rule:
 
 ```gitattributes
 *.safetensors filter=crab diff=crab merge=crab -text
 ```
 
-When Git adds a matching file, it sends the working-tree bytes to the filter's `clean` command. Crab chunks and hashes the data, records reconstruction information in local staging, then returns a small pointer for the Git index.
+Git's [filter attribute](https://git-scm.com/docs/gitattributes#_filter) decides which file content crosses the clean/smudge boundary. The check should report `filter: crab`.
 
-```text
-working tree:  models/model.safetensors  full bytes
-Git index:     models/model.safetensors  Crab pointer
-staging:       ordered chunks and file recipe
+Now use Git's add path so the filter boundary is visible, then inspect Git's copy:
+
+```bash
+git add models/encoder.safetensors
+git show :models/encoder.safetensors
 ```
 
-The pointer is an ordinary Git blob. Its format records a version, BLAKE3 file hash, byte size, and optional shard hint. Git can diff commits and move refs without carrying the full file bytes in its object database.
+The worktree still holds 8 GB. Crab streams those bytes through hashing and content-defined chunking, saves the ordered recipe in local staging, and gives Git a compact pointer.
 
-## The pointer is the Git-facing file contract
+For many large files, `crab add` reaches the same index and staging state through Crab's parallel native path instead of Git's serial filter requests. The trace below shows that optimized route.
 
-Git sees the pointer as file content, so its syntax must remain stable, parseable, and distinguishable from ordinary user data. A conceptual pointer has this shape:
+<GitArchitecturePlayer story="add" />
+
+The staged blob has this shape:
 
 ```text
 version https://crab.dev/spec/v1
-file-hash 4d8f…
+file-hash <64-hex BLAKE3>
 size 8589934592
-shard-hint 9a21…
 ```
 
-The version selects the parser contract. The file hash identifies the expected original bytes. The size rejects truncation and supports planning. The optional hint can shorten metadata lookup without becoming the sole location authority.
+An optional shard hint may also appear. It can speed lookup, but the file hash remains the identity Crab verifies.
 
-Git's blob object ID identifies the pointer text, not the 8 GB file. Crab's full-file BLAKE3 hash identifies the original file. Keeping those identities separate lets Git preserve ordinary object semantics while Crab verifies materialization.
+Git now has two IDs for two different things:
 
-Pointer parsing fails closed. Unsupported versions, malformed hashes, invalid sizes, and contradictory fields cannot enter hydration as though they named valid content. Ordinary blobs that do not match the pointer grammar pass through the normal Git path.
+| Identity | Names |
+| --- | --- |
+| Git blob object ID | The pointer text stored in the commit |
+| Crab `file-hash` | The original 8 GB file bytes |
 
-## The filter process persists across paths
+If Crab cannot stage a complete recipe, clean returns an error. It does not hand Git a pointer that only looks valid.
 
-Git filter protocol version 2 keeps one process alive for a batch of clean and smudge requests. Process reuse avoids startup and metadata initialization for every tracked path.
+## 2. Push calls the remote helper
 
-The process exchanges packet-line framed headers and content with Git. A request identifies the command and path, then streams bytes. The response contains a status section, optional content, and a terminating flush packet.
-
-Session state can reuse chunk buffers, indexes, and prefetch work across files. The filter still treats each response as a complete contract. A failure for one clean request must not emit a successful pointer for that path.
-
-The process also has an idle-exit boundary on supported platforms. If Git disappears while leaving a pipe open, Crab eventually releases the process and its staging lock instead of blocking later adds indefinitely.
-
-## The filter handshake establishes the shared protocol
-
-Git and Crab begin by agreeing on filter protocol version 2 and the capabilities used by the session. Only after that exchange does Git send path-specific work.
-
-```text
-Git                                      Crab filter
- |  git-filter-client                    |
- |  version=2                            |
- |  capability=clean                     |
- |  capability=smudge                    |
- |  capability=delay                     |
- |<-------------------------------------->|
- |  command=clean or command=smudge      |
- |  pathname=models/model.safetensors    |
- |  content packets, then flush          |
-```
-
-Packet framing separates headers, content, and status. A missing flush or an unexpected line can desynchronize the complete process, so protocol output cannot share standard output with human diagnostics.
-
-Capability negotiation also prevents accidental assumptions. Git can request delayed smudge only when both sides agreed to it. A client that does not negotiate delay receives the regular synchronous result.
-
-## Clean must fail before it lies
-
-The filter does not return a pointer unless Crab has enough local state to reconstruct and later upload the file. If staging cannot open or accept the content, clean reports an error instead of committing a pointer with no backing recipe.
-
-Staging is opened lazily on the first clean request. A filter session that only handles smudge requests does not take the staging writer lock, which prevents read-only Git commands from blocking behind an unrelated add.
-
-Clean streams input rather than requiring the complete file in memory. The chunker finds boundaries, hashes chunks, and records recipe order while bytes arrive. New chunk content can enter bounded staging buffers and xorb preparation without changing the file-level result.
-
-Known content can take a shorter path. If Crab already has a verified recipe for the exact file identity, it can reuse that result instead of chunking the same bytes into new storage work. The returned pointer must still match the input file's identity and size.
-
-The filter distinguishes an ordinary non-pointer payload from a managed pointer during later comparisons. It cannot classify arbitrary small text as a Crab pointer merely because the file resembles the format. Strict parsing keeps user content from entering the reconstruction path by accident.
-
-## Clean connects file identity to later publication
-
-Clean completes before Git writes the pointer into the index. At that moment, Crab must retain enough state for a future push even though clean does not know which branch, commit, or remote will eventually use the pointer.
-
-The recipe records every chunk identity and its logical order. New chunk bytes remain in staging until a push flushes them into immutable xorbs. Known chunks can reference existing durable locations after canonical proof.
-
-Because staging owns the bytes before push, a contributor can add and commit managed files without immediate object-store access when the required local state is available. Push becomes the network and durability boundary.
-
-Offline preparation also creates responsibility. Deleting staging before first publication can remove the only recipe or new bytes behind a committed pointer. The committed Git blob remains, but the client can no longer prove its Crab closure.
-
-Status and diff conversions should avoid mutating staging when Git only needs a comparison. Lazy staging acquisition keeps these read-oriented commands from taking the writer lock or creating unrelated data work.
-
-## Smudge owns working-tree materialization
-
-During checkout, Git passes a stored blob through the filter's `smudge` command. Ordinary content passes through. A Crab pointer can remain a pointer for a lazy checkout or resolve through shards and xorbs into verified file bytes.
-
-The filter advertises Git filter protocol v2 capabilities for `clean`, `smudge`, and delayed smudge. Delay support lets Git continue checkout while Crab reconstructs requested files in the background.
-
-Smudge begins by parsing the stored blob. Ordinary content passes through unchanged. A valid Crab pointer enters repository lookup, recipe resolution, shard lookup, range planning, chunk verification, ordered assembly, and final file verification.
-
-The selected checkout policy decides whether smudge returns full bytes or preserves the pointer. That policy changes local materialization, not the committed blob. Two clients can therefore check out the same commit with different local working sets.
-
-## Hydration follows metadata from identity to bytes
-
-Smudge and `crab hydrate` share the same reconstruction contract even though Git invokes one during checkout and a contributor invokes the other explicitly.
-
-The resolver performs these steps:
-
-1. Parse the pointer and obtain the expected file hash and size.
-2. Resolve the file index into a complete ordered chunk recipe.
-3. Resolve shard terms for every chunk identity.
-4. Group required terms by xorb and coalesce compatible ranges.
-5. Read from staging, verified cache, shared cache, or canonical storage.
-6. Verify chunks, restore recipe order, and verify the final file.
-7. Replace the pointer only after the complete result passes.
-
-Checkout policy can stop after step one and preserve the pointer. Once materialization begins, the result remains binary: complete verified bytes or an error. The filter cannot emit a prefix of the file and report success.
-
-Archived xorbs add an availability state to step five. The caller's restore policy decides whether to request restoration, wait, or fail. Archive state does not change the pointer identity or recipe.
-
-## Delayed smudge separates scheduling from delivery
-
-When Git sends `can-delay=1`, Crab may accept a pointer without returning the full file immediately. The prefetch queue reconstructs eligible content while Git processes other paths.
-
-Git later asks which delayed paths are ready and requests their content. Crab drains background work before the filter session exits, so reconstructors do not outlive the process that owns their output contract.
-
-Delay improves checkout scheduling, but it does not weaken verification. The worktree receives complete verified bytes or retains the pointer according to the selected lazy policy.
-
-Delayed work has three distinct moments. The first request registers the path and starts reconstruction. A later list request tells Git which paths have completed. Git then requests content for each ready path.
-
-The session must retain enough state to connect those moments without mixing output between files. Completion order can differ from request order, while each final response still belongs to its original path.
-
-Cancellation also belongs to the session boundary. If Git stops requesting delayed paths, Crab drains or cancels owned work and closes resources. A background reconstructor must not survive and write into a later filter session.
-
-## Session state removes repeated setup without merging requests
-
-One filter session can process hundreds of tracked paths. Shared repositories, object-store clients, shard indexes, chunk buffers, and prefetch queues reduce repeated initialization.
-
-Each path still owns its status and content response. A failed model checkout cannot consume the packet framing or reconstructed bytes of the next path. The session records request identity until Git receives the corresponding terminal response.
-
-Bounded concurrency protects memory and provider traffic when Git supplies a large checkout batch. Delay lets work overlap, while the scheduler limits active metadata lookups, xorb reads, decompression, and buffered output.
-
-Session shutdown is part of correctness. Crab closes staging handles, waits for owned reconstructors, and releases locks before exit. A fast process termination that abandons those owners can block later Git commands or leave temporary output unaccounted for.
-
-## The remote helper owns repository transport
-
-Git maps a URL such as `crab://team-data/vision-search` to an executable named `git-remote-crab`. Crab's main binary detects that invocation name and starts the remote-helper protocol loop.
-
-The helper implements the operations Git needs to discover refs and batch fetch or push work:
-
-```text
-Git                         git-remote-crab
- | capabilities                    |
- | list / list for-push            |
- | fetch <oid> <ref> [batch]       |
- | push <src>:<dst> [batch]        |
- |<------ blank-line framed ------>|
-```
-
-Helper standard output is reserved for Git protocol responses. Diagnostics go through the logging and error boundaries so a status line cannot corrupt the transport conversation.
-
-Git chooses the helper from the remote URL scheme. For `crab://`, it searches for `git-remote-crab` and passes the remote name and URL. The Crab executable detects the helper invocation and enters protocol mode instead of the interactive CLI parser.
-
-This dispatch keeps installation compact, but the modes remain separate contracts. A CLI help message on helper standard output would be a transport failure. A remote-helper error must be formatted for Git while preserving detailed diagnostics through the logging path.
-
-## Ref listing defines Git's remote view
-
-Git begins by asking the helper for capabilities and refs. Crab reads the stored ref state and formats each object ID with its ref name. A symbolic `HEAD` and peeled annotated tags use the shapes Git expects.
-
-`list for-push` returns only addressable push destinations. The helper omits symbolic `HEAD` and peeled tag targets because neither should become a destination ref edit.
-
-The response ends with a blank line. This small framing rule matters because Git waits for the complete batch before it chooses fetch or push work.
-
-Listing is also the first consistency read. Crab must interpret the committed ref journal and expose only a complete repository state. A writer's temporary plan or uploaded orphan cannot appear as a branch merely because related objects exist in the bucket.
-
-Annotated tags add one more Git-specific detail. The tag ref names the tag object, while a peeled entry can name the referenced commit. Crab formats both so Git can negotiate objects without inventing another tag representation.
-
-## Fetch batches preserve Git's object model
-
-After listing, Git decides which object IDs it lacks and sends one or more fetch commands before the batch terminator. Crab can satisfy several requested refs from shared immutable packs.
-
-The helper downloads the required pack data and imports it through Git's object database boundary. Git then validates and indexes the objects according to its normal rules. Crab does not unpack commits into a parallel repository model.
-
-Remote-tracking refs update only after Git receives the requested object closure. Managed files remain pointer blobs at this stage. Fetch therefore proves history transport, while later smudge or hydration proves large-file reconstruction.
-
-A code-review job can therefore fetch and inspect a mixed commit without obtaining any xorb ranges. The repository history is present even though managed working-tree bytes remain deferred.
-
-## Fetch and push cross both storage paths
-
-A fetch reads the remote ref view, downloads the required Git packs, and imports them into the local Git object database. Large-file pointers arrive as normal Git blobs; hydration follows their separate metadata path later.
-
-A push discovers the Git closure and every Crab pointer reachable from the proposed ref. It uploads new Git packs, xorbs, and shard metadata, proves pointer closure, then commits the ref transaction. The ref is the final visibility change.
-
-Fetch commands arrive as a batch of object IDs and ref names. The helper resolves the required pack set, downloads immutable Git data, and imports the objects into the local database. Pointer blobs require no special Git representation during this transfer.
-
-Push commands arrive as refspecs. Crab preserves their order in the response and returns `ok` or `error` for each destination. Structured rejection reasons let Git and scripts distinguish stale refs from missing dependencies or protocol failures.
-
-Fetch does not hydrate every pointer it imports. It makes the commit graph and pointer blobs available to Git. Checkout policy and later hydration decide which managed paths become full bytes.
-
-Push cannot treat the Git pack as the complete dependency set when reachable pointers changed. It walks pointer closure, resolves staged or durable recipes, flushes xorbs before bundle publication, and verifies that remote readers can resolve every managed file from canonical state.
-
-A batch can contain several destinations. Each destination keeps its ref outcome, but immutable Git and Crab objects can be shared across the batch. One rejected ref does not change the identity of already uploaded immutable dependencies.
-
-## Push connects commits to Crab metadata
-
-Pointer discovery begins from the commits reachable through each proposed destination. Crab inspects tracked blobs, distinguishes native pointers from ordinary content, and creates the managed dependency set.
-
-For each pointer, push needs one of two proofs. Local staging can supply a complete recipe and new bytes for first publication. Canonical remote state can prove that an earlier publication already made the file reconstructable.
-
-New chunks flush into xorbs before shard metadata can name them. Shard and file-index updates become durable before pointer closure passes. Git-pack connectivity also passes before the helper attempts the ref transaction.
-
-The final `ok <destination>` response therefore means more than “some objects uploaded.” It means the destination ref transaction committed after both dependency lanes became complete. An `error <destination> <reason>` keeps the branch at its prior complete value.
-
-Ref deletion skips file upload but still validates the expected old value. Physical objects remain for retained branches, tags, recovery history, and garbage collection to evaluate later.
-
-## Local staging connects clean to push
-
-Clean and push can run in different Git processes. The staging area persists the file recipe and new chunks between them.
-
-This handoff explains an important failure pattern. Git can contain a valid-looking pointer after clean, but push still needs the matching staged recipe or durable remote proof. Removing staging before publication can therefore make a new pointer unpushable.
-
-Once a push flushes staged xorbs and publishes complete metadata, later clients no longer depend on the original machine's staging area. Canonical object storage becomes the shared reconstruction boundary.
-
-Staging also keeps file versions separate from path names. Clean records content identity and ordered chunks, while the Git index records which path receives the pointer. The same staged content can support copies or renames without duplicating its chunk bytes.
-
-Staging lifetime still matters. Removing it before the first successful publication can strand a pointer whose recipe exists nowhere else. After canonical publication, clearing local staging affects retry performance and local recovery, not the shared file contract.
-
-## Lazy staging avoids unrelated lock contention
-
-Git starts the filter for operations beyond an explicit `git add`. Status, checkout, merge, and diff machinery can all reach conversion paths depending on attributes and configuration.
-
-Opening the staging writer at process startup would make every filter session contend with active adds. Crab delays that open until a clean request needs persistent recipe or chunk state.
-
-Smudge-only and pass-through sessions can remain readers. This ownership rule reduces blocked Git commands and makes lock diagnostics meaningful: a staging writer exists because some path attempted managed clean work.
-
-Once acquired, the writer follows the filter session lifecycle. It flushes required local state, reports errors before a successful pointer response, and closes on normal or failed session exit.
-
-## Match commands to the process Git invokes
-
-| Git action | Crab integration | Main result |
-| --- | --- | --- |
-| `git add` on a tracked path | Filter `clean` | Staged Crab recipe and pointer blob |
-| `git status` or diff conversion | Filter, without a required staging write | Worktree and index comparison |
-| `git checkout` | Filter `smudge` | Pointer or verified materialized bytes |
-| `git fetch` | Remote helper fetch batch | Git objects and updated remote refs |
-| `git push` | Remote helper push batch | Durable dependencies and ref outcome |
-| `crab hydrate` | Shard-backed reconstructor | Verified working-tree file |
-
-The table identifies the first log and source boundary to inspect. It also prevents a common debugging mistake: changing the remote helper cannot repair a `.gitattributes` rule that never invoked clean.
-
-## The two integrations share four invariants
-
-The filter and helper run in different processes, but the repository depends on shared rules:
-
-1. A clean response never claims a file identity without a complete local recipe.
-2. Every staged xorb flushes before a bundle or ref can depend on its chunks.
-3. Hydration covers every recipe chunk and verifies the final file identity.
-4. A ref becomes visible only after Git and Crab dependency closure succeeds.
-
-These invariants explain why some failures surface later than the action that introduced the path. Clean can prepare local state without network access. Push becomes the boundary that proves the state is durable for another client.
-
-<TakeawayBox title="Two hooks, one invariant">
-  The filter may create a pointer only when it has backing local state. The
-  remote helper may publish a ref only when every pointer has durable backing
-  state.
-</TakeawayBox>
-
-## Debug from the boundary inward
-
-Use Git's own view first, then ask Crab to verify repository state:
+Git sees a URL such as `crab://team-data/vision-search` and looks for `git-remote-crab`. That follows Git's standard [remote-helper contract](https://git-scm.com/docs/gitremote-helpers): helpers advertise capabilities, list refs, and handle fetch or push batches over standard input and output.
 
 ```bash
-git check-attr filter diff merge -- models/model.safetensors
-git show :models/model.safetensors
+git remote get-url origin
+git commit -m "Train encoder v1"
+git push
+```
+
+The helper finds every pointer reachable from the proposed branch. It prepares two immutable lanes:
+
+- Git commits, trees, and pointer blobs become a Git pack.
+- New chunks and reconstruction metadata become xorbs and shards.
+
+The ref moves only after both lanes pass closure checks. `crab push` reaches the same repository outcome through Crab's native concurrent pipeline rather than Git's helper loop.
+
+<GitArchitecturePlayer story="push" />
+
+Local staging connects clean to push. Clean does not know which branch or remote will use the pointer, so it keeps the recipe and new bytes until publication. After a successful push, another client can reconstruct the file from canonical remote state.
+
+To confirm the visible result:
+
+```bash
+git rev-parse HEAD
+git ls-remote origin "refs/heads/$(git branch --show-current)"
+```
+
+The two commit IDs should match.
+
+## 3. Fetch moves Git history first
+
+On another client:
+
+```bash
+git fetch origin
+git show FETCH_HEAD:models/encoder.safetensors
+```
+
+`git fetch` asks the helper to list refs and import the required Git packs. The model arrives as its pointer blob. Fetch does not need to download 8 GB just to let Git inspect the commit.
+
+This distinction is useful when debugging:
+
+- If Git cannot see the commit, inspect the remote helper.
+- If Git sees the pointer but cannot rebuild the model, inspect Crab metadata and object access.
+
+## 4. Checkout calls the smudge filter
+
+During checkout, Git sends the stored blob to `smudge`. Ordinary blobs pass through unchanged. A Crab pointer can remain a pointer for a lazy checkout or resolve to complete file bytes.
+
+```bash
+git checkout FETCH_HEAD -- models/encoder.safetensors
+crab status
+crab hydrate models/encoder.safetensors
+```
+
+`crab hydrate` makes the read path explicit: resolve the recipe, locate every chunk, plan object-store ranges, reconstruct in order, and verify the final BLAKE3 hash before replacing the pointer.
+
+<GitArchitecturePlayer story="hydrate" />
+
+Two clients can therefore check out the same commit with different local working sets. The committed pointer does not change.
+
+## Why the filter stays alive
+
+Git's [long-running filter process](https://git-scm.com/docs/gitattributes#_long_running_filter_process) handles many paths during one Git command. Git and Crab first agree on protocol version 2 and the supported operations:
+
+```text
+git-filter-client
+version=2
+capability=clean
+capability=smudge
+capability=delay
+```
+
+Keeping one process alive avoids starting Crab and reopening indexes for every model. Each path still receives its own status and content response.
+
+The optional delay capability lets checkout continue while eligible files reconstruct in the background. It changes scheduling, not integrity: the final result is complete verified bytes or an error.
+
+Protocol output belongs to Git. Human debug text on standard output can break packet or line framing, so Crab sends diagnostics through its logging boundary.
+
+## One file, two extension points
+
+<FlowSteps
+  title="The complete round trip"
+  steps={[
+    ".gitattributes selects models/encoder.safetensors.",
+    "Clean stages its recipe and returns a pointer to Git.",
+    "Git commits the pointer with ordinary source blobs.",
+    "git-remote-crab uploads both dependency lanes, then moves the ref.",
+    "Another client fetches the commit and pointer.",
+    "Smudge or hydrate reconstructs and verifies the original model."
+  ]}
+/>
+
+The pointer is the handoff. Clean creates it with local backing state; the helper publishes it with durable backing state; hydration uses it to verify the returned bytes.
+
+## Debug the first broken boundary
+
+```bash
+git check-attr filter -- models/encoder.safetensors
+git show :models/encoder.safetensors
 git remote -v
+git ls-remote origin
 crab status
 crab doctor
 crab fsck
 ```
 
-If the attribute is wrong, fix tracking. If the index contains full bytes, inspect clean. If Git cannot list the remote, inspect helper configuration and credentials. If a pointer cannot hydrate, inspect metadata closure and object-store access.
-
-## Preserve protocol output during debugging
-
-Git communicates with both integrations through standard input and standard output. Debug text written to the protocol stream can create errors that look unrelated to the original operation.
-
-Use Crab's configured logs, structured command output, and Git tracing instead of adding ad hoc prints. Capture the command, process invocation name, path or ref, and first stable Crab error code.
-
-Reproduce the narrowest boundary available. `git check-attr` tests selection without uploading. `git show :path` tests clean output without a push.
-
-Ref listing tests the helper before pack transfer. `crab hydrate path` tests reconstruction without changing history.
-
-Git tracing can show which executable and protocol operation ran, but trace output may contain repository paths and remote details. Store it as diagnostic evidence with the same access controls as build logs.
-
-When a failure depends on several files, reduce the reproduction to one tracked path and one destination ref. Protocol framing bugs can affect the next request after the original error, so preserve the first failing request rather than diagnosing only the final Git message.
-
-## Recognize failures by their first broken contract
-
-| Symptom | First contract to inspect |
+| Symptom | Inspect first |
 | --- | --- |
-| Tracked file enters Git as full bytes | Attribute selection and clean invocation |
-| `git add` reports a filter failure | Clean staging, chunking, or pointer creation |
-| Checkout leaves a pointer unexpectedly | Smudge policy, pointer parsing, or delayed delivery |
-| Remote appears to have no refs | Helper dispatch, credentials, or ref-journal listing |
-| Fetch has commits but a file cannot hydrate | Crab metadata or xorb read path, not Git pack import |
-| Push uploads data but rejects the branch | Pointer closure or expected-old ref comparison |
+| Git stages the complete model | `.gitattributes`, filter installation, and clean |
+| `git add` reports a filter error | Local staging, chunking, or pointer creation |
+| The remote appears to have no refs | Helper installation, remote URL, or credentials |
+| Fetch succeeds but hydration fails | Recipe, shard, xorb, or object-store read access |
+| Push uploads data but rejects the branch | Pointer closure or a stale destination ref |
 
-The last visible Git error can combine several lower-level facts. Start with the earliest contract that failed and keep the successful boundaries out of the repair scope.
+Start with the earliest failed check. Changing the remote helper cannot repair a path that never entered clean, and changing the filter cannot repair a missing remote xorb.
 
-## Advanced behavior preserves the same boundaries
-
-Mounts, selective hydration, shared cache, storage tiering, and xorb repacking extend the data path without changing Git's integration contract.
-
-A mount resolves committed pointers through the same recipe and range proof. Selective hydration changes which paths enter reconstruction. Shared cache changes where verified immutable bytes come from.
-
-Tiering changes when a xorb range becomes readable. Repacking changes physical chunk location.
-
-None of these features changes which pointer blob belongs to a commit. None can publish a branch without helper closure. Keeping those invariants stable allows performance and storage policy to evolve below Git history.
-
-## Follow one path through the complete integration
-
-For `models/model.safetensors`, the end-to-end sequence is:
-
-1. `.gitattributes` selects `filter=crab`.
-2. Git sends working-tree bytes to clean.
-3. Clean stages the recipe and returns a pointer blob.
-4. Git writes the pointer into a tree and commit.
-5. Push sends the refspec to `git-remote-crab`.
-6. The helper discovers the pointer and prepares its Git and Crab closure.
-7. Immutable Git packs, xorbs, and metadata become durable.
-8. Expected-old comparison and the ref transaction publish the commit.
-9. Another client lists the ref and fetches the pointer through Git.
-10. Smudge or hydrate resolves the pointer and verifies the original bytes.
-
-Two Git extension points divide the work, while staging and canonical metadata connect their outputs. The pointer is the shared identity contract between them.
+<TakeawayBox title="Filter files; helper moves the repository">
+  The filter decides what Git stores for each managed file. The remote helper
+  makes that Git state and every Crab dependency durable before the branch
+  becomes visible.
+</TakeawayBox>
 
 ## Source map
 
 | Contract | Implementation |
 | --- | --- |
-| invocation dispatch | `crab/src/main.rs` |
-| tracking attributes | `crab/src/cmd/track.rs` |
-| remote-helper protocol | `crab/src/git/remote_helper.rs` |
-| filter protocol | `crab/src/git/filter_process.rs` |
-| clean transformation | `crab/src/git/clean.rs` |
-| smudge reconstruction | `crab/src/git/smudge.rs` |
-| pointer parsing | `crab/src/engine/pointer.rs` |
+| Invocation dispatch | `crab/src/main.rs` |
+| Tracking attributes | `crab/src/cmd/track.rs` |
+| Filter protocol | `crab/src/git/filter_process.rs` |
+| Clean and smudge | `crab/src/git/clean.rs`, `crab/src/git/smudge.rs` |
+| Remote-helper protocol | `crab/src/git/remote_helper.rs` |
 
 Continue with [How does Crab avoid storing duplicate data?](/blog/xet-protocol-deduplication) to follow the bytes after clean begins.

--- a/packages/web/content/blog/lazy-checkout-fuse.mdx
+++ b/packages/web/content/blog/lazy-checkout-fuse.mdx
@@ -19,23 +19,35 @@ meta:
   audience: "Developers working with repositories that exceed local disk or transfer budgets."
 ---
 
-A Crab clone leaves managed large files as pointers by default. You can keep them that way for Git operations, hydrate a known working set, or mount a repository so files resolve when applications read them.
+Imagine a **4 TB** vision repository and a laptop with **256 GB** of storage.
+The repository fits in Crab. It does not fit on the laptop.
 
-<LazyCheckoutDiagram />
+That is fine. Choose when bytes become local:
 
-## Start from the application's access shape
+- Keep pointers for Git work.
+- Hydrate a known working set.
+- Mount the repository for on-demand reads.
 
-Choose materialization from what the task reads, how predictable those paths are, and whether the tool expects normal filesystem calls. Repository size alone does not decide the mode.
+<MaterializationPackingDesk />
 
-A source review task knows it needs no managed bytes, so pointers are enough. A training job usually has a declared model and dataset set, so hydration gives deterministic startup. An asset browser may discover paths from user navigation, so a mount can defer reads until access.
+## Pick from the access pattern
 
-Also classify writes. Pointer checkout and hydration use the normal Git worktree. A read-only mount exposes a snapshot without a commit path. A writable mount needs an overlay, an explicit commit, and a stale-base check before publication.
+Repository size is not the deciding factor. Predictability is.
 
-The choice can differ by job while all jobs use the same commit. Materialization is a client policy layered on the committed file identity.
+| If the task...                     | Start with...       |
+| ---------------------------------- | ------------------- |
+| Reviews source and history         | Pointer-only clone  |
+| Always needs the same files        | Selective hydration |
+| Has a committed input list         | Manifest hydration  |
+| Discovers paths while running      | Read-only mount     |
+| Must edit through filesystem calls | Writable mount      |
 
-## Keep pointers when you need history, not bytes
+All five choices can use the same commit. The file identity does not change;
+only the local materialization policy does.
 
-A lazy clone downloads the Git history and Crab metadata needed to identify tracked files. It does not materialize every large file.
+## 1. Keep pointers for Git work
+
+A normal Crab clone is lazy by default:
 
 ```bash
 crab clone crab://team-data/vision-search
@@ -43,48 +55,32 @@ cd vision-search
 crab status
 ```
 
-This mode fits code review, branch inspection, metadata-only automation, and any task that needs only a small subset of assets.
+Git history, source, and pointer blobs are local. The 820 GB of models and
+3.1 TB of datasets stay in object storage.
 
-Pointer checkout differs from Git sparse checkout. Sparse checkout controls which paths appear in the working tree. Crab pointers allow the managed path to appear with its identity while deferring the full content.
+A pointer still identifies the complete file. It records the content hash and
+size. Git can compare it, switch branches, and merge it without downloading the
+payload.
 
-The two controls can work together. Sparse checkout can exclude unrelated directories, while Crab keeps included managed files lightweight until hydration. Document both patterns because a missing path and a pointer path require different next actions.
+This is different from sparse checkout:
 
-## A pointer checkout still has complete identity
+- **Sparse checkout:** the path may be absent.
+- **Crab pointer:** the path is present, but the large payload is deferred.
 
-The working-tree pointer is not an incomplete file version. It records the hash and size of the committed full file, plus metadata that helps Crab locate its recipe.
+A parser expecting a real model or image cannot use the pointer as data. That
+tool needs hydration or a mount.
 
-Git commands can compare pointer blobs, switch branches, and merge path identity without materializing every managed file. Tools that need the actual format must hydrate or read through a mount.
+## 2. Hydrate a known set
 
-Use `crab status` to distinguish pointers, clean hydrated files, and modified materialized files. File size alone is not a safe indicator because a small application file could resemble a pointer in size.
-
-## Hydrate a predictable working set
-
-When you know the paths a task needs, hydrate them explicitly:
+Suppose training needs one model, tokenizers, and the current dataset slice.
+Hydrate just those paths:
 
 ```bash
 crab hydrate 'models/current/**'
 crab hydrate --manifest .crab/manifests/training.txt
 ```
 
-Hydration uses the normal pointer-to-shard-to-xorb proof pipeline. Already materialized files are skipped, and local cache state can satisfy bytes fetched by earlier tasks.
-
-You can also select content during clone:
-
-```bash
-crab clone crab://team-data/vision-search \
-  --include 'configs/**' \
-  --include 'models/current/**'
-```
-
-Hydration is an explicit batch boundary. Crab can resolve metadata once, group ranges by xorb, and process independent files with bounded concurrency. The command returns only after selected outputs are verified or their failures are reported.
-
-Use narrow patterns with a dry inventory of matching paths when repository structure is unfamiliar. A pattern that expands across historical exports or archived partitions can exceed local capacity and trigger provider restores.
-
-For repeat jobs, prefer a committed manifest over shell-specific glob construction. The manifest makes the intended data dependency visible in review and reproducible on another runner.
-
-## Commit working-set manifests
-
-A manifest turns local capacity policy into reviewable repository data. Each line names a path or glob required by a task, environment, or pipeline.
+For repeatable jobs, commit the selection:
 
 ```text
 # .crab/manifests/training.txt
@@ -93,38 +89,43 @@ models/current/*.safetensors
 data/tokenizers/**
 ```
 
-Hydrate the committed manifest directly:
+Then hydrate the manifest from the commit:
 
 ```bash
 crab hydrate --manifest-ref HEAD:.crab/manifests/training.txt
 ```
 
-The commit now identifies both file versions and the intended working set. A branch can update the manifest when its training inputs change.
+The manifest makes the disk requirement reviewable. A branch changing its
+training inputs changes the manifest too.
 
-Keep manifests narrow. A broad `**` pattern can turn a selective job into a full-repository download and trigger restores for archived data.
+You can also materialize a selection during clone:
 
-## Dehydrate clean files to recover space
+```bash
+crab clone crab://team-data/vision-search \
+  --include 'configs/**' \
+  --include 'models/current/**'
+```
 
-Dehydration replaces a clean committed file with its pointer. Modified files are skipped so local edits are not discarded.
+Avoid a casual `**`. A broad glob can turn an 84 GB job into a 4 TB download.
+
+### Recover space with dehydrate
+
+`dehydrate` replaces clean materialized files with their pointers:
 
 ```bash
 crab dehydrate 'models/archive/**'
 crab status
 ```
 
-The remote objects remain unchanged and can hydrate again later.
+Modified files are skipped. Crab will not discard local edits to reclaim disk.
 
-Dehydration skips modified files because replacing them would discard local data. Review `crab status`, commit or move the edits, then retry the selected paths.
+The read cache is separate. Dehydrating a file does not promise that every
+cached range or application output disappears.
 
-Prefetch profiles may protect files from routine dehydration. Use `--ignore-profiles` only when you intend to remove those materialized copies as well.
+## 3. Mount for unpredictable reads
 
-Dehydration does not guarantee that all related disk use disappears. Verified xorb ranges can remain in the local cache, and an application may have created derived output beside the managed path. Use cache statistics and normal disk inventory to account for those stores separately.
-
-Run dehydration before the disk reaches exhaustion. The operation needs enough capacity and filesystem access to inspect state and replace clean files safely.
-
-## Mount for unpredictable reads
-
-A mount presents a repository snapshot as a filesystem and resolves file content on demand. The automatic backend prefers NFS when available; `--backend=fuse` selects the FUSE adapter and requires FUSE support on the machine.
+An asset browser does not know which file the user will click. Mounting avoids
+guessing the working set:
 
 ```bash
 crab mount \
@@ -133,7 +134,41 @@ crab mount \
   --read-only
 ```
 
-Read-only mounts fit analysis tools that discover files dynamically. Writable mounts use a local copy-on-write overlay; changes do not enter Git history until an explicit mount commit.
+The application sees ordinary paths. Crab serves each filesystem operation
+from a stable repository snapshot.
+
+Automatic backend selection prefers NFS when available. Use
+`--backend=fuse` to request FUSE; that machine must have fuse3 or macFUSE.
+Backend choice does not change content verification.
+
+<MountedReadCutaway />
+
+### What a mounted read changes
+
+Listing `models/` reads snapshot and overlay metadata. It does not fetch every
+model.
+
+The first 64 KiB read of a managed file resolves its pointer, reconstructs the
+needed read window from xorb ranges, verifies it, and saves that window in the
+local cache. A repeat read can stop at the cache.
+
+Sequential readers benefit from adaptive prefetch. Random seeks and memory
+mapping can touch many windows. Benchmark the real application, not only a
+single `cp`.
+
+An unavailable or corrupt range remains an error. Crab does not substitute
+zero-filled or truncated bytes.
+
+## Writes are a different capacity event
+
+A writable mount adds a copy-on-write overlay. The base snapshot remains
+unchanged until you explicitly commit.
+
+The first write to a pointer-backed file promotes the **full file** into local
+overlay backing. Editing one byte of a 12 GB model therefore needs roughly 12
+GB of overlay space, plus temporary headroom during promotion.
+
+Inspect and publish changes explicitly:
 
 ```bash
 crab mount diff --mountpoint /mnt/vision-search
@@ -142,67 +177,51 @@ crab mount commit --mountpoint /mnt/vision-search \
   --push
 ```
 
-The overlay separates filesystem writes from the mounted base snapshot. `crab mount diff` shows local changes, while `crab mount export` copies them to a normal directory for inspection.
+Commit freezes writes and checks that the base ref has not moved. If the push
+fails, Crab keeps the local commit identity and overlay recovery state.
 
-Before commit, Crab freezes writes, checks that the mounted base ref has not moved, and creates a Git commit. A failed push preserves the local commit and overlay recovery state rather than reporting that remote publication succeeded.
+Use `crab mount export` when you want the overlay in a normal directory before
+committing it.
 
-## Understand read behavior through a mount
+## Budget four local stores
 
-Directory listing can use Git trees and Crab metadata without downloading every file. Opening a managed file resolves its pointer and begins the required range reads. Repeated reads can use the local or shared cache.
+Do not compare only “repository size” with “free disk.” Track:
 
-Applications differ in how they access files. Sequential readers work well with coalesced ranges and readahead. Memory mapping, random seeks, and repeated metadata probes can create a wider request pattern. Benchmark the real application rather than a single sequential copy.
+1. Hydrated worktree files.
+2. Verified read cache.
+3. Writable overlay backing.
+4. Application scratch and temporary output.
 
-Filesystem errors must preserve their origin. An archived xorb, denied range read, or integrity mismatch should reach the application as a read failure. Returning zero-filled or truncated data would violate the same reconstruction contract used by hydration.
+<DiskBudgetWorkbench />
 
-Unmount cleanly before removing the mountpoint or cache state. A process with an open file may still depend on the mounted snapshot and its in-flight reads.
+Keep headroom below the filesystem limit. Hydration needs temporary output,
+overlay promotion may reconstruct a full file, and concurrent reads can grow
+the cache before eviction catches up.
 
-## Mount backends share the repository contract
+Cold and warm runs also differ. A cold read includes origin transfer and cache
+population. A warm read may avoid the network, but the application still reads
+and processes the requested bytes.
 
-Automatic mode prefers the available Network File System (NFS) path. `--backend=fuse` selects Filesystem in Userspace (FUSE) and requires the platform adapter.
+## A practical daily workflow
 
-Backend choice affects installation, caching, and filesystem behavior. It does not change pointer identity, shard resolution, xorb verification, or ref consistency.
+For the example laptop:
 
-Use a read-only mount for analysis and serving workloads. Use a writable overlay only when the application must edit through filesystem calls and your workflow includes explicit review and commit.
+1. Clone pointer-only for normal development.
+2. Commit a narrow manifest for the 84 GB training set.
+3. Mount the archive read-only for occasional exploration.
+4. Dehydrate old, clean worktree files before the disk becomes tight.
+5. Use a writable mount only with an overlay budget and commit plan.
 
-Backend behavior still affects operations. Platform support, file-lock semantics, case sensitivity, permission mapping, and unmount behavior can differ. Qualify the selected backend with the applications and operating systems used by the team.
+Before switching branches, refresh the mount or create one at the intended
+ref. A long-running mount is a stable snapshot; it does not silently follow
+every branch update.
 
-Keep the repository-level acceptance test backend-independent: the same pointer must produce the same verified bytes. Add backend-specific tests for filesystem semantics that the application relies on.
+Unmount cleanly before deleting its mountpoint or cache state. Open processes
+may still depend on the snapshot and in-flight reads.
 
-## Choose from the access pattern
-
-| Workload | Best starting mode |
-| --- | --- |
-| Inspect commits or edit source only | Pointer-only clone |
-| Train with a known model and dataset set | Selective hydration |
-| CI job with a committed input list | Manifest hydration |
-| Browse a data lake with unpredictable access | Read-only mount |
-| Edit through filesystem tools | Writable mount with explicit commit |
-
-## Plan for transitions between modes
-
-A team may hydrate a manifest for routine work and mount the archive for occasional exploration. These modes can share verified local cache state, but they should not edit the same managed path concurrently.
-
-Before switching a writable mount back to a normal worktree, inspect and commit or export the overlay. Before dehydrating a path used by a running process, stop the process and confirm the file is clean.
-
-When a branch changes, refresh the mount snapshot or create a new mount at the intended ref. Do not assume a long-running mount follows branch updates automatically. A stable snapshot is easier to reason about than path contents changing underneath an application.
-
-## Budget disk and transfer from the working set
-
-Estimate local capacity from the largest concurrent working set, not total repository history. Include hydrated files, temporary reconstruction output, local cache, mount overlay, and application scratch space.
-
-For continuous integration, set manifests by job. A lint job may need no managed data. A model test may need one checkpoint. A release job may need a complete declared artifact set.
-
-Measure cold and warm runs separately. The first read includes origin transfer and cache population. Later reads may use local or shared cache, but final assembly and verification still process the requested bytes.
-
-When a workload reads the complete repository every time, lazy checkout cannot remove that transfer. Its value appears when access is selective, repeated, or unpredictable enough for on-demand range reads.
-
-Include failure headroom in the capacity model. Atomic hydration needs temporary output before replacement. Writable mounts need overlay space. Cache eviction may lag behind a burst of concurrent reads.
-
-Set operational thresholds below the filesystem limit. Alert on hydrated bytes, cache bytes, overlay bytes, and free space as separate values so the response can target the correct store.
-
-<TakeawayBox title="Materialization is a policy choice">
-  The committed pointer identity stays the same. Choose when full bytes become
-  local based on the task's access pattern.
+<TakeawayBox title="Choose when bytes become local">
+  Pointers carry identity. Hydration materializes a declared set. A mount
+  materializes read windows as applications ask for them.
 </TakeawayBox>
 
-For exact mount management commands, see the [`crab mount`](/docs/cli/reference/crab-mount) reference.
+For exact lifecycle and backend options, see the [`crab mount`](/docs/cli/reference/crab-mount) reference.

--- a/packages/web/content/blog/multi-layer-caching.mdx
+++ b/packages/web/content/blog/multi-layer-caching.mdx
@@ -1,184 +1,171 @@
 ---
 title: "How does Crab avoid repeated object-store reads?"
-description: "See how verified local data, staging, metadata indexes, and an optional shared cache reduce object-store traffic."
+description: "Follow one immutable read through local disk, an optional team cache, and canonical object storage."
 date: "2026-06-26"
 author: "Crab Team"
 category: "architecture"
 tags: ["caching", "performance", "xorb", "object-storage"]
-excerpt: "Crab resolves immutable data locally when possible and falls back to canonical object storage when proof is missing."
+excerpt: "Crab serves verified immutable data from the nearest available source, then falls back to canonical object storage."
 level: "intermediate"
 path: "core-internals"
 order: 3
 concepts: ["cache", "range reads", "metadata indexes", "object storage"]
 prerequisites: ["What happens during a Crab push?"]
-outcome: "Explain which cache can accelerate a read and why cache state cannot replace remote proof."
-diagramType: "Cache hierarchy"
+outcome: "Predict which source serves a read and measure the difference between cold and warm hydration."
+diagramType: "Interactive cache routing"
 meta:
   contentType: "Conceptual"
-  goal: "Explain caching as verified reuse rather than a collection of opaque layers."
-  audience: "Developers diagnosing hydration performance or object-store traffic."
+  goal: "Explain caching through one repeated hydration instead of a list of cache layers."
+  audience: "Developers diagnosing hydration time or object-store traffic."
 ---
 
-Crab's origin is object storage, but repeated work should not require repeated origin reads. Local data and metadata caches shorten the path while content identities keep the result verifiable.
+Suppose `models/encoder.safetensors` is 12 GiB. Alex hydrates it, dehydrates it, then hydrates it again.
 
-<CacheHierarchyDiagram />
+The second read should not travel to the bucket for bytes already verified on Alex's machine.
 
-## Metadata answers where; cached data answers whether to download
+That is the whole cache model:
 
-Hydration begins with a file pointer and reconstruction metadata. The file index and shards identify the ordered chunks, their xorb objects, and their byte ranges.
+> Ask the nearest verified source. Stop on a hit. Use object storage when no cache can prove the bytes.
 
-The local cache can then satisfy xorb data that the machine has already fetched. If a required range is absent, Crab reads the canonical object from the origin and can retain the verified result for later work.
+<CacheRouteTicket />
 
-These are related but different responsibilities. Metadata resolves placement. The data cache avoids downloading known immutable bytes again.
+## One file, three possible trips
 
-## A cold hydration fills several caches
+The file pointer does not contain 12 GiB of data. It identifies a file recipe. That recipe identifies ordered chunks and the xorb objects that contain them.
 
-Consider a pointer whose recipe references twelve chunks across three xorbs. The first hydration may need shard metadata, xorb range reads, decompression, and final file verification.
-
-Crab can retain verified xorb data and metadata after that read. A second hydration on the same machine can resolve the pointer with fewer origin operations. A different file that references six of the same chunks may reuse the same cached xorb ranges.
-
-The working-tree file is not the cache entry. Dehydrating the path removes materialized content but does not require Crab to discard separately managed cache data.
-
-## The lookup order favors the nearest verified source
-
-Crab can resolve one requested chunk through several sources. The client first checks session-owned data and local staging, then verified local cache state, then an optional shared cache, and finally canonical object storage.
+For each immutable object, Crab follows this route:
 
 ```text
-session or staging
-        ↓ miss
-verified local cache
-        ↓ miss
-optional shared cache
-        ↓ miss or unavailable
-canonical object storage
+local disk → optional team cache → object storage
 ```
 
-A hit must still correspond to the expected content identity. The order optimizes latency and repeated transfer, not trust based on proximity. Wrong or incomplete bytes fail verification and cannot become the hydrated output.
+- **First read:** both caches miss, so origin serves the bytes.
+- **Repeat read:** Alex's local disk serves them.
+- **Teammate read:** a team cache may serve bytes that another machine warmed.
+- **Cache outage:** Crab bypasses the accelerator and reads origin.
 
-Metadata follows a related path. In-memory and local indexes can answer repeated lookups, while canonical shard and file-index state remains the authority when the client lacks a complete generation.
+A cache hit changes the trip, not the expected content identity.
 
-## Local staging can satisfy recent content
+## Try a cold and warm hydration
 
-Staging contains chunks and recipes produced by clean operations before or during a push. When the same process or repository needs those bytes again, Crab can reuse them without round-tripping through object storage.
-
-Staging is not a substitute for publication. A remote reader can rely only on objects and metadata that the push proved durable.
-
-Staging can also bridge repeated Git filter operations before push. If a tool asks Git to clean the same content again, the session and staging indexes can avoid repeating chunk work.
-
-This reuse remains local to the repository operation. Another machine cannot resolve the pointer until a successful push publishes its shared dependencies.
-
-## Immutable identity makes cache reuse safe
-
-Xorbs and chunks are content-addressed. A cache entry is useful because Crab can connect it to the expected identity, not because the file happens to exist at a familiar path.
-
-Corrupt or incomplete data must fail verification and return to the canonical read path. Hydration does not expose a partially reconstructed file as a successful result.
-
-## Content addressing changes invalidation
-
-Mutable caches need invalidation when the value behind a key changes. A content-addressed xorb has a different rule: the key names immutable content, so a valid cached value never becomes an older version of that key.
-
-Crab still needs eviction, corruption handling, and metadata generation checks. Eviction controls disk capacity. Hash verification detects wrong bytes. Generation-aware metadata prevents a stale index view from hiding newer canonical state.
-
-Immutable keys reduce invalidation complexity, but they do not eliminate authority checks. A locally known chunk cannot prove that the remote repository published the same dependency.
-
-Concurrent readers can share immutable cache entries without coordinating version replacement. If two hydrations request the same absent xorb range, request coalescing can prevent duplicate origin reads while both consumers wait for one verified result.
-
-A failed producer must wake consumers with an error rather than leaving a partial cache entry. The next request can retry from origin after the temporary state is removed or marked invalid.
-
-## Range planning reduces request fan-out
-
-A file recipe may reference dozens of chunks inside the same xorb. Fetching each chunk with a separate request would make request overhead dominate the data transfer.
-
-Crab groups required chunks by xorb and coalesces compatible byte ranges. It can fetch independent xorb ranges concurrently while keeping memory and I/O bounded.
-
-Coalescing has an economic threshold. One wider range may cost fewer requests but transfer bytes that the file does not need. Several narrow ranges reduce unused transfer but add latency and request charges.
-
-Choose range width from xorb layout and workload locality. Sequential model reads favor wider adjacent ranges. Sparse access through a mount may favor narrow reads, especially when object-store transfer costs exceed request costs.
-
-Cache measurements should retain both figures. A lower request count is not automatically an improvement if origin bytes increase enough to erase the benefit.
-
-## A shared cache is optional
-
-The default local cache serves one machine. Teams can also deploy the optional Crab cache service so developers and CI runners share recently used objects before falling back to cloud storage.
-
-The shared service is an acceleration layer, not the repository's source of truth. If it is unavailable or misses an object, canonical object storage remains the durable origin.
-
-The service should receive no authority to edit repository refs or delete canonical data. Its access path can be limited to reading immutable objects and serving cached responses to authenticated clients.
-
-Segment shared-cache metrics by repository or tenant boundary. A global hit rate can hide a repository whose active set never fits or a workload that evicts higher-value objects for other teams.
-
-## Decide whether a shared cache pays for itself
-
-A shared cache helps when several machines read the same active data set. Developer teams, repeated continuous integration jobs, and regional training workers can avoid duplicate object-store reads.
-
-It helps less when every job reads unique content or already runs near the bucket. The service also needs capacity planning, authentication, health checks, and eviction policy.
-
-Compare these measurements before deployment:
-
-- **Origin bytes avoided**: data served by the shared cache instead of object storage
-- **Request reduction**: origin operations removed from repeated hydration
-- **Cache hit rate**: hits divided by eligible lookups, segmented by workload
-- **Added latency**: cache lookup time on hits and misses
-- **Operating cost**: compute, local solid-state drive capacity, and network transfer
-
-Treat a high hit rate carefully. Tiny metadata hits can dominate count while large xorb misses dominate bytes and cost.
-
-## Inspect and reset local cache state
-
-Use the cache commands to observe local behavior or reclaim disk space:
+Use one real file so the comparison stays honest:
 
 ```bash
 crab cache stats
-crab cache clean
+time crab hydrate 'models/encoder.safetensors' --jsonl | tee cold.jsonl
+
+crab dehydrate 'models/encoder.safetensors'
+
+time crab hydrate 'models/encoder.safetensors' --jsonl | tee warm.jsonl
+crab cache stats
 ```
 
-Cleaning the cache does not delete repository data. It removes local copies that Crab can fetch again from the origin.
+The warm run can remove remote transfer. It cannot remove local work: Crab still assembles chunks in order, writes 12 GiB, and verifies the result.
 
-## Set capacity from byte value, not object count
+If you only need to warm the cache, skip file materialization:
 
-Cache policy needs a disk budget and an eviction rule. Object count alone is misleading because metadata entries, small xorb ranges, and complete xorb objects have different sizes and retrieval costs.
+```bash
+crab fetch --include 'models/*.safetensors'
+```
 
-Prioritize content that is expensive to fetch again or likely to serve another near-term task. A frequently reused model xorb can be more valuable than thousands of one-time metadata entries. Archived-origin data may have higher cache value because a miss can trigger restore delay and retrieval cost.
+`crab fetch` resolves the same immutable data and sends reconstructed bytes to a discard sink. Later hydration can use the warmed cache.
 
-Leave headroom for reconstruction output and application scratch space. Filling the disk with cache can make hydration fail even though the cache itself reports a high hit rate.
+## Metadata is the map; cached bytes are the cargo
 
-For developer machines, expose cache cleanup as a recoverable disk action. For shared runners, set an explicit capacity and monitor eviction bytes, not only evicted entries.
+Two questions happen during a read:
 
-## Distinguish positive and negative metadata cache entries
+| Question                    | Answered by                   | Example                           |
+| --------------------------- | ----------------------------- | --------------------------------- |
+| Where are the file's bytes? | file index and shard metadata | chunk C is in xorb X, position 14 |
+| Do I need to download them? | local or team data cache      | range 14–18 is already verified   |
 
-A positive entry says a file recipe or chunk location was known at a particular canonical generation. A negative entry says the client did not find that identity in the state it examined.
+A warm metadata index does not mean the xorb bytes are local. A warm data cache does not tell Crab the file's chunk order. Hydration needs both answers.
 
-Positive immutable data can remain valid after newer repository writes. Negative knowledge can become stale as soon as another writer publishes the missing identity. Crab must therefore refresh or generation-check negative results before deciding that push needs a new upload or hydration lacks metadata.
+This distinction is useful when debugging: repeated metadata reads point to index synchronization; repeated xorb reads point to cache capacity, eviction, or a changing working set.
 
-This difference explains a common concurrent pattern. Writer A publishes a chunk after writer B cached a miss. Writer B refreshes canonical index state, finds A's durable location, and avoids uploading the duplicate.
+## Range reads are a request-versus-bytes trade
 
-Cache freshness policy should match the consequence. A stale performance hint costs work. A stale authority decision could produce an incomplete plan, so publication and integrity checks consult canonical state.
+A recipe may need several chunks from one xorb. Fetching each chunk separately wastes request round trips. Fetching one enormous span may transfer bytes the file never uses.
 
-## Protect cache state from partial writes
+Select an access pattern below. Green blocks are required; striped amber blocks are extra bytes accepted to remove requests.
 
-Download into temporary cache state, verify the expected identity, then publish the entry for readers. A process crash or full disk must not leave a truncated file under a key that later lookups treat as valid.
+<RangePlanningTape />
 
-On startup, Crab can discard incomplete temporary entries and retain verified immutable ones. This keeps crash recovery local and avoids clearing the complete cache after one interrupted read.
+The toy tape uses 8 MiB blocks for legibility. Crab's planner works from actual chunk offsets and xorb layout.
 
-Shared cache responses need the same content verification at the client boundary. Transport security and service authentication protect the connection, while content hashes protect the repository result.
+The useful measurement is not hit count alone. Track both:
 
-## Diagnose performance from the miss path
+- origin request count
+- origin bytes transferred
 
-Begin with `crab cache stats`, then compare a cold and warm hydration of the same file. Record elapsed time, bytes read from origin, cache bytes read, request count, and verification failures.
+One request can be faster than three and still cost more transfer. Sparse access often favors narrow ranges. Neighboring reads often favor coalescing.
 
-If metadata lookup dominates, warming xorb data alone will not help. Inspect shard synchronization and chunk-index state. If origin range reads dominate, inspect xorb grouping, cache capacity, and access locality.
+## Why cached content stays safe
 
-A warm run that remains slow may be doing required final assembly and hashing. Cache eliminates remote work, not the byte processing needed to produce and verify the output file.
+Chunks and xorbs are content-addressed. Their identity names their content. A valid object under that identity does not become an older version later.
 
-Use cache cleaning only as a controlled diagnostic or disk-reclamation action. Repeatedly clearing healthy cache state makes every workload look cold and hides the benefit you are trying to measure.
+That removes the usual “is this cached value stale?” problem for immutable data. Crab still needs three safeguards:
 
-When a warm result becomes slower, separate cache lookup time from verification and assembly. A large file still requires ordered writes and a final hash even when every source range is local. CPU saturation or destination-disk throughput can dominate after origin traffic disappears.
+1. Verify that bytes match the expected identity.
+2. Publish a cache entry only after a complete write.
+3. Evict or repair corrupt entries before returning file content.
 
-When a cold result issues unexpected reads, map each request back to a shard lookup or xorb range. This exposes missing metadata warming, fragmented xorb layout, or a working set wider than cache capacity.
+Mutable repository state follows a different rule.
 
-<TakeawayBox title="Cache is acceleration, not authority">
-  Local and shared caches reduce latency and requests. Canonical object
-  storage and verified content identities remain the correctness boundary.
+<CacheObjectPassport />
+
+A branch ref can move from commit A to commit B. Treating a cached ref as authority could hide B. Mutable paths therefore consult origin directly, while immutable shards and xorbs can use the read-through cache.
+
+This is why “cache is acceleration, not authority” is more than a slogan. It describes which objects may take the shortcut.
+
+## Dehydrating is not clearing the cache
+
+These actions affect different state:
+
+```text
+crab dehydrate   → replace working-tree content with a pointer
+crab cache clean → remove reusable local cache data
+```
+
+Dehydrating a file frees working-tree space. It does not require Crab to forget separately cached xorb ranges.
+
+Use the cache commands deliberately:
+
+```bash
+crab cache stats   # capacity, resident bytes, and entries
+crab cache verify  # verify entries; evict corrupt ones
+crab cache clean   # reclaim local disk; later reads become cold
+```
+
+Cleaning does not delete repository data from object storage. It removes local copies that Crab can fetch again.
+
+## When a team cache helps
+
+The optional cache service pays off when machines repeat the same reads:
+
+| Workload                               | Likely value  |
+| -------------------------------------- | ------------- |
+| CI runners test the same checkpoint    | high          |
+| A team pulls the same active model set | high          |
+| Every job reads unique data once       | low           |
+| Workers already sit next to the bucket | measure first |
+
+Do not judge it by object hit rate alone. Thousands of tiny metadata hits can hide one large xorb miss. Compare origin bytes avoided, origin requests avoided, added lookup latency, and cache operating cost.
+
+## Diagnose the slow leg
+
+Start with one cold run and one warm run of the same file.
+
+- **Cold is slow, warm is fast:** remote transfer dominates. The cache is helping.
+- **Both are slow:** assembly, hashing, or destination-disk throughput may dominate.
+- **Warm still contacts origin:** inspect cache size, eviction, integrity failures, and whether the working set changed.
+- **Many small origin reads:** inspect range grouping and xorb locality.
+
+Keep the experiment controlled. Repeatedly clearing healthy cache state only proves that cold reads are cold.
+
+<TakeawayBox title="Nearest verified bytes win">
+  Local disk avoids a network trip. A team cache avoids a bucket trip. Object
+  storage remains the durable fallback and authority.
 </TakeawayBox>
 
-Continue with [How does Crab rebuild a file from chunks?](/blog/shard-reconstruction-hydration) to see how metadata and range reads become one verified file.
+Continue with [How does Crab rebuild a file from chunks?](/blog/shard-reconstruction-hydration) to follow the selected ranges into one verified file.

--- a/packages/web/content/blog/push-pipeline-14-steps.mdx
+++ b/packages/web/content/blog/push-pipeline-14-steps.mdx
@@ -1,17 +1,17 @@
 ---
 title: "What happens during a Crab push?"
-description: "Step through the fourteen stages that discover dependencies, upload immutable objects, prove closure, and publish one ref transaction."
+description: "Follow one Crab push from local commit to durable objects and one atomic ref update."
 date: "2026-06-19"
 author: "Crab Team"
 category: "architecture"
 tags: ["push", "pipeline", "deduplication", "xorb", "consistency"]
-excerpt: "A Crab push prepares thirteen stages of immutable state before the fourteenth stage changes branch visibility."
+excerpt: "A visual walkthrough of the fourteen stages behind one safe Crab push."
 level: "deep-dive"
 path: "core-internals"
 order: 2
 concepts: ["push", "staging", "dedup upload", "atomic refs"]
 prerequisites: ["How does Crab avoid storing duplicate data?"]
-outcome: "Locate the durability, recovery, and concurrency boundaries in a Crab push."
+outcome: "Explain what Crab uploads, what it proves, and when a pushed commit becomes visible."
 diagramType: "Interactive transaction trace"
 meta:
   contentType: "Conceptual"
@@ -19,184 +19,180 @@ meta:
   audience: "Developers operating Crab or reviewing its consistency model."
 ---
 
-A Crab push is a transaction assembled from immutable object uploads and one final ref update. The client can retry preparation work, but it must not expose the new commit until every Git and large-file dependency is durable.
+A Crab push has one hard rule:
 
-<BlogProcessPlayer story="pipeline" />
+> **Upload first. Prove everything exists. Move the branch last.**
 
-## The fourteen stages form one evidence chain
+The implementation has fourteen stages, but you only need four ideas to understand it: **plan, upload, prove, publish**.
 
-The numbered stages are easier to remember when each produces evidence required by a later decision:
+<PushPipelineBoard />
 
-| Stage | Operation | Evidence produced |
-| --- | --- | --- |
-| 1 | Parse the source and destination refspec | Intended ref edit |
-| 2 | Read the destination tip | Expected-old object ID |
-| 3 | Acquire the destination lease | Contention boundary |
-| 4 | Discover reachable Git objects and Crab pointers | Complete dependency plan |
-| 5 | Classify known and new chunks | Upload set |
-| 6 | Build the Git pack | Git transport object |
-| 7 | Pack new chunks into xorbs | Immutable data objects |
-| 8 | Flush and upload staged xorbs | Durable chunk bytes |
-| 9 | Upload the Git pack | Durable Git objects |
-| 10 | Publish shard and file metadata | Durable reconstruction terms |
-| 11 | Verify Git connectivity | Complete Git closure |
-| 12 | Verify pointer closure | Complete Crab closure |
-| 13 | Compare the destination with expected-old | Freshness decision |
-| 14 | Commit the ref transaction | Visible branch update |
+## Start with one real push
 
-Implementation can overlap independent immutable work, but the dependency order remains. For example, xorb and Git-pack uploads can use bounded concurrency. Neither can justify a visible ref before both closure checks pass.
+Imagine `main` points to commit `A`. Your local commit `B` changes two files:
 
-## Stages 1–4 define the intended state
+```text
+src/train.rs          4 KiB source change
+models/ranker.bin    12 GiB model update
+```
 
-The push begins by resolving the source, destination, and expected old object ID. It acquires a short lock for the destination ref, walks the reachable Git graph, and resolves every Crab pointer in that graph.
+The new model shares about 80% of its chunks with the previous version. That percentage is illustrative; actual reuse depends on the file content.
 
-This is the rejection boundary for incomplete local state. A pointer without staged content or durable remote proof cannot enter a publishable plan.
+```bash
+git add src/train.rs models/ranker.bin
+git commit -m "Improve ranking model"
+crab push origin main
+```
 
-The discovery walk treats ordinary Git blobs and Crab pointers differently after Git identifies them. Ordinary blobs need Git-pack connectivity. Crab pointers add a second dependency closure through file recipes, shards, and xorbs.
+`crab push` uses Crab's native concurrent path. A normal `git push` to a `crab://` remote enters the same publication model through Git's remote helper.
 
-A source-only push can therefore complete without creating xorb or shard data. A mixed push prepares both lanes but still publishes one destination ref transaction.
+The intended result is simple:
 
-## Stages 5–7 decide what must be created
+```text
+main: A ───────────────► B
+      visible            visible only after proof
+```
 
-Crab classifies chunks as known or new, builds a standard Git pack for reachable Git objects, and packs new chunks into xorbs. Existing chunks can be reused only when canonical metadata proves their remote location.
+While the push runs, readers continue to see `A`. Uploaded bytes do not make `B` visible.
 
-Staged xorbs must flush before the push can continue to publication. This ordering prevents a file recipe from referring to bytes that exist only in a short-lived local process.
+## The fourteen stages fit into four phases
 
-Classification can reuse chunks from the same add session, earlier local work, or canonical remote indexes. The source of the hint changes lookup cost, but the publication proof still requires a durable remote location.
+| Phase | Stages | Question Crab answers | Visible branch |
+| --- | ---: | --- | --- |
+| **Plan** | 1–4 | What ref and objects does `B` need? | `A` |
+| **Upload** | 5–10 | Are the Git and large-file objects durable? | `A` |
+| **Prove** | 11–12 | Can another client reconstruct everything? | `A` |
+| **Publish** | 13–14 | Is `A` still current, and may the ref move? | `A`, then `B` |
 
-The Git pack remains compatible Git data. Crab does not embed large-file xorbs inside that pack because Git clients and object storage have different access and lifecycle requirements.
+That last cell is the key. Stage 14 is the only visibility change.
 
-## Stages 8–10 make immutable dependencies durable
+## Phase 1: plan the complete push
 
-The client uploads the Git pack and xorbs with bounded concurrency. It then creates and uploads shard metadata that records complete reconstruction terms for each file.
+Stages 1–4 resolve the ref edit, read the destination tip, acquire the ref lock, and walk commit `B`.
 
-An interruption here can leave an unreferenced immutable object. That object is safe because no visible ref names it. A later retry can reuse it, and garbage collection can reclaim it after the grace period if it remains unreachable.
+The walk finds two kinds of dependencies:
 
-The write journal records enough progress to distinguish completed uploads from pending work. A retry can skip immutable objects that canonical storage already contains.
+- Git objects: commit, trees, source blobs, and Crab pointer blobs.
+- Crab objects: file recipes, chunks, xorbs, and shards needed by each pointer.
 
-Retry safety depends on immutable identity. Repeating an upload for the same content cannot replace a different object's meaning. Mutable state remains concentrated in the final ref decision.
+For the example, the plan records `A` as the **expected old** value of `main`. If the model pointer has neither staged content nor proven remote metadata, the push stops here.
 
-## Stages 11–12 prove closure
+## Phase 2: upload immutable objects
 
-Before publishing, Crab proves two closures. Git connectivity confirms that the proposed commit graph is complete at the origin. Pointer closure confirms that every Crab pointer resolves through durable metadata to durable xorb bytes.
+Stages 5–10 prepare both data lanes. Select a lane to isolate its work.
 
-This proof uses canonical storage state. A local cache can accelerate the checks, but it cannot substitute for the remote dependency contract.
+<PushDataLanesDiagram />
 
-Closure proof also protects readers in other regions or machines. The writer's local cache may contain every required byte while the shared origin is incomplete. Publication waits for the shared state, not the writer's ability to reconstruct locally.
+Crab classifies the model chunks before uploading. With the illustrative 80% reuse:
 
-## Stages 13–14 decide visibility
+| Model content | Approximate size | Push action |
+| --- | ---: | --- |
+| Already proven at the origin | 9.6 GiB | Reuse existing chunk locations |
+| New content | 2.4 GiB | Pack into xorbs and upload |
+| File mapping | Small metadata | Publish complete shard terms |
 
-The push compares the branch's current value with the expected old object ID. If another writer changed the ref, the stale push is rejected instead of overwriting newer history.
+Crab can build and upload independent immutable objects concurrently. It still preserves the dependency order: staged xorbs flush before metadata can refer to them.
 
-Only after that comparison succeeds does Crab append the ref transaction that makes the new tip visible. The lock can then be released.
+An interrupted upload may leave a complete but unreachable object. That is safe. No ref points to it, a retry can reuse it, and garbage collection can reclaim it after the grace period.
 
-The expected-old check applies to creation and deletion as well as ordinary updates. Creating a ref expects it not to exist. Updating expects the observed object ID. Deleting expects the ref still to name the object the client intended to remove.
-
-Multi-ref pushes preserve a result for each destination. Shared immutable preparation can serve several edits, but Crab must not report a rejected destination as updated. Scripts should inspect the per-ref results rather than treating uploaded bytes as a batch-wide success.
-
-## Locking and compare-and-swap solve different problems
-
-The ref lock reduces duplicate work by keeping same-ref writers from performing contested publication concurrently. Lease expiration means the lock cannot provide permanent correctness on its own.
-
-Compare-and-swap checks the expected old object ID at the visibility boundary. A writer with an expired lease or stale plan cannot overwrite a branch that changed after discovery.
-
-Different refs can progress in parallel because their visibility decisions are independent. They may still reuse the same immutable Git packs or xorbs.
-
-<TakeawayBox title="One publication point">
-  Git packs, xorbs, shards, and closure proofs prepare the update. The ref
-  transaction is the only step that makes the new commit visible to readers.
+<TakeawayBox title="Uploads are preparation">
+  Seeing a Git pack, xorb, or shard in object storage does not mean the push is
+  visible. Readers still follow the old ref.
 </TakeawayBox>
 
-## Recovery follows the last durable boundary
+## Phase 3: prove both closures
 
-The write journal records progress for interrupted operations. A retry can determine which immutable uploads already completed and continue without pretending that the ref moved.
+Stages 11–12 ask two different questions:
 
-A failure after the ref transaction is different: the update is visible and its dependencies were already proven. Cleanup releases the lock and closes local staging, but it does not roll back a complete published state.
+1. **Git closure:** Can the origin reach every commit, tree, and blob required by `B`?
+2. **Pointer closure:** Can every Crab pointer resolve through durable shards to durable xorb bytes?
 
-The retry should begin by reading canonical state, not by trusting the previous process's final log line. An object upload may have completed even if the client lost the response. A ref transaction may have committed even if cleanup or response delivery failed afterward.
+A local cache can make these checks faster, but it cannot supply the proof. The shared origin must contain the dependencies because another machine will not have the writer's cache.
 
-Content identities and transaction records let Crab distinguish those cases. Retrying an immutable object is safe, while repeating a ref edit requires another current expected-old comparison.
+For `models/ranker.bin`, pointer closure means the recipe covers every ordered chunk—including the reused 9.6 GiB and the new 2.4 GiB.
 
-## Failure location determines visible state
+## Phase 4: compare, then publish
 
-| Failure point | Durable side effect | Visible ref result | Retry action |
+Stage 13 reads `main` again and compares it with expected-old `A`.
+
+- If `main` is still `A`, stage 14 can commit `A → B`.
+- If another writer changed it to `C`, Crab rejects this ref update.
+
+The rejected push may have uploaded useful immutable data. It did **not** overwrite `C`. After reconciling the history, a retry can reuse objects that are already durable.
+
+<PushVisibilityLab />
+
+The lock and expected-old check have different jobs:
+
+| Mechanism | Job |
+| --- | --- |
+| Ref lock | Avoid duplicate contested work on the same destination |
+| Expected-old comparison | Prevent a stale writer from replacing newer history |
+
+Locks can expire. The expected-old check at the visibility boundary is what protects the ref decision.
+
+## What happens when a stage fails?
+
+Use the incident selector above to move between an interrupted upload, a failed proof, two competing writers, and post-commit cleanup. The visible state is always a complete ref.
+
+| Failure point | What may remain | What readers see | Next move |
 | --- | --- | --- | --- |
-| Before discovery completes | None required | Old ref remains | Fix local input and restart |
-| During xorb or pack upload | Some immutable objects may exist | Old ref remains | Restore access and reuse completed uploads |
-| During shard publication | Data objects may exist | Old ref remains | Publish missing metadata and prove closure |
-| During expected-old comparison | All dependencies may exist | Stale edit is rejected | Fetch and reconcile history |
-| After ref transaction | Complete update exists | New ref is visible | Finish cleanup; do not roll back dependencies |
+| Discovery | Local staging | `A` | Fix the missing input |
+| Object upload | Complete immutable objects | `A` | Retry and reuse them |
+| Closure proof | Uploaded but incomplete dependency set | `A` | Restore the missing dependency |
+| Expected-old check | All uploaded dependencies | Winning ref, such as `C` | Fetch, reconcile, retry |
+| After ref commit | Complete published state | `B` | Finish cleanup; do not roll back |
 
-The table explains why object inventory can contain data that no branch currently reaches. Immutable upload is preparation, not publication.
+Crab does not delete uploaded objects when a stale ref loses. Another writer may already reuse those objects. Repository garbage collection decides when unreachable data is safe to remove.
 
-## The user-facing failures are specific
+## Source-only, model-only, and mixed pushes
 
-A missing recipe fails during discovery. An object-store error fails during upload. A closure failure blocks publication.
+The transaction shape stays the same even when one lane has little work.
 
-A compare-and-swap conflict rejects the stale ref edit. Each outcome preserves the previous complete branch view.
+| Commit type | Git lane | Crab lane | Publication |
+| --- | --- | --- | --- |
+| Source only | New Git pack data | No new chunks | One ref transaction |
+| Model only | Commit, tree, pointer | Reused and/or new xorbs | One ref transaction |
+| Mixed | Source blobs and pointer | Reused and/or new xorbs | One ref transaction |
 
-## Deletion follows the same visibility discipline
+One history never gets two meanings of “pushed.” Every successful case ends at the same ref boundary.
 
-A branch deletion does not delete Git packs, xorbs, or shards during the push. It appends a ref transaction that removes the current destination after validating expected-old state.
+## Verify from a reader's point of view
 
-Separating ref deletion from object deletion protects other branches, tags, recovery roots, and concurrent work that may share immutable objects. Repository garbage collection later walks every retained root and applies a grace period before classifying data for deletion.
+A successful command exit is useful. A fresh reader is stronger proof.
 
-This separation also makes branch restoration possible while recovery history remains retained. An operator can reason about history policy before an irreversible storage action occurs.
+```bash
+# In a second clone or an isolated cache
+git pull --ff-only origin main
+git rev-parse HEAD
+git show HEAD:models/ranker.bin
+crab hydrate models/ranker.bin
+crab fsck
+```
 
-## Source-only and mixed pushes use the same transaction
+Check four things:
 
-A source-only change has no new Crab chunks, but it still needs Git connectivity and a fresh ref comparison. A managed-file-only change still creates a Git commit and pointer blob. A mixed change needs both dependency closures.
+- The fetched object ID is the pushed commit.
+- Git can read the pointer blob.
+- Hydration reconstructs the expected file.
+- `crab fsck` reports a complete repository.
 
-Keeping one transaction shape prevents a branch from acquiring a second publication mechanism based on file type. The preparation set becomes smaller when one lane has no work, while stage 14 remains the only visibility change.
+For a concurrency test, start two writers from `A`. One may publish. The other must receive a conflict instead of silently replacing the winner.
 
-This is also why a pointer copied from another commit is not automatically unsafe. If its recipe and durable ranges already exist, closure can prove the dependency without uploading new xorb bytes.
+<FlowSteps
+  title="The push contract"
+  steps={[
+    "Plan every Git and Crab dependency behind the proposed commit.",
+    "Upload immutable Git packs, xorbs, and complete shard metadata.",
+    "Prove Git connectivity and pointer closure from canonical storage.",
+    "Compare expected-old state and commit exactly one ref transaction.",
+  ]}
+/>
 
-## Walk one mixed push through the stages
-
-Assume commit `B` changes `src/train.rs` and updates `models/current.bin` from a branch currently at commit `A`. The model shares 80 percent of its chunks with the prior version.
-
-Stages 1 through 4 record `A` as expected-old, acquire the `main` lease, and walk commit `B`. The walk discovers the new pointer.
-
-Stages 5 through 7 prove reused chunks and pack only unproven chunks into xorbs. Git also builds a pack with the commit, tree, source blob, and pointer blob.
-
-Stages 8 through 10 upload the Git pack and new xorbs, then publish recipe and shard terms that combine old and new chunk locations. The new model remains invisible at `main` during this work.
-
-Stages 11 and 12 prove that commit `B` and every pointer behind it are reconstructable from shared storage. Stage 13 confirms `main` still names `A`. Stage 14 commits `A → B` and returns success for the destination.
-
-If stage 13 finds commit `C`, the push rejects `B` even though all model data is durable. The contributor can reconcile `B` with `C` and reuse the completed xorb work in a new plan.
-
-## Publication does not require destructive rollback
-
-Traditional mutable transactions may undo writes when the final decision fails. Crab can leave immutable preparation objects because they do not become history until a ref reaches them.
-
-This reduces recovery risk. Deleting uploaded xorbs during a stale-ref rejection could remove chunks another writer reused between upload and cleanup. Leaving them unreferenced lets repository-wide GC evaluate all roots after the grace period.
-
-The cost is temporary storage. Operators should expect a bounded orphan set after interrupted or rejected pushes and monitor its age. Immediate zero-orphan cleanup would require broader coordination and weaken writer independence.
-
-Journals provide retry evidence during the protection window. Once no retained operation or ref reaches an old preparation object, collection can reclaim it safely.
-
-## Verify the transaction from another client
-
-The writer can inspect local status and logs, but another client supplies stronger evidence. Fetch the destination ref from an empty or isolated cache, then hydrate representative managed paths.
-
-Record the new commit object ID, ref result, pointer count, hydration hashes, and `crab fsck` result. For concurrent-push testing, start two edits from the same old tip and confirm that one stale writer receives a conflict.
-
-This evidence reaches beyond a successful process exit. It proves that the visible ref, Git closure, Crab metadata, and immutable data agree from a reader's perspective.
-
-Test interruption boundaries in a disposable destination. Stop a push during an immutable upload and confirm the old ref remains. Create two writers from the same base and confirm one stale edit is rejected. Retry the interrupted writer and confirm completed objects can be reused.
-
-Do not inject failures into a production ref without an agreed maintenance window. The safety model protects repository correctness, but repeated interrupted uploads can consume temporary storage and create operational noise until garbage collection runs.
-
-Automate a transaction matrix in a dedicated repository:
-
-- **Source only**: no new xorb bytes, complete Git ref update
-- **Managed file only**: new pointer closure and complete hydration
-- **Mixed commit**: both lanes publish through one ref outcome
-- **Interrupted upload**: old ref remains visible
-- **Stale writer**: complete dependencies but rejected ref
-- **Retry**: completed immutable objects are reused
-- **Deletion**: ref disappears while retained data follows GC policy
-
-The matrix tests the invariant across different plan shapes. One successful mixed push does not prove interruption, concurrency, or deletion behavior.
+<TakeawayBox title="Remember the visibility boundary">
+  Stages 1–13 prepare or validate the new state. Stage 14 moves the ref. A
+  reader therefore sees the old complete commit or the new complete commit—not
+  a branch that points at missing data.
+</TakeawayBox>
 
 Next, [see how local caches reduce the reads that prepare and verify these stages](/blog/multi-layer-caching).

--- a/packages/web/content/blog/shard-reconstruction-hydration.mdx
+++ b/packages/web/content/blog/shard-reconstruction-hydration.mdx
@@ -1,198 +1,140 @@
 ---
 title: "How does Crab rebuild a file from chunks?"
-description: "Trace hydration from a Git pointer through shard terms and xorb ranges to an atomically replaced, verified file."
+description: "Follow one pointer through file terms, xorb reads, ordered assembly, BLAKE3 verification, and atomic replacement."
 date: "2026-07-03"
 author: "Crab Team"
 category: "architecture"
 tags: ["hydration", "shard", "xorb", "blake3", "reconstruction"]
-excerpt: "Hydration resolves every chunk, plans bounded range reads, assembles bytes in recipe order, and verifies the result before replacement."
+excerpt: "Hydration resolves every recipe position, restores logical order, and replaces the pointer only after the complete file matches."
 level: "deep-dive"
 path: "core-internals"
 order: 4
 concepts: ["hydration", "shard", "xorb", "verification"]
 prerequisites: ["How does Crab avoid repeated object-store reads?"]
-outcome: "Explain the complete reconstruction and verification path for one Crab pointer."
-diagramType: "Hydration proof pipeline"
+outcome: "Trace one recipe from pointer to verified working-tree file and identify where failures stop it."
+diagramType: "Interactive reconstruction workbench"
 meta:
   contentType: "Conceptual"
-  goal: "Explain why hydration is both a download plan and an integrity proof."
-  audience: "Developers investigating checkout behavior, corruption, or read performance."
+  goal: "Explain reconstruction through one small repeated-chunk recipe."
+  audience: "Developers investigating checkout behavior, missing chunks, or integrity failures."
 ---
 
-A Crab pointer contains the file identity and size, but not the file bytes. Hydration resolves that identity into a complete ordered recipe, finds each chunk inside immutable xorbs, and verifies the assembled file before replacing the pointer.
+Git checks out a small Crab pointer. You need the original multi-gigabyte file.
 
-<HydrationPlanDiagram />
+Hydration has one job:
 
-## The pointer names the expected result
+> Produce exactly the bytes named by the pointer—or leave the pointer in place and return an error.
 
-The Git blob records a BLAKE3 file hash, decimal byte size, and optional shard hint. These fields define what a successful hydration must produce.
+The download is only one part. Crab must also find every chunk, restore recipe order, verify the complete file, and replace the pointer safely.
+
+## The pointer defines success
+
+A pointer records the expected file identity and size:
 
 ```text
 version https://crab.dev/spec/v1
-file-hash <64 hexadecimal characters>
-size <decimal bytes>
-shard-hint <optional 64-character hash>
+file-hash 8f2c…91a4
+size 348160
+shard-hint 41de…770b
 ```
 
-The hint can shorten lookup, but correctness cannot depend on a stale hint. Crab still resolves canonical metadata for the requested file identity.
+- `file-hash` is the expected BLAKE3 of the complete file.
+- `size` catches missing or extra bytes.
+- `shard-hint` can accelerate lookup, but it is not authority. Crab falls back to the file index when the hint is stale or absent.
 
-## The file index separates identity from recipe storage
+The pointer does not list thousands of chunks. Metadata outside Git holds that larger recipe.
 
-The full-file hash is the stable lookup key. File-index metadata connects that key to the recipe information needed for reconstruction, while shard metadata connects chunk identities to physical ranges.
+## Follow one five-position recipe
 
-This indirection lets Crab change storage layout without rewriting Git history. Repacking can move a chunk into another xorb and publish updated location metadata. The pointer still names the same expected file bytes.
-
-It also keeps pointers compact. A file with thousands of chunks does not place thousands of terms in Git. Git stores the file identity, while object storage holds the larger reconstruction structures that hydration reads only when needed.
-
-## A recipe can span files, revisions, and xorbs
-
-Imagine a file recipe with four ordered chunks: `A`, `B`, `C`, and `D`. Shard metadata may locate `A` and `C` in one older xorb, `B` in a newer xorb, and `D` in the local verified cache.
-
-The recipe does not require chunks to share an upload or commit. Content identity lets the file reuse any durable matching chunk. Reconstruction order comes from the recipe, not object creation time.
+Use this toy file:
 
 ```text
-file recipe:  A → B → C → D
-xorb 17:      A, C, unrelated chunk E
-xorb 42:      B, unrelated chunk F
-local cache:  D
+recipe: A → B → C → D → B
 ```
 
-The planner turns this logical order into physical reads, then the assembler restores the logical order after data arrives.
+Chunk `B` appears twice in the output. Storage needs one verified copy; assembly writes it at positions 2 and 5.
 
-## Trace one recipe into a concrete read plan
+Select any output slot below to see its physical placement.
 
-Suppose the recipe is `A, B, C, D, B`. The last term repeats chunk `B`, so the output contains those bytes twice even though storage needs one durable copy.
+<ReconstructionWorkbench />
 
-Shard resolution produces these locations:
+This separation matters:
+
+| Structure        | What it answers                              | Example field             |
+| ---------------- | -------------------------------------------- | ------------------------- |
+| Pointer          | What final file is expected?                 | file hash and size        |
+| File recipe      | Which chunks, in what order?                 | `A, B, C, D, B`           |
+| `ChunkPlacement` | Where is one chunk packed?                   | xorb hash and chunk index |
+| `FileTerm`       | Which contiguous xorb range serves the file? | `chunk_start..chunk_end`  |
+
+A `FileTerm` also records `unpacked_bytes`. Its end index is exclusive, so `3..4` contains one xorb-local chunk.
+
+## Planning physical reads does not change file order
+
+Crab groups compatible terms by xorb. In the example, `A` and `C` can share one read from `xorb-17`; `B` comes from `xorb-42`; `D` may already be cached.
+
+Those sources finish independently. Change the completion order:
+
+<ReconstructionArrivalBoard />
+
+The output remains `A, B, C, D, B` every time.
+
+That is the key distinction:
 
 ```text
-A -> xorb-17 bytes 0..4095
-B -> xorb-42 bytes 8192..12287
-C -> xorb-17 bytes 4096..8191
-D -> local verified cache
-B -> reuse the verified xorb-42 result
+physical plan → minimize reads and reuse verified bytes
+logical recipe → define the only valid output order
 ```
 
-The planner can coalesce `A` and `C` into one compatible range from `xorb-17`. It requests `B` once from `xorb-42`, obtains `D` locally, and records that the verified `B` result fills two recipe positions.
+Concurrency can change when bytes arrive. It cannot change what the file means.
 
-The assembler writes `A`, `B`, `C`, `D`, and `B` in that order. Range completion order and xorb object order do not change the output sequence.
+## Every recipe position must be covered
 
-The final expected size catches missing or extra bytes. The full-file BLAKE3 hash catches wrong content or order even when every individual source chunk passed its own identity check.
+Before reconstruction spends bandwidth, Crab checks that shard terms cover the expected file. A missing term is not treated as a smaller valid file.
 
-## Shard terms locate every chunk
+For the toy recipe, coverage means five output positions even though only four chunk identities are unique:
 
-The file recipe lists chunks in reconstruction order. Shard metadata maps those chunk identities to xorb objects and byte ranges.
+```text
+positions expected: 5
+positions resolved: 5
+unpacked bytes:      348160
+```
 
-A complete plan must cover every chunk for the file version. Missing or conflicting terms are an error; Crab does not create a shorter file and call the hydration complete.
+If position 4 has no placement, the plan stops. Crab does not fetch `A`, `B`, and `C`, write a short file, and hope the final hash explains the problem later.
 
-Shard lookup can use the optional pointer hint to begin near likely metadata. If the hint does not contain every term, Crab continues through canonical index state.
+## Verification happens at two scales
 
-Each resolved term includes enough information to locate and verify its chunk. A term that names a missing xorb range fails before final publication to the worktree.
+Chunk verification answers: “Did this range return the bytes for chunk C?”
 
-Metadata can span shard generations because files reuse chunks created at different times. The resolver gathers terms until it covers the complete ordered recipe. Finding the first matching shard is not enough when later chunks live elsewhere.
+Final verification answers: “Did all chunks produce the exact file, in the exact order, at the expected size?”
 
-Duplicate location terms are acceptable only when they describe valid copies of the same chunk identity. Conflicting identities or ranges cannot be resolved by choosing whichever response arrives first. Crab needs one verified source for every recipe term.
+Both are needed. Every chunk can be individually valid while the assembled order is wrong.
 
-This rule supports repair and replication. A chunk can gain another durable location without changing the file recipe, and hydration can choose an available verified copy.
+<HydrationSafetyGate />
 
-## The planner groups remote work
+The successful path is:
 
-Chunks that belong to the same xorb can share a range request when their locations are compatible. Crab groups the terms by xorb, coalesces compatible ranges, and fetches independent work with bounded concurrency.
+1. Resolve complete reconstruction terms.
+2. Fetch or reuse verified chunk data.
+3. Stream chunks to a sibling temporary file in recipe order.
+4. Update the BLAKE3 hasher as bytes are written.
+5. Compare final hash and byte count with the pointer.
+6. Atomically rename the temporary file over the pointer.
 
-Local cache hits can remove ranges from the remote plan. Archived xorbs may require a restore before their ranges become readable, and `crab hydrate --restore` makes that policy explicit.
+On cancellation, a missing term, or a hash mismatch, temporary output is removed. The tracked path remains a pointer instead of exposing a partial file.
 
-Bounded concurrency protects the client while several ranges are in flight. The reader limits simultaneous requests, decompression, and buffered output rather than loading the complete file into memory.
+## Hydrate one file and keep evidence
 
-Coalescing also has a boundary. Crab can join nearby ranges when extra bytes cost less than another request. It should not download an entire large xorb for one distant chunk by default.
+Run a narrow example first:
 
-The plan also separates dependencies from scheduling. Recipe order defines the output. Xorb grouping defines efficient reads. Concurrency defines when independent reads execute.
+```bash
+crab hydrate 'models/encoder.safetensors' --jsonl | tee hydration.jsonl
+crab status
+```
 
-Keeping those concerns separate prevents a performance optimization from changing file meaning. Ranges may complete in any order, but the assembler consumes verified chunks at their declared logical positions.
+The JSONL stream preserves progress and the terminal result for diagnosis. `crab status` shows whether the working-tree path is hydrated or still a pointer.
 
-Before issuing reads, the planner can remove chunks already available in local staging or verified cache. It retains their recipe positions so local and remote results join the same assembly plan.
-
-## Archived data introduces a waiting state
-
-Some storage classes cannot serve a range read until the provider restores the object. Hydration can request restoration, wait for readability, and then resume the same verified reconstruction plan.
-
-`--no-restore` changes that policy into an immediate error. This option fits latency-sensitive automation that must not wait or incur an unplanned retrieval charge.
-
-The pointer and recipe remain valid while the xorb is archived. Archive state changes availability and cost, not content identity.
-
-Restore planning should group files by required archived xorbs. Ten files may share one cold xorb, so requesting restore per file would create duplicate provider work.
-
-The client can report which objects need restore, which requests already exist, and the earliest provider availability. Operators then decide whether to wait, choose a different retained version, or move the workflow to a latency-tolerant queue.
-
-After restoration, the same range, chunk, and final-file verification applies. Provider restore success means the object is readable; it does not replace Crab's integrity proof.
-
-## Assembly follows recipe order
-
-Download completion order does not define file order. The assembler writes verified chunks according to the file recipe, even when later ranges arrive first.
-
-The output is built away from the committed pointer path. Only a complete, verified result can replace the working-tree pointer, which prevents a cancelled or failed hydration from appearing successful.
-
-Assembly should stream whenever possible. The client does not need to hold a multi-gigabyte file in memory, but it may need bounded buffers for decompression, out-of-order range completion, and final writes.
-
-Backpressure connects these buffers to the read scheduler. If the destination disk cannot consume output, Crab limits additional range work instead of accumulating the remaining file in memory.
-
-Repeated recipe terms still write repeated output. Deduplication reduces stored and transferred sources, while assembly restores every logical occurrence required by the file.
-
-## Verification closes the loop
-
-Chunk identities detect incorrect range content. The final BLAKE3 file hash and expected size verify the assembled result as a whole.
-
-This contract is binary: hydration returns the byte-identical original or an error. A corrupted cache entry, incomplete range, missing shard term, or wrong final hash cannot produce a successful materialized file.
-
-## Atomic replacement protects local work
-
-Crab assembles hydrated output away from the committed pointer path. It verifies chunk identities, final size, and full-file hash before replacing the pointer.
-
-A cancelled process can leave temporary local work, but it must not leave a truncated file at the tracked path. Cleanup removes or ignores incomplete temporary output on the next operation.
-
-Hydration also checks working-tree state before replacement. A locally modified materialized file should not be overwritten as though it were an unchanged pointer.
-
-The temporary output should live on a filesystem that supports an atomic replacement into the destination path. When platform constraints prevent that shape, Crab must preserve the same observable contract through an equivalent safe sequence.
-
-Permissions and executable bits belong to the checkout path around content replacement. Hydration proves bytes; Git's tree and worktree logic determine path metadata. A content repair should not silently invent a new mode.
-
-## Failure signals identify the broken layer
-
-| Failure | Likely boundary | Safe response |
-| --- | --- | --- |
-| Pointer parse error | Git blob or path selection | Inspect the committed blob and tracking rule |
-| File recipe not found | File index or retained metadata | Sync metadata and run `crab fsck` |
-| Missing chunk term | Shard closure | Stop hydration and repair repository metadata |
-| Xorb range unavailable | Object access, deletion, or archive state | Restore access or archived data |
-| Chunk hash mismatch | Cache, range response, or stored object | Discard cached bytes and verify origin |
-| Final file hash mismatch | Recipe order or assembled content | Keep the pointer and report integrity failure |
-
-Do not work around an integrity error by copying the temporary output into place. Preserve the pointer and diagnostic evidence until the repository boundary is repaired.
-
-## Retry only the failed dependency work
-
-A transient range-read failure does not invalidate chunks already verified from other xorbs. A retry can reuse those cache entries and request the missing ranges again.
-
-A metadata refresh can repair a stale location view, but it cannot make a genuinely missing xorb appear. After refresh, the same unresolved chunk identity is repository-integrity evidence and should reach `crab fsck` or repair tooling.
-
-Final hash failure requires a broader response. Individual chunk hashes may all pass while recipe order, length, or duplicate placement is wrong. Keep the complete recipe and assembly diagnostics because retrying the same ranges alone will reproduce the result.
-
-Archive waiting is not an integrity failure. It is an availability state with an explicit restore policy. Report it separately so operators do not repair valid metadata or delete cache state while the provider restores the object.
-
-## Replicas and repaired locations preserve file identity
-
-A chunk can have more than one durable source after replication or repair. Shard metadata can expose eligible locations while the recipe continues to name one content identity.
-
-The reader may choose a location based on provider availability, region, storage class, or measured latency. It still verifies the returned bytes against the chunk hash before assembly.
-
-If one replica fails verification, discard that result and report the bad location. Another verified replica can satisfy the read without changing the pointer or recipe. Repair tooling can then restore the damaged copy from known-good content.
-
-Location choice must not hide a systemic metadata conflict. Two ranges that claim the same identity but return different bytes require integrity investigation, even when one copy allows hydration to finish.
-
-<GitArchitecturePlayer story="hydrate" />
-
-## Selective hydration uses the same proof
-
-Patterns only choose which pointers enter the pipeline. They do not weaken reconstruction or verification.
+Patterns only choose which pointers enter the pipeline. They do not weaken verification:
 
 ```bash
 crab hydrate '*.safetensors'
@@ -200,29 +142,56 @@ crab hydrate --manifest .crab/manifests/ci.txt
 crab hydrate --all
 ```
 
-Already hydrated files can be skipped. Clean committed files can later return to pointers with `crab dehydrate`, freeing local disk while preserving remote data.
+Already hydrated files can be skipped. Use `crab dehydrate` later to replace clean materialized content with pointers and reclaim working-tree space.
 
-## Verify hydration independently
+## Archived xorbs add waiting, not uncertainty
 
-Save a cryptographic hash before the original push, then compare it after hydration on a separate machine. An isolated cache ensures the test reads canonical remote dependencies.
+An archived xorb can still be the correct source; it is temporarily unreadable.
 
-Run `crab fsck` after representative hydrations. The file hash proves one output; repository integrity checks cover broader metadata and storage relationships.
+```bash
+crab hydrate 'archive/model.bin' --restore
+```
 
-For performance evidence, record file size, number of chunks, number of xorbs, coalesced range count, cache bytes, origin bytes, and total duration. These measurements show whether the bottleneck is lookup, retrieval, assembly, or verification.
+`--restore` allows the provider restore workflow. `--no-restore` turns the same condition into an immediate error for automation that cannot wait or accept retrieval cost.
 
-Test more than the branch tip. Select one current file, one file reused across revisions, and one historical file near the retention boundary. Hydrate each from an isolated client and compare its expected full-file hash.
+After restoration, the same chunk and final-file verification still runs. Provider readability is not an integrity proof.
 
-The sample tests identity and access across different metadata ages. Repository-wide integrity checks then cover the wider set of recipes and shard relationships that the sample did not materialize.
+## Read failures by boundary
 
-For cancellation testing, stop hydration during metadata lookup, range reads, and final assembly. Each case should preserve the committed pointer or the prior clean file and leave no truncated destination presented as success.
+| Signal                | Broken boundary                       | Next check                                    |
+| --------------------- | ------------------------------------- | --------------------------------------------- |
+| Pointer parse error   | Git blob                              | inspect the committed pointer                 |
+| File recipe not found | file index                            | sync metadata and inspect repository health   |
+| Missing term          | shard coverage                        | repair or republish the incomplete data chain |
+| Xorb unavailable      | object access or archive state        | restore access or the archived object         |
+| Chunk hash mismatch   | cache, range response, or stored xorb | discard bad cached data and verify origin     |
+| Final hash mismatch   | order, length, or assembled bytes     | preserve the recipe and assembly evidence     |
 
-For cache testing, run the same file cold and warm. The origin byte count should decrease when verified ranges remain local, while the final hash and size stay identical across both runs.
+Do not copy failed temporary output into place. It is diagnostic material, not a hydrated file.
 
-For repair testing, use a disposable repository or injected failure layer. Production object mutation is not an acceptable way to prove corruption handling.
+If the original file still exists elsewhere, Crab can try local recovery before remote reconstruction:
+
+```bash
+crab hydrate 'models/encoder.safetensors' --recover-from /mnt/recovery/models
+```
+
+The recovered candidate must still match the pointer identity.
+
+## Measure the slow stage, not just total time
+
+For one representative file, record:
+
+- metadata lookup time
+- number of xorb reads
+- local versus origin bytes
+- assembly and final-hash time
+- destination-disk throughput
+
+A warm cache removes remote work, not ordered writes or final hashing. If cold and warm runs take similar time, the destination disk or verification pass may be the bottleneck.
 
 <TakeawayBox title="Hydration has one valid result">
-  Resolve every term, read the required ranges, assemble in recipe order, and
-  publish only after the final identity matches.
+  Cover every recipe position, fetch verified bytes, restore logical order, and
+  replace the pointer only after the complete identity matches.
 </TakeawayBox>
 
 For the complete code-and-data story, continue with [How does Crab keep one history across two data paths?](/blog/crab-interpreted-one-history-two-data-paths).

--- a/packages/web/content/blog/what-is-crab.mdx
+++ b/packages/web/content/blog/what-is-crab.mdx
@@ -28,6 +28,31 @@ Crab is a Git remote helper for repositories that contain large binary files. Gi
 
 <CrabMentalModelDiagram />
 
+## Start with one repository you can picture
+
+Imagine a project that keeps training code beside the model it produces:
+
+```text
+vision-search/
+├── README.md
+├── src/
+│   └── train.py
+└── models/
+    └── encoder.safetensors
+```
+
+The README and Python file remain ordinary Git blobs. A rule such as `crab track '*.safetensors'` sends the model through Crab. The repository still creates one commit containing all three paths.
+
+| Path | Git commits | Object storage keeps | A pointer-only clone sees |
+| --- | --- | --- | --- |
+| `README.md` | File bytes | Nothing extra | File bytes |
+| `src/train.py` | File bytes | Nothing extra | File bytes |
+| `models/encoder.safetensors` | Crab pointer | Reconstructable model data | Pointer until hydration |
+
+Select each stage below to follow the model and source file from the working tree to one visible repository state.
+
+<GitArchitecturePlayer story="overview" />
+
 ## Crab changes the data path, not the history
 
 Source code, configuration, and documentation remain ordinary Git blobs. Files matched by Crab tracking rules pass through Crab's filter, which replaces the Git blob with a pointer to a byte-identical recipe.
@@ -48,6 +73,12 @@ That distinction matters during recovery. A loose bucket URL can change, disappe
 
 The pointer also gives publication a testable boundary. Before the branch can advance, Crab must prove that the pointer resolves through durable metadata to durable data. During hydration, Crab must rebuild the complete file and match the recorded identity. Both sides test the same contract.
 
+For example, suppose commit `A` names a 4 GB model. Git records the small pointer for that exact model version. Crab metadata records every chunk required to rebuild it, in order. Object storage holds the packed byte ranges. A checkout succeeds only after those layers reconstruct the expected 4 GB file and verify its identity.
+
+<HydrationPlanDiagram />
+
+This is why a pointer-only checkout is useful rather than ambiguous: it already knows _which_ file belongs at the path, even before the client downloads the file's bytes.
+
 ## “Serverless” means the bucket is the shared service
 
 Crab does not require a Crab data server or database between the repository and object storage. Each client reads and writes the bucket directly with the credentials and policies your team controls.
@@ -59,6 +90,10 @@ This removes a service from the architecture, but it does not remove coordinatio
 Git handles text changes well because its object model and compression are designed around source history. Large binary changes can make whole-file versions expensive.
 
 Crab finds content-defined chunks inside a file. If a new checkpoint reuses most bytes from the previous checkpoint, those identical chunks keep the same identity and do not need another upload. Storage grows with new content, not automatically with every full file version.
+
+<ChunkReuseDiagram />
+
+In the diagram, the middle region changes while the surrounding regions keep their earlier identities. Crab uploads the new region and writes a new ordered recipe; it does not upload the four unchanged regions again.
 
 ## Crab is a strong fit when three conditions hold
 
@@ -78,6 +113,17 @@ Git LFS can be a better fit when your forge already supplies enough storage and 
 ## Different contributors can materialize different working sets
 
 One repository does not require one checkout shape. A source developer can keep all model paths as pointers. A model engineer can hydrate the active checkpoints. A release job can hydrate a committed manifest, while an exploratory analysis tool can read through a mount.
+
+<LazyCheckoutDiagram />
+
+For the `vision-search` repository, that can look like this:
+
+| Contributor or job | Local choice | Large bytes downloaded |
+| --- | --- | --- |
+| Source developer changing `train.py` | Keep model pointers | None |
+| Evaluation job using the current encoder | `crab hydrate models/encoder.safetensors` | One selected model |
+| Asset explorer with unpredictable reads | Mount the repository | Only ranges that are read |
+| Release job validating all artifacts | Hydrate a committed manifest | The declared release set |
 
 These clients still share the same commits and refs. Materialization is local policy, not a separate version of history. A pointer-only checkout and a hydrated checkout agree about which file belongs at a path, even though only one has the full bytes on disk.
 

--- a/packages/web/content/blog/why-we-built-crab.mdx
+++ b/packages/web/content/blog/why-we-built-crab.mdx
@@ -12,115 +12,147 @@ order: 2
 concepts: ["large files", "git limits", "serverless architecture"]
 prerequisites: ["What is Crab, and when should you use it?"]
 outcome: "Explain the scaling problem Crab is designed to solve and the tradeoffs of its architecture."
-diagramType: "Problem framing"
+diagramType: "Interactive cost and failure model"
 meta:
   contentType: "Conceptual"
   goal: "Explain why large binary history needs a different data path."
   audience: "Developers who have experienced slow clones, pushes, or repository growth."
 ---
 
-Git's object model is excellent for source code, but large binary versions create a different workload. A clone must transfer the reachable history, binary changes can reuse poorly at the Git-object level, and every contributor pays the local disk cost.
+Git can store an 8 GB model. The trouble starts when the repository keeps ten, fifty, or one hundred versions of it.
+
+A normal full clone transfers every reachable version. Mirrors, backups, and scans also have to account for that history, even when a developer only wants to edit Python.
 
 <LargeFileProblemDiagram />
 
-## The problem compounds with every version
+## Follow one model through four commits
 
-A binary file can be perfectly valid in Git. The scaling problem appears when that file is large, changes across regular work, and remains reachable through history.
+Consider this repository:
 
-Suppose a model checkpoint is 8 GB and a training run changes a small region. The new version is still another large Git object. Repeat that cycle across branches and releases, and the repository becomes expensive to clone, cache, back up, and operate.
+~~~text
+vision-search/
+├── src/train.py
+├── configs/base.toml
+└── models/encoder.safetensors  # 8 GB
+~~~
 
-Slow commands change team behavior. Teams move related data outside the repository or share bucket paths in documents. Naming conventions then reconnect a model with the source commit that produced it.
+The model changes after each training run. The source and configuration should stay in the same commit as the model that uses them.
 
-The pressure follows from Git's strongest guarantee. A commit closes over its trees and blobs, and a clone can obtain the complete reachable object graph. That self-contained model is valuable for source code because the graph remains compact and Git can compress related objects effectively.
+In a configured Crab repository, the workflow is:
 
-Large binary history changes the economics of the same guarantee. Every clone, mirror, scan, and backup must account for the reachable objects. A shallow clone can narrow history for one client, but it does not change what the repository retains or what other workflows may need.
+~~~bash
+crab track '*.safetensors'
+crab ship . -m "Train encoder v1"
 
-The problem becomes organizational when teams avoid fresh clones, retain undocumented local copies, or split code from data without a durable identity link. At that point, slow transfer has already changed how the repository is trusted.
+# After the next training run
+crab ship models/encoder.safetensors -m "Train encoder v2"
+~~~
 
-## Common alternatives move the pressure elsewhere
+`crab track` writes the `.gitattributes` rule. `crab ship` stages the selected files, creates a Git commit, and pushes through Crab's native pipeline.
 
-Keeping binaries outside Git makes the source repository smaller, but version identity becomes a separate process. A hosted large-file service preserves Git integration, but introduces service limits, bandwidth policies, and another availability boundary.
+Assume each new 8 GB checkpoint keeps 7.5 GB of the previous version's encoded bytes:
 
-Self-hosting can provide more control. It also makes the team responsible for deployment, upgrades, scaling, observability, and recovery. None of these choices is universally wrong; they assign the operational cost to different places.
+<BinaryHistoryGrowthDiagram />
 
-A whole-file pointer system solves Git object growth, but each changed file can still become another complete storage and transfer unit. This tradeoff is acceptable for stable assets and smaller repositories. It becomes expensive when a producer rewrites multi-gigabyte files on every iteration while preserving large regions of identical bytes.
+With ordinary Git blobs, four versions contribute 32 GB of reachable binary objects. With Crab, Git keeps four compact pointers while the bucket adds the 8 GB base and roughly 0.5 GB of new chunks per later version.
 
-Pipeline-oriented data tools solve another part of the problem. They can connect outputs to stages and remote storage, but they introduce a second command and metadata workflow beside Git. That separation can be valuable for a dedicated data pipeline. It is less attractive when source, configuration, and large artifacts must review and roll back as one commit.
+That 9.5 GB result is an example, not a guarantee. Recompression, encryption, or a container rewrite can change most bytes and leave little to reuse.
 
-Manual object-store paths remove tooling overhead at first. They also make atomicity, naming, retention, and verification local conventions. Each script must decide which object belongs to a commit and what to do when the upload and source push do not complete together.
+## What Crab does at each step
 
-## Repository growth changes team behavior
+<FlowSteps
+  title="One model, five states"
+  steps={[
+    "Track: crab track writes the shared rule. It does not move or upload the model.",
+    "Ship version 1: Git commits a pointer, Crab uploads the chunks and recipe, and the full model stays in the working tree.",
+    "Ship version 2: Git commits a new pointer, but Crab uploads only chunks that are not already durable.",
+    "Clone with pointers: Git checks out the pointer without downloading the 8 GB model.",
+    "Hydrate: Crab reads the required ranges, rebuilds and verifies the model, and leaves the commit unchanged."
+  ]}
+/>
 
-Large history affects more than clone duration. Continuous integration runners download data they may never read. Developers keep old clones because creating a new one is expensive. Backups, mirrors, and security scans repeat the same transfer cost.
+The pointer answers “which model belongs to this commit?” The bucket answers “where are its bytes?”
 
-Teams may respond by separating code and data informally. A commit message names a bucket key, a spreadsheet maps experiments to checkpoints, or a script assumes the newest timestamp is correct. These conventions reduce Git pressure but weaken reproducibility.
+<ChunkReuseDiagram />
 
-The missing contract is identity. A source commit should identify the exact data it consumes or produces. That relationship must survive renames, branch changes, storage lifecycle rules, and work on another machine.
+In this example, the changed weights region gets a new chunk identity. Stable regions keep the same identity, so Crab can reuse them across both file recipes.
 
-## A large-file path must preserve four properties
+## Why a bucket URL is not enough
 
-Moving bytes out of Git solves only the first constraint. A practical large-file path also needs to preserve these properties:
+A team can put this in a configuration file:
 
-1. **Reviewable identity**: the Git commit records which exact file version belongs at each tracked path.
-2. **Byte-exact reconstruction**: another client either rebuilds the original content or receives an error.
-3. **Bounded transfer**: a changed binary does not automatically require another full-file upload.
-4. **Complete publication**: a visible branch never points to large-file data that has not become durable.
+~~~text
+MODEL_URI=s3://team-models/encoder/latest.safetensors
+~~~
 
-Crab's pointer, chunk, shard, and ref contracts follow from these requirements. The formats are implementation details, but each format exists to protect one property.
+That keeps the 8 GB file out of Git, but it leaves important questions to scripts and convention:
 
-These properties also expose incomplete solutions. A URL in a configuration file can be reviewable but may not prove byte identity. A content hash can prove identity but says nothing about whether the bytes are durable. An uploaded object can be durable while the branch still points at an older commit.
+- Can `latest` change after the source commit is reviewed?
+- How does another machine verify the downloaded bytes?
+- What happens if the model upload succeeds but the Git push fails?
+- Which object can retention policy delete safely?
 
-Crab treats those facts as separate evidence. The pointer names the file, the recipe names every chunk, shard terms locate durable ranges, and the ref transaction decides visibility. The added metadata pays for a narrower failure model.
+A committed Crab pointer records the expected file identity and size. Crab then requires a complete reconstruction recipe before it publishes the ref.
 
-## Crab separates identity from storage
+| Approach | Works well when | Cost moves to |
+| --- | --- | --- |
+| Keep binaries in Git | Files are small or rarely change | Every clone and mirror |
+| Store bucket URLs in source | Data already has a separate catalog | Naming, verification, and publish scripts |
+| Use hosted Git LFS | Forge integration matters most | Service quotas and whole-file transfer |
+| Use Crab | Versions share bytes and need Git identity | Client credentials and bucket operations |
 
-Crab keeps a compact pointer in the Git commit and stores the large-file data in object storage. The pointer identifies the original file and the recipe required to reconstruct it.
+## A failed push must leave the old branch valid
 
-This split preserves the relationship between code and data without forcing each large version through Git's normal blob path. Content-defined chunking also lets a new version reuse unchanged chunks from earlier files and commits.
+A successful upload is not the same as a published commit. Crab moves the visible ref only after the Git objects, large-file data, and reconstruction metadata are durable.
 
-## Object storage becomes the durable boundary
-
-Object stores already provide durable objects, range reads, lifecycle policies, and access control. Crab uses those primitives directly instead of placing a permanent Crab service in front of them.
-
-The absence of a central writer creates a consistency requirement: readers must never observe a Git ref before all referenced data is durable. Crab therefore follows one central rule.
-
-<TakeawayBox title="The publication invariant">
-  Large-file data and metadata become durable first. The visible Git ref moves
-  last, with an atomic compare-and-swap update.
+<TakeawayBox title="Data first, ref last">
+  If Crab cannot prove that every pointer can be rebuilt, the push fails and
+  the remote branch stays on its previous valid commit.
 </TakeawayBox>
 
-## The storage boundary changes the cost model
+A `crab ship` failure after the commit step leaves the local commit in place. If the problem was network access or credentials, fix it and run `crab push` again. Completed immutable uploads can be reused by the retry.
 
-With ordinary Git blobs, every reachable binary version contributes to repository storage and clone transfer. With a pointer path, Git history grows with compact identities while object storage grows with unique large-file content.
+Select a stage below to see what readers observe at each failure boundary.
 
-This does not make storage free. The bucket still charges for stored bytes, requests, retrieval, and network transfer. Crab adds controls for those terms: deduplication reduces new bytes, xorb packing reduces requests, caching reduces repeated reads, and lifecycle rules can tier old xorbs.
+<GitArchitecturePlayer story="failure" />
 
-The architecture also makes costs observable at the storage account your team controls. You can connect object inventory, access logs, retention, and billing to the repository's actual data path.
+## Different jobs can download different files
 
-## The system favors explicit failure
+A commit identifies the complete repository. It does not force every machine to materialize every large file.
 
-A large-file tool must not hide missing bytes behind a successful Git operation. Crab blocks clean when it cannot stage a tracked file. It blocks push when a pointer lacks durable backing data. It blocks hydration when reconstruction or verification fails.
+<LazyCheckoutDiagram />
 
-These errors can interrupt work, but they preserve the stronger contract. A failed command is recoverable. A successful command that published incomplete history would spread corruption to every later reader.
+| Job | Local choice | Large-file download |
+| --- | --- | --- |
+| Developer editing `src/train.py` | Keep pointers | None |
+| Evaluation job | `crab hydrate models/encoder.safetensors` | One model |
+| CI job with a known input list | `crab hydrate --manifest .crab/manifests/ci.txt` | Files in the manifest |
+| Explorer with unpredictable reads | Mount the repository | Ranges read by the application |
 
-## The design starts from recovery, not only the happy path
+All four jobs use the same commits and refs. Hydration changes the working tree, not repository history.
 
-A large upload can fail after minutes of useful work. A writer can disappear while holding a lease. Two contributors can push the same branch from the same old tip. A storage class can make an older xorb temporarily unreadable.
+## What you pay for
 
-Crab's immutable data objects let retries reuse completed uploads. The write journal records preparation without claiming publication. Expected-old ref updates reject stale writers, while retained roots and grace periods keep garbage collection away from in-flight or recoverable content.
+Crab changes the cost; it does not remove it.
 
-The resulting system does not promise that every command succeeds through a network interruption. It promises that interruption does not create a visible commit with missing dependencies. Operators can reason from the last durable boundary and retry the remaining work.
+- Every client needs Crab installed.
+- Every client that reads or writes model data needs scoped bucket credentials.
+- The bucket still charges for storage, requests, retrieval, and network transfer.
+- Chunk reuse depends on physical byte overlap, not on how similar two models seem.
+- Your team owns retention and lifecycle policy.
 
-## The tradeoff is explicit client responsibility
+## When Crab is worth the extra machinery
 
-Each client needs Crab and valid object-storage access. Bucket permissions, retention, and lifecycle rules remain part of the repository's operational design. A team that prefers a fully hosted service may choose Git LFS through its forge instead.
+Crab is a strong fit when all of these are true:
 
-Crab is designed for teams that value direct storage ownership, chunk-level reuse, and selective hydration enough to accept that client-side responsibility. The next decision is architectural, not ideological: [compare Crab and Git LFS on the constraints that matter to your team](/blog/crab-vs-git-lfs).
+- Large files change often.
+- New versions preserve substantial byte regions.
+- Source and data must review and roll back as one commit.
+- Different jobs need different subsets of the repository.
+- The team wants direct control of object storage.
 
-## Where the architecture earns its cost
+A few stable release archives may work fine in Git LFS or plain object storage. A dataset with its own catalog may not need Git identity at all.
 
-The strongest candidates combine large mutable binaries, repeated versions, and selective access. Model training, game asset production, data snapshots, and research repositories can satisfy all three conditions. Chunk reuse reduces new storage, and lazy materialization prevents every reader from paying for the complete history.
+We built Crab for the middle ground: keep Git's history and workflow, but stop making every clone carry every large-file version.
 
-A repository with a few stable release archives may not need this machinery. A team whose forge LFS allowance already covers its workload may prefer the hosted integration. A pipeline whose data never needs to share commit identity with source may benefit from a data-specific catalog instead.
-
-We built Crab for the boundary where Git's history model remains valuable but Git's byte-storage path stops scaling. The goal is not to make every file take the Crab path. It is to let each content class use an appropriate path without breaking one repository history.
+Next, [compare Crab and Git LFS using your repository's constraints](/blog/crab-vs-git-lfs).

--- a/packages/web/content/blog/xet-protocol-deduplication.mdx
+++ b/packages/web/content/blog/xet-protocol-deduplication.mdx
@@ -1,203 +1,182 @@
 ---
 title: "How does Crab avoid storing duplicate data?"
-description: "Follow a file through content-defined chunking, BLAKE3 identities, deduplication, and xorb packing."
+description: "See how content-defined chunks, proof, recipes, shards, and xorbs turn a changed file into a small upload."
 date: "2026-06-12"
 author: "Crab Team"
 category: "architecture"
 tags: ["deduplication", "chunking", "xorb", "blake3", "storage"]
-excerpt: "Crab recognizes unchanged regions inside changed files and uploads only chunks that lack durable remote proof."
+excerpt: "An interactive byte-level tour of what Crab reuses, uploads, and records when a large file changes."
 level: "intermediate"
 path: "core-internals"
 order: 1
 concepts: ["deduplication", "chunking", "xorb", "BLAKE3"]
 prerequisites: ["How does Crab connect to Git?"]
-outcome: "Explain when a changed file can reuse stored bytes and when Crab must create a new xorb."
-diagramType: "Chunking pipeline"
+outcome: "Predict which bytes a changed file can reuse and which evidence makes that reuse safe."
+diagramType: "Interactive chunk laboratory"
 meta:
   contentType: "Conceptual"
   goal: "Explain Crab's reuse unit and the proof required to skip an upload."
   audience: "Developers evaluating Crab's storage and transfer behavior."
 ---
 
-Crab deduplicates below the file level. It divides a tracked file into content-defined chunks, identifies each chunk with the cryptographic BLAKE3 hash, and packs only new chunks into immutable objects called xorbs.
+Crab does not ask, “Have I seen this file before?”
 
-<DedupPipelineDiagram />
+It asks, **“Which regions of these bytes already exist?”**
 
-## Content chooses the boundaries
+A changed 10 GiB checkpoint might contain 8 GiB of familiar chunks. Crab can reuse those chunks and upload only the 2 GiB it cannot prove durable.
 
-Fixed-size chunking divides a file every _n_ bytes. Insert one byte near the beginning, and every later boundary shifts even when most content remains unchanged.
+<DedupBoundaryLab />
 
-Content-defined chunking chooses boundaries from the byte stream itself. A local edit disturbs nearby boundaries, but stable regions later in the file tend to produce the same chunks as before.
+## 1. Content chooses the cut points
 
-<ChunkReuseDiagram />
+Fixed-size chunking cuts every _n_ bytes. Insert one byte near the start and every later offset shifts.
 
-Boundary recovery creates reuse in model checkpoints, database snapshots, archives, and media containers that preserve large byte regions between versions.
+Content-defined chunking examines a rolling window of bytes. The content itself decides when a chunk ends.
 
-## Boundary stability is local, not absolute
+```text
+fixed size       [ A ][ B ][ C ][ D ]
+insert one byte  [ A ][? B][? C][? D]   every offset stays shifted
 
-Content-defined chunking does not guarantee that one edited byte changes one chunk. The boundary algorithm examines a rolling region of input, so an edit can alter nearby chunks and boundary positions.
+content defined  [ A ][ B ][ C ][ D ]
+insert one byte  [ A ][ N ][ O ][ D ]   boundaries resynchronize
+```
 
-The useful property is resynchronization. Once the rolling content reaches a stable region, later boundaries can match the earlier file again. Fixed-size boundaries remain shifted after an insertion because every later offset changed.
+An edit can change several nearby chunks. The useful property is **recovery**: once the rolling content becomes familiar again, later boundaries can match the earlier version.
 
-A replacement with the same byte length may preserve even more boundaries. An insertion or deletion creates a larger disturbed region, but stable content after that region can still recover its former chunk identities.
+Crab's gearhash chunker targets 64 KiB chunks. That is a target, not a promise that every chunk has the same size.
 
-## Chunk size trades metadata for reuse precision
+## One checkpoint, worked through
 
-Smaller target chunks can isolate local edits and increase potential reuse. They also create more hashes, recipe terms, index entries, and packing work. Larger chunks reduce metadata but make each disturbed region account for more bytes.
+Suppose `models/ranker.bin` is 10 GiB. Version 2 replaces one region but keeps most encoded bytes stable.
 
-Content-defined chunking therefore uses bounded sizes around a target rather than accepting an arbitrary boundary at every matching byte pattern. Minimum and maximum limits prevent pathological tiny chunks or unbounded regions.
+```bash
+crab add models/ranker.bin
+git commit -m "Update ranking model"
+crab push origin main
+```
 
-Choose the target size from the repository's file producers and access patterns. A checkpoint workload and a media archive may preserve byte regions at different scales.
+Use this illustrative classification:
 
-Crab's file identity does not depend on the chosen storage packing. Changing chunking policy for new files can affect reuse with earlier chunks, so policy changes need measurement and a migration rationale.
+| Version 2 source bytes | Amount | Push decision |
+| --- | ---: | --- |
+| Chunks with canonical remote proof | 8 GiB | Reuse their existing locations |
+| Chunks without proof | 2 GiB | Pack and upload them |
+| Complete file | 10 GiB | Record one ordered recipe |
 
-## Hashes turn byte equality into identity
+The **chunk reuse ratio** is 80%. The upload can be smaller than 2 GiB after compression, but xorb framing and metadata add some overhead. Reuse ratio and upload ratio are related, not identical.
 
-Crab computes a BLAKE3 identity for each chunk. Identical bytes produce the same chunk identity regardless of file name, directory, commit, or position.
+## 2. A matching hash is only identity
 
-The identity is useful only with proof. Before Crab skips a chunk, local or remote metadata must establish that the corresponding bytes already exist in durable storage. A cache hint alone is not enough to make a push complete.
+Crab computes a BLAKE3 hash for each chunk. Equal bytes produce the same identity across paths, branches, commits, and file versions.
 
-The file itself also receives a BLAKE3 identity. Chunk hashes support reuse and range verification. The full-file hash closes over recipe order and detects a result that contains the right chunks in the wrong sequence.
+But a hash does not answer:
 
-Hash identity is independent of compression. Crab can compress chunks inside xorbs while keeping the uncompressed content identity used by recipes and reconstruction. A storage-layout change therefore does not require a new file pointer.
+- Where are the bytes?
+- Are they durable?
+- Can another machine read them?
 
-## Deduplication separates identity from location
+Select each evidence level below. Only the final level can authorize skipping a remote upload.
 
-A chunk hash answers whether two byte sequences are equal. It does not answer where the bytes are stored. Shard and chunk-index metadata connect the identity to an xorb and byte range.
+<DedupEvidenceLadder />
 
-Separating identity from location lets storage layout change without changing file identity. A repack operation can place a chunk in a better xorb while the file recipe continues to name the same content hash.
+The distinction prevents a dangerous shortcut. Your local cache may contain a chunk while the shared origin does not. Publishing a pointer from that cache hint would create a file that works only on the writer's machine.
 
-It also protects deletion. Garbage collection cannot treat an unknown location as proof that a chunk is unused. The collector must walk retained recipes and shard terms before classifying an object as unreachable.
+The authority ladder is:
 
-| Evidence | Safe conclusion |
-| --- | --- |
-| Same BLAKE3 chunk hash | The chunk bytes have the same identity |
-| Local cache entry only | The client may avoid a local read, but remote durability is unproven |
-| Staged chunk and recipe | The current client can prepare an upload |
-| Canonical shard term and xorb | A remote reader can locate durable bytes |
-| Complete ordered recipe | Crab can plan reconstruction of the file version |
+1. Session evidence saves repeated work in one process.
+2. Staging evidence proves this client can prepare the bytes.
+3. Canonical placement and origin receipts prove remote durability.
 
-## Deduplication checks several evidence layers
+Negative local lookup results are also provisional. Another writer may have published the chunk. Refreshing canonical state can turn a planned upload into safe reuse.
 
-The cheapest useful evidence should answer first, but each layer has a different authority:
+## 3. Identity, location, and order are separate
 
-1. **Session state** can recognize chunks produced earlier in the same clean or staging operation.
-2. **Local indexes and staging** can reuse recent chunks and recipes without another origin lookup.
-3. **Canonical shard and chunk indexes** prove that a remote reader can locate the durable bytes.
+Crab stores three different facts:
 
-A local hit can remove repeated CPU or disk work. It cannot authorize publication when canonical storage has no corresponding location. Push resolves that distinction before it omits a chunk upload.
-
-Treat a negative lookup as provisional. A stale local metadata view may not know about a chunk published by another writer. Crab can refresh canonical state before classifying the chunk as new, which trades one lookup for an avoided duplicate upload.
-
-## Estimate the byte outcome before compression
-
-For a 10 GB second checkpoint, suppose chunk classification finds 8 GB already durable and 2 GB new. The source-level reuse ratio is 80 percent.
-
-Crab packs only the 2 GB of new source chunks. Compression may reduce the uploaded xorb bytes below 2 GB, while xorb framing and metadata add a smaller overhead. The resulting upload ratio is therefore related to, but not identical to, the reuse ratio.
-
-Hydrating the new checkpoint still produces 10 GB. A cold reader may fetch ranges containing all required chunks, including reused chunks from earlier xorbs. Deduplication reduces new storage and push transfer; it does not mean every first read downloads only the changed 2 GB.
-
-A warm reader can avoid more origin transfer when earlier ranges remain cached. Keep push reuse, cold hydration, and warm hydration as separate measurements.
-
-## New chunks become xorbs
-
-Uploading every chunk as a separate object would create excessive request overhead. Crab therefore packs sequences of new chunks into compressed, content-addressed xorbs.
-
-A xorb is immutable. Once uploaded, any file recipe can refer to its chunk ranges. Shard metadata records where each chunk lives so readers do not need to scan the bucket to reconstruct a file.
-
-Packing balances object size against request and recovery behavior. Tiny objects create excessive writes, listings, and reads. Extremely large objects can make retries and sparse range access less efficient.
-
-Crab uses bounded xorb targets and can optimize layout later. The file contract does not depend on one permanent packing choice because chunk identities remain stable across repacking.
-
-Packing happens after chunk classification. Reused chunks keep their proven locations, while new chunks accumulate into one or more xorb builders. Each completed xorb receives an immutable content identity before upload.
-
-The xorb boundary is an operational unit, not a file boundary. One xorb can contain chunks from several files, and one file can reference chunks across several xorbs created at different times. Cross-file packing improves reuse, so object deletion must follow reachability metadata rather than path naming.
-
-Compression and packing also affect retry size. A bounded xorb limits how much work a failed upload repeats. The target must remain large enough to avoid turning every chunk into its own object-store request.
-
-## Shards make packed data discoverable
-
-Packing removes the one-file-to-one-object relationship, so readers need an index from chunk identity to physical range. Shards publish that relationship in immutable metadata that can evolve as new xorbs arrive.
-
-A shard term identifies the xorb and range required to obtain a chunk. File recipes remain ordered identity lists, while shards answer location. This split lets one shard generation add new locations without rewriting every file recipe that reuses the chunk.
-
-Readers synchronize relevant shard state before planning ranges. Writers prove that every recipe term has a canonical durable location before publishing a ref.
-
-Repacking can add replacement locations, and later maintenance can retire old layouts after retained readers no longer depend on them. Chunk and file identities remain stable throughout that physical change.
-
-## A file recipe preserves order
-
-Deduplication changes storage layout, not file meaning. Crab records the complete ordered chunk sequence for each file hash. The same chunk may appear in multiple files or more than once in one file.
-
-A valid recipe must cover every byte in order. Hydration either reconstructs the byte-identical file and verifies its hash or returns an error.
-
-Repeated chunks remain repeated recipe terms. If a 4 MB block appears three times in one file, Crab can store the bytes once and reference that identity at three logical positions. Reconstruction writes it three times in the declared order.
-
-Recipes also preserve zero-length and boundary conditions explicitly through the file identity and expected size. An empty file does not need data chunks, while a non-empty file cannot succeed with an empty recipe.
-
-## Reuse can cross ordinary boundaries
-
-Because content determines identity, reuse is not limited to adjacent commits. It can occur across renamed paths, copied assets, branches, and file versions, provided the repository metadata can prove that the chunk is already stored.
-
-Savings follow the encoded bytes, not the logical edit. Encrypted or recompressed files may change most bytes even when their logical content changes little. Append-heavy snapshots and iterative checkpoints can preserve physical overlap across versions.
-
-Consider three representative overlap patterns:
-
-| Pattern | Boundary behavior | Expected reuse |
+| Fact | Structure | Answers |
 | --- | --- | --- |
-| Append records to a stable file | Earlier boundaries remain unchanged | High reuse before the append |
-| Replace a fixed-size region | Nearby chunks change, later chunks resynchronize | Reuse on both sides of the edit |
-| Recompress one monolithic archive | The encoded stream can change after the edit | Low physical reuse |
-| Copy an existing asset to another path | Content and chunk identities remain equal | Complete data reuse |
-| Encrypt with a new random nonce | Ciphertext changes throughout | Little or no reuse |
+| Ordered chunk hashes | File recipe | What bytes make this file? |
+| Chunk-to-xorb mapping | `ChunkPlacement` / shard | Where is each identity stored? |
+| Packed compressed bytes | Xorb | Which object-store range contains it? |
 
-These outcomes follow bytes, not filenames or application semantics. A “small” logical edit can still rewrite the full physical stream.
+Select a recipe term to follow it into physical storage.
 
-## Metadata has a cost worth measuring
+<ChunkAddressMap />
 
-Chunk reuse is not free. Each file needs a recipe, each unique chunk needs identity and location metadata, and clients need indexes to resolve those structures.
+This separation matters in two ways.
 
-For large files, metadata should remain a small fraction of source bytes. Repositories with huge numbers of tiny managed files can invert that relationship and create more lookup and request work than the data warrants.
+First, the same chunk can appear more than once in a file. The recipe repeats its identity at each logical position while storage keeps one physical copy.
 
-Keep small source and configuration files on Git's ordinary blob path. Use Crab tracking for content whose size, churn, or materialization pattern earns the additional metadata path.
+Second, Crab can repack a chunk into a better xorb. Its location changes, but the chunk hash and file recipe do not.
 
-Measure recipe terms per file, shard bytes, index synchronization time, and metadata requests beside storage savings. A high reuse ratio can still produce a poor workflow if metadata fan-out dominates every checkout.
+The full file also receives a BLAKE3 identity. That final hash catches missing, reordered, or corrupted chunks during hydration.
 
-## Estimate reuse with two representative versions
+## 4. New chunks become xorbs
 
-Use real output from the producer that creates your large files. Synthetic zero-filled files can prove transport, but they do not represent compression, ordering, or metadata changes in production artifacts.
+Uploading one object per 64 KiB chunk would create too many object-store requests. Crab packs new chunks into immutable compressed objects called **xorbs**.
 
-Publish a baseline, clear any assumptions about local cache, then publish the changed version. Record source bytes, new chunk bytes, reused chunk bytes, xorb bytes uploaded, and object requests.
+The default target is 64 MiB of compressed data, bounded between smaller and larger operational limits. A xorb may contain chunks from several files, and one file may reference several xorbs.
 
-Interpret the counters together. High chunk reuse with high uploaded bytes can indicate packing or staged flush work. Low reuse may reflect a serializer that rewrites the complete file. Low uploaded bytes with a high request count can indicate an inefficient object layout.
+```text
+new chunks from file A ─┐
+new chunks from file B ─┼─► xorb builder ─► immutable xorb
+new chunks from file C ─┘                    hash + chunk metadata
+```
 
-Calculate at least three ratios:
+Once uploaded, shard metadata publishes each chunk's `xorb_hash`, `chunk_index`, and uncompressed size. Readers can resolve recipes without scanning the bucket.
 
-- **Chunk reuse ratio**: reused source bytes divided by total source bytes
-- **Upload ratio**: uploaded xorb bytes divided by total source bytes
-- **Request density**: object-store operations divided by uploaded or hydrated GB
+Packing is deliberately separate from file identity:
 
-The ratios answer different questions. Chunk reuse describes physical overlap. Upload ratio includes packing and compression. Request density shows whether the storage layout turns useful byte savings into excessive provider operations.
+- Reused chunks keep their proven locations.
+- New chunks enter a bounded xorb builder.
+- Shards record complete reconstruction terms.
+- The file recipe continues to name ordered chunk identities.
 
-Repeat the same measurement after clearing only the state you intend to classify as cold. Removing canonical remote data would change the repository, while clearing local cache changes only the client path.
+An interrupted push may leave an unreachable xorb. That object is still valid; a retry can reuse it, and garbage collection can remove it later if no retained root reaches it.
 
-## Design file production for stable bytes
+## What kind of files deduplicate well?
 
-Deduplication works on physical content, so upstream file generation affects the result. Deterministic serialization keeps equivalent data byte-identical. Stable record ordering prevents unrelated entries from shifting. Partitioned outputs isolate changes to smaller files.
+Savings follow encoded bytes, not filenames or logical meaning.
 
-Compression settings also matter. Recompressing one large container can alter the byte stream after a local logical edit. Compressing stable partitions independently can preserve more reusable regions.
+| Producer behavior | Likely physical reuse |
+| --- | --- |
+| Append records to a stable file | High reuse before the new tail |
+| Replace a fixed-size region | Reuse on both sides after resynchronization |
+| Copy or rename an existing asset | Complete data reuse |
+| Recompress one monolithic archive | Often low reuse |
+| Encrypt again with a random nonce | Little or no reuse |
 
-Do not weaken encryption or integrity controls to improve reuse. When confidentiality requires randomized ciphertext, plan for whole-object change and optimize with retention, tiering, or file partitioning instead.
+Deterministic serialization helps. Stable record ordering, stable headers, and independently compressed partitions preserve byte regions between versions.
 
-Version format and serializer changes as data migrations. A new library version can reorder fields, change compression headers, or rewrite container indexes even when the logical tensors or records remain stable.
+Do not weaken encryption or integrity controls for deduplication. When randomized ciphertext is required, plan for whole-stream change and optimize retention or partitioning instead.
 
-Publish one sample through both producer versions before changing the pipeline. Compare full-file bytes, chunk reuse, xorb upload, and hydration behavior. The test can reveal a storage-cost regression before the new format enters long-lived history.
+## Measure three different ratios
 
-When partitioning is valid for the application, use stable independently encoded files. One changed partition then creates local file and chunk changes without forcing every other partition through a new container stream.
+Use two representative outputs from the real producer—not zero-filled synthetic files.
+
+```bash
+# Baseline version
+crab add --jsonl models/ranker.bin | tee add-v1.jsonl
+git commit -m "Add baseline model"
+crab push --jsonl | tee push-v1.jsonl
+
+# Changed version
+crab add --jsonl models/ranker.bin | tee add-v2.jsonl
+git commit -m "Update model"
+crab push --jsonl | tee push-v2.jsonl
+```
+
+Compare:
+
+- **Chunk reuse ratio:** reused source bytes ÷ total source bytes.
+- **Upload ratio:** uploaded xorb bytes ÷ total source bytes.
+- **Request density:** object-store operations ÷ uploaded GiB.
+
+Keep cold hydration separate. Deduplication reduces new storage and push transfer. A new reader still needs all ranges required to reconstruct the 10 GiB file; a warm cache may avoid more origin traffic.
 
 <TakeawayBox title="The deduplication rule">
-  A changed file does not imply a full upload. A chunk uploads only when Crab
-  cannot prove that identical bytes are already durable.
+  A changed file does not imply a full upload. Crab uploads a chunk only when
+  it cannot prove that identical bytes already have a durable remote location.
 </TakeawayBox>
 
-The next layer is transaction ordering. [Trace the fourteen stages that make a push visible](/blog/push-pipeline-14-steps).
+Next, [trace how those proven objects become visible through one ref transaction](/blog/push-pipeline-14-steps).

--- a/packages/web/mdx-components.tsx
+++ b/packages/web/mdx-components.tsx
@@ -18,6 +18,49 @@ import {
 import { GitArchitecturePlayer } from "@/components/blog/git-architecture-player"
 import { BlogProcessPlayer } from "@/components/blog/blog-process-player"
 import {
+  ChunkAddressMap,
+  DedupBoundaryLab,
+  DedupEvidenceLadder,
+} from "@/components/blog/deduplication-visuals"
+import {
+  CacheObjectPassport,
+  CacheRouteTicket,
+  RangePlanningTape,
+} from "@/components/blog/cache-visuals"
+import {
+  HydrationSafetyGate,
+  ReconstructionArrivalBoard,
+  ReconstructionWorkbench,
+} from "@/components/blog/reconstruction-visuals"
+import {
+  ConcurrentPushRaceBoard,
+  LeaseClockInspector,
+  RefVisibilitySignal,
+} from "@/components/blog/consistency-visuals"
+import {
+  DiskBudgetWorkbench,
+  MaterializationPackingDesk,
+  MountedReadCutaway,
+} from "@/components/blog/lazy-checkout-visuals"
+import { GcObjectEvidenceLab, GcRaceReplay } from "@/components/blog/gc-visuals"
+import { GcRunPermit } from "@/components/blog/gc-run-permit"
+import { CostReceiptMixer } from "@/components/blog/cost-ledger-visual"
+import {
+  RestoreDispatchBoard,
+  TierEligibilitySorter,
+} from "@/components/blog/tiering-visuals"
+import {
+  LfsIdentityLab,
+  LfsRehearsalConsole,
+  LfsRewriteMap,
+} from "@/components/blog/lfs-compatibility-visuals"
+import {
+  PushDataLanesDiagram,
+  PushPipelineBoard,
+  PushVisibilityLab,
+} from "@/components/blog/push-pipeline-visuals"
+import {
+  BinaryHistoryGrowthDiagram,
   ChunkReuseDiagram,
   GarbageCollectionReachabilityDiagram,
 } from "@/components/blog/blog-detail-diagrams"
@@ -126,6 +169,34 @@ export function getMDXComponents(components?: MDXComponents) {
     TakeawayBox,
     GitArchitecturePlayer,
     BlogProcessPlayer,
+    ChunkAddressMap,
+    DedupBoundaryLab,
+    DedupEvidenceLadder,
+    CacheObjectPassport,
+    CacheRouteTicket,
+    RangePlanningTape,
+    HydrationSafetyGate,
+    ReconstructionArrivalBoard,
+    ReconstructionWorkbench,
+    ConcurrentPushRaceBoard,
+    LeaseClockInspector,
+    RefVisibilitySignal,
+    DiskBudgetWorkbench,
+    MaterializationPackingDesk,
+    MountedReadCutaway,
+    GcObjectEvidenceLab,
+    GcRaceReplay,
+    GcRunPermit,
+    CostReceiptMixer,
+    RestoreDispatchBoard,
+    TierEligibilitySorter,
+    LfsIdentityLab,
+    LfsRehearsalConsole,
+    LfsRewriteMap,
+    PushDataLanesDiagram,
+    PushPipelineBoard,
+    PushVisibilityLab,
+    BinaryHistoryGrowthDiagram,
     ChunkReuseDiagram,
     GarbageCollectionReachabilityDiagram,
     CacheHierarchyDiagram,


### PR DESCRIPTION
## Summary

- rewrite and shorten 15 Crab blog guides around concrete repository examples
- add interactive teaching tools for deduplication, caching, reconstruction, locking, lazy checkout, garbage collection, storage cost, tiering, LFS migration, and the push pipeline
- expose pointer formats, data structures, state changes, failure boundaries, and verification evidence directly in each article
- register the new blog components in the shared MDX component map

## Verification

- npm run typecheck
- npm run lint (17 pre-existing warnings, 0 errors)
- npm run test (4 tests passed)
- npm run check:links (191 pages, 2024 fragments)
- npm run build (230 static pages)
- live browser QA across every interactive state on the enriched articles
