### PR TITLE
style(web): simplify blog and library surfaces

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -271,7 +271,7 @@ Keep new UI code aligned with the existing structure:
 - **Server-first rendering**: Use a server component unless the feature needs browser APIs, event handlers, local state, or animation lifecycle hooks
 - **Client boundaries**: Add `"use client"` only at the smallest component that needs it
 - **Styling**: Use Tailwind classes and `cn()` from `lib/utils.ts` for conditional class merging
-- **Visual restraint**: Use neutral hairline rules and quiet surfaces for containers. Avoid thick colored perimeters, offset block shadows, and full-width saturated bands; reserve brand and status colors for small semantic accents, focus, and active states
+- **Visual restraint**: Use theme-aware neutral hairline rules and quiet surfaces for containers. Avoid thick colored perimeters, offset block shadows, and full-width saturated bands; reserve brand and status colors for small semantic accents, focus, and active states. Every surface and state must remain legible in both light and dark themes
 - **Marketing components**: Put reusable landing-page sections in `components/marketing/`
 - **Documentation components**: Put docs-specific controls and presentation in `components/docs/`
 - **Diagrams**: Add reusable SVG diagrams as React components under `app/diagrams/`

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -27,9 +27,9 @@ The main routes are implemented under `app/`:
 | `/cli`              | Crab CLI product page with installation examples and the push pipeline walkthrough |
 | `/docs`             | Documentation landing page                                                         |
 | `/docs/cli/...`     | Fumadocs-rendered CLI documentation                                                |
-| `/blog`             | Editorial dashboard generated from the blog MDX collection                        |
+| `/blog`             | Editorial dashboard generated from the blog MDX collection                         |
 | `/blog/[slug]`      | Individual metadata-rich blog articles                                             |
-| `/library`          | Ordered learning paths, filters, progress, and knowledge checks                   |
+| `/library`          | Ordered learning paths, filters, progress, and knowledge checks                    |
 | `/library/[slug]`   | Individual interactive learning guides                                             |
 | `/changelog`        | Published or repository-backed release entries                                     |
 | `/pricing`          | Storage provider pricing calculator                                                |
@@ -142,7 +142,7 @@ Run `npm run format` before handing off TypeScript or TSX changes. It does not f
 | `components/ui/`          | shadcn/ui primitives and small reusable interface components                                        |
 | `content/docs/cli/`       | CLI documentation written in MDX, organized by category                                             |
 | `content/blog/`           | Editorial posts written in MDX                                                                      |
-| `content/library/`        | Ordered learning guides with required knowledge checks                             |
+| `content/library/`        | Ordered learning guides with required knowledge checks                                              |
 | `lib/`                    | Fumadocs loaders, blog transforms, pricing data, integrations, changelog data, and shared utilities |
 | `public/`                 | Static images, icons, and the shell and PowerShell installer scripts                                |
 | `scripts/check-links.mjs` | Production-server crawler for internal links and URL fragments                                      |
@@ -271,6 +271,7 @@ Keep new UI code aligned with the existing structure:
 - **Server-first rendering**: Use a server component unless the feature needs browser APIs, event handlers, local state, or animation lifecycle hooks
 - **Client boundaries**: Add `"use client"` only at the smallest component that needs it
 - **Styling**: Use Tailwind classes and `cn()` from `lib/utils.ts` for conditional class merging
+- **Visual restraint**: Use neutral hairline rules and quiet surfaces for containers. Avoid thick colored perimeters, offset block shadows, and full-width saturated bands; reserve brand and status colors for small semantic accents, focus, and active states
 - **Marketing components**: Put reusable landing-page sections in `components/marketing/`
 - **Documentation components**: Put docs-specific controls and presentation in `components/docs/`
 - **Diagrams**: Add reusable SVG diagrams as React components under `app/diagrams/`

