### PR TITLE
fix(web): reorder primary navigation

### DIFF
--- a/packages/web/components/navigation/mega-menu.tsx
+++ b/packages/web/components/navigation/mega-menu.tsx
@@ -23,14 +23,6 @@ export function MegaMenu() {
           </NavigationMenuItem>
           <NavigationMenuItem>
             <Link
-              href="/library"
-              className="inline-flex h-9 items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-            >
-              Library
-            </Link>
-          </NavigationMenuItem>
-          <NavigationMenuItem>
-            <Link
               href="/docs"
               className="inline-flex h-9 items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
             >
@@ -39,10 +31,10 @@ export function MegaMenu() {
           </NavigationMenuItem>
           <NavigationMenuItem>
             <Link
-              href="/blog"
+              href="/library"
               className="inline-flex h-9 items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
             >
-              Blog
+              Library
             </Link>
           </NavigationMenuItem>
           <NavigationMenuItem>
@@ -51,6 +43,14 @@ export function MegaMenu() {
               className="inline-flex h-9 items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
             >
               Use Cases
+            </Link>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <Link
+              href="/blog"
+              className="inline-flex h-9 items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+            >
+              Blog
             </Link>
           </NavigationMenuItem>
           <NavigationMenuItem>

--- a/packages/web/components/navigation/mobile-nav.tsx
+++ b/packages/web/components/navigation/mobile-nav.tsx
@@ -38,8 +38,8 @@ const productNavItems = [
 const topLevelLinks = [
   { name: "Docs", href: "/docs" },
   { name: "Library", href: "/library" },
-  { name: "Blog", href: "/blog" },
   { name: "Use Cases", href: "/use-cases" },
+  { name: "Blog", href: "/blog" },
   { name: "Pricing", href: "/pricing" },
 ]
 


### PR DESCRIPTION
## Summary
- reorder the desktop navigation to Products, Docs, Library, Use Cases, Blog, Pricing
- apply the same order to the mobile navigation

## Testing
- npm run build
- npm run typecheck
- npm run test
- npx eslint components/navigation/mega-menu.tsx components/navigation/mobile-nav.tsx
- git diff --check
- rendered desktop and mobile navigation verification with no console errors