### PR TITLE
feat(web): add structured SEO data

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -13,7 +13,7 @@ The site combines several content and product surfaces:
 - **Technical blog**: MDX articles with learning paths, categories, tags, diagrams, and related-post navigation
 - **Release communication**: A source-backed changelog rendered from typed data in `lib/changelog.ts`
 - **Public installers**: Shell and PowerShell scripts in `public/`, exposed through `/install.sh` and `/install.ps1`
-- **Search and discovery**: CLI documentation search at `/api/search` and a generated sitemap at `/sitemap.xml`
+- **Search and discovery**: CLI documentation search, canonical metadata, social cards, JSON-LD for articles and breadcrumbs, and a generated sitemap at `/sitemap.xml`
 
 The app renders content through Next.js App Router routes. Most pages are server components. Client components are reserved for browser interactions such as animations, filters, theme switching, and interactive demos.
 
@@ -195,7 +195,7 @@ The top-level order is defined in `content/docs/cli/meta.json`. When you add a n
 
 ## Author blog posts
 
-Editorial posts live in `content/blog/` as individual `.mdx` files. Adding a file automatically creates its dashboard card, `/blog/<filename>` page, and sitemap entry. Reading time is calculated from the article body.
+Editorial posts live in `content/blog/` as individual `.mdx` files. Adding a file automatically creates its dashboard card, `/blog/<filename>` page, social images, BlogPosting and breadcrumb structured data, and sitemap entry. Reading time is calculated from the article body.
 
 Use frontmatter like this:
 

--- a/packages/web/app/blog/[slug]/page.tsx
+++ b/packages/web/app/blog/[slug]/page.tsx
@@ -14,11 +14,13 @@ import { isValidElement, type ReactElement, type ReactNode } from "react"
 
 import { FeatureBlogArticle } from "@/components/blog/feature-blog-article"
 import { MarketingLayout } from "@/components/marketing-layout"
+import { StructuredData } from "@/components/structured-data"
 import { Badge } from "@/components/ui/badge"
 import { formatBlogDate } from "@/lib/blog-date"
 import { getBlogPost, type BlogPostMeta } from "@/lib/blog-posts"
 import { blogSource } from "@/lib/blog-source"
 import { createPageMetadata } from "@/lib/metadata"