--- a/packages/web/app/blog/[slug]/page.tsx
+++ b/packages/web/app/blog/[slug]/page.tsx
@@ -88,7 +88,7 @@ export default async function BlogPostPage({
           <div className="mx-auto max-w-6xl px-6 pt-24 pb-12 lg:pt-28 lg:pb-16">
             <Link
               href="/blog"
-              className="inline-flex min-h-11 items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:outline-none"
+              className="inline-flex min-h-11 items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
             >
               <ArrowLeft className="size-4" aria-hidden="true" />
               Blog dashboard
@@ -134,7 +134,7 @@ export default async function BlogPostPage({
       <section className="border-t border-border bg-background text-foreground">
         <div className="mx-auto flex max-w-5xl flex-col gap-5 px-6 py-10 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="font-mono text-[10px] font-black tracking-[0.18em] text-[#2f6fce]">
+            <p className="font-mono text-[10px] font-black tracking-[0.18em] text-primary">
               CONTINUE LEARNING
             </p>
             <h2 className="mt-2 text-xl font-bold">
@@ -143,7 +143,7 @@ export default async function BlogPostPage({
           </div>
           <Link
             href="/library"
-            className="inline-flex min-h-11 w-fit items-center gap-2 rounded-lg bg-[#163052] px-4 py-2 text-sm font-bold text-white hover:bg-[#23466f] focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-2 focus-visible:outline-none"
+            className="inline-flex min-h-11 w-fit items-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-bold text-background hover:bg-foreground/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             <BookOpen className="size-4" aria-hidden="true" />
             Open the Library
@@ -183,7 +183,7 @@ function ReaderContract({ post }: { post: BlogPostMeta }) {
         <Attribute icon={Users} label="For" value={post.audience} />
       </div>
       <div className="mt-4 border-t border-border pt-4">
-        <div className="flex items-center gap-2 font-mono text-[9px] font-black tracking-[0.14em] text-[#607188]">
+        <div className="flex items-center gap-2 font-mono text-[9px] font-black tracking-[0.14em] text-muted-foreground">
           <Tag className="size-3.5" aria-hidden="true" />
           TAGS
         </div>
@@ -213,7 +213,7 @@ function Attribute({
 }) {
   return (
     <div className="grid grid-cols-[1rem_5rem_minmax(0,1fr)] items-start gap-2">
-      <Icon className="mt-0.5 size-3.5 text-[#2f6fce]" aria-hidden="true" />
+      <Icon className="mt-0.5 size-3.5 text-primary" aria-hidden="true" />
       <span>{label}</span>
       <span className="font-bold text-foreground">{value}</span>
     </div>

--- a/packages/web/app/blog/[slug]/page.tsx
+++ b/packages/web/app/blog/[slug]/page.tsx
@@ -84,11 +84,11 @@ export default async function BlogPostPage({
   return (
     <MarketingLayout>
       <article>
-        <header className="border-b border-[#b9c7d8] bg-[#f4f7f9] text-[#142033]">
+        <header className="border-b border-border bg-background text-foreground">
           <div className="mx-auto max-w-6xl px-6 pt-24 pb-12 lg:pt-28 lg:pb-16">
             <Link
               href="/blog"
-              className="inline-flex min-h-11 items-center gap-2 text-sm font-medium text-[#52637a] transition-colors hover:text-[#142033] focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:outline-none"
+              className="inline-flex min-h-11 items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:outline-none"
             >
               <ArrowLeft className="size-4" aria-hidden="true" />
               Blog dashboard
@@ -98,20 +98,23 @@ export default async function BlogPostPage({
               <div>
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant="secondary">{post.category}</Badge>
-                  <Badge variant="outline" className="bg-white">
+                  <Badge variant="outline" className="bg-background">
                     {post.level}
                   </Badge>
-                  <time className="text-xs text-[#607188]" dateTime={post.date}>
+                  <time
+                    className="text-xs text-muted-foreground"
+                    dateTime={post.date}
+                  >
                     {formatBlogDate(post.date)}
                   </time>
                 </div>
                 <h1 className="mt-5 max-w-4xl text-4xl font-black tracking-[-0.045em] sm:text-5xl lg:text-6xl">
                   {post.title}
                 </h1>
-                <p className="mt-5 max-w-3xl text-lg leading-8 text-[#52637a]">
+                <p className="mt-5 max-w-3xl text-lg leading-8 text-muted-foreground">
                   {post.description}
                 </p>
-                <p className="mt-6 text-sm font-medium text-[#607188]">
+                <p className="mt-6 text-sm font-medium text-muted-foreground">
                   {post.author}
                 </p>
               </div>
@@ -128,7 +131,7 @@ export default async function BlogPostPage({
         </div>
       </article>
 
-      <section className="border-t-2 border-[#163052] bg-[#eaf1fc] text-[#142033]">
+      <section className="border-t border-border bg-background text-foreground">
         <div className="mx-auto flex max-w-5xl flex-col gap-5 px-6 py-10 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <p className="font-mono text-[10px] font-black tracking-[0.18em] text-[#2f6fce]">
@@ -166,11 +169,11 @@ function tocTitleToString(node: ReactNode): string {
 
 function ReaderContract({ post }: { post: BlogPostMeta }) {
   return (
-    <aside className="self-start overflow-hidden rounded-xl border-2 border-[#163052] bg-white shadow-[7px_7px_0_#dbe5f2]">
-      <div className="border-b-2 border-[#163052] px-4 py-3 font-mono text-[9px] font-black tracking-[0.17em]">
+    <aside className="self-start rounded-xl border border-border bg-card p-4 shadow-sm">
+      <div className="font-mono text-[9px] font-black tracking-[0.17em]">
         READER CONTRACT
       </div>
-      <div className="grid gap-3 p-4 text-xs text-[#52637a]">
+      <div className="mt-4 grid gap-3 text-xs text-muted-foreground">
         <Attribute
           icon={Clock}
           label="Reading time"
@@ -179,7 +182,7 @@ function ReaderContract({ post }: { post: BlogPostMeta }) {
         <Attribute icon={Gauge} label="Depth" value={post.level} />
         <Attribute icon={Users} label="For" value={post.audience} />
       </div>
-      <div className="border-t border-[#b9c7d8] p-4">
+      <div className="mt-4 border-t border-border pt-4">
         <div className="flex items-center gap-2 font-mono text-[9px] font-black tracking-[0.14em] text-[#607188]">
           <Tag className="size-3.5" aria-hidden="true" />
           TAGS
@@ -188,7 +191,7 @@ function ReaderContract({ post }: { post: BlogPostMeta }) {
           {post.tags.map((tag) => (
             <span
               key={tag}
-              className="rounded-full border border-[#b9c7d8] px-2 py-0.5 text-[10px] text-[#52637a]"
+              className="rounded-full border border-border px-2 py-0.5 text-[10px] text-muted-foreground"
             >
               {tag}
             </span>
@@ -212,7 +215,7 @@ function Attribute({
     <div className="grid grid-cols-[1rem_5rem_minmax(0,1fr)] items-start gap-2">
       <Icon className="mt-0.5 size-3.5 text-[#2f6fce]" aria-hidden="true" />
       <span>{label}</span>
-      <span className="font-bold text-[#142033]">{value}</span>
+      <span className="font-bold text-foreground">{value}</span>
     </div>
   )
 }

--- a/packages/web/app/blog/page.tsx
+++ b/packages/web/app/blog/page.tsx
@@ -29,17 +29,17 @@ export default function BlogDashboardPage() {
 
   return (
     <MarketingLayout>
-      <section className="border-b border-[#b9c7d8] bg-[#f4f7f9] text-[#142033]">
+      <section className="border-b border-border bg-background text-foreground">
         <div className="mx-auto grid max-w-6xl gap-8 px-6 pt-20 pb-14 lg:grid-cols-[minmax(0,1fr)_23rem] lg:pt-24 lg:pb-16">
           <div>
-            <Badge variant="outline" className="gap-1 bg-white">
+            <Badge variant="outline" className="gap-1 bg-background">
               <Newspaper className="size-3" aria-hidden="true" />
               Crab blog
             </Badge>
             <h1 className="mt-5 max-w-3xl text-4xl font-black tracking-[-0.045em] sm:text-5xl">
               Notes from building Git for large files.
             </h1>
-            <p className="mt-5 max-w-2xl text-base leading-7 text-[#52637a]">
+            <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground">
               Product decisions, system boundaries, and lessons from making
               object storage behave like a dependable Git remote.
             </p>
@@ -57,7 +57,7 @@ export default function BlogDashboardPage() {
       </section>
 
       <main className="mx-auto max-w-6xl px-6 py-14 sm:py-16">
-        <div className="flex flex-col gap-3 border-b-2 border-[#163052] pb-5 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex flex-col gap-3 border-b border-border pb-5 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="font-mono text-[10px] font-black tracking-[0.18em] text-[#2f6fce]">
               EDITORIAL LEDGER
@@ -149,7 +149,7 @@ function PostCard({ post }: { post: BlogPostMeta }) {
   return (
     <Link
       href={`/blog/${post.slug}`}
-      className="group flex h-full flex-col rounded-xl border border-[#b9c7d8] bg-white p-5 transition-transform outline-none hover:-translate-y-0.5 hover:shadow-[6px_6px_0_#dbe5f2] focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-2 focus-visible:outline-none"
+      className="group flex h-full flex-col rounded-xl border border-border bg-card p-5 transition-[border-color,box-shadow] outline-none hover:border-primary/30 hover:shadow-sm focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-2 focus-visible:outline-none"
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <Badge variant="secondary">{post.category}</Badge>
@@ -208,18 +208,22 @@ function MetaLine({
 
 function CurrentSubjectDiagram() {
   return (
-    <aside className="self-start overflow-hidden rounded-xl border-2 border-[#163052] bg-white shadow-[7px_7px_0_#dbe5f2]">
-      <div className="flex items-center justify-between border-b-2 border-[#163052] px-4 py-3">
+    <aside className="self-start rounded-xl border border-border bg-card p-5 shadow-sm">
+      <div className="flex items-center justify-between">
         <span className="font-mono text-[9px] font-black tracking-[0.17em]">
           CURRENT SUBJECT
         </span>
         <span className="size-2 rounded-full bg-[#3d9b72]" aria-hidden="true" />
       </div>
-      <div className="p-4">
-        <div className="rounded-md bg-[#163052] px-3 py-2 font-mono text-[10px] font-black text-white">
+      <div className="mt-4">
+        <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-[10px] font-black text-foreground">
+          <span
+            className="size-1.5 rounded-full bg-[#2f6fce]"
+            aria-hidden="true"
+          />
           ONE COMMIT
         </div>
-        <div className="mx-auto h-5 w-px bg-[#163052]" aria-hidden="true" />
+        <div className="mx-auto h-5 w-px bg-border" aria-hidden="true" />
         <div className="grid grid-cols-2 gap-3">
           <DiagramLane
             icon={GitCommit}
@@ -234,7 +238,7 @@ function CurrentSubjectDiagram() {
             color="#e9784a"
           />
         </div>
-        <p className="m-0 mt-3 border border-[#3d9b72] bg-[#e9f6ef] px-3 py-2 text-center text-xs font-bold text-[#287754]">
+        <p className="m-0 mt-4 border-t border-border pt-3 text-center text-xs font-bold text-[#287754]">
           One visible repository state
         </p>
       </div>
@@ -254,15 +258,14 @@ function DiagramLane({
   color: string
 }) {
   return (
-    <div
-      className="border border-[#b9c7d8] p-3"
-      style={{ borderTop: `4px solid ${color}` }}
-    >
+    <div className="rounded-lg border border-border bg-muted/20 p-3">
       <Icon className="size-4" style={{ color }} aria-hidden="true" />
       <p className="m-0 mt-3 text-[10px] font-black tracking-wide uppercase">
         {label}
       </p>
-      <p className="m-0 mt-1 text-[10px] leading-4 text-[#607188]">{value}</p>
+      <p className="m-0 mt-1 text-[10px] leading-4 text-muted-foreground">
+        {value}
+      </p>
     </div>
   )
 }

--- a/packages/web/app/blog/page.tsx
+++ b/packages/web/app/blog/page.tsx
@@ -45,7 +45,7 @@ export default function BlogDashboardPage() {
             </p>
             <Link
               href="/library"
-              className="mt-7 inline-flex min-h-11 items-center gap-2 rounded-lg bg-[#163052] px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-[#23466f] focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-2 focus-visible:outline-none"
+              className="mt-7 inline-flex min-h-11 items-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-bold text-background transition-colors hover:bg-foreground/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               Browse learning materials
               <ArrowRight className="size-4" aria-hidden="true" />
@@ -59,7 +59,7 @@ export default function BlogDashboardPage() {
       <main className="mx-auto max-w-6xl px-6 py-14 sm:py-16">
         <div className="flex flex-col gap-3 border-b border-border pb-5 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <p className="font-mono text-[10px] font-black tracking-[0.18em] text-[#2f6fce]">
+            <p className="font-mono text-[10px] font-black tracking-[0.18em] text-primary">
               EDITORIAL LEDGER
             </p>
             <h2 className="mt-2 text-2xl font-bold tracking-tight">
@@ -72,7 +72,7 @@ export default function BlogDashboardPage() {
         </div>
 
         {!featuredPost ? (
-          <div className="border-b border-[#b9c7d8] py-12">
+          <div className="border-b border-border py-12">
             <h3 className="text-lg font-bold">No notes published yet.</h3>
             <p className="mt-2 text-sm text-muted-foreground">
               Add an MDX file to the blog collection to publish the first note.
@@ -104,10 +104,10 @@ function FeaturedPost({ post }: { post: BlogPostMeta }) {
   return (
     <Link
       href={`/blog/${post.slug}`}
-      className="group grid border-b border-[#b9c7d8] py-8 outline-none focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-4 focus-visible:outline-none md:grid-cols-[9rem_minmax(0,1fr)_13rem] md:items-start"
+      className="group grid border-b border-border py-8 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:outline-none md:grid-cols-[9rem_minmax(0,1fr)_13rem] md:items-start"
     >
-      <div className="font-mono text-xs font-black text-[#52637a]">
-        <span className="block text-3xl tracking-[-0.05em] text-[#142033]">
+      <div className="font-mono text-xs font-black text-muted-foreground">
+        <span className="block text-3xl tracking-[-0.05em] text-foreground">
           {new Date(post.date).getUTCDate().toString().padStart(2, "0")}
         </span>
         {formatBlogDate(post.date, "short")}
@@ -116,11 +116,11 @@ function FeaturedPost({ post }: { post: BlogPostMeta }) {
       <div className="mt-5 md:mt-0">
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="secondary">{post.category}</Badge>
-          <span className="font-mono text-[10px] font-black tracking-[0.14em] text-[#3d9b72]">
+          <span className="font-mono text-[10px] font-black tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
             FEATURED
           </span>
         </div>
-        <h3 className="mt-3 max-w-3xl text-2xl font-bold tracking-tight transition-colors group-hover:text-[#2f6fce] sm:text-3xl">
+        <h3 className="mt-3 max-w-3xl text-2xl font-bold tracking-tight transition-colors group-hover:text-primary sm:text-3xl">
           {post.title}
         </h3>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
@@ -129,11 +129,11 @@ function FeaturedPost({ post }: { post: BlogPostMeta }) {
         <TagList tags={post.tags} />
       </div>
 
-      <div className="mt-6 grid gap-3 border-l-0 border-[#b9c7d8] text-xs md:mt-0 md:border-l md:pl-6">
+      <div className="mt-6 grid gap-3 border-l-0 border-border text-xs md:mt-0 md:border-l md:pl-6">
         <MetaLine icon={Clock} label={`${post.readingTimeMinutes} min read`} />
         <MetaLine icon={Gauge} label={post.level} />
         <MetaLine icon={Users} label={post.audience} />
-        <span className="mt-2 inline-flex min-h-11 items-center gap-2 font-bold text-[#2f6fce]">
+        <span className="mt-2 inline-flex min-h-11 items-center gap-2 font-bold text-primary">
           Read article
           <ArrowRight
             className="size-4 transition-transform group-hover:translate-x-1"
@@ -149,7 +149,7 @@ function PostCard({ post }: { post: BlogPostMeta }) {
   return (
     <Link
       href={`/blog/${post.slug}`}
-      className="group flex h-full flex-col rounded-xl border border-border bg-card p-5 transition-[border-color,box-shadow] outline-none hover:border-primary/30 hover:shadow-sm focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-2 focus-visible:outline-none"
+      className="group flex h-full flex-col rounded-xl border border-border bg-card p-5 transition-[border-color,box-shadow] outline-none hover:border-primary/30 hover:shadow-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <Badge variant="secondary">{post.category}</Badge>
@@ -157,14 +157,14 @@ function PostCard({ post }: { post: BlogPostMeta }) {
           {formatBlogDate(post.date, "short")}
         </time>
       </div>
-      <h3 className="mt-4 text-xl font-bold tracking-tight transition-colors group-hover:text-[#2f6fce]">
+      <h3 className="mt-4 text-xl font-bold tracking-tight transition-colors group-hover:text-primary">
         {post.title}
       </h3>
       <p className="mt-3 text-sm leading-6 text-muted-foreground">
         {post.excerpt}
       </p>
       <TagList tags={post.tags} />
-      <div className="mt-auto grid gap-2 border-t border-[#dbe3ec] pt-4 text-xs">
+      <div className="mt-auto grid gap-2 border-t border-border pt-4 text-xs">
         <MetaLine icon={Clock} label={`${post.readingTimeMinutes} min read`} />
         <MetaLine icon={Gauge} label={post.level} />
         <MetaLine icon={Users} label={post.audience} />
@@ -179,7 +179,7 @@ function TagList({ tags }: { tags: string[] }) {
       {tags.map((tag) => (
         <span
           key={tag}
-          className="rounded-full border border-[#b9c7d8] px-2 py-0.5 text-[10px] font-medium text-[#52637a]"
+          className="rounded-full border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground"
         >
           {tag}
         </span>
@@ -196,9 +196,9 @@ function MetaLine({
   label: string
 }) {
   return (
-    <span className="flex items-start gap-2 text-[#52637a]">
+    <span className="flex items-start gap-2 text-muted-foreground">
       <Icon
-        className="mt-0.5 size-3.5 shrink-0 text-[#2f6fce]"
+        className="mt-0.5 size-3.5 shrink-0 text-primary"
         aria-hidden="true"
       />
       <span className="leading-5">{label}</span>
@@ -213,12 +213,15 @@ function CurrentSubjectDiagram() {
         <span className="font-mono text-[9px] font-black tracking-[0.17em]">
           CURRENT SUBJECT
         </span>
-        <span className="size-2 rounded-full bg-[#3d9b72]" aria-hidden="true" />
+        <span
+          className="size-2 rounded-full bg-emerald-500"
+          aria-hidden="true"
+        />
       </div>
       <div className="mt-4">
         <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-[10px] font-black text-foreground">
           <span
-            className="size-1.5 rounded-full bg-[#2f6fce]"
+            className="size-1.5 rounded-full bg-primary"
             aria-hidden="true"
           />
           ONE COMMIT
@@ -229,16 +232,16 @@ function CurrentSubjectDiagram() {
             icon={GitCommit}
             label="Git history"
             value="code + pointer"
-            color="#2f6fce"
+            colorClassName="text-blue-600 dark:text-blue-400"
           />
           <DiagramLane
             icon={Cloud}
             label="Object store"
             value="large bytes"
-            color="#e9784a"
+            colorClassName="text-orange-600 dark:text-orange-400"
           />
         </div>
-        <p className="m-0 mt-4 border-t border-border pt-3 text-center text-xs font-bold text-[#287754]">
+        <p className="m-0 mt-4 border-t border-border pt-3 text-center text-xs font-bold text-emerald-700 dark:text-emerald-300">
           One visible repository state
         </p>
       </div>
@@ -250,16 +253,16 @@ function DiagramLane({
   icon: Icon,
   label,
   value,
-  color,
+  colorClassName,
 }: {
   icon: typeof GitCommit
   label: string
   value: string
-  color: string
+  colorClassName: string
 }) {
   return (
     <div className="rounded-lg border border-border bg-muted/20 p-3">
-      <Icon className="size-4" style={{ color }} aria-hidden="true" />
+      <Icon className={`size-4 ${colorClassName}`} aria-hidden="true" />
       <p className="m-0 mt-3 text-[10px] font-black tracking-wide uppercase">
         {label}
       </p>

--- a/packages/web/app/library/page.tsx
+++ b/packages/web/app/library/page.tsx
@@ -86,7 +86,7 @@ export default function LibraryIndexPage() {
 
   return (
     <MarketingLayout>
-      <section className="border-b border-[#b9c7d8] bg-[#f4f7f9] text-[#142033]">
+      <section className="border-b border-border bg-background text-foreground">
         <div className="mx-auto grid max-w-6xl gap-8 px-6 pt-20 pb-12 lg:grid-cols-[minmax(0,1fr)_24rem] lg:pt-24 lg:pb-14">
           <div>
             <Badge variant="outline" className="gap-1">
@@ -137,42 +137,39 @@ export default function LibraryIndexPage() {
             <LibraryProgress total={posts.length} />
           </div>
 
-          <aside className="self-start overflow-hidden rounded-lg border-2 border-[#163052] bg-white shadow-[8px_8px_0_#dbe5f2]">
-            <div className="h-2 bg-[linear-gradient(90deg,#2f6fce_0_50%,#e9784a_50%_78%,#3d9b72_78%)]" />
-            <div className="p-5">
-              <div className="flex items-center justify-between gap-3">
-                <Badge variant="secondary">Recommended first</Badge>
-                <span className="text-xs font-medium text-muted-foreground">
-                  Step {firstPost.pathOrder}
-                </span>
-              </div>
-              <h2 className="mt-4 text-xl leading-tight font-semibold">
-                {firstPost.title}
-              </h2>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                {firstPost.description}
-              </p>
-              <div className="mt-5 divide-y divide-border text-sm">
-                <HeroInfoRow label="Depth" value={firstPost.level} />
-                <HeroInfoRow
-                  label="Read time"
-                  value={`${firstPost.readingTimeMinutes} min`}
-                />
-                <HeroInfoRow label="Path" value={firstPath.label} />
-                <HeroInfoRow
-                  label="Diagram"
-                  value={firstPost.diagramType ?? "Guide"}
-                />
-                <HeroInfoRow label="Proof" value="1 knowledge check" />
-              </div>
-              <Link
-                href={`/library/${firstPost.slug}`}
-                className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary-hover"
-              >
-                Read the guide
-                <ArrowRight size={14} />
-              </Link>
+          <aside className="self-start rounded-xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <Badge variant="secondary">Recommended first</Badge>
+              <span className="text-xs font-medium text-muted-foreground">
+                Step {firstPost.pathOrder}
+              </span>
             </div>
+            <h2 className="mt-4 text-xl leading-tight font-semibold">
+              {firstPost.title}
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              {firstPost.description}
+            </p>
+            <div className="mt-5 divide-y divide-border text-sm">
+              <HeroInfoRow label="Depth" value={firstPost.level} />
+              <HeroInfoRow
+                label="Read time"
+                value={`${firstPost.readingTimeMinutes} min`}
+              />
+              <HeroInfoRow label="Path" value={firstPath.label} />
+              <HeroInfoRow
+                label="Diagram"
+                value={firstPost.diagramType ?? "Guide"}
+              />
+              <HeroInfoRow label="Proof" value="1 knowledge check" />
+            </div>
+            <Link
+              href={`/library/${firstPost.slug}`}
+              className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary-hover"
+            >
+              Read the guide
+              <ArrowRight size={14} />
+            </Link>
           </aside>
         </div>
       </section>

--- a/packages/web/components/blog/crab-introduction-workbench.tsx
+++ b/packages/web/components/blog/crab-introduction-workbench.tsx
@@ -73,18 +73,18 @@ export function CrabIntroductionWorkbench() {
   const active = stages.find((stage) => stage.id === activeId) ?? stages[0]
 
   return (
-    <section className="wide-article-visual not-prose my-10 overflow-hidden rounded-2xl border border-[#dbe3ec] bg-white text-[#142033] shadow-sm lg:relative lg:left-1/2 lg:w-[min(72rem,calc(100vw-3rem))] lg:-translate-x-1/2">
-      <header className="border-b border-[#dbe3ec] px-5 py-5 sm:px-7">
+    <section className="wide-article-visual not-prose my-10 overflow-hidden rounded-2xl border border-border bg-card text-card-foreground shadow-sm lg:relative lg:left-1/2 lg:w-[min(72rem,calc(100vw-3rem))] lg:-translate-x-1/2">
+      <header className="border-b border-border px-5 py-5 sm:px-7">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#2f6fce]">
+            <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-primary">
               INTERACTIVE REPOSITORY WORKBENCH
             </p>
             <h2 className="m-0 mt-1 text-2xl font-black tracking-[-0.04em]">
               One commit. Two data paths.
             </h2>
           </div>
-          <p className="m-0 max-w-sm text-sm leading-6 text-[#52637a]">
+          <p className="m-0 max-w-sm text-sm leading-6 text-muted-foreground">
             Select a stage to see what Git stores, what the bucket stores, and
             which state becomes true.
           </p>
@@ -92,7 +92,7 @@ export function CrabIntroductionWorkbench() {
       </header>
 
       <div
-        className="grid border-b border-[#dbe3ec] bg-[#f8fafc] sm:grid-cols-4"
+        className="grid border-b border-border bg-muted/40 sm:grid-cols-4"
         role="tablist"
         aria-label="Crab repository stages"
       >
@@ -106,10 +106,10 @@ export function CrabIntroductionWorkbench() {
             aria-controls="crab-stage-panel"
             onClick={() => setActiveId(stage.id)}
             className={cn(
-              "relative min-h-12 border-b border-[#dbe3ec] px-4 py-3 text-left font-mono text-xs font-black text-[#607188] transition-colors outline-none after:absolute after:inset-x-4 after:bottom-0 after:h-0.5 after:scale-x-0 after:bg-[#2f6fce] after:transition-transform last:border-b-0 focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-inset sm:border-r sm:border-b-0 sm:last:border-r-0",
+              "relative min-h-12 border-b border-border px-4 py-3 text-left font-mono text-xs font-black text-muted-foreground transition-colors outline-none after:absolute after:inset-x-4 after:bottom-0 after:h-0.5 after:scale-x-0 after:bg-primary after:transition-transform last:border-b-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:border-r sm:border-b-0 sm:last:border-r-0",
               active.id === stage.id
-                ? "bg-white text-[#142033] after:scale-x-100"
-                : "hover:bg-white hover:text-[#142033]"
+                ? "bg-card text-card-foreground after:scale-x-100"
+                : "hover:bg-card hover:text-card-foreground"
             )}
           >
             {stage.label}
@@ -124,15 +124,18 @@ export function CrabIntroductionWorkbench() {
         className="p-4 sm:p-6"
       >
         <div className="grid gap-4 xl:grid-cols-[15rem_minmax(0,1fr)_minmax(0,1fr)]">
-          <div className="rounded-xl border border-[#dbe3ec] bg-[#f8fafc] p-4">
-            <div className="flex items-center gap-2 text-xs font-black tracking-[0.12em] text-[#52637a] uppercase">
-              <Code2 className="size-4 text-[#e9784a]" aria-hidden="true" />
+          <div className="rounded-xl border border-border bg-muted/40 p-4">
+            <div className="flex items-center gap-2 text-xs font-black tracking-[0.12em] text-muted-foreground uppercase">
+              <Code2
+                className="size-4 text-orange-600 dark:text-orange-400"
+                aria-hidden="true"
+              />
               Action
             </div>
             <code className="mt-4 block overflow-x-auto rounded-lg bg-[#142033] px-3 py-3 text-xs leading-5 text-white">
               {active.action}
             </code>
-            <p className="m-0 mt-4 text-sm leading-6 text-[#52637a]">
+            <p className="m-0 mt-4 text-sm leading-6 text-muted-foreground">
               {active.note}
             </p>
           </div>
@@ -141,31 +144,33 @@ export function CrabIntroductionWorkbench() {
             icon={GitCommit}
             eyebrow="GIT LANE"
             title="Commit graph"
-            accent="#2f6fce"
+            iconClassName="text-blue-600 dark:text-blue-400"
+            dotClassName="bg-blue-600 dark:bg-blue-400"
             items={active.git}
           />
           <DataLane
             icon={Cloud}
             eyebrow="CRAB LANE"
             title="Object storage"
-            accent="#e9784a"
+            iconClassName="text-orange-600 dark:text-orange-400"
+            dotClassName="bg-orange-600 dark:bg-orange-400"
             items={active.bucket}
           />
         </div>
 
-        <div className="mt-4 grid gap-3 border-t border-[#dbe3ec] pt-4 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center">
-          <span className="flex size-10 items-center justify-center rounded-full bg-[#e9f6ef] text-[#287754]">
+        <div className="mt-4 grid gap-3 border-t border-border pt-4 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center">
+          <span className="flex size-10 items-center justify-center rounded-full bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300">
             <Check className="size-5" aria-hidden="true" />
           </span>
           <div>
-            <p className="m-0 font-mono text-[9px] font-black tracking-[0.18em] text-[#287754]">
+            <p className="m-0 font-mono text-[9px] font-black tracking-[0.18em] text-emerald-700 dark:text-emerald-300">
               STATE NOW TRUE
             </p>
             <p aria-live="polite" className="m-0 mt-1 text-sm font-bold">
               {active.state}
             </p>
           </div>
-          <div className="flex items-center gap-2 text-xs font-bold text-[#287754]">
+          <div className="flex items-center gap-2 text-xs font-bold text-emerald-700 dark:text-emerald-300">
             {active.id === "hydrate" ? (
               <PackageOpen className="size-4" aria-hidden="true" />
             ) : (
@@ -183,35 +188,36 @@ function DataLane({
   icon: Icon,
   eyebrow,
   title,
-  accent,
+  iconClassName,
+  dotClassName,
   items,
 }: {
   icon: typeof GitCommit
   eyebrow: string
   title: string
-  accent: string
+  iconClassName: string
+  dotClassName: string
   items: readonly string[]
 }) {
   return (
-    <section className="overflow-hidden rounded-xl border border-[#dbe3ec] bg-white">
-      <header className="flex items-center gap-3 border-b border-[#dbe3ec] px-4 py-3">
-        <Icon className="size-5" style={{ color: accent }} aria-hidden="true" />
+    <section className="overflow-hidden rounded-xl border border-border bg-card">
+      <header className="flex items-center gap-3 border-b border-border px-4 py-3">
+        <Icon className={cn("size-5", iconClassName)} aria-hidden="true" />
         <div>
-          <p className="m-0 font-mono text-[9px] font-black tracking-[0.18em] text-[#607188]">
+          <p className="m-0 font-mono text-[9px] font-black tracking-[0.18em] text-muted-foreground">
             {eyebrow}
           </p>
           <h3 className="m-0 mt-0.5 text-sm font-black">{title}</h3>
         </div>
       </header>
-      <ul className="m-0 grid list-none divide-y divide-[#dbe3ec] p-0">
+      <ul className="m-0 grid list-none divide-y divide-border p-0">
         {items.map((item) => (
           <li
             key={item}
             className="flex min-h-11 items-center gap-3 px-4 py-3 text-xs leading-5"
           >
             <span
-              className="size-2 shrink-0 rounded-sm"
-              style={{ backgroundColor: accent }}
+              className={cn("size-2 shrink-0 rounded-sm", dotClassName)}
               aria-hidden="true"
             />
             {item}

--- a/packages/web/components/blog/crab-introduction-workbench.tsx
+++ b/packages/web/components/blog/crab-introduction-workbench.tsx
@@ -73,8 +73,8 @@ export function CrabIntroductionWorkbench() {
   const active = stages.find((stage) => stage.id === activeId) ?? stages[0]
 
   return (
-    <section className="wide-article-visual not-prose my-10 overflow-hidden rounded-2xl border-2 border-[#163052] bg-[#f4f7f9] text-[#142033] shadow-[0_22px_55px_rgba(20,32,51,0.16)] lg:relative lg:left-1/2 lg:w-[min(72rem,calc(100vw-3rem))] lg:-translate-x-1/2">
-      <header className="border-b-2 border-[#163052] bg-white px-5 py-5 sm:px-7">
+    <section className="wide-article-visual not-prose my-10 overflow-hidden rounded-2xl border border-[#dbe3ec] bg-white text-[#142033] shadow-sm lg:relative lg:left-1/2 lg:w-[min(72rem,calc(100vw-3rem))] lg:-translate-x-1/2">
+      <header className="border-b border-[#dbe3ec] px-5 py-5 sm:px-7">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#2f6fce]">
@@ -92,7 +92,7 @@ export function CrabIntroductionWorkbench() {
       </header>
 
       <div
-        className="grid border-b-2 border-[#163052] bg-[#163052] sm:grid-cols-4"
+        className="grid border-b border-[#dbe3ec] bg-[#f8fafc] sm:grid-cols-4"
         role="tablist"
         aria-label="Crab repository stages"
       >
@@ -106,10 +106,10 @@ export function CrabIntroductionWorkbench() {
             aria-controls="crab-stage-panel"
             onClick={() => setActiveId(stage.id)}
             className={cn(
-              "min-h-12 border-b border-white/20 px-4 py-3 text-left font-mono text-xs font-black text-white transition-colors outline-none last:border-b-0 focus-visible:ring-2 focus-visible:ring-[#7fb0ff] focus-visible:ring-inset sm:border-r sm:border-b-0 sm:last:border-r-0",
+              "relative min-h-12 border-b border-[#dbe3ec] px-4 py-3 text-left font-mono text-xs font-black text-[#607188] transition-colors outline-none after:absolute after:inset-x-4 after:bottom-0 after:h-0.5 after:scale-x-0 after:bg-[#2f6fce] after:transition-transform last:border-b-0 focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-inset sm:border-r sm:border-b-0 sm:last:border-r-0",
               active.id === stage.id
-                ? "bg-[#2f6fce]"
-                : "bg-[#163052] hover:bg-[#23466f]"
+                ? "bg-white text-[#142033] after:scale-x-100"
+                : "hover:bg-white hover:text-[#142033]"
             )}
           >
             {stage.label}
@@ -124,7 +124,7 @@ export function CrabIntroductionWorkbench() {
         className="p-4 sm:p-6"
       >
         <div className="grid gap-4 xl:grid-cols-[15rem_minmax(0,1fr)_minmax(0,1fr)]">
-          <div className="rounded-xl border border-[#b9c7d8] bg-white p-4">
+          <div className="rounded-xl border border-[#dbe3ec] bg-[#f8fafc] p-4">
             <div className="flex items-center gap-2 text-xs font-black tracking-[0.12em] text-[#52637a] uppercase">
               <Code2 className="size-4 text-[#e9784a]" aria-hidden="true" />
               Action
@@ -153,8 +153,8 @@ export function CrabIntroductionWorkbench() {
           />
         </div>
 
-        <div className="mt-4 grid gap-3 rounded-xl border-2 border-[#3d9b72] bg-[#e9f6ef] p-4 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center">
-          <span className="flex size-10 items-center justify-center rounded-full bg-[#3d9b72] text-white">
+        <div className="mt-4 grid gap-3 border-t border-[#dbe3ec] pt-4 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center">
+          <span className="flex size-10 items-center justify-center rounded-full bg-[#e9f6ef] text-[#287754]">
             <Check className="size-5" aria-hidden="true" />
           </span>
           <div>
@@ -193,11 +193,8 @@ function DataLane({
   items: readonly string[]
 }) {
   return (
-    <section className="overflow-hidden rounded-xl border border-[#b9c7d8] bg-white">
-      <header
-        className="flex items-center gap-3 border-b border-[#b9c7d8] px-4 py-3"
-        style={{ borderTop: `5px solid ${accent}` }}
-      >
+    <section className="overflow-hidden rounded-xl border border-[#dbe3ec] bg-white">
+      <header className="flex items-center gap-3 border-b border-[#dbe3ec] px-4 py-3">
         <Icon className="size-5" style={{ color: accent }} aria-hidden="true" />
         <div>
           <p className="m-0 font-mono text-[9px] font-black tracking-[0.18em] text-[#607188]">

--- a/packages/web/components/library/knowledge-check.tsx
+++ b/packages/web/components/library/knowledge-check.tsx
@@ -52,7 +52,7 @@ export function KnowledgeCheck({
   return (
     <section
       aria-labelledby={`knowledge-check-${slug}`}
-      className="not-prose mt-12 overflow-hidden rounded-2xl border-2 border-[#163052] bg-[#f4f7f9] text-[#142033] shadow-[0_18px_45px_rgba(20,32,51,0.12)]"
+      className="not-prose mt-12 overflow-hidden rounded-2xl border border-[#dbe3ec] bg-white text-[#142033] shadow-sm"
     >
       <header className="flex flex-col gap-3 border-b border-[#b9c7d8] px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
         <div>

--- a/packages/web/components/library/knowledge-check.tsx
+++ b/packages/web/components/library/knowledge-check.tsx
@@ -52,11 +52,11 @@ export function KnowledgeCheck({
   return (
     <section
       aria-labelledby={`knowledge-check-${slug}`}
-      className="not-prose mt-12 overflow-hidden rounded-2xl border border-[#dbe3ec] bg-white text-[#142033] shadow-sm"
+      className="not-prose mt-12 overflow-hidden rounded-2xl border border-border bg-card text-card-foreground shadow-sm"
     >
-      <header className="flex flex-col gap-3 border-b border-[#b9c7d8] px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
+      <header className="flex flex-col gap-3 border-b border-border px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
         <div>
-          <p className="m-0 font-mono text-[10px] font-black tracking-[0.18em] text-[#2f6fce]">
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.18em] text-primary">
             KNOWLEDGE PROOF
           </p>
           <h2
@@ -66,12 +66,15 @@ export function KnowledgeCheck({
             Check the decision, not your memory.
           </h2>
         </div>
-        <span className="inline-flex w-fit items-center gap-1.5 rounded-full border border-[#b9c7d8] bg-white px-3 py-1.5 font-mono text-[9px] font-black text-[#52637a]">
+        <span className="inline-flex w-fit items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 font-mono text-[9px] font-black text-muted-foreground">
           {passed ? (
-            <ShieldCheck className="size-4 text-[#3d9b72]" aria-hidden="true" />
+            <ShieldCheck
+              className="size-4 text-emerald-600 dark:text-emerald-400"
+              aria-hidden="true"
+            />
           ) : (
             <span
-              className="size-2 rounded-full bg-[#e9784a]"
+              className="size-2 rounded-full bg-orange-500"
               aria-hidden="true"
             />
           )}
@@ -103,28 +106,32 @@ export function KnowledgeCheck({
                 disabled={checked}
                 onClick={() => setSelected(index)}
                 className={cn(
-                  "flex min-h-12 items-start gap-3 rounded-xl border bg-white px-4 py-3 text-left text-sm leading-6 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-2 disabled:cursor-default",
-                  isCorrect && "border-[#3d9b72] bg-[#e9f6ef]",
-                  isWrong && "border-[#e9784a] bg-[#fff0eb]",
-                  !checked && isSelected && "border-[#2f6fce] bg-[#eaf1fc]",
+                  "flex min-h-12 items-start gap-3 rounded-xl border bg-background px-4 py-3 text-left text-sm leading-6 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card disabled:cursor-default",
+                  isCorrect &&
+                    "border-emerald-500 bg-emerald-50 dark:border-emerald-400 dark:bg-emerald-950/40",
+                  isWrong &&
+                    "border-orange-500 bg-orange-50 dark:border-orange-400 dark:bg-orange-950/40",
+                  !checked && isSelected && "border-primary bg-primary-muted",
                   !checked &&
                     !isSelected &&
-                    "border-[#b9c7d8] hover:border-[#2f6fce]"
+                    "border-border hover:border-primary"
                 )}
               >
                 <span
                   className={cn(
                     "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border font-mono text-[9px] font-black",
-                    isCorrect && "border-[#3d9b72] bg-[#3d9b72] text-white",
-                    isWrong && "border-[#e9784a] bg-[#e9784a] text-white",
+                    isCorrect &&
+                      "border-emerald-600 bg-emerald-600 text-white dark:border-emerald-400 dark:bg-emerald-400 dark:text-emerald-950",
+                    isWrong &&
+                      "border-orange-600 bg-orange-600 text-white dark:border-orange-400 dark:bg-orange-400 dark:text-orange-950",
                     !isCorrect &&
                       !isWrong &&
                       isSelected &&
-                      "border-[#2f6fce] text-[#2f6fce]",
+                      "border-primary text-primary",
                     !isCorrect &&
                       !isWrong &&
                       !isSelected &&
-                      "border-[#9cabbc] text-[#607188]"
+                      "border-muted-foreground/50 text-muted-foreground"
                   )}
                 >
                   {isCorrect ? (
@@ -147,7 +154,7 @@ export function KnowledgeCheck({
               type="button"
               disabled={selected === null}
               onClick={verify}
-              className="min-h-11 rounded-lg bg-[#163052] px-4 py-2 text-sm font-bold text-white transition-colors outline-none hover:bg-[#23466f] focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-45"
+              className="min-h-11 rounded-lg bg-foreground px-4 py-2 text-sm font-bold text-background transition-colors outline-none hover:bg-foreground/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card disabled:cursor-not-allowed disabled:opacity-45"
             >
               Check my answer
             </button>
@@ -155,7 +162,7 @@ export function KnowledgeCheck({
             <button
               type="button"
               onClick={retry}
-              className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-[#163052] bg-white px-4 py-2 text-sm font-bold outline-none hover:bg-[#eaf1fc] focus-visible:ring-2 focus-visible:ring-[#2f6fce] focus-visible:ring-offset-2"
+              className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-border bg-background px-4 py-2 text-sm font-bold outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
             >
               <RotateCcw className="size-4" aria-hidden="true" />
               Try again
@@ -169,8 +176,8 @@ export function KnowledgeCheck({
             className={cn(
               "mt-5 rounded-xl border-l-4 p-4 text-sm leading-6",
               passed
-                ? "border-[#3d9b72] bg-[#e9f6ef]"
-                : "border-[#e9784a] bg-[#fff0eb]"
+                ? "border-emerald-500 bg-emerald-50 dark:border-emerald-400 dark:bg-emerald-950/40"
+                : "border-orange-500 bg-orange-50 dark:border-orange-400 dark:bg-orange-950/40"
             )}
           >
             <p className="m-0 font-bold">
@@ -178,7 +185,9 @@ export function KnowledgeCheck({
                 ? "Correct — keep this boundary."
                 : "Not yet — use the system boundary."}
             </p>
-            <p className="m-0 mt-1 text-[#52637a]">{check.explanation}</p>
+            <p className="m-0 mt-1 text-muted-foreground">
+              {check.explanation}
+            </p>
           </div>
         )}
       </div>

--- a/packages/web/components/library/library-progress.tsx
+++ b/packages/web/components/library/library-progress.tsx
@@ -32,7 +32,7 @@ export function LibraryProgress({ total }: { total: number }) {
   const percent = total === 0 ? 0 : Math.round((safeCompleted / total) * 100)
 
   return (
-    <div className="mt-7 max-w-2xl rounded-xl border border-[#b9c7d8] bg-white p-4">
+    <div className="mt-7 max-w-2xl rounded-xl border border-border bg-card p-4">
       <div className="flex items-center justify-between gap-4 text-xs font-bold">
         <span className="inline-flex items-center gap-2">
           <ShieldCheck className="size-4 text-[#3d9b72]" aria-hidden="true" />
@@ -43,7 +43,7 @@ export function LibraryProgress({ total }: { total: number }) {
         </span>
       </div>
       <div
-        className="mt-3 h-2 overflow-hidden rounded-full bg-[#dbe5f2]"
+        className="mt-3 h-2 overflow-hidden rounded-full bg-muted"
         role="progressbar"
         aria-label="Library knowledge checks completed"
         aria-valuemin={0}

--- a/packages/web/components/library/library-progress.tsx
+++ b/packages/web/components/library/library-progress.tsx
@@ -35,7 +35,10 @@ export function LibraryProgress({ total }: { total: number }) {
     <div className="mt-7 max-w-2xl rounded-xl border border-border bg-card p-4">
       <div className="flex items-center justify-between gap-4 text-xs font-bold">
         <span className="inline-flex items-center gap-2">
-          <ShieldCheck className="size-4 text-[#3d9b72]" aria-hidden="true" />
+          <ShieldCheck
+            className="size-4 text-emerald-600 dark:text-emerald-400"
+            aria-hidden="true"
+          />
           Knowledge proofs
         </span>
         <span aria-live="polite">
@@ -51,7 +54,7 @@ export function LibraryProgress({ total }: { total: number }) {
         aria-valuenow={safeCompleted}
       >
         <div
-          className="h-full rounded-full bg-[#3d9b72] transition-[width] duration-300"
+          className="h-full rounded-full bg-emerald-600 transition-[width] duration-300 dark:bg-emerald-400"
           style={{ width: `${percent}%` }}
         />
       </div>


### PR DESCRIPTION
## Summary

- replace thick colored outlines, offset shadows, and broad color bands on blog and library surfaces with neutral hairline rules and quiet card elevation
- keep Crab’s technical identity through monospaced labels, data-lane icons and nodes, semantic status color, and active-state accents
- make the touched blog and library shells theme-aware and document the visual-restraint convention

## Validation

- npm run typecheck
- npm run lint (passes with 17 pre-existing warnings outside the touched files)
- npm run test (3 files, 6 tests)
- npm run build (232 static pages)
- browser QA on /library, /blog, and /library/what-is-crab in light and dark themes
- responsive QA at 390px and wide desktop viewports, including tab interaction and horizontal-overflow checks