### PR TITLE
fix: use Windows-safe release migration gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -696,7 +696,7 @@ jobs:
         run: cargo test -p crab-workflow --locked
 
       - name: Run CLI migration contract tests
-        run: cargo test -p crab --test workflow_migration --locked
+        run: cargo test -p crab --test workflow_migration --no-default-features --features simd-accel,tier,watch --locked
 
       - name: Build and execute the Windows release candidate
         if: runner.os == 'Windows'

--- a/crab/scripts/release/check-release-archive-contents.py
+++ b/crab/scripts/release/check-release-archive-contents.py
@@ -277,6 +277,7 @@ def check_release_workflow(root: Path) -> list[str]:
         "--verify-tag",
         "--fail-on-no-commits",
         '--notes-file "$notes_file"',
+        "cargo test -p crab --test workflow_migration --no-default-features --features simd-accel,tier,watch --locked",
         "require_nfs_evidence:",
         "require_cloud_evidence:",
         "nfs_release_verify_args:",


### PR DESCRIPTION
## Summary

- align the release migration test with the native workflow's no-default-feature contract
- prevent the Windows release gate from compiling unsupported `fuser` defaults
- statically protect the release workflow command

## Proof

- `make -C crab release-archive-contents-check`
- release workflow YAML parse
- `actionlint .github/workflows/release.yml`
- `cargo test -p crab --test workflow_migration --no-default-features --features simd-accel,tier,watch --locked` (9 passed)
