### PR TITLE
fix: withhold v2 without visibility evidence

### DIFF
--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -7111,7 +7111,7 @@ pub(crate) async fn git_visibility_index_exists_for_manifest(
     .map_err(CrabError::from)
 }
 
-async fn git_visibility_proof_available_for_manifest(
+pub(crate) async fn git_visibility_proof_available_for_manifest(
     store: &Store,
     router: &StoreLayout,
     manifest: &Manifest,
@@ -22998,12 +22998,21 @@ mod tests {
             .expect("owner should publish locator coverage before visibility repair")
         );
         let visibility_path = router.git_visibility_catalog_path(&manifest.git_validation_digest);
+        let legacy_visibility_path = router.git_visibility_path(&manifest.git_validation_digest);
         store
             .delete(&visibility_path)
             .await
             .expect("remove derived visibility proof");
+        store
+            .delete(&legacy_visibility_path)
+            .await
+            .expect("remove legacy visibility proof");
         assert!(matches!(
             store.head(&visibility_path).await,
+            Err(CrabError::NotFound { .. })
+        ));
+        assert!(matches!(
+            store.head(&legacy_visibility_path).await,
             Err(CrabError::NotFound { .. })
         ));
 
@@ -23025,6 +23034,15 @@ mod tests {
             "capability discovery must leave visibility repair to the active owner"
         );
         owner.release().await.expect("release generation owner");
+        assert!(
+            !crate::git::upload_pack_wire::snapshot_available(
+                store.as_storage(),
+                repo_prefix,
+                &CancellationToken::new(),
+            )
+            .await,
+            "protocol v2 must remain withheld while the current visibility proof is missing"
+        );
 
         let (repository, _) = crate::git::upload_pack_wire::open_repository_with_visibility(
             store.as_storage(),

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -210,15 +210,14 @@ struct FetchRequest {
     filter: UploadPackFilter,
 }
 
-/// Check whether protocol-v2 admission has a stable manifest to repair or use.
+/// Check whether protocol-v2 admission has usable generation evidence.
 pub async fn snapshot_available(
     store: &crab_storage::Store,
     prefix: &str,
     cancellation: &CancellationToken,
 ) -> bool {
-    // Filtered fetch has no useful legacy complete-pack fallback. Keep the
-    // capability probe cheap and let upload-pack admission repair derived
-    // coverage once a client actually requests a v2 session.
+    // A v2 session cannot fall back after the terminal handoff. Only advertise
+    // it when admission has current visibility evidence to use or migrate.
     let Ok(stable) = capability_snapshot_is_stable(store, prefix, cancellation).await else {
         return false;
     };
@@ -231,7 +230,7 @@ async fn capability_snapshot_is_stable(
     cancellation: &CancellationToken,
 ) -> crab_remote_git::Result<bool> {
     let layout = crab_storage::StoreLayout::new(store.clone(), prefix.to_owned());
-    let (_manifest, _) = tokio::select! {
+    let (manifest, _) = tokio::select! {
         biased;
         () = cancellation.cancelled() => return Err(RemoteGitError::Cancelled),
         result = read_manifest(store, &layout) => result.map_err(|source| RemoteGitError::Manifest { source })?,
@@ -257,7 +256,22 @@ async fn capability_snapshot_is_stable(
         );
         return Ok(false);
     }
-    Ok(true)
+    if manifest.refs.is_empty() {
+        return Ok(true);
+    }
+    match super::push::git_visibility_proof_available_for_manifest(
+        &repair_store,
+        &repair_layout,
+        &manifest,
+    )
+    .await
+    {
+        Ok(available) => Ok(available),
+        Err(error) => {
+            tracing::warn!(%error, "visibility proof probe failed during capability discovery");
+            Ok(false)
+        }
+    }
 }
 
 fn visibility_index_needs_repair(error: &RemoteGitError) -> bool {


### PR DESCRIPTION
## Summary

- require current catalog-bound or digest-bound visibility evidence before advertising protocol v2 for a non-empty repository
- preserve v2 admission repair when usable evidence exists and preserve empty-repository behavior
- cover the no-evidence state by removing both proof formats in the visibility-repair regression

## Why

A RustFS qualification using Django’s 519 published refs exceeded the bounded visibility-proof profile. The stable manifest still caused the helper to advertise `stateless-connect`, but the terminal v2 session could not fall back after the missing proof failed to open. Ordinary complete-pack clones should remain available while visibility evidence is unavailable.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p crab --locked --lib git::push::tests::upload_pack_repairs_locator_for_current_manifest_generation -- --exact`
- `cargo test -p crab --locked --lib git::push::tests::upload_pack_repairs_missing_visibility_for_current_manifest_generation -- --exact`
- `cargo test -p crab --locked --lib git::upload_pack_wire::tests::capability_snapshot_short_circuits_empty_repositories -- --exact`
- live RustFS: helper withheld `stateless-connect`, listed all 519 refs, cloned 52,642 commits / 564,235 reachable objects, and passed `git fsck --strict --no-dangling`
