### PR TITLE
fix: use native linker for Linux ARM release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -869,6 +869,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=cc
+            export CC_aarch64_unknown_linux_gnu=cc
+          fi
+
           no_fuse_features="simd-accel,tier,replication-s3-control-plane,replication-gcs-control-plane,replication-azure-control-plane,coordinator-dynamodb,coordinator-spanner,coordinator-cosmosdb,watch,nfs,gix-pathmatch"
           with_fuse_features="${no_fuse_features},fuse"
           if [ "${{ matrix.windows }}" = "true" ]; then

--- a/crab/scripts/release/check-release-archive-contents.py
+++ b/crab/scripts/release/check-release-archive-contents.py
@@ -216,6 +216,9 @@ def check_release_workflow(root: Path) -> list[str]:
         errors.append(f"release.yml: {error}")
     else:
         for needle in (
+            'if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then',
+            "export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=cc",
+            "export CC_aarch64_unknown_linux_gnu=cc",
             'no_fuse_features="simd-accel,tier,replication-s3-control-plane,replication-gcs-control-plane,replication-azure-control-plane,coordinator-dynamodb,coordinator-spanner,coordinator-cosmosdb,watch,nfs,gix-pathmatch"',
             "--no-default-features --features simd-accel,tier,watch,nfs,gix-pathmatch",
             '--no-default-features --features "$no_fuse_features"',


### PR DESCRIPTION
## Summary
- override the repository cross-linker on the native Linux ARM64 release runner
- preserve the existing `.cargo/config.toml` cross-compilation contract elsewhere
- enforce the native ARM linker contract in the release archive checker

## Failure proof
Release run 33132004473 failed on `ubuntu-24.04-arm` because `aarch64-unknown-linux-gnu-gcc` was unavailable on the native ARM runner.

## Proof
- `make -C crab release-archive-contents-check`
- release workflow YAML parse
- `actionlint .github/workflows/release.yml`