### PR TITLE
release: prepare Crab 1.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1581,7 +1581,7 @@ jobs:
             echo "::error::Could not extract release notes for $VERSION from CHANGELOG.md." >&2
             exit 1
           fi
-          printf '\n---\n\nSource commit: `%s`\n\nVerify an archive with `%s`.\n' \
+          printf '\n---\n\nSource commit: %s\n\nVerify an archive with: %s\n' \
             "$SOURCE_SHA" \
             "gh attestation verify <archive> --repo ${GITHUB_REPOSITORY}" \
             >> "$notes_file"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1571,8 +1571,7 @@ jobs:
             gh release delete "$TAG" --repo "$RELEASE_REPO" --yes
           fi
 
-          notes_file="$(mktemp)"
-          trap 'rm -f "$notes_file"' EXIT
+          notes_file="${RUNNER_TEMP}/release-notes.md"
           awk -v version="$VERSION" '
             $0 ~ "^## " version " - " { found = 1; next }
             found && /^## / { exit }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release — Build + Publish + Homebrew
+name: Release
 
 # Triggered by pushing a version tag (e.g. `git tag v1.0.2 && git push origin v1.0.2`)
 on:
@@ -18,7 +18,12 @@ on:
         description: "Require retained native NFS mount evidence before building CLI artifacts"
         type: boolean
         required: false
-        default: true
+        default: false
+      require_cloud_evidence:
+        description: "Require live AWS S3 and cross-platform protocol evidence before publishing"
+        type: boolean
+        required: false
+        default: false
       replica_evidence_run_id:
         description: "Run ID from the Replica Live Evidence enterprise workflow"
         required: false
@@ -50,7 +55,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  RELEASE_REPO: crabbuild/crab-release
+  RELEASE_REPO: ${{ github.repository }}
   TAP_REPO: crabbuild/homebrew-tap
   CARGO_TERM_COLOR: always
   REPLICA_RELEASE_EVIDENCE_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.replica_evidence_run_id || vars.CRAB_REPLICA_RELEASE_EVIDENCE_RUN_ID }}
@@ -74,26 +79,21 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          fetch-depth: 0
 
       - name: Validate release tag
         id: release
         shell: bash
+        env:
+          REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag="${GITHUB_REF_NAME}"
+          tag="$REQUESTED_TAG"
+          if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Release tag must be stable SemVer such as v1.2.3, got '$tag'."
+            exit 1
           fi
-
-          case "$tag" in
-            v[0-9]*.[0-9]*.[0-9]*) ;;
-            *)
-              echo "::error::Release tag must look like v1.2.3, got '$tag'."
-              exit 1
-              ;;
-          esac
 
           version="$(sed -n 's/^version = "\(.*\)"/\1/p' crab/Cargo.toml | head -1)"
           if [ -z "$version" ]; then
@@ -103,6 +103,41 @@ jobs:
 
           if [ "v${version}" != "$tag" ]; then
             echo "::error::Release tag $tag does not match crab/Cargo.toml version ${version}."
