### PR TITLE
fix: bind release evidence to tag commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,12 +218,12 @@ jobs:
       - name: Run workflow smoke against release candidate
         env:
           CRAB_RUSTFS_IMAGE: ${{ env.WORKFLOW_RUSTFS_IMAGE }}
-          GITHUB_SHA: ${{ needs.prepare.outputs.source_sha }}
         run: |
           export PATH="$GITHUB_WORKSPACE/target/release:$PATH"
           python3 crab/scripts/e2e/run_dvc_workflow_smoke.py \
             --root "${WORKFLOW_RUSTFS_ROOT}" \
             --run-id "${WORKFLOW_RUSTFS_RUN_ID}" \
+            --source-sha "${{ needs.prepare.outputs.source_sha }}" \
             --bucket "${WORKFLOW_RUSTFS_BUCKET}" \
             --endpoint-url "${WORKFLOW_RUSTFS_ENDPOINT}" \
             --region "${WORKFLOW_RUSTFS_REGION}" \

--- a/crab/scripts/e2e/run_dvc_workflow_smoke.py
+++ b/crab/scripts/e2e/run_dvc_workflow_smoke.py
@@ -113,7 +113,7 @@ class Smoke:
             remote=self.remote,
             root=str(self.run_root),
             endpoint_url=args.endpoint_url,
-            source_sha=os.environ.get("GITHUB_SHA", "unknown"),
+            source_sha=args.source_sha,
             workflow_run_id=os.environ.get("GITHUB_RUN_ID", "local"),
             workflow_run_attempt=os.environ.get("GITHUB_RUN_ATTEMPT", "1"),
             crab_version="unknown",
@@ -1211,6 +1211,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--access-key", default="crab")
     parser.add_argument("--secret-key", default="crab")
     parser.add_argument("--run-id")
+    parser.add_argument("--source-sha", default=os.environ.get("GITHUB_SHA", "unknown"))
     parser.add_argument(
         "--min-free-bytes",
         type=int,

--- a/crab/scripts/release/check-release-archive-contents.py
+++ b/crab/scripts/release/check-release-archive-contents.py
@@ -278,6 +278,7 @@ def check_release_workflow(root: Path) -> list[str]:
         "--fail-on-no-commits",
         '--notes-file "$notes_file"',
         "cargo test -p crab --test workflow_migration --no-default-features --features simd-accel,tier,watch --locked",
+        '--source-sha "${{ needs.prepare.outputs.source_sha }}"',
         'if ! aws --endpoint-url "${WORKFLOW_RUSTFS_ENDPOINT}" s3api head-bucket --bucket "${WORKFLOW_RUSTFS_BUCKET}" >/dev/null 2>&1; then',
         'aws --endpoint-url "${WORKFLOW_RUSTFS_ENDPOINT}" s3api create-bucket --bucket "${WORKFLOW_RUSTFS_BUCKET}" >/dev/null',
         'aws --endpoint-url "${WORKFLOW_RUSTFS_ENDPOINT}" s3api head-bucket --bucket "${WORKFLOW_RUSTFS_BUCKET}" >/dev/null',
@@ -320,6 +321,7 @@ def check_release_workflow(root: Path) -> list[str]:
         "CRAB_RELEASE_GITHUB_TOKEN",
         "crabbuild/crab-release",
         "--clobber",
+        "GITHUB_SHA: ${{ needs.prepare.outputs.source_sha }}",
     ):
         if forbidden in text:
             errors.append(f"release.yml: unexpected {forbidden!r}")
@@ -361,6 +363,15 @@ def check_homebrew_script(
 
 def checks(root: Path) -> list[TextCheck]:
     return [
+        TextCheck(
+            "workflow smoke accepts an explicit release source SHA",
+            root / "crab" / "scripts" / "e2e" / "run_dvc_workflow_smoke.py",
+            contains=(
+                'source_sha=args.source_sha',
+                'parser.add_argument("--source-sha", default=os.environ.get("GITHUB_SHA", "unknown"))',
+            ),
+            excludes=(),
+        ),
         TextCheck(
             "version bump keeps all shipped product manifests aligned",
             root / "crab" / "scripts" / "release" / "bump-version.sh",


### PR DESCRIPTION
## Summary

- add an explicit source SHA input to workflow smoke evidence
- pass the immutable release tag commit instead of attempting to override reserved `GITHUB_SHA`
- keep the verifier strict and statically forbid the broken override contract

## Proof

- `make -C crab release-archive-contents-check`
- release workflow YAML parse
- `actionlint .github/workflows/release.yml`
- parser probe for default and explicit `--source-sha` behavior