+import { createArticleStructuredData } from "@/lib/structured-data"
 import { getMDXComponents } from "@/mdx-components"
 
 export function generateStaticParams() {
@@ -50,6 +52,7 @@ export async function generateMetadata({
     article: {
       publishedTime: new Date(post.date).toISOString(),
       authors: [post.author],
+      section: post.category,
       tags: post.tags,
     },
   })
@@ -66,6 +69,18 @@ export default async function BlogPostPage({
   if (!page || !post) notFound()
 
   const MDX = page.data.body
+  const structuredData = createArticleStructuredData({
+    type: "BlogPosting",
+    title: post.title,
+    description: post.description,
+    path: `/blog/${slug}`,
+    imagePath: `/blog/${slug}/opengraph-image`,
+    publishedTime: post.date,
+    author: post.author,
+    section: post.category,
+    tags: post.tags,
+    breadcrumbs: [{ name: "Blog", path: "/blog" }, { name: post.title }],
+  })
 
   if (page.data.presentation === "feature") {
     const toc = page.data.toc.map((item) => ({
@@ -75,14 +90,18 @@ export default async function BlogPostPage({
     }))
 
     return (
-      <FeatureBlogArticle post={post} toc={toc}>
-        <MDX components={getMDXComponents({})} />
-      </FeatureBlogArticle>
+      <>
+        <StructuredData data={structuredData} />
+        <FeatureBlogArticle post={post} toc={toc}>
+          <MDX components={getMDXComponents({})} />
+        </FeatureBlogArticle>
+      </>
     )
   }
 
   return (
     <MarketingLayout>
+      <StructuredData data={structuredData} />
       <article>
         <header className="border-b border-[#b9c7d8] bg-[#f4f7f9] text-[#142033]">
           <div className="mx-auto max-w-6xl px-6 pt-24 pb-12 lg:pt-28 lg:pb-16">

--- a/packages/web/app/docs/cli/[[...slug]]/page.tsx
+++ b/packages/web/app/docs/cli/[[...slug]]/page.tsx
@@ -4,6 +4,8 @@ import { getMDXComponents } from '@/mdx-components';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { createPageMetadata } from '@/lib/metadata';
+import { StructuredData } from '@/components/structured-data';
+import { createBreadcrumbStructuredData } from '@/lib/structured-data';
 
 export default async function CliDocPage({
   params,
@@ -20,13 +22,20 @@ export default async function CliDocPage({
   if (!page) notFound();
 
   const MDX = page.data.body;
+  const structuredData = createBreadcrumbStructuredData([
+    { name: 'Documentation', path: '/docs' },
+    { name: page.data.title ?? 'Crab CLI Documentation' },
+  ]);
 
   return (
-    <DocsPage toc={page.data.toc} id="main-content">
-      <DocsBody>
-        <MDX components={getMDXComponents({})} />
-      </DocsBody>
-    </DocsPage>
+    <>
+      <StructuredData data={structuredData} />
+      <DocsPage toc={page.data.toc} id="main-content">
+        <DocsBody>
+          <MDX components={getMDXComponents({})} />
+        </DocsBody>
+      </DocsPage>
+    </>
   );
 }
 

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { RootProvider } from "fumadocs-ui/provider/next"
 import { SkipNavLink } from "@/components/navigation/skip-nav-link"
+import { StructuredData } from "@/components/structured-data"
 import {
   CRAB_LOGO_PATH,
   SITE_DESCRIPTION,
@@ -121,10 +122,7 @@ export default function RootLayout({
       )}
     >
       <body>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-        />
+        <StructuredData data={structuredData} />
         <SkipNavLink />
         <RootProvider>
           <ThemeProvider>{children}</ThemeProvider>

--- a/packages/web/app/library/[slug]/page.tsx
+++ b/packages/web/app/library/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
 import { MarketingLayout } from "@/components/marketing-layout"
 import { KnowledgeCheck } from "@/components/library/knowledge-check"
 import { Reveal } from "@/components/marketing/reveal"
+import { StructuredData } from "@/components/structured-data"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardHeader, CardTitle } from "@/components/ui/card"
 import {
@@ -33,6 +34,7 @@ import { formatBlogDate } from "@/lib/blog-date"
 import { librarySource } from "@/lib/library-source"
 import { getLibraryGuide, getLibraryGuides } from "@/lib/library-guides"
 import { createPageMetadata } from "@/lib/metadata"
+import { createArticleStructuredData } from "@/lib/structured-data"
 import { cn } from "@/lib/utils"
 import { getMDXComponents } from "@/mdx-components"
 
@@ -84,6 +86,7 @@ export async function generateMetadata({
       ? {
           publishedTime: new Date(post.date).toISOString(),
           authors: [post.author.name],
+          section: getLibraryPath(post.path).label,
           tags: post.tags,
         }
       : undefined,
@@ -109,9 +112,25 @@ export default async function LibraryGuidePage({
   const relatedPosts = getRelatedGuides(currentPost, allPosts)
   const CategoryIcon = categoryIcons[currentPost.category] ?? Package
   const PathIcon = pathIcons[currentPost.path] ?? BookOpen
+  const structuredData = createArticleStructuredData({
+    type: "Article",
+    title: currentPost.title,
+    description: currentPost.description,
+    path: `/library/${slug}`,
+    imagePath: `/library/${slug}/opengraph-image`,
+    publishedTime: currentPost.date,
+    author: currentPost.author.name,
+    section: learningPath.label,
+    tags: currentPost.tags,
+    breadcrumbs: [
+      { name: "Learning library", path: "/library" },
+      { name: currentPost.title },
+    ],
+  })
 
   return (
     <MarketingLayout>
+      <StructuredData data={structuredData} />
       <article className="border-b border-border">
         <section className="mx-auto max-w-6xl px-4 pt-24 pb-10 sm:px-6 lg:px-8 lg:pt-28">
           <nav className="mb-8">

--- a/packages/web/app/sitemap.ts
+++ b/packages/web/app/sitemap.ts
@@ -35,7 +35,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     .getPages()
     .map((post) => ({
       url: `${SITE_URL}/blog/${post.slugs[0]}`,
-      lastModified: post.data.date ? new Date(post.data.date) : new Date(),
+      ...(post.data.date ? { lastModified: new Date(post.data.date) } : {}),
       changeFrequency: "monthly",
       priority: 0.7,
     }))
@@ -44,7 +44,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     .getPages()
     .map((guide) => ({
       url: `${SITE_URL}/library/${guide.slugs[0]}`,
-      lastModified: guide.data.date ? new Date(guide.data.date) : new Date(),
+      ...(guide.data.date ? { lastModified: new Date(guide.data.date) } : {}),
       changeFrequency: "monthly",
       priority: 0.8,
     }))

--- a/packages/web/components/structured-data.tsx
+++ b/packages/web/components/structured-data.tsx
@@ -1,0 +1,13 @@
+import {
+  serializeStructuredData,
+  type StructuredDataValue,
+} from "@/lib/structured-data"
+
+export function StructuredData({ data }: { data: StructuredDataValue }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serializeStructuredData(data) }}
+    />
+  )
+}

--- a/packages/web/lib/metadata.ts
+++ b/packages/web/lib/metadata.ts
@@ -14,6 +14,7 @@ interface PageMetadataOptions {
   article?: {
     publishedTime: string
     authors: string[]
+    section?: string
     tags?: string[]
   }
   image?: {
@@ -59,6 +60,7 @@ export function createPageMetadata({
           type: "article",
           publishedTime: article.publishedTime,
           authors: article.authors,
+          section: article.section,
           tags: article.tags,
         }
       : { ...sharedOpenGraph, type: "website" },

--- a/packages/web/lib/structured-data.test.ts
+++ b/packages/web/lib/structured-data.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createArticleStructuredData,
+  createBreadcrumbStructuredData,
+  serializeStructuredData,
+} from "@/lib/structured-data"
+
+describe("structured data", () => {
+  it("builds absolute article and breadcrumb references", () => {
+    expect(
+      createArticleStructuredData({
+        type: "BlogPosting",
+        title: "Git for large files",
+        description: "An article about large-file version control.",
+        path: "/blog/git-for-large-files",
+        imagePath: "/blog/git-for-large-files/opengraph-image",
+        publishedTime: "2026-08-25",
+        author: "Crab Team",
+        section: "Product",
+        tags: ["git", "large-files"],
+        breadcrumbs: [
+          { name: "Blog", path: "/blog" },
+          { name: "Git for large files" },
+        ],
+      })
+    ).toMatchObject({
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "BlogPosting",
+          "@id": "https://crab.build/blog/git-for-large-files#article",
+          image: [
+            "https://crab.build/blog/git-for-large-files/opengraph-image",
+          ],
+          datePublished: "2026-08-25T00:00:00.000Z",
+          publisher: { "@id": "https://crab.build/#organization" },
+          mainEntityOfPage: {
+            "@type": "WebPage",
+            "@id": "https://crab.build/blog/git-for-large-files",
+          },
+        },
+        {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Blog",
+              item: "https://crab.build/blog",
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Git for large files",
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("builds standalone breadcrumb data", () => {
+    expect(
+      createBreadcrumbStructuredData([
+        { name: "Documentation", path: "/docs" },
+        { name: "Crab clone" },
+      ])
+    ).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+    })
+  })
+
+  it("escapes markup delimiters before embedding JSON-LD", () => {
+    expect(serializeStructuredData({ value: "</script>" })).toBe(
+      '{"value":"\\u003c/script>"}'
+    )
+  })
+})

--- a/packages/web/lib/structured-data.ts
+++ b/packages/web/lib/structured-data.ts
@@ -1,0 +1,90 @@
+import { SITE_URL } from "@/lib/metadata"
+
+export type StructuredDataValue = Record<string, unknown>
+
+interface BreadcrumbItem {
+  name: string
+  path?: string
+}
+
+interface ArticleStructuredDataOptions {
+  type: "Article" | "BlogPosting"
+  title: string
+  description: string
+  path: string
+  imagePath: string
+  publishedTime: string
+  author: string
+  section: string
+  tags: string[]
+  breadcrumbs: BreadcrumbItem[]
+}
+
+function absoluteUrl(path: string): string {
+  return new URL(path, SITE_URL).toString()
+}
+
+function breadcrumbList(items: BreadcrumbItem[]): StructuredDataValue {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      ...(item.path ? { item: absoluteUrl(item.path) } : {}),
+    })),
+  }
+}
+
+export function createBreadcrumbStructuredData(
+  items: BreadcrumbItem[]
+): StructuredDataValue {
+  return {
+    "@context": "https://schema.org",
+    ...breadcrumbList(items),
+  }
+}
+
+export function createArticleStructuredData({
+  type,
+  title,
+  description,
+  path,
+  imagePath,
+  publishedTime,
+  author,
+  section,
+  tags,
+  breadcrumbs,
+}: ArticleStructuredDataOptions): StructuredDataValue {
+  const url = absoluteUrl(path)
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": type,
+        "@id": `${url}#article`,
+        headline: title,
+        description,
+        image: [absoluteUrl(imagePath)],
+        datePublished: new Date(publishedTime).toISOString(),
+        author: {
+          "@type": "Organization",
+          name: author,
+          ...(author === "Crab Team" ? { url: absoluteUrl("/about-us") } : {}),
+        },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+        mainEntityOfPage: { "@type": "WebPage", "@id": url },
+        articleSection: section,
+        keywords: tags,
+        inLanguage: "en-US",
+      },
+      breadcrumbList(breadcrumbs),
+    ],
+  }
+}
+
+export function serializeStructuredData(data: StructuredDataValue): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c")
+}


### PR DESCRIPTION
## Summary

- add Article and BlogPosting JSON-LD to library and blog entries
- add breadcrumb structured data to blog, library, and CLI documentation pages
- safely serialize JSON-LD and expose article sections in Open Graph metadata
- stop undated sitemap entries from claiming a new modification date on every build

## Validation

- `npm run typecheck`
- `npm run lint` (no errors; 17 existing warnings)
- `npm run test` (9 tests)
- `npm run build` (232 pages)
- `npm run check:links` (198 HTML pages, 2,101 fragments)
- inspected rendered production HTML for BlogPosting, Article, breadcrumb, and article-section metadata