### PR TITLE
fix: run release gates after optional skips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -962,7 +962,7 @@ jobs:
   protocol-v2-release-gate:
     name: Protocol v2 partial-clone release gate
     needs: [prepare, build]
-    if: ${{ needs.prepare.result == 'success' && needs.build.result == 'success' }}
+    if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -1054,7 +1054,7 @@ jobs:
   protocol-v2-git-compatibility-release-gate:
     name: Protocol v2 packaged Git compatibility (${{ matrix.label }})
     needs: [prepare, build, protocol-v2-release-gate]
-    if: ${{ needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}
+    if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -1189,7 +1189,7 @@ jobs:
   protocol-v2-rollback-release-gate:
     name: Protocol v2 rollback compatibility release gate
     needs: [prepare, build, protocol-v2-release-gate]
-    if: ${{ needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}
+    if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
@@ -1315,7 +1315,7 @@ jobs:
   protocol-v2-aws-release-gate:
     name: Protocol v2 partial-clone AWS S3 release gate
     needs: [prepare, build, protocol-v2-release-gate]
-    if: ${{ ((github.event_name == 'workflow_dispatch' && inputs.require_cloud_evidence) || (github.event_name != 'workflow_dispatch' && vars.CRAB_RELEASE_REQUIRE_CLOUD_EVIDENCE == 'true')) && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}
+    if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.require_cloud_evidence) || (github.event_name != 'workflow_dispatch' && vars.CRAB_RELEASE_REQUIRE_CLOUD_EVIDENCE == 'true')) && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -1391,7 +1391,7 @@ jobs:
   protocol-v2-platform-release-gate:
     name: Protocol v2 platform gate (${{ matrix.platform }})
     needs: [prepare, build, protocol-v2-release-gate, protocol-v2-aws-release-gate]
-    if: ${{ needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' && needs.protocol-v2-aws-release-gate.result == 'success' }}
+    if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' && needs.protocol-v2-aws-release-gate.result == 'success' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:

--- a/crab/scripts/release/check-release-archive-contents.py
+++ b/crab/scripts/release/check-release-archive-contents.py
@@ -72,6 +72,17 @@ def workflow_step_run(text: str, step_name: str) -> str:
     return text[body_start:next_step]
 
 
+def workflow_job(text: str, job_name: str) -> str:
+    marker = f"  {job_name}:\n"
+    start = text.find(marker)
+    if start == -1:
+        raise ValueError(f"missing workflow job {job_name}")
+    next_job = re.search(r"^  [a-zA-Z0-9_-]+:\n", text[start + len(marker) :], re.MULTILINE)
+    if next_job is None:
+        return text[start:]
+    return text[start : start + len(marker) + next_job.start()]
+
+
 def heredoc_block(text: str, marker: str, terminator: str) -> str:
     lines = text.splitlines()
     start_index = next((index for index, line in enumerate(lines) if marker in line), None)
@@ -186,6 +197,22 @@ def check_release_workflow(root: Path) -> list[str]:
     path = root / ".github" / "workflows" / "release.yml"
     text = read_text(path)
     errors: list[str] = []
+
+    downstream_conditions = {
+        "protocol-v2-release-gate": "if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' }}",
+        "protocol-v2-git-compatibility-release-gate": "if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}",
+        "protocol-v2-rollback-release-gate": "if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' }}",
+        "protocol-v2-aws-release-gate": "if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.require_cloud_evidence)",
+        "protocol-v2-platform-release-gate": "if: ${{ always() && needs.prepare.result == 'success' && needs.build.result == 'success' && needs.protocol-v2-release-gate.result == 'success' && needs.protocol-v2-aws-release-gate.result == 'success' }}",
+    }
+    for job_name, condition in downstream_conditions.items():
+        try:
+            job = workflow_job(text, job_name)
+        except ValueError as error:
+            errors.append(f"release.yml: {error}")
+        else:
+            if condition not in job:
+                errors.append(f"release.yml {job_name}: expected {condition!r}")
 
     try:
         package_step = workflow_step_run(text, "Package archive")


### PR DESCRIPTION
## Summary
- make required downstream protocol jobs explicitly evaluate after optional evidence jobs are skipped
- retain strict per-need success checks so real failures still block publication
- enforce each downstream job condition in the static release contract

## Failure proof
Release run 33134844360 built and attested all six archives but skipped protocol qualification and publication because optional skipped ancestors triggered the implicit `success()` guard.

## Proof
- `make -C crab release-archive-contents-check`
- release workflow YAML parse
- `actionlint .github/workflows/release.yml`