+            exit 1
+          fi
+
+          for manifest in crab/Cargo.toml crates/crab-auth-server/Cargo.toml crates/crab-cache-server/Cargo.toml; do
+            manifest_version="$(sed -n 's/^version = "\(.*\)"/\1/p' "$manifest" | head -1)"
+            if [ "$manifest_version" != "$version" ]; then
+              echo "::error::$manifest has $manifest_version, expected $version."
+              exit 1
+            fi
+          done
+
+          for package in crab crab-auth-server crab-cache-server; do
+            lock_version="$(awk -v package="$package" '
+              $0 == "name = \"" package "\"" { found = 1; next }
+              found && /^version = / { gsub(/^version = \"|\"$/, ""); print; exit }
+            ' Cargo.lock)"
+            if [ "$lock_version" != "$version" ]; then
+              echo "::error::Cargo.lock has $package $lock_version, expected $version."
+              exit 1
+            fi
+          done
+
+          if ! grep -Eq "^## ${version} - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md must contain a dated ${version} release section."
+            exit 1
+          fi
+
+          if [ "$(git cat-file -t "refs/tags/$tag")" != "tag" ]; then
+            echo "::error::$tag must be an annotated tag."
+            exit 1
+          fi
+
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::$tag is not reachable from origin/main."
             exit 1
           fi
 
@@ -485,7 +520,7 @@ jobs:
   nfs-native-evidence-gate:
     name: NFS native evidence gate
     needs: prepare
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.require_nfs_evidence) || (github.event_name != 'workflow_dispatch' && vars.CRAB_RELEASE_REQUIRE_NFS_EVIDENCE != 'false') }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.require_nfs_evidence) || (github.event_name != 'workflow_dispatch' && vars.CRAB_RELEASE_REQUIRE_NFS_EVIDENCE == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1240,7 +1275,7 @@ jobs:
   protocol-v2-aws-release-gate:
     name: Protocol v2 partial-clone AWS S3 release gate
     needs: [prepare, build, protocol-v2-release-gate]
-    if: ${{ needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}
+    if: ${{ ((github.event_name == 'workflow_dispatch' && inputs.require_cloud_evidence) || (github.event_name != 'workflow_dispatch' && vars.CRAB_RELEASE_REQUIRE_CLOUD_EVIDENCE == 'true')) && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -1438,8 +1473,11 @@ jobs:
   publish:
     name: Publish release
     needs: [prepare, build, protocol-v2-release-gate, protocol-v2-git-compatibility-release-gate, protocol-v2-rollback-release-gate, protocol-v2-aws-release-gate, protocol-v2-platform-release-gate]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' && needs.protocol-v2-git-compatibility-release-gate.result == 'success' && needs.protocol-v2-rollback-release-gate.result == 'success' && (needs.protocol-v2-aws-release-gate.result == 'success' || needs.protocol-v2-aws-release-gate.result == 'skipped') && (needs.protocol-v2-platform-release-gate.result == 'success' || needs.protocol-v2-platform-release-gate.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -1514,53 +1552,63 @@ jobs:
           sha256sum crab-*.* > SHA256SUMS.txt
           sha256sum -c SHA256SUMS.txt
 
-      - name: Validate release repository token
+      - name: Publish GitHub release
         env:
-          GH_TOKEN: ${{ secrets.CRAB_RELEASE_GITHUB_TOKEN || secrets.TAP_GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            {
-              echo "::error::Set CRAB_RELEASE_GITHUB_TOKEN with contents:write access to ${RELEASE_REPO}."
-              echo "The workflow cannot use the source repository GITHUB_TOKEN to publish to a separate release repository."
-            } >&2
-            exit 1
-          fi
-
-          gh repo view "$RELEASE_REPO" >/dev/null
-
-      - name: Create release on crab-release repo
-        env:
-          GH_TOKEN: ${{ secrets.CRAB_RELEASE_GITHUB_TOKEN || secrets.TAP_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           TAG="${{ needs.prepare.outputs.tag }}"
+          VERSION="${{ needs.prepare.outputs.version }}"
           SOURCE_SHA="${{ needs.prepare.outputs.source_sha }}"
           FILES=(dist/crab-*.tar.gz dist/crab-*.zip dist/SHA256SUMS.txt)
-          notes_file="$(mktemp)"
-          trap 'rm -f "$notes_file"' EXIT
-          {
-            echo "Crab CLI ${TAG} release artifacts for macOS, Linux, and Windows on ARM64 and x86_64."
-            echo
-            echo "Source: https://github.com/${GITHUB_REPOSITORY}/tree/${TAG}"
-            echo "Commit: ${SOURCE_SHA}"
-            echo
-            echo 'Verify an archive with:'
-            echo "\`gh attestation verify <archive> --repo ${GITHUB_REPOSITORY}\`"
-          } > "$notes_file"
-
-          if gh release view "$TAG" --repo "$RELEASE_REPO" &>/dev/null; then
-            echo "Release $TAG exists — uploading assets (clobber)."
-            gh release upload "$TAG" "${FILES[@]}" \
-              --repo "$RELEASE_REPO" --clobber
-          else
-            gh release create "$TAG" "${FILES[@]}" \
-              --repo "$RELEASE_REPO" \
-              --title "Crab CLI ${TAG}" \
-              --notes-file "$notes_file"
+          existing="$(gh release view "$TAG" --repo "$RELEASE_REPO" --json isDraft --jq .isDraft 2>/dev/null || true)"
+          if [ "$existing" = "false" ]; then
+            echo "::error::Release $TAG is already published and cannot be replaced." >&2
+            exit 1
+          fi
+          if [ "$existing" = "true" ]; then
+            echo "Removing incomplete draft from an earlier attempt."
+            gh release delete "$TAG" --repo "$RELEASE_REPO" --yes
           fi
 
-      - name: Update Homebrew tap
+          notes_file="$(mktemp)"
+          trap 'rm -f "$notes_file"' EXIT
+          awk -v version="$VERSION" '
+            $0 ~ "^## " version " - " { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > "$notes_file"
+          if [ ! -s "$notes_file" ]; then
+            echo "::error::Could not extract release notes for $VERSION from CHANGELOG.md." >&2
+            exit 1
+          fi
+          printf '\n---\n\nSource commit: `%s`\n\nVerify an archive with `%s`.\n' \
+            "$SOURCE_SHA" \
+            "gh attestation verify <archive> --repo ${GITHUB_REPOSITORY}" \
+            >> "$notes_file"
+
+          gh release create "$TAG" "${FILES[@]}" \
+            --repo "$RELEASE_REPO" \
+            --verify-tag \
+            --fail-on-no-commits \
+            --latest \
+            --title "Crab ${TAG}" \
+            --notes-file "$notes_file"
+
+  homebrew:
+    name: Update Homebrew tap
+    needs: [prepare, publish]
+    if: ${{ needs.prepare.result == 'success' && needs.publish.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Update tap
         env:
           GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
@@ -1570,4 +1618,4 @@ jobs:
             exit 0
           fi
           TAG="${{ needs.prepare.outputs.tag }}"
-          DIST_DIR="$PWD/dist" crab/scripts/release/update-homebrew.sh --local "$TAG"
+          crab/scripts/release/update-homebrew.sh "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ integration surfaces should be recorded here before release.
 
 ## Unreleased
 
+## 1.1.0 - 2026-08-27
+
+### Git And Large Files
+
+- Made Crab LFS a direct object-storage workflow with bounded transfers,
+  publication coordination, lock ownership, and fail-closed push behavior.
+- Hardened partial clone, fetch, push, and remote-pack maintenance for large
+  repositories, including generation-aware visibility and bounded locator work.
+- Added safer mixed LFS/Xet conversion and filtering, with expanded regression
+  coverage across checkout, fetch, transfer-agent, and concurrent publication
+  paths.
+
+### Storage And Performance
+
+- Hardened repository and bucket garbage collection so referenced content and
+  grace-period objects remain protected while remote collections scale.
+- Added geometric remote-pack compaction and reduced lock, listing, and
+  publication amplification on hot repositories.
+- Moved xorb maintenance under `crab optimize` and expanded RustFS performance
+  qualification for repository creation and large-repository workflows.
+
+### Release And Distribution
+
+- Consolidated release publishing into the open-source repository's tag-driven
+  GitHub Actions workflow; local tooling can build but cannot publish or replace
+  release assets.
+- Added native ARM64 and x86_64 archives for macOS, Linux, and Windows,
+  checksums, packaged-binary smoke tests, and GitHub build-provenance
+  attestations.
+- Made the installer, self-updater, release badge, and Homebrew formula consume
+  releases from `crabbuild/crab-oss`.
+
+### Documentation And Website
+
+- Launched the learning library and file-backed blog with improved navigation,
+  structured SEO data, and responsive architecture and workflow diagrams.
+- Added direct-storage Crab LFS onboarding and expanded large-file, GC,
+  optimization, and Continuity architecture guidance.
+
 ## 1.0.15 - 2026-08-22
 
 ### Release Automation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "crab"
-version = "1.0.15"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "crab-auth-server"
-version = "1.0.15"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "crab-cache-server"
-version = "1.0.15"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "axum 0.8.9",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://github.com/crabbuild/crab-oss/actions/workflows/rust.yml"><img src="https://github.com/crabbuild/crab-oss/actions/workflows/rust.yml/badge.svg" alt="CI status"></a>
-  <a href="https://github.com/crabbuild/crab-release/releases/latest"><img src="https://img.shields.io/github/v/release/crabbuild/crab-release?display_name=tag" alt="Latest release"></a>
+  <a href="https://github.com/crabbuild/crab-oss/releases/latest"><img src="https://img.shields.io/github/v/release/crabbuild/crab-oss?display_name=tag" alt="Latest release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/crabbuild/crab-oss" alt="Apache 2.0 license"></a>
 </p>
 
@@ -471,6 +471,8 @@ command -v git-remote-crab
 Use a separate `CARGO_TARGET_DIR` when building multiple checkouts or when
 working on a disk-constrained machine. Do not commit generated build artifacts,
 local credentials, cache contents, staging databases, or cloud test output.
+Maintainers should follow [RELEASING.md](RELEASING.md) for versioning, tagging,
+and GitHub release verification.
 
 ### Local end-to-end testing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,76 @@
+# Releasing Crab
+
+Crab releases are built and published by `.github/workflows/release.yml`. The
+workflow is the only release publisher. A stable annotated tag reachable from
+`main` starts the pipeline; local release tooling only builds artifacts.
+
+## Release contract
+
+- Stable tags use `vMAJOR.MINOR.PATCH` and are annotated.
+- The CLI, auth-server, and cache-server manifests, their `Cargo.lock` entries,
+  the tag, and the dated `CHANGELOG.md` section carry the same version.
+- The release workflow builds six native archives: ARM64 and x86_64 for macOS,
+  Linux, and Windows. It executes the packaged CLI, validates archive layouts,
+  generates `SHA256SUMS.txt`, and records build-provenance attestations.
+- Self-contained RustFS, native workflow, NFS feature, partial-clone, rollback,
+  and Git compatibility gates must pass before publication.
+- Retained enterprise, native NFS, and live AWS/cross-platform evidence are
+  opt-in gates. Enable them with the corresponding workflow-dispatch input or
+  repository variable when a release claims those environments.
+- GitHub releases and their assets are immutable after publication. A failed
+  run may replace its incomplete draft, but it cannot replace a published
+  release.
+
+## Prepare a release
+
+Create a release branch from current `main`, then run:
+
+```bash
+cd crab
+make bump-set VERSION=1.2.3
+```
+
+Move the `CHANGELOG.md` entries from `Unreleased` into a dated `1.2.3` section.
+Validate the metadata and release contracts:
+
+```bash
+cd crab
+make release-metadata-check
+make release-archive-contents-check
+```
+
+Run the normal Rust, architecture, and web checks for the touched surfaces.
+Merge the release change through the usual pull-request process.
+
+## Publish
+
+From an up-to-date, clean `main`, create and push the annotated tag:
+
+```bash
+git pull --rebase origin main
+git tag -a v1.2.3 -m "Release Crab v1.2.3"
+git push origin v1.2.3
+```
+
+Do not create the GitHub release manually. The tag starts the release workflow,
+which publishes to `crabbuild/crab-oss` and updates Homebrew when
+`TAP_GITHUB_TOKEN` is configured.
+
+For a failed run, fix the cause without moving or recreating the tag, merge the
+fix to `main`, and publish a new version. If the failure was transient and the
+tagged source needs no change, rerun the failed workflow from GitHub Actions or
+dispatch it with `make release` while checked out at the tagged version.
+
+## Verify
+
+Download the release into a new directory, verify every checksum, and execute
+the platform binary. GitHub provenance can be checked with:
+
+```bash
+gh release verify v1.2.3 --repo crabbuild/crab-oss
+gh attestation verify crab-linux-x86_64.tar.gz --repo crabbuild/crab-oss
+```
+
+Confirm that the release is marked latest and immutable, the public installers
+resolve the new tag, and `crab update --check` reports the new version from an
+older installation.

--- a/crab/Cargo.toml
+++ b/crab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab"
-version = "1.0.15"
+version = "1.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Serverless git remote helper backed by object storage with Xet-style chunk dedup."

--- a/crab/Makefile
+++ b/crab/Makefile
@@ -129,23 +129,15 @@
 # Release & Homebrew:
 #   make release          Dispatch the hosted full-matrix GitHub release
 #   make release-build    Build local release archives, no upload
-#   make release-dry      Alias for release-build
-#   make release-strict   Require every locally-scripted target, no upload
-#   make release-macos-full
-#                         Build full local matrix from macOS, including slow
-#                         linux/amd64 Docker emulation on Apple Silicon
 #   make release-target TARGET=linux-x86_64
 #   make release-list     Show supported release targets
 #   make release-ci       Dispatch the hosted GitHub release workflow
 #                         CLI artifacts only by default. Set
 #                         RELEASE_REQUIRE_ENTERPRISE_EVIDENCE=1 to require
-#                         retained replica/cache-service evidence. Native NFS
-#                         release evidence is required by default. Optional:
-#                         NFS_RELEASE_VERIFY_ARGS="--max-native-read-rpcs-per-mib 32"
-#   make release-macos-publish
-#                         Build full local macOS matrix and publish
-#   make release-publish-dist
-#                         Publish existing dist/ artifacts after checksum check
+#                         retained replica/cache-service evidence,
+#                         RELEASE_REQUIRE_NFS_EVIDENCE=1 for native mount
+#                         evidence, or RELEASE_REQUIRE_CLOUD_EVIDENCE=1 for
+#                         live AWS and cross-platform protocol evidence.
 #   make release-full     Release + update Homebrew tap
 #   make homebrew         Update tap from latest GitHub release
 #   make homebrew-local   Update tap using local dist/ checksums
@@ -243,19 +235,9 @@ NFS_RELEASE_VERIFY_ARGS ?=
 NFS_RELEASE_REQUIRE_EVIDENCE ?= 1
 NFS_RELEASE_REQUIRE_EXPECTED_RUN_SUFFIX ?= 1
 NFS_RELEASE_REQUIRE_EXPECTED_GIT_COMMIT ?= 1
-RELEASE_REPO ?= crabbuild/crab-release
-RELEASE_DIST_DIR ?= dist
-RELEASE_BYPASS_EVIDENCE ?= 0
 RELEASE_REQUIRE_ENTERPRISE_EVIDENCE ?= 0
-RELEASE_REQUIRE_NFS_EVIDENCE ?= 1
-RELEASE_DIST_ARTIFACTS := \
-	crab-darwin-aarch64.tar.gz \
-	crab-darwin-x86_64.tar.gz \
-	crab-linux-aarch64.tar.gz \
-	crab-linux-x86_64.tar.gz \
-	crab-windows-aarch64.zip \
-	crab-windows-x86_64.zip \
-	SHA256SUMS.txt
+RELEASE_REQUIRE_NFS_EVIDENCE ?= 0
+RELEASE_REQUIRE_CLOUD_EVIDENCE ?= 0
 
 # Release build flags
 RELEASE_FLAGS := --release
@@ -302,7 +284,7 @@ SPLIT_CRATE_PACKAGES := \
 	-p crab-storage \
 	-p crab-workflow
 
-.PHONY: all build debug test clippy split-crate-clippy-check split-crate-test-check fmt check architecture-check crate-interface-check crate-behavior-check shipped-binary-version-check install-layout-check auth-helper-packaging-check release-archive-contents-check final-integration-check crab-types-admission replica-feature-matrix replica-feature-matrix-all replica-feature-matrix-locked replica-feature-matrix-all-locked replica-live-preflight replica-release-evidence replica-release-gate mount-large-rustfs-smoke mount-nfs-linux-smoke mount-nfs-macos-smoke mount-nfs-windows-smoke nfs-smoke-report-verify nfs-smoke-report-verify-dir nfs-smoke-report-compare nfs-smoke-report-compare-dir nfs-smoke-report-verify-self-test nfs-smoke-script-check nfs-release-evidence-dispatch-self-test nfs-evidence-summary-self-test nfs-feature-gate nfs-threshold-suggestions nfs-read-path-bench-report-verify nfs-read-path-bench-report-compare nfs-read-path-bench-report-self-test mount-large-macos-rustfs-smoke mount-large-macos-nfs-rustfs-smoke cache-service-release-gate cache-service-validate-manifests cache-service-rustfs-smoke cache-service-onboarding-rustfs-smoke cache-service-verify-smoke-report clean install uninstall release release-build release-dry release-strict release-macos-full release-target release-list release-ci release-macos-publish release-publish-dist release-full homebrew homebrew-local homebrew-dry
+.PHONY: all build debug test clippy split-crate-clippy-check split-crate-test-check fmt check architecture-check crate-interface-check crate-behavior-check shipped-binary-version-check install-layout-check auth-helper-packaging-check release-archive-contents-check final-integration-check crab-types-admission replica-feature-matrix replica-feature-matrix-all replica-feature-matrix-locked replica-feature-matrix-all-locked replica-live-preflight replica-release-evidence replica-release-gate mount-large-rustfs-smoke mount-nfs-linux-smoke mount-nfs-macos-smoke mount-nfs-windows-smoke nfs-smoke-report-verify nfs-smoke-report-verify-dir nfs-smoke-report-compare nfs-smoke-report-compare-dir nfs-smoke-report-verify-self-test nfs-smoke-script-check nfs-release-evidence-dispatch-self-test nfs-evidence-summary-self-test nfs-feature-gate nfs-threshold-suggestions nfs-read-path-bench-report-verify nfs-read-path-bench-report-compare nfs-read-path-bench-report-self-test mount-large-macos-rustfs-smoke mount-large-macos-nfs-rustfs-smoke cache-service-release-gate cache-service-validate-manifests cache-service-rustfs-smoke cache-service-onboarding-rustfs-smoke cache-service-verify-smoke-report clean install uninstall release release-build release-target release-list release-metadata-check release-ci release-full homebrew homebrew-local homebrew-dry
 .PHONY: nfs-release-gate nfs-release-evidence-ci
 
 all: build
@@ -842,16 +824,8 @@ release-major: bump-major install
 
 release: release-ci
 
-release-build: replica-release-gate cache-service-release-gate nfs-release-gate
-	@./scripts/release/release.sh --dry-run --allow-partial
-
-release-dry: release-build
-
-release-strict: replica-release-gate cache-service-release-gate nfs-release-gate
-	@./scripts/release/release.sh --dry-run
-
-release-macos-full: replica-release-gate cache-service-release-gate nfs-release-gate
-	@./scripts/release/release.sh --dry-run
+release-build:
+	@./scripts/release/release.sh --allow-partial
 
 release-target:
 	@if [ -z "$(TARGET)" ]; then \
@@ -859,15 +833,35 @@ release-target:
 		./scripts/release/release.sh --list-targets; \
 		exit 2; \
 	fi
-	@$(MAKE) --no-print-directory replica-release-gate
-	@$(MAKE) --no-print-directory cache-service-release-gate
-	@$(MAKE) --no-print-directory nfs-release-gate
-	@./scripts/release/release.sh --dry-run --target "$(TARGET)"
+	@./scripts/release/release.sh --target "$(TARGET)"
 
 release-list:
 	@./scripts/release/release.sh --list-targets
 
-release-ci:
+release-metadata-check:
+	@set -eu; \
+	version=$$(grep -m1 '^version' Cargo.toml | cut -d '"' -f2); \
+	for manifest in Cargo.toml ../crates/crab-auth-server/Cargo.toml ../crates/crab-cache-server/Cargo.toml; do \
+		manifest_version=$$(grep -m1 '^version' "$$manifest" | cut -d '"' -f2); \
+		if [ "$$manifest_version" != "$$version" ]; then \
+			echo "$$manifest has $$manifest_version, expected $$version" >&2; \
+			exit 1; \
+		fi; \
+	done; \
+	for package in crab crab-auth-server crab-cache-server; do \
+		lock_version=$$(awk -v package="$$package" '$$0 == "name = \"" package "\"" { found = 1; next } found && /^version = / { gsub(/^version = \"|\"$$/, ""); print; exit }' ../Cargo.lock); \
+		if [ "$$lock_version" != "$$version" ]; then \
+			echo "Cargo.lock has $$package $$lock_version, expected $$version" >&2; \
+			exit 1; \
+		fi; \
+	done; \
+	if ! grep -Eq "^## $$version - [0-9]{4}-[0-9]{2}-[0-9]{2}$$" ../CHANGELOG.md; then \
+		echo "CHANGELOG.md has no dated $$version release section" >&2; \
+		exit 1; \
+	fi; \
+	echo "release metadata is consistent for v$$version"
+
+release-ci: release-metadata-check
 	@if ! command -v gh >/dev/null 2>&1; then \
 		echo "gh CLI is required for make release-ci"; \
 		exit 127; \
@@ -891,16 +885,21 @@ release-ci:
 	echo "dispatching GitHub release workflow for $$TAG"; \
 	require_enterprise_evidence=false; \
 	require_nfs_evidence=false; \
+	require_cloud_evidence=false; \
 	if [ "$(RELEASE_REQUIRE_ENTERPRISE_EVIDENCE)" = "1" ]; then \
 		require_enterprise_evidence=true; \
 	fi; \
 	if [ "$(RELEASE_REQUIRE_NFS_EVIDENCE)" = "1" ]; then \
 		require_nfs_evidence=true; \
 	fi; \
+	if [ "$(RELEASE_REQUIRE_CLOUD_EVIDENCE)" = "1" ]; then \
+		require_cloud_evidence=true; \
+	fi; \
 		set -- \
 			-f "tag=$$TAG" \
 			-f "require_enterprise_evidence=$$require_enterprise_evidence" \
-			-f "require_nfs_evidence=$$require_nfs_evidence"; \
+			-f "require_nfs_evidence=$$require_nfs_evidence" \
+			-f "require_cloud_evidence=$$require_cloud_evidence"; \
 		if [ -n "$(REPLICA_RELEASE_EVIDENCE_RUN_ID)" ]; then \
 			set -- "$$@" -f "replica_evidence_run_id=$(REPLICA_RELEASE_EVIDENCE_RUN_ID)"; \
 		fi; \
@@ -920,80 +919,6 @@ release-ci:
 			set -- "$$@" -f "nfs_release_verify_args=$(NFS_RELEASE_VERIFY_ARGS)"; \
 		fi; \
 		gh workflow run release.yml "$$@"
-
-release-macos-publish:
-	@set -e; \
-	if [ "$(RELEASE_BYPASS_EVIDENCE)" = "1" ]; then \
-		echo "warning: RELEASE_BYPASS_EVIDENCE=1; publishing artifacts without release-grade evidence gates" >&2; \
-		$(MAKE) --no-print-directory release-macos-full \
-			REPLICA_RELEASE_REQUIRE_EVIDENCE=0 \
-			CACHE_SERVICE_RELEASE_REQUIRE_EVIDENCE=0 \
-			NFS_RELEASE_REQUIRE_EVIDENCE=0; \
-		$(MAKE) --no-print-directory release-publish-dist RELEASE_BYPASS_EVIDENCE=1; \
-	else \
-		$(MAKE) --no-print-directory replica-release-gate; \
-		$(MAKE) --no-print-directory cache-service-release-gate; \
-		$(MAKE) --no-print-directory nfs-release-gate; \
-		RELEASE_REPO="$(RELEASE_REPO)" \
-		REPLICA_RELEASE_EVIDENCE_DIR="$(REPLICA_RELEASE_EVIDENCE_DIR)" \
-		REPLICA_RELEASE_EVIDENCE_OUTPUT="$(REPLICA_RELEASE_EVIDENCE_OUTPUT)" \
-		REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID="$(REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID)" \
-			./scripts/release/release.sh; \
-	fi
-
-release-publish-dist:
-	@set -e; \
-	if [ "$(RELEASE_BYPASS_EVIDENCE)" = "1" ]; then \
-		echo "warning: RELEASE_BYPASS_EVIDENCE=1; publishing existing artifacts without release-grade evidence gates" >&2; \
-	else \
-		$(MAKE) --no-print-directory replica-release-gate; \
-		$(MAKE) --no-print-directory cache-service-release-gate; \
-		$(MAKE) --no-print-directory nfs-release-gate; \
-	fi
-	@if ! command -v gh >/dev/null 2>&1; then \
-		echo "gh CLI is required for make release-publish-dist"; \
-		exit 127; \
-	fi
-	@if ! gh auth status >/dev/null 2>&1; then \
-		echo "gh is not authenticated. Run: gh auth login"; \
-		exit 2; \
-	fi
-	@set -e; \
-	tag=v$$(grep -m1 '^version' Cargo.toml | cut -d '"' -f2); \
-	dist="$(RELEASE_DIST_DIR)"; \
-	artifacts="$(RELEASE_DIST_ARTIFACTS)"; \
-	files=""; \
-	for artifact in $$artifacts; do \
-		file="$$dist/$$artifact"; \
-		if [ ! -f "$$file" ]; then \
-			echo "missing release artifact: $$file"; \
-			exit 2; \
-		fi; \
-		files="$$files $$file"; \
-	done; \
-	if command -v shasum >/dev/null 2>&1; then \
-		(cd "$$dist" && shasum -a 256 -c SHA256SUMS.txt); \
-	elif command -v sha256sum >/dev/null 2>&1; then \
-		(cd "$$dist" && sha256sum -c SHA256SUMS.txt); \
-	else \
-		echo "Neither shasum nor sha256sum is available."; \
-		exit 127; \
-	fi; \
-	if gh release view "$$tag" --repo "$(RELEASE_REPO)" >/dev/null 2>&1; then \
-		echo "uploading artifacts to existing $(RELEASE_REPO) release $$tag"; \
-		gh release upload "$$tag" $$files --repo "$(RELEASE_REPO)" --clobber; \
-	else \
-		notes_file=$$(mktemp); \
-		trap 'rm -f "$$notes_file"' EXIT; \
-		printf "Crab CLI %s release artifacts for macOS, Linux, and Windows on ARM64 and x86_64.\\n" "$$tag" > "$$notes_file"; \
-		if [ "$(RELEASE_BYPASS_EVIDENCE)" = "1" ]; then \
-			printf "\\nPublished from local %s with RELEASE_BYPASS_EVIDENCE=1.\\n" "$$dist" >> "$$notes_file"; \
-		fi; \
-		gh release create "$$tag" $$files \
-			--repo "$(RELEASE_REPO)" \
-			--title "Crab CLI $$tag" \
-			--notes-file "$$notes_file"; \
-	fi
 
 # --- Homebrew tap ---
 

--- a/crab/docs/guides/replica.md
+++ b/crab/docs/guides/replica.md
@@ -828,13 +828,14 @@ and do not replace the live evidence harnesses below.
 
 The root GitHub workflow `.github/workflows/replica-enterprise.yml` runs the
 locked offline gate on replica-related pull requests and pushes to `main`.
-The release workflow also runs `make replica-feature-matrix-all-locked`,
-replica schema validation, and retained-evidence recorder contract tests before
-building release archives. Release packaging then downloads a retained live
-evidence artifact from `.github/workflows/replica-live-evidence.yml` and runs
+When enterprise evidence is required, the release workflow runs
+`make replica-feature-matrix-all-locked`, replica schema validation, and
+retained-evidence recorder contract tests before building release archives. It
+then downloads a retained live artifact from
+`.github/workflows/replica-live-evidence.yml` and runs
 `crab/scripts/release/verify-replica-release-evidence.sh` against the artifact's
-`replica-live-evidence/` directory. A release cannot build archives unless that
-bundle passes `crab replica evidence verify --profile enterprise
+`replica-live-evidence/` directory. The enterprise gate passes only when that
+bundle satisfies `crab replica evidence verify --profile enterprise
 --require-redacted --expected-run-id replica-live-<run-id>-<attempt>`.
 
 For workflow-dispatch releases, pass the GitHub run ID from the enterprise live
@@ -857,12 +858,11 @@ cd crab
 make release-ci REPLICA_RELEASE_EVIDENCE_RUN_ID=<live-evidence-github-run-id>
 ```
 
-Local archive targets are also release-gated by default. `make release-build`,
-`make release-strict`, and `make release-target TARGET=...` require
-`REPLICA_RELEASE_EVIDENCE_DIR` plus the exact
-`REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID=replica-live-<run-id>-<attempt>`.
-Set `REPLICA_RELEASE_REQUIRE_EVIDENCE=0` only for a non-release smoke archive;
-that output is not enterprise release evidence.
+Local archive targets only build artifacts and do not publish releases or
+claim enterprise evidence. Use `make release-build` for the host-supported
+matrix or `make release-target TARGET=...` for one target. The tag-triggered
+GitHub Actions workflow is the only publisher and owns the release evidence
+decision.
 
 ## Live Provider Validation
 

--- a/crab/scripts/release/bump-version.sh
+++ b/crab/scripts/release/bump-version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bump-version.sh — Bump the crab version in Cargo.toml
+# bump-version.sh — Bump all shipped Crab product versions.
 #
 # Usage:
 #   ./scripts/release/bump-version.sh patch   # 0.1.0 → 0.1.1
@@ -12,20 +12,38 @@
 
 set -euo pipefail
 
-CARGO_TOML="$(dirname "$0")/../../Cargo.toml"
+CRAB_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKSPACE_DIR="$(cd "$CRAB_DIR/.." && pwd)"
+CARGO_LOCK="$WORKSPACE_DIR/Cargo.lock"
+PRODUCT_MANIFESTS=(
+    "$CRAB_DIR/Cargo.toml"
+    "$WORKSPACE_DIR/crates/crab-auth-server/Cargo.toml"
+    "$WORKSPACE_DIR/crates/crab-cache-server/Cargo.toml"
+)
 
-if [[ ! -f "$CARGO_TOML" ]]; then
-    echo "error: Cargo.toml not found at $CARGO_TOML" >&2
+if [[ ! -f "$CARGO_LOCK" ]]; then
+    echo "error: workspace lockfile is missing" >&2
     exit 1
 fi
 
 # Extract current version from the [package] section.
-CURRENT=$(grep -m1 '^version' "$CARGO_TOML" | sed 's/.*"\(.*\)"/\1/')
+CURRENT=$(grep -m1 '^version' "${PRODUCT_MANIFESTS[0]}" | sed 's/.*"\(.*\)"/\1/')
 
 if [[ -z "$CURRENT" ]]; then
-    echo "error: could not parse version from $CARGO_TOML" >&2
+    echo "error: could not parse current Crab version" >&2
     exit 1
 fi
+for manifest in "${PRODUCT_MANIFESTS[@]}"; do
+    if [[ ! -f "$manifest" ]]; then
+        echo "error: product manifest is missing: $manifest" >&2
+        exit 1
+    fi
+    manifest_version=$(grep -m1 '^version' "$manifest" | sed 's/.*"\(.*\)"/\1/')
+    if [[ "$manifest_version" != "$CURRENT" ]]; then
+        echo "error: $manifest has version $manifest_version, expected $CURRENT" >&2
+        exit 1
+    fi
+done
 
 IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 
@@ -47,6 +65,10 @@ case "${1:-}" in
             echo "usage: $0 set <version>" >&2
             exit 1
         fi
+        if [[ ! "$2" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "error: version must be stable SemVer such as 1.2.3" >&2
+            exit 1
+        fi
         IFS='.' read -r MAJOR MINOR PATCH <<< "$2"
         ;;
     *)
@@ -58,7 +80,35 @@ esac
 
 NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
 
-# Replace the version line in Cargo.toml (first occurrence only).
-sed -i '' "s/^version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" "$CARGO_TOML"
+# Replace product versions together and let Cargo update the workspace lockfile.
+backup_dir="$(mktemp -d)"
+for i in "${!PRODUCT_MANIFESTS[@]}"; do
+    cp "${PRODUCT_MANIFESTS[$i]}" "$backup_dir/manifest-$i"
+done
+cp "$CARGO_LOCK" "$backup_dir/Cargo.lock"
+restore_on_error() {
+    status=$?
+    trap - EXIT
+    if [[ "$status" -ne 0 ]]; then
+        for i in "${!PRODUCT_MANIFESTS[@]}"; do
+            cp "$backup_dir/manifest-$i" "${PRODUCT_MANIFESTS[$i]}"
+        done
+        cp "$backup_dir/Cargo.lock" "$CARGO_LOCK"
+    fi
+    rm -r "$backup_dir"
+    exit "$status"
+}
+trap restore_on_error EXIT
+
+for manifest in "${PRODUCT_MANIFESTS[@]}"; do
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        sed -i '' "s/^version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" "$manifest"
+    else
+        sed -i "s/^version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" "$manifest"
+    fi
+done
+(cd "$WORKSPACE_DIR" && cargo metadata --format-version 1 --no-deps >/dev/null)
+trap - EXIT
+rm -r "$backup_dir"
 
 echo "$CURRENT → $NEW_VERSION"

--- a/crab/scripts/release/check-release-archive-contents.py
+++ b/crab/scripts/release/check-release-archive-contents.py
@@ -175,6 +175,9 @@ def check_release_script(root: Path) -> list[str]:
     for forbidden in FORBIDDEN_CLI_ARCHIVE_BINARIES:
         if forbidden in text:
             errors.append(f"release.sh: CLI release archive script must not package {forbidden}")
+    for forbidden in ("gh release create", "gh release upload", "RELEASE_REPO"):
+        if forbidden in text:
+            errors.append(f"release.sh: local builds must not publish releases: {forbidden!r}")
 
     return errors
 
@@ -243,7 +246,7 @@ def check_release_workflow(root: Path) -> list[str]:
             if needle not in verify_step:
                 errors.append(f"release.yml Verify archive layout: expected {needle!r}")
 
-    if 'DIST_DIR="$PWD/dist" crab/scripts/release/update-homebrew.sh --local "$TAG"' not in text:
+    if 'crab/scripts/release/update-homebrew.sh "$TAG"' not in text:
         errors.append("release.yml: Homebrew publishing must use crab/scripts/release/update-homebrew.sh")
 
     for needle in (
@@ -267,9 +270,18 @@ def check_release_workflow(root: Path) -> list[str]:
         "if-no-files-found: error",
         "sha256sum crab-*.* > SHA256SUMS.txt",
         "FILES=(dist/crab-*.tar.gz dist/crab-*.zip dist/SHA256SUMS.txt)",
+        "RELEASE_REPO: ${{ github.repository }}",
+        "contents: write",
+        "Publish GitHub release",
+        "GH_TOKEN: ${{ github.token }}",
+        "--verify-tag",
+        "--fail-on-no-commits",
+        '--notes-file "$notes_file"',
         "require_nfs_evidence:",
+        "require_cloud_evidence:",
         "nfs_release_verify_args:",
-        "vars.CRAB_RELEASE_REQUIRE_NFS_EVIDENCE != 'false'",
+        "vars.CRAB_RELEASE_REQUIRE_NFS_EVIDENCE == 'true'",
+        "vars.CRAB_RELEASE_REQUIRE_CLOUD_EVIDENCE == 'true'",
         "CRAB_NFS_RELEASE_VERIFY_ARGS",
         "nfs_evidence_run_id:",
         "NFS_RELEASE_EVIDENCE_RUN_ID",
@@ -298,6 +310,9 @@ def check_release_workflow(root: Path) -> list[str]:
         "cargo install cargo-xwin",
         "cargo xwin build",
         "cross build",
+        "CRAB_RELEASE_GITHUB_TOKEN",
+        "crabbuild/crab-release",
+        "--clobber",
     ):
         if forbidden in text:
             errors.append(f"release.yml: unexpected {forbidden!r}")
@@ -340,6 +355,43 @@ def check_homebrew_script(
 def checks(root: Path) -> list[TextCheck]:
     return [
         TextCheck(
+            "version bump keeps all shipped product manifests aligned",
+            root / "crab" / "scripts" / "release" / "bump-version.sh",
+            contains=(
+                "PRODUCT_MANIFESTS=(",
+                '"$CRAB_DIR/Cargo.toml"',
+                '"$WORKSPACE_DIR/crates/crab-auth-server/Cargo.toml"',
+                '"$WORKSPACE_DIR/crates/crab-cache-server/Cargo.toml"',
+                "cargo metadata --format-version 1 --no-deps",
+                "restore_on_error",
+            ),
+            excludes=(),
+        ),
+        TextCheck(
+            "public release badge follows the source repository",
+            root / "README.md",
+            contains=(
+                "https://github.com/crabbuild/crab-oss/releases/latest",
+                "github/v/release/crabbuild/crab-oss",
+            ),
+            excludes=("github/v/release/crabbuild/crab-release",),
+        ),
+        TextCheck(
+            "self-updater follows the source repository release API",
+            root / "crab" / "src" / "cmd" / "update.rs",
+            contains=(
+                "https://api.github.com/repos/crabbuild/crab-oss/releases/latest",
+                "No crab release is available from crabbuild/crab-oss.",
+            ),
+            excludes=("crabbuild/crab-release",),
+        ),
+        TextCheck(
+            "Homebrew updater follows source repository releases",
+            root / "crab" / "scripts" / "release" / "update-homebrew.sh",
+            contains=('RELEASE_REPO="${RELEASE_REPO:-crabbuild/crab-oss}"',),
+            excludes=("crabbuild/crab-release",),
+        ),
+        TextCheck(
             "release profile strips symbols from published binaries",
             root / "Cargo.toml",
             contains=(
@@ -376,7 +428,7 @@ def checks(root: Path) -> list[TextCheck]:
             "POSIX installer targets release repo and verifies archives",
             root / "packages" / "web" / "public" / "install.sh",
             contains=(
-                'REPO="crabbuild/crab-release"',
+                'REPO="crabbuild/crab-oss"',
                 "verify_checksum",
                 "verify_tarball_layout",
                 "crab-fuse-mount",
@@ -385,19 +437,19 @@ def checks(root: Path) -> list[TextCheck]:
                 'ln -sf "crab" "$INSTALL_DIR/crab-nfs-mount"',
                 'ln -sf "$INSTALL_DIR/crab" "$INSTALL_DIR/git-remote-crab"',
             ),
-            excludes=("CrabBuild/crab-release",),
+            excludes=("CrabBuild/crab-release", "crabbuild/crab-release"),
         ),
         TextCheck(
             "PowerShell installer targets release repo and installs helper exe",
             root / "packages" / "web" / "public" / "install.ps1",
             contains=(
-                '$Repo = "crabbuild/crab-release"',
+                '$Repo = "crabbuild/crab-oss"',
                 "Verify-Checksum",
                 "Verify-ZipLayout",
                 '"crab-nfs-mount.exe"',
                 '"git-remote-crab.exe"',
             ),
-            excludes=("CrabBuild/crab-release", "Created wrapper: git-remote-crab.cmd"),
+            excludes=("CrabBuild/crab-release", "crabbuild/crab-release", "Created wrapper: git-remote-crab.cmd"),
         ),
         TextCheck(
             "local install-layout verifier covers mount helpers",
@@ -644,7 +696,8 @@ def checks(root: Path) -> list[TextCheck]:
                 "NFS_RELEASE_REQUIRE_EXPECTED_GIT_COMMIT ?= 1",
                 "NFS_RELEASE_EXPECTED_GIT_COMMIT is required for release-grade NFS evidence",
                 "--expected-git-commit",
-                "RELEASE_REQUIRE_NFS_EVIDENCE ?= 1",
+                "RELEASE_REQUIRE_NFS_EVIDENCE ?= 0",
+                "RELEASE_REQUIRE_CLOUD_EVIDENCE ?= 0",
                 "NFS_RELEASE_EVIDENCE_RUN_ID is required for make release-ci",
                 "Run the NFS Mount Evidence workflow on the exact release commit",
                 "NFS_RELEASE_EVIDENCE_WAIT",
@@ -674,7 +727,13 @@ def checks(root: Path) -> list[TextCheck]:
                 "--test prop_coordinator response_contains --features fuse",
                 "scripts/verify-nfs-smoke-report.py self-test",
             ),
-            excludes=(),
+            excludes=(
+                "release-macos-publish:",
+                "release-publish-dist:",
+                "RELEASE_BYPASS_EVIDENCE",
+                "gh release create",
+                "gh release upload",
+            ),
         ),
         TextCheck(
             "Native NFS smoke script contract checker covers retained evidence",

--- a/crab/scripts/release/release.sh
+++ b/crab/scripts/release/release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# release.sh - Build crab CLI release archives and optionally publish them.
+# release.sh - Build crab CLI release archives locally.
 #
 # The release contract is six CLI artifacts:
 #   - macOS:   x86_64, aarch64
@@ -11,14 +11,9 @@
 # GitHub Actions workflow for publishing.
 #
 # Usage:
-#   ./scripts/release/release.sh --dry-run
 #   ./scripts/release/release.sh
-#   ./scripts/release/release.sh --target linux-x86_64 --dry-run
-#   ./scripts/release/release.sh --allow-partial --dry-run
-#
-# Publishing requires `gh` authenticated with access to crabbuild/crab-release.
-# Publishing also requires retained enterprise replica evidence verified through
-# `scripts/release/verify-replica-release-evidence.sh`.
+#   ./scripts/release/release.sh --target linux-x86_64
+#   ./scripts/release/release.sh --allow-partial
 
 set -euo pipefail
 export LC_ALL=C
@@ -28,18 +23,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CRAB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WORKSPACE_DIR="$(cd "$CRAB_DIR/.." && pwd)"
 
-RELEASE_REPO="${RELEASE_REPO:-crabbuild/crab-release}"
 DIST_DIR="${DIST_DIR:-$CRAB_DIR/dist}"
 TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_DIR/target}"
 DOCKER="${DOCKER:-docker}"
 CARGO="${CARGO:-cargo}"
-REPLICA_RELEASE_EVIDENCE_DIR="${REPLICA_RELEASE_EVIDENCE_DIR:-}"
-REPLICA_RELEASE_EVIDENCE_OUTPUT="${REPLICA_RELEASE_EVIDENCE_OUTPUT:-replica-release-evidence-verify.json}"
-REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID="${REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID:-}"
 CRAB_CLI_FEATURES_NO_FUSE="simd-accel,tier,replication-s3-control-plane,replication-gcs-control-plane,replication-azure-control-plane,coordinator-dynamodb,coordinator-spanner,coordinator-cosmosdb,watch,nfs,gix-pathmatch"
 CRAB_CLI_FEATURES_WITH_FUSE="${CRAB_CLI_FEATURES_NO_FUSE},fuse"
 
-DRY_RUN=false
 ALLOW_PARTIAL=false
 LIST_TARGETS=false
 REQUESTED_TARGETS=()
@@ -59,30 +49,20 @@ usage() {
 Usage: $0 [options]
 
 Options:
-  --dry-run            Build archives and checksums without publishing.
   --target NAME        Build one target. May be repeated.
   --allow-partial      Build only targets available on this machine.
   --list-targets       Print the release target matrix.
-  --all                Accepted for compatibility; all targets are the default.
   -h, --help           Show this help.
 
 Targets:
   darwin-aarch64, darwin-x86_64, linux-aarch64, linux-x86_64,
   windows-aarch64, windows-x86_64
 
-Environment for publishing:
-  REPLICA_RELEASE_EVIDENCE_DIR              Retained live evidence directory.
-  REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID  Exact replica-live-<run>-<attempt> ID.
-  REPLICA_RELEASE_EVIDENCE_OUTPUT           Verification JSON output path.
 USAGE
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --dry-run)
-            DRY_RUN=true
-            shift
-            ;;
         --target)
             [[ $# -ge 2 ]] || die "--target requires a target name"
             REQUESTED_TARGETS+=("$2")
@@ -94,9 +74,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --list-targets)
             LIST_TARGETS=true
-            shift
-            ;;
-        --all)
             shift
             ;;
         -h|--help)
@@ -186,11 +163,6 @@ fi
 HAS_CARGO_XWIN=false
 if "$CARGO" xwin --version >/dev/null 2>&1; then
     HAS_CARGO_XWIN=true
-fi
-
-HAS_GH=false
-if command -v gh >/dev/null 2>&1; then
-    HAS_GH=true
 fi
 
 can_build_index() {
@@ -559,25 +531,6 @@ build_index() {
     info "Created $(basename "$archive") ($size)"
 }
 
-verify_replica_release_evidence() {
-    if [[ -z "$REPLICA_RELEASE_EVIDENCE_DIR" ]]; then
-        die "REPLICA_RELEASE_EVIDENCE_DIR is required before publishing an enterprise replica release."
-    fi
-    if [[ -z "$REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID" ]]; then
-        die "REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID is required before publishing; use replica-live-<github-run-id>-<attempt>."
-    fi
-
-    info "Verifying retained enterprise replica evidence"
-    "$SCRIPT_DIR/verify-replica-release-evidence.sh" \
-        "$REPLICA_RELEASE_EVIDENCE_DIR" \
-        "$REPLICA_RELEASE_EVIDENCE_OUTPUT" \
-        "$REPLICA_RELEASE_EVIDENCE_EXPECTED_RUN_ID"
-}
-
-if [[ "$DRY_RUN" != true ]]; then
-    verify_replica_release_evidence
-fi
-
 SELECTED_TARGETS=()
 BUILD_TARGETS=()
 select_targets
@@ -589,7 +542,6 @@ mkdir -p "$DIST_DIR"
 echo ""
 printf "${BOLD}Crab %s - Release Build${RESET}\n" "$TAG"
 echo ""
-info "Release repo: $RELEASE_REPO"
 info "Targets:"
 for i in "${BUILD_TARGETS[@]}"; do
     printf "  %-18s %-30s %s\n" \
@@ -623,37 +575,5 @@ for a in "${BUILT_ARCHIVES[@]}"; do
 done
 echo ""
 
-if [[ "$DRY_RUN" == true ]]; then
-    info "Dry run complete - artifacts in $DIST_DIR"
-    cat "$DIST_DIR/SHA256SUMS.txt"
-    exit 0
-fi
-
-if [[ "$ALLOW_PARTIAL" == true ]]; then
-    die "Refusing to publish a partial release. Re-run without --allow-partial."
-fi
-
-if [[ "$HAS_GH" != true ]]; then
-    die "\`gh\` CLI not found. Install: https://cli.github.com/"
-fi
-
-if ! gh auth status >/dev/null 2>&1; then
-    die "\`gh\` is not authenticated. Run: gh auth login"
-fi
-
-info "Publishing $TAG to $RELEASE_REPO"
-if gh release view "$TAG" --repo "$RELEASE_REPO" >/dev/null 2>&1; then
-    warn "Release $TAG exists - uploading assets with --clobber."
-    gh release upload "$TAG" "${BUILT_ARCHIVES[@]}" \
-        --repo "$RELEASE_REPO" \
-        --clobber
-else
-    gh release create "$TAG" "${BUILT_ARCHIVES[@]}" \
-        --repo "$RELEASE_REPO" \
-        --title "Crab CLI ${TAG}" \
-        --generate-notes
-fi
-
-echo ""
-printf "${GREEN}${BOLD}Released crab %s${RESET}\n" "$TAG"
-printf "  https://github.com/%s/releases/tag/%s\n" "$RELEASE_REPO" "$TAG"
+info "Local build complete - artifacts in $DIST_DIR"
+cat "$DIST_DIR/SHA256SUMS.txt"

--- a/crab/scripts/release/seed-homebrew-tap.sh
+++ b/crab/scripts/release/seed-homebrew-tap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # seed-homebrew-tap.sh — Initialize the crabbuild/homebrew-tap repo with
 # a README, then publish the current release formula. Run once after creating
-# the repo and publishing the matching crabbuild/crab-release tag.
+# the repo and publishing the matching crabbuild/crab-oss tag.
 #
 # Usage:
 #   ./scripts/release/seed-homebrew-tap.sh

--- a/crab/scripts/release/update-homebrew.sh
+++ b/crab/scripts/release/update-homebrew.sh
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CRAB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 TAP_REPO="${TAP_REPO:-crabbuild/homebrew-tap}"
-RELEASE_REPO="${RELEASE_REPO:-crabbuild/crab-release}"
+RELEASE_REPO="${RELEASE_REPO:-crabbuild/crab-oss}"
 FORMULA_NAME="${FORMULA_NAME:-crab}"
 DIST_DIR="${DIST_DIR:-$CRAB_DIR/dist}"
 

--- a/crab/src/cmd/update.rs
+++ b/crab/src/cmd/update.rs
@@ -15,7 +15,7 @@ use tempfile::Builder;
 use crate::core::error::{CrabError, Result};
 use crate::core::output::{OutputMode, emit_json};
 
-const RELEASE_API_URL: &str = "https://api.github.com/repos/crabbuild/crab-release/releases/latest";
+const RELEASE_API_URL: &str = "https://api.github.com/repos/crabbuild/crab-oss/releases/latest";
 const CHECKSUMS_ASSET: &str = "SHA256SUMS.txt";
 const UPDATE_SCHEMA: &str = "update";
 const UPDATE_SCHEMA_VERSION: &str = "1.0";
@@ -81,7 +81,7 @@ pub async fn run_update(args: UpdateArgs) -> Result<()> {
             release_tag: None,
             status: UpdateStatus::NoRelease,
             asset: None,
-            message: "No crab release is available from crabbuild/crab-release.".to_owned(),
+            message: "No crab release is available from crabbuild/crab-oss.".to_owned(),
         };
         emit_payload(&payload, args.mode);
         return Ok(());
@@ -640,9 +640,7 @@ mod tests {
     fn release_with_assets(names: &[&str]) -> ReleaseResponse {
         ReleaseResponse {
             tag_name: "v1.2.3".to_owned(),
-            html_url: Some(
-                "https://github.com/crabbuild/crab-release/releases/tag/v1.2.3".to_owned(),
-            ),
+            html_url: Some("https://github.com/crabbuild/crab-oss/releases/tag/v1.2.3".to_owned()),
             assets: names
                 .iter()
                 .map(|name| ReleaseAsset {

--- a/crates/crab-auth-server/Cargo.toml
+++ b/crates/crab-auth-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-auth-server"
-version = "1.0.15"
+version = "1.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Protected-push and path-scoped view helper binaries for Crab Auth."

--- a/crates/crab-cache-server/Cargo.toml
+++ b/crates/crab-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-cache-server"
-version = "1.0.15"
+version = "1.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Cache server runtime contracts for Crab."

--- a/crates/crab-cache-server/tests/cache_server_preflight_cli.rs
+++ b/crates/crab-cache-server/tests/cache_server_preflight_cli.rs
@@ -88,7 +88,7 @@ fn cache_service_workflow_gates_client_cache_integration_surfaces() {
 }
 
 #[test]
-fn makefile_exposes_cache_service_release_gate() {
+fn makefile_exposes_cache_service_release_gate_and_hosted_dispatch() {
     let body = workflow_body("crab/Makefile");
 
     for needle in [
@@ -105,13 +105,19 @@ fn makefile_exposes_cache_service_release_gate() {
         "\"$(CACHE_SERVER_DEBUG_BIN)\" evidence gate",
         "--evidence-dir \"$(CACHE_SERVICE_RELEASE_EVIDENCE_DIR)\"",
         "--expected-run-id \"$(CACHE_SERVICE_RELEASE_EXPECTED_RUN_ID)\"",
-        "release-build: replica-release-gate cache-service-release-gate",
-        "release-strict: replica-release-gate cache-service-release-gate",
-        "release-macos-full: replica-release-gate cache-service-release-gate",
-        "@$(MAKE) --no-print-directory cache-service-release-gate",
+        "release-build:\n\t@./scripts/release/release.sh --allow-partial",
+        "release-ci: release-metadata-check",
+        "CACHE_SERVICE_RELEASE_EVIDENCE_RUN_ID is required for make release-ci",
+        "-f \"require_enterprise_evidence=$$require_enterprise_evidence\"",
+        "-f \"cache_service_evidence_run_id=$(CACHE_SERVICE_RELEASE_EVIDENCE_RUN_ID)\"",
     ] {
         assert!(body.contains(needle), "{needle}");
     }
+
+    assert!(
+        !body.contains("release-build: replica-release-gate cache-service-release-gate"),
+        "local archive builds must not own hosted release evidence policy"
+    );
 }
 
 #[test]

--- a/packages/web/public/install.ps1
+++ b/packages/web/public/install.ps1
@@ -9,7 +9,7 @@
 
 $ErrorActionPreference = "Stop"
 
-$Repo = "crabbuild/crab-release"
+$Repo = "crabbuild/crab-oss"
 $InstallDir = if ($env:CRAB_INSTALL_DIR) { $env:CRAB_INSTALL_DIR } else { "$HOME\.crab\bin" }
 $Version = if ($env:CRAB_VERSION) { $env:CRAB_VERSION } else { "latest" }
 

--- a/packages/web/public/install.sh
+++ b/packages/web/public/install.sh
@@ -19,7 +19,7 @@ set -eu
 export LC_ALL=C
 export LANG=C
 
-REPO="crabbuild/crab-release"
+REPO="crabbuild/crab-oss"
 INSTALL_DIR="${CRAB_INSTALL_DIR:-$HOME/.crab/bin}"
 VERSION="${CRAB_VERSION:-latest}"
 TMP_DIR=""


### PR DESCRIPTION
## Summary

- publish Crab releases from `crabbuild/crab-oss` through one tag-triggered GitHub Actions path
- build, smoke-test, checksum, and attest six native archives; keep enterprise/NFS/cloud evidence opt-in
- make published releases immutable, isolate Homebrew as a retryable post-release job, and remove local publishing/bypass paths
- align the CLI, auth-server, and cache-server product versions at 1.1.0 and update installers, updater, changelog, and maintainer procedure

## Local proof

- `make release-metadata-check`
- `make release-archive-contents-check`
- `bash -n` on release scripts and `sh -n packages/web/public/install.sh`
- release workflow YAML parse
- `cargo fmt --all -- --check`
- `cargo test -p crab cmd::update --locked` (9 passed)
- `make shipped-binary-version-check` (4 binaries report 1.1.0)
