### PR TITLE
fix: harden NFS Xet mounts and operator workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
  "crab-types",
  "crab-xet",
  "dashmap",
+ "fs4",
  "fuser",
  "gix-hash",
  "gix-object",

--- a/crab/docs/architecture/virtual-filesystem.md
+++ b/crab/docs/architecture/virtual-filesystem.md
@@ -93,6 +93,12 @@ modifications are stored in an overlay database plus an upper directory and are
 merged with the immutable snapshot view. The overlay tracks creates, writes,
 truncates, mode changes, symlinks, unlinks, and directory renames.
 
+Mutations take a shared, cross-process publish lease. Independent paths can
+write their backing files concurrently, while the VFS engine serializes the
+same path and intersecting ancestor/subtree mutations. Publish, export, and
+reset take the exclusive lease, wait for in-flight backing-file mutations, and
+prevent a partial overlay snapshot from being observed.
+
 Overlay writes remain local until the user runs a publish operation:
 - `crab mount diff` inspects the live overlay.
 - `crab mount export` copies overlay changes to a normal directory.

--- a/crab/docs/guides/mount.md
+++ b/crab/docs/guides/mount.md
@@ -310,6 +310,11 @@ crab mount reset --mountpoint /mnt/models --overlay --yes
 checks that the mounted base ref has not moved, creates a Git commit, refreshes
 the mounted snapshot, and clears the overlay after a successful local commit.
 
+Processes using one mount may write independent paths concurrently. Mutations
+to the same path or intersecting directory subtree are serialized. Commit,
+export, and reset drain in-flight mutations before taking a stable overlay
+snapshot.
+
 For large crab-tracked files, commit streams overlay file content directly into
 Crab staging when `.gitattributes` is stable, then writes pointer files into the
 Git index. If `.gitattributes` changed in the overlay, commit first materializes
@@ -357,6 +362,8 @@ crab unmount --all
   client-side/no-remote-lock-manager options because Crab serves one local
   loopback export per mount and does not run an NLM service. Advisory locks
   coordinate processes on the same mounted client, not separate clients.
+  Separate mounts have independent overlays, and overlapping byte-range writes
+  to one file require application coordination.
 
 - **FUSE is optional.** `--backend=fuse` requires macFUSE on macOS or fuse3 on
   Linux. Windows FUSE is not supported.
@@ -422,9 +429,12 @@ make mount-large-macos-nfs-rustfs-smoke
 ```
 
 This starts an isolated RustFS backend, verifies chunk dedup for identical
-large files, range and whole-file reads, writable large-file commit/push and a
-fresh byte-identical clone, and enumerates a 10,000-entry directory through the
-native NFS client. Evidence is retained under the configured
+large files, range and whole-file reads, overlapping independent writer
+processes, writable large-file commit/push and a fresh byte-identical clone,
+and enumerates a 10,000-entry directory through the native NFS client. The
+concurrent writer count and bytes per writer are configurable with
+`CRAB_MOUNT_MACOS_CONCURRENT_WRITERS` and
+`CRAB_MOUNT_MACOS_CONCURRENT_MIB`. Evidence is retained under the configured
 `CRAB_MOUNT_MACOS_ROOT` run directory.
 
 **Windows:**

--- a/crab/scripts/mount-concurrent-writer-probe.py
+++ b/crab/scripts/mount-concurrent-writer-probe.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Create and verify deterministic concurrent mount writes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+from typing import Optional
+
+
+WORKER = r"""
+import hashlib
+import json
+import os
+import pathlib
+import sys
+import time
+
+index = int(sys.argv[1])
+size = int(sys.argv[2])
+path = pathlib.Path(sys.argv[3])
+started_ns = time.monotonic_ns()
+digest = hashlib.sha256()
+remaining = size
+counter = 0
+with path.open("wb", buffering=0) as output:
+    while remaining:
+        wanted = min(1024 * 1024, remaining)
+        data = bytearray()
+        while len(data) < wanted:
+            data.extend(hashlib.sha256(f"concurrent-{index}:{counter}".encode()).digest())
+            counter += 1
+        block = bytes(data[:wanted])
+        output.write(block)
+        digest.update(block)
+        remaining -= wanted
+    os.fsync(output.fileno())
+ended_ns = time.monotonic_ns()
+print(json.dumps({
+    "index": index,
+    "path": path.name,
+    "size_bytes": size,
+    "sha256": digest.hexdigest(),
+    "started_ns": started_ns,
+    "ended_ns": ended_ns,
+}))
+"""
+
+
+def load_manifest(path: pathlib.Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def file_hash(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while block := source.read(1024 * 1024):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def write_files(models: pathlib.Path, writers: int, mib: int, output: pathlib.Path) -> None:
+    size_bytes = mib * 1024 * 1024
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                WORKER,
+                str(index),
+                str(size_bytes),
+                str(models / f"concurrent-{index:02}.bin"),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for index in range(writers)
+    ]
+    results = []
+    for process in processes:
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            raise RuntimeError(stderr or f"concurrent writer exited {process.returncode}")
+        results.append(json.loads(stdout))
+
+    overlap_ns = min(item["ended_ns"] for item in results) - max(
+        item["started_ns"] for item in results
+    )
+    if overlap_ns <= 0:
+        raise RuntimeError("concurrent writer intervals did not overlap")
+    elapsed_ns = max(item["ended_ns"] for item in results) - min(
+        item["started_ns"] for item in results
+    )
+    logical_bytes = writers * size_bytes
+    payload = {
+        "writer_count": writers,
+        "bytes_per_writer": size_bytes,
+        "logical_bytes": logical_bytes,
+        "elapsed_ms": elapsed_ns // 1_000_000,
+        "overlap_ms": overlap_ns // 1_000_000,
+        "throughput_mib_per_second": logical_bytes
+        / (1024 * 1024)
+        / (elapsed_ns / 1e9),
+        "files": sorted(results, key=lambda item: item["index"]),
+    }
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def verify_files(manifest: pathlib.Path, models: pathlib.Path, label: str) -> None:
+    for item in load_manifest(manifest)["files"]:
+        digest = file_hash(models / item["path"])
+        if digest != item["sha256"]:
+            raise RuntimeError(f"{label} hash mismatch for {item['path']}: {digest}")
+
+
+def verify_pointers(
+    manifest: pathlib.Path,
+    *,
+    models: Optional[pathlib.Path],
+    repo: Optional[pathlib.Path],
+) -> None:
+    for item in load_manifest(manifest)["files"]:
+        if repo is not None:
+            pointer = subprocess.check_output(
+                ["git", "show", f"HEAD:models/{item['path']}"], cwd=repo, text=True
+            )
+        else:
+            if models is None:
+                raise RuntimeError("models path is required")
+            pointer = (models / item["path"]).read_text()
+        if "version https://crab.dev/spec/v1" not in pointer or len(pointer) >= 1000:
+            raise RuntimeError(f"invalid pointer for {item['path']}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    write = subparsers.add_parser("write")
+    write.add_argument("--models", type=pathlib.Path, required=True)
+    write.add_argument("--writers", type=int, required=True)
+    write.add_argument("--mib", type=int, required=True)
+    write.add_argument("--output", type=pathlib.Path, required=True)
+
+    verify = subparsers.add_parser("verify-files")
+    verify.add_argument("--manifest", type=pathlib.Path, required=True)
+    verify.add_argument("--models", type=pathlib.Path, required=True)
+    verify.add_argument("--label", required=True)
+
+    pointers = subparsers.add_parser("verify-pointers")
+    pointers.add_argument("--manifest", type=pathlib.Path, required=True)
+    target = pointers.add_mutually_exclusive_group(required=True)
+    target.add_argument("--models", type=pathlib.Path)
+    target.add_argument("--repo", type=pathlib.Path)
+
+    subparsers.add_parser("self-test")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "write":
+        write_files(args.models, args.writers, args.mib, args.output)
+    elif args.command == "verify-files":
+        verify_files(args.manifest, args.models, args.label)
+    elif args.command == "verify-pointers":
+        verify_pointers(args.manifest, models=args.models, repo=args.repo)
+    else:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            manifest = root / "manifest.json"
+            write_files(root, 2, 1, manifest)
+            verify_files(manifest, root, "self-test")
+
+
+if __name__ == "__main__":
+    main()

--- a/crab/scripts/run-mount-large-macos-rustfs-smoke.sh
+++ b/crab/scripts/run-mount-large-macos-rustfs-smoke.sh
@@ -301,8 +301,15 @@ fi
 
 with_test_env "$BIN_DIR/crab" add --jobs 0 models/model.bin archive/base-move.bin models/delete-me.bin >"$RUN_ROOT/logs/crab-add-seed.log" 2>&1
 git show :models/model.bin > "$RUN_ROOT/seed-pointer.txt"
+git show :archive/base-move.bin > "$RUN_ROOT/seed-base-move-pointer.txt"
+git show :models/delete-me.bin > "$RUN_ROOT/seed-delete-me-pointer.txt"
+cmp "$RUN_ROOT/seed-pointer.txt" "$RUN_ROOT/seed-base-move-pointer.txt"
+cmp "$RUN_ROOT/seed-pointer.txt" "$RUN_ROOT/seed-delete-me-pointer.txt"
 git -c user.email=mount-e2e@example.invalid -c user.name="Crab Mount E2E" \
     commit -m "seed large model" >"$RUN_ROOT/logs/git-commit-seed.log" 2>&1
+AWS_ACCESS_KEY_ID=crab AWS_SECRET_ACCESS_KEY=crab AWS_DEFAULT_REGION="$REGION" AWS_EC2_METADATA_DISABLED=true \
+    "$AWS" --endpoint-url "$ENDPOINT_URL" s3api list-objects-v2 \
+    --bucket "$BUCKET" --prefix ".crab/xorbs/" --output json > "$RUN_ROOT/seed-xorbs-before.json"
 phase_start_ms="$(now_ms)"
 with_test_env "$BIN_DIR/crab" push --json --upload-concurrency 0 origin HEAD:refs/heads/main \
     >"$RUN_ROOT/logs/crab-push-seed.json" 2>"$RUN_ROOT/logs/crab-push-seed.err"
@@ -310,19 +317,28 @@ record_duration_since seed_push_ms "$phase_start_ms"
 AWS_ACCESS_KEY_ID=crab AWS_SECRET_ACCESS_KEY=crab AWS_DEFAULT_REGION="$REGION" AWS_EC2_METADATA_DISABLED=true \
     "$AWS" --endpoint-url "$ENDPOINT_URL" s3api list-objects-v2 \
     --bucket "$BUCKET" --prefix ".crab/xorbs/" --output json > "$RUN_ROOT/seed-xorbs.json"
-python3 - "$RUN_ROOT/seed-xorbs.json" "$SEED_MIB" "$RUN_ROOT/seed-dedup.json" <<'PY'
+python3 - "$RUN_ROOT/seed-xorbs-before.json" "$RUN_ROOT/seed-xorbs.json" "$SEED_MIB" "$RUN_ROOT/seed-dedup.json" <<'PY'
 import json
 import pathlib
 import sys
 
-objects_path = pathlib.Path(sys.argv[1])
-seed_bytes = int(sys.argv[2]) * 1024 * 1024
-output_path = pathlib.Path(sys.argv[3])
-objects = json.loads(objects_path.read_text()).get("Contents", [])
-stored_bytes = sum(int(item.get("Size", 0)) for item in objects)
+before_path = pathlib.Path(sys.argv[1])
+objects_path = pathlib.Path(sys.argv[2])
+seed_bytes = int(sys.argv[3]) * 1024 * 1024
+output_path = pathlib.Path(sys.argv[4])
+before = {
+    item["Key"]: int(item.get("Size", 0))
+    for item in json.loads(before_path.read_text()).get("Contents", [])
+}
+objects = {
+    item["Key"]: int(item.get("Size", 0))
+    for item in json.loads(objects_path.read_text()).get("Contents", [])
+}
+new_objects = {key: size for key, size in objects.items() if key not in before}
+stored_bytes = sum(new_objects.values())
 logical_bytes = seed_bytes * 3
-if not objects or stored_bytes <= 0:
-    raise SystemExit("seed push did not create xorb data")
+if not objects:
+    raise SystemExit("seed push did not leave xorb data in the bucket")
 if stored_bytes >= seed_bytes * 2:
     raise SystemExit(
         f"three identical files stored {stored_bytes} xorb bytes for {logical_bytes} logical bytes"
@@ -330,7 +346,9 @@ if stored_bytes >= seed_bytes * 2:
 payload = {
     "logical_bytes": logical_bytes,
     "stored_xorb_bytes": stored_bytes,
-    "xorb_count": len(objects),
+    "xorb_count": len(new_objects),
+    "bucket_xorb_bytes": sum(objects.values()),
+    "bucket_xorb_count": len(objects),
     "dedup_ratio": 1 - stored_bytes / logical_bytes,
 }
 output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
@@ -611,7 +629,10 @@ if [[ -d "$MOUNT_CACHE/.git" ]]; then
 fi
 [[ -f "$MOUNT_GIT_DIR/HEAD" ]]
 git --git-dir "$MOUNT_GIT_DIR" rev-parse refs/heads/main > "$RUN_ROOT/local-ref-before-push-failure.txt"
-git --git-dir "$MOUNT_GIT_DIR" config remote.origin.url "$RUN_ROOT/run/missing-origin.git"
+# Keep the fetch URL healthy for any promised base objects needed while the
+# commit is built. A broken push-only URL isolates retry behavior after the
+# local commit has actually been created.
+git --git-dir "$MOUNT_GIT_DIR" config remote.origin.pushurl "$RUN_ROOT/run/missing-origin.git"
 if with_test_env "$BIN_DIR/crab" mount commit --mountpoint "$RW" --message "mount large writeback should retry" --push --json \
     > "$RUN_ROOT/rw-commit-push-failure.json" 2>"$RUN_ROOT/logs/rw-commit-push-failure.err"; then
     die "commit unexpectedly succeeded with broken origin"
@@ -647,7 +668,7 @@ if payload.get("status") != "failed" or payload.get("pushed"):
 if not payload.get("commit_oid"):
     raise SystemExit(json.dumps(payload, sort_keys=True))
 PY
-git --git-dir "$MOUNT_GIT_DIR" config remote.origin.url "$REMOTE_URL"
+git --git-dir "$MOUNT_GIT_DIR" config --unset-all remote.origin.pushurl
 record_duration_since push_failure_retry_probe_ms "$phase_start_ms"
 
 phase_start_ms="$(now_ms)"

--- a/crab/scripts/run-mount-large-macos-rustfs-smoke.sh
+++ b/crab/scripts/run-mount-large-macos-rustfs-smoke.sh
@@ -19,6 +19,8 @@ TEST_HOME="$RUN_ROOT/home"
 BACKEND="${CRAB_MOUNT_MACOS_BACKEND:-fuse}"
 SEED_MIB="${CRAB_MOUNT_MACOS_SEED_MIB:-32}"
 NEW_MIB="${CRAB_MOUNT_MACOS_NEW_MIB:-40}"
+CONCURRENT_WRITERS="${CRAB_MOUNT_MACOS_CONCURRENT_WRITERS:-4}"
+CONCURRENT_MIB="${CRAB_MOUNT_MACOS_CONCURRENT_MIB:-16}"
 DIRECTORY_ENTRIES="${CRAB_MOUNT_MACOS_DIRECTORY_ENTRIES:-0}"
 RUSTFS_IMAGE="${CRAB_MOUNT_MACOS_RUSTFS_IMAGE:-rustfs/rustfs:1.0.0-beta.8-glibc}"
 BUCKET="${CRAB_MOUNT_MACOS_BUCKET:-crab}"
@@ -143,9 +145,13 @@ ensure_macfuse_ready() {
 [[ "$BACKEND" == "fuse" || "$BACKEND" == "nfs" ]] || die "CRAB_MOUNT_MACOS_BACKEND must be fuse or nfs"
 [[ "$SEED_MIB" =~ ^[0-9]+$ ]] || die "CRAB_MOUNT_MACOS_SEED_MIB must be an integer"
 [[ "$NEW_MIB" =~ ^[0-9]+$ ]] || die "CRAB_MOUNT_MACOS_NEW_MIB must be an integer"
+[[ "$CONCURRENT_WRITERS" =~ ^[0-9]+$ ]] || die "CRAB_MOUNT_MACOS_CONCURRENT_WRITERS must be an integer"
+[[ "$CONCURRENT_MIB" =~ ^[0-9]+$ ]] || die "CRAB_MOUNT_MACOS_CONCURRENT_MIB must be an integer"
 [[ "$DIRECTORY_ENTRIES" =~ ^[0-9]+$ ]] || die "CRAB_MOUNT_MACOS_DIRECTORY_ENTRIES must be an integer"
 ((SEED_MIB >= 32)) || die "CRAB_MOUNT_MACOS_SEED_MIB must be at least 32"
 ((NEW_MIB >= 8)) || die "CRAB_MOUNT_MACOS_NEW_MIB must be at least 8"
+((CONCURRENT_WRITERS >= 2)) || die "CRAB_MOUNT_MACOS_CONCURRENT_WRITERS must be at least 2"
+((CONCURRENT_MIB >= 1)) || die "CRAB_MOUNT_MACOS_CONCURRENT_MIB must be at least 1"
 
 if [[ -z "$EXTERNAL_ENDPOINT" ]]; then
     command -v "$DOCKER" >/dev/null 2>&1 || die "docker is required"
@@ -478,6 +484,14 @@ cmp "$RUN_ROOT/delete-me.sha256" "$RUN_ROOT/reset-delete-me.sha256"
 record_duration_since reset_ms "$phase_start_ms"
 
 phase_start_ms="$(now_ms)"
+python3 "$SCRIPT_DIR/mount-concurrent-writer-probe.py" write \
+    --models "$RW/models" \
+    --writers "$CONCURRENT_WRITERS" \
+    --mib "$CONCURRENT_MIB" \
+    --output "$RUN_ROOT/concurrent-writes.json"
+record_duration_since concurrent_overlay_write_ms "$phase_start_ms"
+
+phase_start_ms="$(now_ms)"
 cp "$RUN_ROOT/run/seed/models/model.bin" "$RUN_ROOT/run/expected-model.bin"
 mv "$RW/archive" "$RW/moved-archive"
 hash_file "$RW/moved-archive/base-move.bin" > "$RUN_ROOT/rw-base-move.sha256"
@@ -581,7 +595,8 @@ import pathlib
 
 root = pathlib.Path(os.environ["RUN_ROOT_ENV"])
 text = (root / "rw-diff.json").read_text()
-for path in [
+concurrent = json.loads((root / "concurrent-writes.json").read_text())
+expected_paths = [
     "models/model.bin",
     "models/new-large.bin",
     "models/sparse-extend.bin",
@@ -589,7 +604,9 @@ for path in [
     "models/delete-me.bin",
     "moved-archive/base-move.bin",
     "dir-after/nested/note.txt",
-]:
+]
+expected_paths.extend(f"models/{item['path']}" for item in concurrent["files"])
+for path in expected_paths:
     if path not in text:
         raise SystemExit(text)
 if "symlink" not in text:
@@ -615,6 +632,10 @@ cmp "$RUN_ROOT/expected-model.sha256" "$RUN_ROOT/export-model.sha256"
 cmp "$RUN_ROOT/expected-new-large.sha256" "$RUN_ROOT/export-new-large.sha256"
 cmp "$RUN_ROOT/expected-sparse-extend.sha256" "$RUN_ROOT/export-sparse-extend.sha256"
 cmp "$RUN_ROOT/base-move.sha256" "$RUN_ROOT/export-base-move.sha256"
+python3 "$SCRIPT_DIR/mount-concurrent-writer-probe.py" verify-files \
+    --manifest "$RUN_ROOT/concurrent-writes.json" \
+    --models "$EXPORT/models" \
+    --label export
 [[ "$(readlink "$EXPORT/models/model-link.bin")" == "model.bin" ]]
 grep -q '^archive/base-move.bin$' "$EXPORT/.crab-overlay-deletions"
 grep -q '^models/delete-me.bin$' "$EXPORT/.crab-overlay-deletions"
@@ -702,6 +723,10 @@ cmp "$RUN_ROOT/expected-model.sha256" "$RUN_ROOT/clone-model.sha256"
 cmp "$RUN_ROOT/expected-new-large.sha256" "$RUN_ROOT/clone-new-large.sha256"
 cmp "$RUN_ROOT/expected-sparse-extend.sha256" "$RUN_ROOT/clone-sparse-extend.sha256"
 cmp "$RUN_ROOT/base-move.sha256" "$RUN_ROOT/clone-base-move.sha256"
+python3 "$SCRIPT_DIR/mount-concurrent-writer-probe.py" verify-files \
+    --manifest "$RUN_ROOT/concurrent-writes.json" \
+    --models "$CLONE/models" \
+    --label clone
 [[ "$(readlink "$CLONE/models/model-link.bin")" == "model.bin" ]]
 [[ "$(stat -f "%z" "$CLONE/models/model.bin")" == "$((31 * 1024 * 1024))" ]]
 [[ "$(stat -f "%z" "$CLONE/models/sparse-extend.bin")" == "$((48 * 1024 * 1024))" ]]
@@ -739,6 +764,9 @@ grep -q "version https://crab.dev/spec/v1" "$RUN_ROOT/clone-model-pointer.txt"
 grep -q "version https://crab.dev/spec/v1" "$RUN_ROOT/clone-new-large-pointer.txt"
 grep -q "version https://crab.dev/spec/v1" "$RUN_ROOT/clone-sparse-extend-pointer.txt"
 grep -q "version https://crab.dev/spec/v1" "$RUN_ROOT/clone-base-move-pointer.txt"
+python3 "$SCRIPT_DIR/mount-concurrent-writer-probe.py" verify-pointers \
+    --manifest "$RUN_ROOT/concurrent-writes.json" \
+    --repo "$CLONE"
 grep -q "^100755$" "$RUN_ROOT/clone-model-mode.txt"
 grep -q "^100755$" "$RUN_ROOT/clone-new-large-mode.txt"
 grep -q "^100755$" "$RUN_ROOT/clone-sparse-extend-mode.txt"
@@ -770,6 +798,9 @@ cmp "$CLONE/models/model.bin" "$RUN_ROOT/clone-model-pointer.txt"
 cmp "$CLONE/models/new-large.bin" "$RUN_ROOT/clone-new-large-pointer.txt"
 cmp "$CLONE/models/sparse-extend.bin" "$RUN_ROOT/clone-sparse-extend-pointer.txt"
 cmp "$CLONE/moved-archive/base-move.bin" "$RUN_ROOT/clone-base-move-pointer.txt"
+python3 "$SCRIPT_DIR/mount-concurrent-writer-probe.py" verify-pointers \
+    --manifest "$RUN_ROOT/concurrent-writes.json" \
+    --models "$CLONE/models"
 [[ -x "$CLONE/models/model.bin" ]]
 [[ -x "$CLONE/models/new-large.bin" ]]
 [[ -x "$CLONE/models/sparse-extend.bin" ]]
@@ -789,6 +820,10 @@ cmp "$RUN_ROOT/expected-model.sha256" "$RUN_ROOT/rehydrated-model.sha256"
 cmp "$RUN_ROOT/expected-new-large.sha256" "$RUN_ROOT/rehydrated-new-large.sha256"
 cmp "$RUN_ROOT/expected-sparse-extend.sha256" "$RUN_ROOT/rehydrated-sparse-extend.sha256"
 cmp "$RUN_ROOT/base-move.sha256" "$RUN_ROOT/rehydrated-base-move.sha256"
+python3 "$SCRIPT_DIR/mount-concurrent-writer-probe.py" verify-files \
+    --manifest "$RUN_ROOT/concurrent-writes.json" \
+    --models "$CLONE/models" \
+    --label rehydrated
 [[ -x "$CLONE/models/model.bin" ]]
 [[ -x "$CLONE/models/new-large.bin" ]]
 [[ -x "$CLONE/models/sparse-extend.bin" ]]
@@ -832,6 +867,7 @@ summary = {
     "base_move_sha256": (root / "base-move.sha256").read_text().strip(),
     "deleted_large_sha256": (root / "delete-me.sha256").read_text().strip(),
     "seed_dedup": json.loads((root / "seed-dedup.json").read_text()),
+    "concurrent_writes": json.loads((root / "concurrent-writes.json").read_text()),
     "clone_commit": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
     "model_pointer_bytes": (root / "clone-model-pointer.txt").stat().st_size,
     "new_pointer_bytes": (root / "clone-new-large-pointer.txt").stat().st_size,

--- a/crab/src/cmd/hydrate.rs
+++ b/crab/src/cmd/hydrate.rs
@@ -4131,7 +4131,7 @@ fn git_small_blobs<'a>(
         });
     }
 
-    let mut check = Command::new("git")
+    let check = Command::new("git")
         .args([
             "cat-file",
             "--batch-check=%(objectname) %(objecttype) %(objectsize)",
@@ -4144,14 +4144,7 @@ fn git_small_blobs<'a>(
         .stdout(std::process::Stdio::piped())
         .spawn()
         .map_err(error::CrabError::Io)?;
-    check
-        .stdin
-        .as_mut()
-        .ok_or_else(|| error::CrabError::Internal("git cat-file stdin unavailable".to_owned()))?
-        .write_all(input.as_bytes())
-        .map_err(error::CrabError::Io)?;
-    drop(check.stdin.take());
-    let checked = check.wait_with_output().map_err(error::CrabError::Io)?;
+    let checked = command_output_with_input(check, input, "git cat-file --batch-check")?;
     if !checked.status.success() {
         return Err(error::CrabError::Internal(format!(
             "`git cat-file --batch-check` failed: {}",
@@ -4180,7 +4173,7 @@ fn git_small_blobs<'a>(
         return Ok(HashMap::new());
     }
 
-    let mut batch = Command::new("git")
+    let batch = Command::new("git")
         .args(["cat-file", "--batch"])
         .current_dir(root)
         .env_remove("GIT_DIR")
@@ -4199,14 +4192,7 @@ fn git_small_blobs<'a>(
             ),
         });
     }
-    batch
-        .stdin
-        .as_mut()
-        .ok_or_else(|| error::CrabError::Internal("git cat-file stdin unavailable".to_owned()))?
-        .write_all(batch_input.as_bytes())
-        .map_err(error::CrabError::Io)?;
-    drop(batch.stdin.take());
-    let output = batch.wait_with_output().map_err(error::CrabError::Io)?;
+    let output = command_output_with_input(batch, batch_input, "git cat-file --batch")?;
     if !output.status.success() {
         return Err(error::CrabError::Internal(format!(
             "`git cat-file --batch` failed: {}",
@@ -4267,6 +4253,28 @@ fn git_small_blobs<'a>(
         cursor = content_end + 1;
     }
     Ok(blobs)
+}
+
+fn command_output_with_input(
+    mut child: std::process::Child,
+    input: String,
+    operation: &str,
+) -> Result<std::process::Output> {
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| error::CrabError::Internal(format!("{operation} stdin unavailable")))?;
+    // Read output while input is written. Large Git batches can fill both OS
+    // pipes and deadlock if either side is drained only after the other.
+    let writer = std::thread::spawn(move || stdin.write_all(input.as_bytes()));
+    let output = child.wait_with_output().map_err(error::CrabError::Io)?;
+    let write_result = writer
+        .join()
+        .map_err(|_| error::CrabError::Internal(format!("{operation} stdin writer panicked")))?;
+    if output.status.success() {
+        write_result.map_err(error::CrabError::Io)?;
+    }
+    Ok(output)
 }
 
 fn is_safe_repo_relative_path(path: &Path) -> bool {
@@ -5385,6 +5393,37 @@ mod tests {
         assert_eq!(all.len(), 2);
         assert_eq!(main_only.len(), 1);
         assert_eq!(main_only[0].1.file_hash, main_pointer.file_hash);
+    }
+
+    #[test]
+    fn git_small_blobs_drains_large_input_and_output_concurrently() {
+        let fixture = GitFixture::new();
+        let root = fixture.work_tree();
+        let paths = (0..2_500)
+            .map(|index| {
+                let path = format!("blob-{index:04}.txt");
+                std::fs::write(root.join(&path), format!("blob {index}\n")).unwrap();
+                path
+            })
+            .collect::<Vec<_>>();
+        let output = Command::new("git")
+            .args(["hash-object", "-w"])
+            .args(&paths)
+            .current_dir(root)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_COMMON_DIR")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let oids = stdout.lines().map(str::to_owned).collect::<Vec<_>>();
+        assert_eq!(oids.len(), paths.len());
+
+        let blobs = git_small_blobs(root, oids.iter().map(String::as_str)).unwrap();
+
+        assert_eq!(blobs.len(), paths.len());
+        assert!(blobs.values().any(|blob| blob == b"blob 2499\n"));
     }
 
     #[tokio::test]

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -1590,7 +1590,8 @@ where
     Fut: Future<Output = Result<crate::replication::ReadStoreSelection>>,
 {
     tracing::debug!(entries = entries.len(), "fetch batch");
-    if options.filter_requested || options.fetch_options.filter.is_some() {
+    let raw_object_fetch = classify_raw_object_fetch(entries)?;
+    if (options.filter_requested || options.fetch_options.filter.is_some()) && !raw_object_fetch {
         return Err(CrabError::Protocol(
             "filtered fetch requires protocol v2".to_owned(),
         ));
@@ -2181,6 +2182,14 @@ async fn fetch_packs(
     cancel: &tokio_util::sync::CancellationToken,
     check_connectivity: bool,
 ) -> Result<Option<std::path::PathBuf>> {
+    if classify_raw_object_fetch(entries)? {
+        // Git resolves missing partial-clone objects through legacy exact-OID
+        // fetches. The catalog planner below authorizes every object against
+        // visible ref closure before generating or returning pack bytes.
+        fetch_promisor_objects(store, router.repo_prefix(), entries, config, cancel).await?;
+        return Ok(None);
+    }
+
     let snapshot = crate::metadata::manifest::read_repository_snapshot(store, router).await?;
     let manifest = snapshot.materialized_manifest();
 
@@ -2194,25 +2203,6 @@ async fn fetch_packs(
         config.download_concurrency,
     ));
 
-    let raw_object_count = entries
-        .iter()
-        .filter(|entry| entry.sha == entry.ref_name)
-        .count();
-    if raw_object_count > 0 {
-        if raw_object_count != entries.len() {
-            return Err(CrabError::Protocol(
-                "raw object fetches cannot be mixed with ref fetches".to_owned(),
-            ));
-        }
-    }
-
-    // Upload-pack policy gate. Raw-SHA `fetch <sha> <ref>` lines
-    // must be validated before we hand the client back any pack
-    // bytes, otherwise a client can ask for an arbitrary interior
-    // commit SHA and receive its pack data — the same
-    // information-leak vector that git's
-    // `uploadpack.allow*SHA1InWant` knobs were added to cover.
-    //
     // A rejected entry produces a per-entry `error {ref}
     // {protocol-tag} ({detail})` line on the writer (matching the
     // push response shape), but does not fail the batch. If every
@@ -2260,11 +2250,6 @@ async fn fetch_packs(
             writer.flush().await?;
             return Ok(None);
         }
-    }
-
-    if raw_object_count > 0 {
-        fetch_promisor_objects(store, router.repo_prefix(), entries, config, cancel).await?;
-        return Ok(None);
     }
 
     let git_dir = super::discover::discover_git_dir()?;
@@ -2393,6 +2378,19 @@ async fn fetch_packs(
         &manifest.git_validation_digest,
     )
     .await
+}
+
+fn classify_raw_object_fetch(entries: &[FetchEntry]) -> Result<bool> {
+    let raw_object_count = entries
+        .iter()
+        .filter(|entry| entry.sha == entry.ref_name)
+        .count();
+    if raw_object_count > 0 && raw_object_count != entries.len() {
+        return Err(CrabError::Protocol(
+            "raw object fetches cannot be mixed with ref fetches".to_owned(),
+        ));
+    }
+    Ok(raw_object_count > 0)
 }
 
 async fn try_fetch_exact_shallow_closure(
@@ -4855,6 +4853,60 @@ mod tests {
             matches!(result, Err(CrabError::Protocol(message)) if message == "filtered fetch requires protocol v2")
         );
         assert!(writer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn legacy_filtered_promisor_fetch_reaches_store_boundary() {
+        let options = HelperOptions {
+            filter_requested: true,
+            ..HelperOptions::default()
+        };
+        let mut cache = SessionCache::new(crate::core::config::Config::default());
+        let mut writer = Vec::new();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let oid = "a".repeat(40);
+        let entries = vec![FetchEntry {
+            sha: oid.clone(),
+            ref_name: oid,
+        }];
+
+        dispatch_fetch_batch_with_selector(
+            &entries,
+            &options,
+            &mut writer,
+            None,
+            "org/repo",
+            &mut cache,
+            Some("crab://bucket/org/repo"),
+            None,
+            &cancel,
+            |_, _, _| async { Err(CrabError::Internal("selector must not run".into())) },
+        )
+        .await
+        .expect("promisor fetch reaches the store boundary");
+
+        assert_eq!(writer, b"\n");
+    }
+
+    #[test]
+    fn raw_object_fetches_cannot_be_mixed_with_ref_fetches() {
+        let oid = "a".repeat(40);
+        let entries = vec![
+            FetchEntry {
+                sha: oid.clone(),
+                ref_name: oid,
+            },
+            FetchEntry {
+                sha: "b".repeat(40),
+                ref_name: "refs/heads/main".to_owned(),
+            },
+        ];
+
+        let result = classify_raw_object_fetch(&entries);
+
+        assert!(
+            matches!(result, Err(CrabError::Protocol(message)) if message == "raw object fetches cannot be mixed with ref fetches")
+        );
     }
 
     // --- option atomic parsing ---

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -34,7 +34,9 @@ use crate::core::error::{CrabError, Result};
 use crate::storage::retry::{RetryClass, retry_class};
 
 const MAX_PACKET_BYTES: usize = 65_520;
-const MAX_REQUEST_PACKETS: usize = 4_096;
+// Git batches promised-object wants for partial clones, so large trees can
+// legitimately exceed 4K lines. The byte limit remains the allocation bound.
+const MAX_REQUEST_PACKETS: usize = 65_536;
 const MAX_REQUEST_BYTES: usize = 4 * 1024 * 1024;
 const LOCATOR_READ_REPAIR_LOCK_TTL: Duration = Duration::from_secs(30);
 const LOCATOR_READ_RETRY_LIMIT: usize = 120;
@@ -638,7 +640,7 @@ fn validate_fetch_wants(
     for want in &request.wants {
         if policy.allow_any_sha_in_want
             || (policy.allow_tip_sha_in_want && advertised_tips.contains(want))
-            || (policy.allow_reachable_sha_in_want
+            || (visible_reachable_wants_allowed(request, policy)
                 && want.as_bytes().try_into().ok().is_some_and(|oid| {
                     visibility.contains_for_refs(visible_ref_names.iter().map(String::as_str), &oid)
                 }))
@@ -668,7 +670,7 @@ async fn validate_fetch_admission_catalog(
         .flat_map(|reference| [Some(reference.target), reference.peeled])
         .flatten()
         .collect::<HashSet<_>>();
-    let reachable = if policy.allow_reachable_sha_in_want {
+    let reachable = if visible_reachable_wants_allowed(request, policy) {
         let operation = repository
             .operation(crab_remote_git::OperationKind::UploadPack, cancellation)
             .await
@@ -705,6 +707,13 @@ async fn validate_fetch_admission_catalog(
         )));
     }
     Ok(())
+}
+
+fn visible_reachable_wants_allowed(request: &FetchRequest, policy: &FetchAdmissionPolicy) -> bool {
+    // Partial-clone clients must request promised interior objects by OID.
+    // Filtered requests remain bounded by the generation-pinned visible-ref
+    // catalog, so they do not need the general raw-SHA policy opt-in.
+    policy.allow_reachable_sha_in_want || !matches!(&request.filter, UploadPackFilter::None)
 }
 
 async fn open_repository_with_visibility_requirement(
@@ -2155,6 +2164,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn command_request_accepts_large_promisor_want_batch() {
+        let mut bytes = packet(b"command=fetch\n");
+        bytes.extend_from_slice(b"0001");
+        for index in 0..10_000 {
+            bytes.extend_from_slice(&packet(format!("want {index:040x}\n").as_bytes()));
+        }
+        bytes.extend_from_slice(&packet(b"filter blob:none\n"));
+        bytes.extend_from_slice(&packet(b"done\n"));
+        bytes.extend_from_slice(b"0000");
+        let mut reader = BufReader::new(Cursor::new(bytes));
+        let cancellation = CancellationToken::new();
+
+        let request = read_command_request(&mut reader, &cancellation)
+            .await
+            .expect("large promisor request should stay within the byte bound")
+            .expect("request should be present");
+        assert_eq!(request.args.len(), 10_002);
+    }
+
+    #[tokio::test]
     async fn request_byte_limit_is_enforced_before_flush() {
         let mut bytes = packet(b"command=ls-refs\n");
         bytes.extend_from_slice(b"0001");
@@ -2232,6 +2261,72 @@ mod tests {
             &FetchAdmissionPolicy::default(),
         )
         .expect_err("a reachable non-tip want must be denied without opt-in");
+
+        assert!(error.to_string().contains("denied by upload-pack policy"));
+    }
+
+    #[test]
+    fn filtered_reachable_non_tip_want_is_accepted_by_default() {
+        let blob = parse_oid(&"a".repeat(40)).expect("blob oid");
+        let tip = parse_oid(&"b".repeat(40)).expect("tip oid");
+        let request = FetchRequest {
+            wants: vec![blob],
+            filter: UploadPackFilter::BlobNone,
+            ..FetchRequest::default()
+        };
+        let visible_refs = vec!["refs/heads/main".to_owned()];
+        let visibility = GitVisibilityIndex::new(
+            1,
+            "c".repeat(64),
+            "d".repeat(64),
+            std::collections::BTreeMap::from([(
+                visible_refs[0].clone(),
+                vec![blob.to_string(), tip.to_string()],
+            )]),
+        )
+        .expect("valid visibility proof");
+
+        let result = validate_fetch_wants(
+            &HashSet::from([tip]),
+            &visibility,
+            &visible_refs,
+            &request,
+            &FetchAdmissionPolicy::default(),
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn filtered_reachable_non_tip_want_outside_visible_ref_closure_is_denied() {
+        let hidden_blob = parse_oid(&"a".repeat(40)).expect("hidden blob oid");
+        let visible_blob = parse_oid(&"b".repeat(40)).expect("visible blob oid");
+        let tip = parse_oid(&"c".repeat(40)).expect("tip oid");
+        let request = FetchRequest {
+            wants: vec![hidden_blob],
+            filter: UploadPackFilter::BlobNone,
+            ..FetchRequest::default()
+        };
+        let visible_refs = vec!["refs/heads/main".to_owned()];
+        let visibility = GitVisibilityIndex::new(
+            1,
+            "d".repeat(64),
+            "e".repeat(64),
+            std::collections::BTreeMap::from([(
+                visible_refs[0].clone(),
+                vec![visible_blob.to_string(), tip.to_string()],
+            )]),
+        )
+        .expect("valid visibility proof");
+
+        let error = validate_fetch_wants(
+            &HashSet::from([tip]),
+            &visibility,
+            &visible_refs,
+            &request,
+            &FetchAdmissionPolicy::default(),
+        )
+        .expect_err("objects outside visible ref closure must remain denied");
 
         assert!(error.to_string().contains("denied by upload-pack policy"));
     }

--- a/crates/crab-vfs/Cargo.toml
+++ b/crates/crab-vfs/Cargo.toml
@@ -30,6 +30,7 @@ crab-types = { workspace = true }
 crab-xet = { workspace = true }
 dashmap = "6"
 fuser = { version = "0.17", optional = true }
+fs4 = "0.13"
 gix-hash = { workspace = true, features = ["sha1"] }
 gix-object = { workspace = true }
 gix-odb = { workspace = true, features = ["sha1"] }

--- a/crates/crab-vfs/src/engine.rs
+++ b/crates/crab-vfs/src/engine.rs
@@ -24,7 +24,7 @@ use crate::core::error::{CrabError, Result};
 use crate::hydration::{HydrationReadStatsSnapshot, HydrationService};
 use crate::resolver::{FuseResolver, OverlayEntry, ResolvedNode};
 use crate::snapshot::{BaseNode, NodeType, SnapshotStore};
-use crab_types::pointer::{Pointer, hex_encode};
+use crab_types::pointer::{Pointer, hex_encode, is_pointer};
 
 // ---------------------------------------------------------------------------
 // OverlayWriter trait
@@ -666,20 +666,10 @@ impl VfsReadLease {
 
 #[derive(Debug)]
 enum ReadSource {
-    BasePointer {
-        path: String,
-        pointer: Pointer,
-    },
-    BaseBlob {
-        path: String,
-        oid: String,
-        known_size: Option<u64>,
-    },
+    BasePointer { path: String, pointer: Pointer },
+    BaseBlob { path: String, oid: String },
     BaseEmpty,
-    OverlayFile {
-        path: String,
-        backing: PathBuf,
-    },
+    OverlayFile { path: String, backing: PathBuf },
 }
 
 impl ReadSource {
@@ -1231,27 +1221,53 @@ impl VfsEngine {
         match self.resolver.resolve_path(path)? {
             ResolvedNode::Overlay(entry) => Ok(entry.size),
             ResolvedNode::Base(base) => {
+                let base = self.classify_unknown_base_node(path, base)?;
                 if let Some(pointer) = base.pointer {
                     return Ok(pointer.size);
                 }
                 if base.size != 0 || base.node_type != NodeType::File {
                     return Ok(base.size);
                 }
-                let Some(oid) = base.object_oid else {
-                    return Ok(0);
-                };
-                let reader = self.odb_reader.as_ref().ok_or_else(|| {
-                    CrabError::Internal(format!(
+                if base.object_oid.is_some() && self.odb_reader.is_none() {
+                    return Err(CrabError::Internal(format!(
                         "no ODB reader configured for size lookup of {path}"
-                    ))
-                })?;
-                let size = reader.read_blob(&oid)?.len() as u64;
-                if let Some(snapshot) = &self.snapshot {
-                    snapshot.update_node_size(self.resolver.generation(), path, size)?;
+                    )));
                 }
-                Ok(size)
+                Ok(base.size)
             }
         }
+    }
+
+    fn classify_unknown_base_node(&self, path: &str, mut base: BaseNode) -> Result<BaseNode> {
+        if base.node_type != NodeType::File
+            || base.size != 0
+            || base.pointer.is_some()
+            || base.object_oid.is_none()
+        {
+            return Ok(base);
+        }
+        let oid = base.object_oid.as_deref().ok_or_else(|| {
+            CrabError::Internal(format!(
+                "missing OID while classifying fetched blob at {path}"
+            ))
+        })?;
+        let Some(reader) = self.odb_reader.as_ref() else {
+            return Ok(base);
+        };
+        let blob = reader.read_blob(oid)?;
+        let (size, pointer) = if let Some(snapshot) = &self.snapshot {
+            snapshot.update_node_from_blob(self.resolver.generation(), path, &blob)?
+        } else if is_pointer(&blob) {
+            let pointer = Pointer::parse(&blob).map_err(|error| {
+                CrabError::Internal(format!("invalid Crab pointer at {path}: {error}"))
+            })?;
+            (pointer.size, Some(pointer))
+        } else {
+            (blob.len() as u64, None)
+        };
+        base.size = size;
+        base.pointer = pointer;
+        Ok(base)
     }
 
     /// Flush overlay data and metadata for protocols with explicit commit semantics.
@@ -1333,6 +1349,7 @@ impl VfsEngine {
         let overlay_version = self.overlay_view_version_for_path(&path);
         match node {
             ResolvedNode::Base(base) => {
+                let base = self.classify_unknown_base_node(&path, base)?;
                 Ok(self.open_base_read(path, generation, overlay_version, base))
             }
             ResolvedNode::Overlay(_) => {
@@ -1379,11 +1396,7 @@ impl VfsEngine {
                 object_oid: oid.clone(),
                 known_size,
             };
-            let source = ReadSource::BaseBlob {
-                path,
-                oid,
-                known_size,
-            };
+            let source = ReadSource::BaseBlob { path, oid };
             return VfsReadLease::new(key, source);
         }
 
@@ -1425,11 +1438,7 @@ impl VfsEngine {
                 }
                 result
             }
-            ReadSource::BaseBlob {
-                path,
-                oid,
-                known_size,
-            } => {
+            ReadSource::BaseBlob { path, oid } => {
                 let Some(ref reader) = self.odb_reader else {
                     return Err(CrabError::Internal(format!(
                         "no ODB reader configured for small-file read of {path}"
@@ -1443,9 +1452,6 @@ impl VfsEngine {
                     "reading small file from ODB"
                 );
                 let data = reader.read_blob_range(oid, offset, size)?;
-                if known_size.is_none() {
-                    self.on_hydrated(path, oid);
-                }
                 Ok(data)
             }
             ReadSource::BaseEmpty => Ok(Bytes::new()),
@@ -1773,43 +1779,6 @@ impl VfsEngine {
     }
 
     // -----------------------------------------------------------------------
-    // Size backfill after hydration
-    // -----------------------------------------------------------------------
-
-    /// Callback invoked after a small file is read from the ODB for the
-    /// first time. If the snapshot node's size was zero (unknown at tree
-    /// walk time), updates it with the actual blob size.
-    fn on_hydrated(&self, path: &str, oid: &str) {
-        let (Some(snapshot), Some(reader)) = (&self.snapshot, &self.odb_reader) else {
-            return;
-        };
-
-        let generation = self.resolver.generation();
-
-        // Read the full blob to get its actual size.
-        let blob_size = match reader.read_blob(oid) {
-            Ok(blob) => blob.len() as u64,
-            Err(e) => {
-                warn!(path, oid, error = %e, "size backfill: failed to read blob");
-                return;
-            }
-        };
-
-        if blob_size == 0 {
-            return;
-        }
-
-        if let Err(e) = snapshot.update_node_size(generation, path, blob_size) {
-            warn!(
-                path,
-                generation,
-                error = %e,
-                "size backfill: failed to update node size"
-            );
-        }
-    }
-
-    // -----------------------------------------------------------------------
     // Speculative prefetch
     // -----------------------------------------------------------------------
 
@@ -1999,6 +1968,7 @@ impl VfsEngine {
         path: &str,
         ov: &dyn OverlayWriter,
     ) -> Result<()> {
+        let base = self.classify_unknown_base_node(path, base.clone())?;
         match base.node_type {
             NodeType::Dir => {
                 // Directories don't need content promotion.
@@ -2008,7 +1978,7 @@ impl VfsEngine {
             NodeType::File => {
                 if let Some(ref pointer) = base.pointer {
                     // Large file: stream chunks directly to disk.
-                    let source_oid = base_source_oid(base);
+                    let source_oid = base_source_oid(&base);
                     debug!(
                         path,
                         size = pointer.size,
@@ -2859,6 +2829,47 @@ mod tests {
             }
         );
         assert_eq!(lease.known_size(), Some(pointer.size));
+    }
+
+    #[test]
+    fn unknown_pointer_blob_is_classified_before_direct_read() {
+        let pointer = crab_types::pointer::Pointer {
+            file_hash: [9; 32],
+            size: 64 * 1024 * 1024,
+            shard_hint: Some([4; 32]),
+        };
+        let (odb_root, git_dir, oid) = create_git_repo_with_blob(&pointer.serialize());
+        let mut fixture = test_engine_with_nodes(vec![BaseNode {
+            path: "model.bin".to_owned(),
+            node_type: NodeType::File,
+            mode: 0o100644,
+            object_oid: Some(oid),
+            pointer: None,
+            size: 0,
+        }]);
+        let reader = OdbReader::new(&git_dir, &odb_root.path().join("blob-cache")).unwrap();
+        Arc::get_mut(&mut fixture.engine).unwrap().odb_reader = Some(reader);
+
+        let lease = fixture.engine.open_read("model.bin").unwrap();
+
+        assert_eq!(
+            lease.key(),
+            &ReadSourceKey::BasePointer {
+                generation: 1,
+                overlay_version: 0,
+                file_hash: pointer.file_hash,
+                size: pointer.size,
+            }
+        );
+        let classified = fixture
+            .engine
+            .snapshot
+            .as_ref()
+            .unwrap()
+            .get_node(1, "model.bin")
+            .unwrap()
+            .unwrap();
+        assert_eq!(classified.pointer, Some(pointer));
     }
 
     #[test]

--- a/crates/crab-vfs/src/overlay.rs
+++ b/crates/crab-vfs/src/overlay.rs
@@ -8,10 +8,12 @@
 //! The store implements both [`OverlayLookup`] (read side, used by the
 //! resolver) and [`OverlayWriter`] (write side, used by the engine).
 
+use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use fs4::fs_std::FileExt as LockFileExt;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use tracing::{debug, trace, warn};
 
@@ -42,11 +44,11 @@ const MIGRATIONS: &[&str] = &[
 
 /// SQLite-backed copy-on-write overlay store.
 ///
-/// Thread safety: `rusqlite::Connection` is `!Send`, so we wrap it in a
-/// `Mutex` to allow shared access from multiple FUSE threads.
+/// Thread safety: SQLite metadata access is serialized, while independent
+/// backing-file mutations share a publish lease and may run concurrently.
 pub struct OverlayStore {
     db: Mutex<Connection>,
-    freeze_lock: Mutex<()>,
+    publish_lock: RwLock<()>,
     upper_dir: PathBuf,
 }
 
@@ -86,7 +88,7 @@ impl OverlayStore {
 
         let store = Self {
             db: Mutex::new(conn),
-            freeze_lock: Mutex::new(()),
+            publish_lock: RwLock::new(()),
             upper_dir: upper_dir.to_path_buf(),
         };
 
@@ -334,32 +336,18 @@ impl OverlayStore {
         Ok(records)
     }
 
-    /// Return whether writes are currently frozen for this overlay.
-    pub fn is_frozen(&self) -> bool {
-        self.freeze_marker_path().exists()
-    }
-
     /// Freeze writes to this overlay until the returned guard is dropped.
+    ///
+    /// The exclusive lease spans processes and waits for mutations that
+    /// already hold shared leases to finish.
     pub fn freeze_writes(&self) -> Result<OverlayFreezeGuard<'_>> {
-        let guard = self.freeze_lock.lock().map_err(|_| lock_poisoned())?;
-        let marker = self.freeze_marker_path();
-        if let Some(parent) = marker.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&marker)
-        {
-            Ok(_) => Ok(OverlayFreezeGuard {
-                marker,
-                _guard: guard,
-            }),
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(CrabError::Forbidden {
-                path: "overlay is already frozen by another publish operation".into(),
-            }),
-            Err(e) => Err(CrabError::Io(e)),
-        }
+        let guard = self.publish_lock.write().map_err(|_| lock_poisoned())?;
+        let lock_file = self.open_publish_lock()?;
+        LockFileExt::lock_exclusive(&lock_file).map_err(CrabError::Io)?;
+        Ok(OverlayFreezeGuard {
+            _lock_file: lock_file,
+            _guard: guard,
+        })
     }
 
     /// Reconcile the overlay against a new base snapshot.
@@ -484,37 +472,47 @@ impl OverlayStore {
         self.upper_dir.join(clean_path(path))
     }
 
-    fn freeze_marker_path(&self) -> PathBuf {
+    fn publish_lock_path(&self) -> PathBuf {
         self.upper_dir.parent().map_or_else(
-            || self.upper_dir.join("publish.freeze"),
-            |parent| parent.join("publish.freeze"),
+            || self.upper_dir.join("publish.lock"),
+            |parent| parent.join("publish.lock"),
         )
     }
 
-    fn ensure_not_frozen(&self) -> Result<()> {
-        if self.is_frozen() {
-            return Err(CrabError::Forbidden {
-                path: "overlay writes are frozen during publish".into(),
-            });
+    fn open_publish_lock(&self) -> Result<File> {
+        let path = self.publish_lock_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
         }
-        Ok(())
+        std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)
+            .map_err(CrabError::Io)
     }
 
     fn begin_write(&self) -> Result<OverlayWriteGuard<'_>> {
-        let guard = match self.freeze_lock.try_lock() {
+        let guard = match self.publish_lock.try_read() {
             Ok(guard) => guard,
-            Err(std::sync::TryLockError::WouldBlock) if self.is_frozen() => {
+            Err(std::sync::TryLockError::WouldBlock) => {
                 return Err(CrabError::Forbidden {
                     path: "overlay writes are frozen during publish".into(),
                 });
             }
-            Err(std::sync::TryLockError::WouldBlock) => {
-                self.freeze_lock.lock().map_err(|_| lock_poisoned())?
-            }
             Err(std::sync::TryLockError::Poisoned(_)) => return Err(lock_poisoned()),
         };
-        self.ensure_not_frozen()?;
-        Ok(OverlayWriteGuard { _guard: guard })
+        let lock_file = self.open_publish_lock()?;
+        if !LockFileExt::try_lock_shared(&lock_file).map_err(CrabError::Io)? {
+            return Err(CrabError::Forbidden {
+                path: "overlay writes are frozen during publish".into(),
+            });
+        }
+        Ok(OverlayWriteGuard {
+            _lock_file: lock_file,
+            _guard: guard,
+        })
     }
 
     /// Current time in nanoseconds since epoch.
@@ -758,19 +756,13 @@ fn raw_entry_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawEntry> {
 }
 
 struct OverlayWriteGuard<'a> {
-    _guard: std::sync::MutexGuard<'a, ()>,
+    _lock_file: File,
+    _guard: std::sync::RwLockReadGuard<'a, ()>,
 }
 
-/// Removes the overlay write-freeze marker when dropped.
 pub struct OverlayFreezeGuard<'a> {
-    marker: PathBuf,
-    _guard: std::sync::MutexGuard<'a, ()>,
-}
-
-impl Drop for OverlayFreezeGuard<'_> {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.marker);
-    }
+    _lock_file: File,
+    _guard: std::sync::RwLockWriteGuard<'a, ()>,
 }
 
 // ---------------------------------------------------------------------------
@@ -847,7 +839,6 @@ impl OverlayWriter for OverlayStore {
         std::fs::write(&backing, [])?;
         set_path_permissions(&backing, mode)?;
 
-        self.ensure_not_frozen()?;
         let now = Self::now_ns();
         let db = self.db.lock().map_err(|_| lock_poisoned())?;
         Self::upsert_entry(
@@ -885,7 +876,6 @@ impl OverlayWriter for OverlayStore {
         // symlinks are stored as blob content containing the target path).
         std::fs::write(&backing, target.as_bytes())?;
 
-        self.ensure_not_frozen()?;
         let now = Self::now_ns();
         let db = self.db.lock().map_err(|_| lock_poisoned())?;
         Self::upsert_entry(
@@ -964,7 +954,6 @@ impl OverlayWriter for OverlayStore {
         // first to guard against a concurrent delete or modify race between
         // Phase 1 and now.
         {
-            self.ensure_not_frozen()?;
             let db = self.db.lock().map_err(|_| lock_poisoned())?;
             let current = Self::query_entry(&db, &path)?;
             match current {
@@ -1022,7 +1011,6 @@ impl OverlayWriter for OverlayStore {
         let now = Self::now_ns();
         let oid = source_oid.unwrap_or("");
 
-        self.ensure_not_frozen()?;
         let db = self.db.lock().map_err(|_| lock_poisoned())?;
         Self::upsert_entry(
             &db,
@@ -1059,7 +1047,6 @@ impl OverlayWriter for OverlayStore {
             let _ = std::fs::remove_file(&backing);
         }
 
-        self.ensure_not_frozen()?;
         let now = Self::now_ns();
         let db = self.db.lock().map_err(|_| lock_poisoned())?;
         if let Some(row) = Self::query_rename_row(&db, &path)?
@@ -1304,7 +1291,6 @@ impl OverlayWriter for OverlayStore {
         let backing = self.backing_path(&path);
         std::fs::create_dir_all(&backing)?;
 
-        self.ensure_not_frozen()?;
         let now = Self::now_ns();
         let db = self.db.lock().map_err(|_| lock_poisoned())?;
         Self::upsert_entry(
@@ -1343,7 +1329,6 @@ impl OverlayWriter for OverlayStore {
             })?;
         }
 
-        self.ensure_not_frozen()?;
         let now = Self::now_ns();
         let db = self.db.lock().map_err(|_| lock_poisoned())?;
         if let Some(row) = Self::query_rename_row(&db, &path)?
@@ -1435,7 +1420,6 @@ impl OverlayWriter for OverlayStore {
         let oid = source_oid.unwrap_or("");
         set_path_permissions(&backing, mode)?;
 
-        self.ensure_not_frozen()?;
         let db = self.db.lock().map_err(|_| lock_poisoned())?;
         Self::upsert_entry(
             &db,
@@ -1730,33 +1714,67 @@ mod tests {
     }
 
     #[test]
-    fn freeze_waits_for_in_flight_overlay_mutation() {
+    fn independent_overlay_mutations_share_the_publish_lease() {
         let (_dir, store) = temp_store();
         let store = std::sync::Arc::new(store);
-        let freezer_store = std::sync::Arc::clone(&store);
+        let second_store = std::sync::Arc::clone(&store);
+        let first = store.begin_write().unwrap();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let second = std::thread::spawn(move || {
+            let guard = second_store.begin_write().unwrap();
+            acquired_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            drop(guard);
+        });
+
+        acquired_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        release_tx.send(()).unwrap();
+        second.join().unwrap();
+        drop(first);
+    }
+
+    #[test]
+    fn freeze_waits_for_in_flight_mutations_across_store_handles() {
+        let (dir, store) = temp_store();
+        let store = std::sync::Arc::new(store);
+        let freezer_store = std::sync::Arc::new(
+            OverlayStore::open(&dir.path().join("overlay.db"), &dir.path().join("upper")).unwrap(),
+        );
         let write_guard = store.begin_write().unwrap();
         let (attempted_tx, attempted_rx) = std::sync::mpsc::channel();
         let (frozen_tx, frozen_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
 
         let freezer = std::thread::spawn(move || {
             attempted_tx.send(()).unwrap();
             let freeze = freezer_store.freeze_writes().unwrap();
-            frozen_tx.send(freezer_store.is_frozen()).unwrap();
+            frozen_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
             drop(freeze);
         });
 
         attempted_rx.recv().unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        assert!(frozen_rx.try_recv().is_err());
-
-        drop(write_guard);
         assert!(
             frozen_rx
-                .recv_timeout(std::time::Duration::from_secs(1))
-                .unwrap()
+                .recv_timeout(std::time::Duration::from_millis(50))
+                .is_err()
         );
+
+        drop(write_guard);
+        frozen_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        assert!(matches!(
+            store.begin_write(),
+            Err(CrabError::Forbidden { .. })
+        ));
+        release_tx.send(()).unwrap();
         freezer.join().unwrap();
-        assert!(!store.is_frozen());
+        store.begin_write().unwrap();
     }
 
     #[test]

--- a/crates/crab-vfs/src/publish.rs
+++ b/crates/crab-vfs/src/publish.rs
@@ -297,299 +297,314 @@ pub fn commit_overlay_with_snapshot(
     };
     write_transaction(&options.cache_dir, &transaction)?;
 
-    if records.is_empty() {
-        let cleaned_ignored = if all_records.is_empty() {
-            false
-        } else {
-            store.clear()?;
-            true
-        };
-        if options.push {
-            let commit_oid = push_current_ref(options).inspect_err(|error| {
-                set_transaction_status(&mut transaction, "failed");
-                transaction.error = Some(error.to_string());
-                let _ = write_transaction(&options.cache_dir, &transaction);
-            })?;
-            transaction.commit_oid = Some(commit_oid.clone());
-            transaction.pushed = true;
-            set_transaction_status(&mut transaction, "pushed_cleaned");
+    let result = (|| {
+        if records.is_empty() {
+            let cleaned_ignored = if all_records.is_empty() {
+                false
+            } else {
+                store.clear()?;
+                true
+            };
+            if options.push {
+                let commit_oid = push_current_ref(options).inspect_err(|error| {
+                    set_transaction_status(&mut transaction, "failed");
+                    transaction.error = Some(error.to_string());
+                    let _ = write_transaction(&options.cache_dir, &transaction);
+                })?;
+                transaction.commit_oid = Some(commit_oid.clone());
+                transaction.pushed = true;
+                set_transaction_status(&mut transaction, "pushed_cleaned");
+                write_transaction(&options.cache_dir, &transaction)?;
+                return Ok(OverlayCommitResult {
+                    transaction_id,
+                    commit_oid: Some(commit_oid),
+                    pushed: true,
+                    overlay_cleaned: cleaned_ignored,
+                    diff,
+                });
+            }
+            set_transaction_status(&mut transaction, "empty");
             write_transaction(&options.cache_dir, &transaction)?;
             return Ok(OverlayCommitResult {
                 transaction_id,
-                commit_oid: Some(commit_oid),
-                pushed: true,
+                commit_oid: None,
+                pushed: false,
                 overlay_cleaned: cleaned_ignored,
                 diff,
             });
         }
-        set_transaction_status(&mut transaction, "empty");
-        write_transaction(&options.cache_dir, &transaction)?;
-        return Ok(OverlayCommitResult {
-            transaction_id,
-            commit_oid: None,
-            pushed: false,
-            overlay_cleaned: cleaned_ignored,
-            diff,
-        });
-    }
 
-    if let Some(base_oid) = transaction.base_oid.clone() {
-        let current_oid = rev_parse(&options.git_dir, &options.ref_name)?;
-        if current_oid != base_oid {
-            if let Some(result) = try_finalize_recorded_publish(
-                &options.cache_dir,
-                &paths,
-                &options.git_dir,
-                &options.ref_name,
-                &current_oid,
-                &overlay_fingerprint,
-                &diff,
-                snapshot,
-            )? {
-                set_transaction_status(&mut transaction, "recovered_existing");
-                transaction.commit_oid.clone_from(&result.commit_oid);
-                transaction.pushed = result.pushed;
+        if let Some(base_oid) = transaction.base_oid.clone() {
+            let current_oid = rev_parse(&options.git_dir, &options.ref_name)?;
+            if current_oid != base_oid {
+                if let Some(result) = try_finalize_recorded_publish(
+                    &options.cache_dir,
+                    &paths,
+                    &options.git_dir,
+                    &options.ref_name,
+                    &current_oid,
+                    &overlay_fingerprint,
+                    &diff,
+                    snapshot,
+                )? {
+                    set_transaction_status(&mut transaction, "recovered_existing");
+                    transaction.commit_oid.clone_from(&result.commit_oid);
+                    transaction.pushed = result.pushed;
+                    write_transaction(&options.cache_dir, &transaction)?;
+                    return Ok(result);
+                }
+                set_transaction_status(&mut transaction, "failed");
+                transaction.error = Some(format!(
+                    "base ref moved from {base_oid} to {current_oid}; refresh or remount before committing overlay changes"
+                ));
                 write_transaction(&options.cache_dir, &transaction)?;
-                return Ok(result);
+                return Err(CrabError::Internal(
+                    transaction.error.clone().unwrap_or_default(),
+                ));
             }
-            set_transaction_status(&mut transaction, "failed");
-            transaction.error = Some(format!(
-                "base ref moved from {base_oid} to {current_oid}; refresh or remount before committing overlay changes"
-            ));
-            write_transaction(&options.cache_dir, &transaction)?;
-            return Err(CrabError::Internal(
-                transaction.error.clone().unwrap_or_default(),
-            ));
         }
-    }
 
-    let mut worktree = PublishWorktree::create(&options.git_dir)?;
-    let base = transaction
-        .base_oid
-        .clone()
-        .unwrap_or_else(|| options.ref_name.clone());
-    run_git(
-        Command::new("git")
-            .arg("--git-dir")
-            .arg(&options.git_dir)
-            .args(["worktree", "add", "--detach", "--no-checkout"])
-            .arg(worktree.path())
-            .arg(&base),
-        "git worktree add",
-    )
-    .inspect_err(|e| {
-        set_transaction_status(&mut transaction, "failed");
-        transaction.error = Some(e.to_string());
-        let _ = write_transaction(&options.cache_dir, &transaction);
-    })?;
-    worktree.mark_registered();
-
-    run_git(
-        Command::new("git")
-            .arg("-C")
-            .arg(worktree.path())
-            .args(["read-tree", &base]),
-        "git read-tree",
-    )?;
-
-    ensure_git_commit_identity(worktree.path()).inspect_err(|e| {
-        set_transaction_status(&mut transaction, "failed");
-        transaction.error = Some(e.to_string());
-        let _ = write_transaction(&options.cache_dir, &transaction);
-    })?;
-
-    let applied_base_renames = apply_metadata_base_renames(&records, worktree.path())?;
-    materialize_git_policy_files(worktree.path())?;
-    if overlay_changes_git_attributes(&records) {
-        let attribute_records = records
-            .iter()
-            .filter(|record| is_git_attributes_path(&record.path))
-            .cloned()
-            .collect::<Vec<_>>();
-        apply_records(
-            &attribute_records,
-            worktree.path(),
-            &std::collections::HashSet::new(),
-            &applied_base_renames,
-        )?;
-        run_git_add(
-            worktree.path(),
-            &attribute_records,
-            &[],
-            &applied_base_renames,
-        )?;
-    }
-    let crab_files = crab_overlay_files(&records, worktree.path())?;
-    let skipped_crab_paths = crab_files
-        .iter()
-        .map(|file| file.path.clone())
-        .collect::<std::collections::HashSet<_>>();
-
-    if let Err(err) = apply_records(
-        &records,
-        worktree.path(),
-        &skipped_crab_paths,
-        &applied_base_renames,
-    ) {
-        set_transaction_status(&mut transaction, "failed");
-        transaction.error = Some(err.to_string());
-        write_transaction(&options.cache_dir, &transaction)?;
-        return Err(err);
-    }
-
-    run_git_add(
-        worktree.path(),
-        &records,
-        &crab_files,
-        &applied_base_renames,
-    )
-    .inspect_err(|e| {
-        set_transaction_status(&mut transaction, "failed");
-        transaction.error = Some(e.to_string());
-        let _ = write_transaction(&options.cache_dir, &transaction);
-    })?;
-
-    if !crab_files.is_empty() {
-        let pointer_entries =
-            stage_crab_overlay_files(&crab_files, worktree.path(), &options.git_dir).inspect_err(
-                |e| {
-                    set_transaction_status(&mut transaction, "failed");
-                    transaction.error = Some(e.to_string());
-                    let _ = write_transaction(&options.cache_dir, &transaction);
-                },
-            )?;
-        if let Err(error) = write_pointer_entries_to_git_index(worktree.path(), &pointer_entries) {
-            if let Err(rollback_error) =
-                rollback_staged_pointer_entries(&options.git_dir, &pointer_entries)
-            {
-                tracing::warn!(
-                    error = %rollback_error,
-                    "failed to roll back mount staging after Git index publication failed"
-                );
-            }
-            set_transaction_status(&mut transaction, "failed");
-            transaction.error = Some(error.to_string());
-            write_transaction(&options.cache_dir, &transaction)?;
-            return Err(error);
-        }
-        if let Err(error) =
-            mark_staged_pointer_entries_published(&options.git_dir, &pointer_entries)
-        {
-            if let Err(rollback_error) =
-                rollback_staged_pointer_entries(&options.git_dir, &pointer_entries)
-            {
-                tracing::warn!(
-                    error = %rollback_error,
-                    "failed to roll back mount staging after batch publication failed"
-                );
-            }
-            set_transaction_status(&mut transaction, "failed");
-            transaction.error = Some(error.to_string());
-            write_transaction(&options.cache_dir, &transaction)?;
-            return Err(error);
-        }
-    }
-
-    let tree_oid = command_stdout(
-        Command::new("git")
-            .arg("-C")
-            .arg(worktree.path())
-            .arg("write-tree"),
-        "git write-tree",
-    )?;
-    let base_tree = rev_parse(&options.git_dir, &format!("{base}^{{tree}}"))?;
-    if tree_oid == base_tree {
-        let error = CrabError::Internal("overlay has no publishable Git changes".into());
-        set_transaction_status(&mut transaction, "failed");
-        transaction.error = Some(error.to_string());
-        write_transaction(&options.cache_dir, &transaction)?;
-        return Err(error);
-    }
-    let commit_oid = command_stdout(
-        Command::new("git")
-            .arg("-C")
-            .arg(worktree.path())
-            .arg("commit-tree")
-            .arg(&tree_oid)
-            .arg("-p")
-            .arg(&base)
-            .arg("-m")
-            .arg(&options.message),
-        "git commit-tree",
-    )
-    .inspect_err(|e| {
-        set_transaction_status(&mut transaction, "failed");
-        transaction.error = Some(e.to_string());
-        let _ = write_transaction(&options.cache_dir, &transaction);
-    })?;
-    transaction.commit_oid = Some(commit_oid.clone());
-    set_transaction_status(&mut transaction, "created");
-    write_transaction(&options.cache_dir, &transaction)?;
-
-    if options.push {
-        let refspec = format!("{commit_oid}:{}", options.ref_name);
+        let mut worktree = PublishWorktree::create(&options.git_dir)?;
+        let base = transaction
+            .base_oid
+            .clone()
+            .unwrap_or_else(|| options.ref_name.clone());
         run_git(
             Command::new("git")
-                .arg("-C")
+                .arg("--git-dir")
+                .arg(&options.git_dir)
+                .args(["worktree", "add", "--detach", "--no-checkout"])
                 .arg(worktree.path())
-                .args(["push", "origin", &refspec]),
-            "git push",
+                .arg(&base),
+            "git worktree add",
         )
         .inspect_err(|e| {
             set_transaction_status(&mut transaction, "failed");
             transaction.error = Some(e.to_string());
             let _ = write_transaction(&options.cache_dir, &transaction);
         })?;
-        set_transaction_status(&mut transaction, "pushed");
-        transaction.pushed = true;
-        write_transaction(&options.cache_dir, &transaction)?;
-    }
+        worktree.mark_registered();
 
-    update_published_ref(
-        &options.git_dir,
-        &options.ref_name,
-        &commit_oid,
-        transaction.base_oid.as_deref(),
-        transaction.pushed,
-    )
-    .inspect_err(|e| {
+        run_git(
+            Command::new("git")
+                .arg("-C")
+                .arg(worktree.path())
+                .args(["read-tree", &base]),
+            "git read-tree",
+        )?;
+
+        ensure_git_commit_identity(worktree.path()).inspect_err(|e| {
+            set_transaction_status(&mut transaction, "failed");
+            transaction.error = Some(e.to_string());
+            let _ = write_transaction(&options.cache_dir, &transaction);
+        })?;
+
+        let applied_base_renames = apply_metadata_base_renames(&records, worktree.path())?;
+        materialize_git_policy_files(worktree.path())?;
+        if overlay_changes_git_attributes(&records) {
+            let attribute_records = records
+                .iter()
+                .filter(|record| is_git_attributes_path(&record.path))
+                .cloned()
+                .collect::<Vec<_>>();
+            apply_records(
+                &attribute_records,
+                worktree.path(),
+                &std::collections::HashSet::new(),
+                &applied_base_renames,
+            )?;
+            run_git_add(
+                worktree.path(),
+                &attribute_records,
+                &[],
+                &applied_base_renames,
+            )?;
+        }
+        let crab_files = crab_overlay_files(&records, worktree.path())?;
+        let skipped_crab_paths = crab_files
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<std::collections::HashSet<_>>();
+
+        if let Err(err) = apply_records(
+            &records,
+            worktree.path(),
+            &skipped_crab_paths,
+            &applied_base_renames,
+        ) {
+            set_transaction_status(&mut transaction, "failed");
+            transaction.error = Some(err.to_string());
+            write_transaction(&options.cache_dir, &transaction)?;
+            return Err(err);
+        }
+
+        run_git_add(
+            worktree.path(),
+            &records,
+            &crab_files,
+            &applied_base_renames,
+        )
+        .inspect_err(|e| {
+            set_transaction_status(&mut transaction, "failed");
+            transaction.error = Some(e.to_string());
+            let _ = write_transaction(&options.cache_dir, &transaction);
+        })?;
+
+        if !crab_files.is_empty() {
+            let pointer_entries =
+                stage_crab_overlay_files(&crab_files, worktree.path(), &options.git_dir)
+                    .inspect_err(|e| {
+                        set_transaction_status(&mut transaction, "failed");
+                        transaction.error = Some(e.to_string());
+                        let _ = write_transaction(&options.cache_dir, &transaction);
+                    })?;
+            if let Err(error) =
+                write_pointer_entries_to_git_index(worktree.path(), &pointer_entries)
+            {
+                if let Err(rollback_error) =
+                    rollback_staged_pointer_entries(&options.git_dir, &pointer_entries)
+                {
+                    tracing::warn!(
+                        error = %rollback_error,
+                        "failed to roll back mount staging after Git index publication failed"
+                    );
+                }
+                set_transaction_status(&mut transaction, "failed");
+                transaction.error = Some(error.to_string());
+                write_transaction(&options.cache_dir, &transaction)?;
+                return Err(error);
+            }
+            if let Err(error) =
+                mark_staged_pointer_entries_published(&options.git_dir, &pointer_entries)
+            {
+                if let Err(rollback_error) =
+                    rollback_staged_pointer_entries(&options.git_dir, &pointer_entries)
+                {
+                    tracing::warn!(
+                        error = %rollback_error,
+                        "failed to roll back mount staging after batch publication failed"
+                    );
+                }
+                set_transaction_status(&mut transaction, "failed");
+                transaction.error = Some(error.to_string());
+                write_transaction(&options.cache_dir, &transaction)?;
+                return Err(error);
+            }
+        }
+
+        let tree_oid = command_stdout(
+            Command::new("git")
+                .arg("-C")
+                .arg(worktree.path())
+                .arg("write-tree"),
+            "git write-tree",
+        )?;
+        let base_tree = rev_parse(&options.git_dir, &format!("{base}^{{tree}}"))?;
+        if tree_oid == base_tree {
+            let error = CrabError::Internal("overlay has no publishable Git changes".into());
+            set_transaction_status(&mut transaction, "failed");
+            transaction.error = Some(error.to_string());
+            write_transaction(&options.cache_dir, &transaction)?;
+            return Err(error);
+        }
+        let commit_oid = command_stdout(
+            Command::new("git")
+                .arg("-C")
+                .arg(worktree.path())
+                .arg("commit-tree")
+                .arg(&tree_oid)
+                .arg("-p")
+                .arg(&base)
+                .arg("-m")
+                .arg(&options.message),
+            "git commit-tree",
+        )
+        .inspect_err(|e| {
+            set_transaction_status(&mut transaction, "failed");
+            transaction.error = Some(e.to_string());
+            let _ = write_transaction(&options.cache_dir, &transaction);
+        })?;
+        transaction.commit_oid = Some(commit_oid.clone());
+        set_transaction_status(&mut transaction, "created");
+        write_transaction(&options.cache_dir, &transaction)?;
+
+        if options.push {
+            let refspec = format!("{commit_oid}:{}", options.ref_name);
+            run_git(
+                Command::new("git")
+                    .arg("-C")
+                    .arg(worktree.path())
+                    .args(["push", "origin", &refspec]),
+                "git push",
+            )
+            .inspect_err(|e| {
+                set_transaction_status(&mut transaction, "failed");
+                transaction.error = Some(e.to_string());
+                let _ = write_transaction(&options.cache_dir, &transaction);
+            })?;
+            set_transaction_status(&mut transaction, "pushed");
+            transaction.pushed = true;
+            write_transaction(&options.cache_dir, &transaction)?;
+        }
+
+        update_published_ref(
+            &options.git_dir,
+            &options.ref_name,
+            &commit_oid,
+            transaction.base_oid.as_deref(),
+            transaction.pushed,
+        )
+        .inspect_err(|e| {
+            set_transaction_status(&mut transaction, "failed");
+            transaction.error = Some(e.to_string());
+            let _ = write_transaction(&options.cache_dir, &transaction);
+        })?;
+
+        if !transaction.pushed {
+            set_transaction_status(&mut transaction, "committed");
+            write_transaction(&options.cache_dir, &transaction)?;
+        }
+
+        if let Err(err) = finalize_committed_overlay(
+            &paths,
+            &options.git_dir,
+            &commit_oid,
+            &options.ref_name,
+            snapshot,
+        ) {
+            set_transaction_status(&mut transaction, "failed");
+            transaction.error = Some(err.to_string());
+            write_transaction(&options.cache_dir, &transaction)?;
+            return Err(err);
+        }
+        let final_status = if transaction.pushed {
+            "pushed_cleaned"
+        } else {
+            "committed_cleaned"
+        };
+        set_transaction_status(&mut transaction, final_status);
+        write_transaction(&options.cache_dir, &transaction)?;
+
+        Ok(OverlayCommitResult {
+            transaction_id,
+            commit_oid: Some(commit_oid),
+            pushed: transaction.pushed,
+            overlay_cleaned: true,
+            diff,
+        })
+    })();
+    if let Err(error) = &result {
         set_transaction_status(&mut transaction, "failed");
-        transaction.error = Some(e.to_string());
-        let _ = write_transaction(&options.cache_dir, &transaction);
-    })?;
-
-    if !transaction.pushed {
-        set_transaction_status(&mut transaction, "committed");
-        write_transaction(&options.cache_dir, &transaction)?;
+        transaction.error = Some(error.to_string());
+        if let Err(write_error) = write_transaction(&options.cache_dir, &transaction) {
+            tracing::warn!(
+                error = %write_error,
+                transaction_id = %transaction.id,
+                "failed to record publish transaction failure"
+            );
+        }
     }
-
-    if let Err(err) = finalize_committed_overlay(
-        &paths,
-        &options.git_dir,
-        &commit_oid,
-        &options.ref_name,
-        snapshot,
-    ) {
-        set_transaction_status(&mut transaction, "failed");
-        transaction.error = Some(err.to_string());
-        write_transaction(&options.cache_dir, &transaction)?;
-        return Err(err);
-    }
-    let final_status = if transaction.pushed {
-        "pushed_cleaned"
-    } else {
-        "committed_cleaned"
-    };
-    set_transaction_status(&mut transaction, final_status);
-    write_transaction(&options.cache_dir, &transaction)?;
-
-    Ok(OverlayCommitResult {
-        transaction_id,
-        commit_oid: Some(commit_oid),
-        pushed: transaction.pushed,
-        overlay_cleaned: true,
-        diff,
-    })
+    result
 }
 
 fn push_current_ref(options: &OverlayCommitOptions) -> Result<String> {
@@ -2481,6 +2496,39 @@ mod tests {
             git_stdout(&retry_remote, ["show", "refs/heads/main:new.txt"]),
             "overlay content"
         );
+    }
+
+    #[test]
+    fn commit_overlay_records_precommit_failure_and_preserves_overlay() {
+        let fixture = GitFixture::new();
+        let cache_dir = fixture.root.path().join("cache");
+        let paths = OverlayPaths::from_cache_dir(&cache_dir);
+        let snapshot = SnapshotStore::open_or_create(&cache_dir.join("snapshot.sqlite")).unwrap();
+        snapshot
+            .publish_generation(&fixture.base_oid, "refs/heads/main", &[])
+            .unwrap();
+        let store = OverlayStore::open(&paths.db_path, &paths.upper_dir).unwrap();
+        store.create_file("new.txt", 0o100644).unwrap();
+        store.write_file("new.txt", 0, b"overlay content").unwrap();
+
+        let error = commit_overlay(&OverlayCommitOptions {
+            cache_dir: cache_dir.clone(),
+            git_dir: fixture.bare_git_dir.clone(),
+            ref_name: "refs/heads/missing".to_owned(),
+            message: "publish overlay".to_owned(),
+            push: false,
+        })
+        .unwrap_err();
+
+        let transactions = read_publish_transactions(&cache_dir).unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].status, "failed");
+        assert_eq!(
+            transactions[0].error.as_deref(),
+            Some(error.to_string().as_str())
+        );
+        assert!(transactions[0].commit_oid.is_none());
+        assert_eq!(inspect_overlay(&paths).unwrap().changes.len(), 1);
     }
 
     #[test]

--- a/crates/crab-vfs/src/snapshot.rs
+++ b/crates/crab-vfs/src/snapshot.rs
@@ -319,10 +319,18 @@ impl SnapshotStore {
         self.get_state(STATE_REF_NAME)
     }
 
-    /// Update a single node's size in the given generation without a full
-    /// republish. Used by the size-backfill callback after hydrating a
-    /// small file whose tree entry had an unknown (zero) size.
-    pub fn update_node_size(&self, generation: i64, path: &str, size: u64) -> Result<()> {
+    /// Classify a fetched blob and update its node without a full republish.
+    ///
+    /// Blobless snapshots cannot distinguish ordinary blobs from Crab
+    /// pointers until Git fetches the object. This updates both logical size
+    /// and pointer metadata atomically once the promised blob is available.
+    pub fn update_node_from_blob(
+        &self,
+        generation: i64,
+        path: &str,
+        blob: &[u8],
+    ) -> Result<(u64, Option<Pointer>)> {
+        let (size, pointer) = classify_blob(path, blob)?;
         let mut conn = self.connection()?;
         let tx = conn.transaction().map_err(map_sqlite_err)?;
         let existing = tx
@@ -337,13 +345,14 @@ impl SnapshotStore {
         let Some(existing) = existing else {
             debug!(
                 generation,
-                path, "update_node_size: node not found, skipping"
+                path, "update_node_from_blob: node not found, skipping"
             );
-            return Ok(());
+            return Ok((size, pointer));
         };
 
         let mut node = deserialize_base_node(&existing)?;
         node.size = size;
+        node.pointer = pointer.clone();
         let value = serialize_base_node(&node);
         tx.execute(
             "UPDATE base_nodes_v1 SET node = ?3 WHERE generation = ?1 AND path = ?2",
@@ -352,8 +361,14 @@ impl SnapshotStore {
         .map_err(map_sqlite_err)?;
         tx.commit().map_err(map_sqlite_err)?;
 
-        debug!(generation, path, size, "backfilled node size");
-        Ok(())
+        debug!(
+            generation,
+            path,
+            size,
+            pointer = pointer.is_some(),
+            "classified fetched blob"
+        );
+        Ok((size, pointer))
     }
 
     fn connection(&self) -> Result<MutexGuard<'_, Connection>> {
@@ -645,12 +660,7 @@ where
                 "tree entry {path} references non-blob object {oid_hex}"
             )));
         }
-        if is_pointer(data.data) {
-            let parsed = Pointer::parse(data.data)
-                .map_err(|e| CrabError::Internal(format!("invalid Crab pointer at {path}: {e}")))?;
-            size = parsed.size;
-            pointer = Some(parsed);
-        }
+        (size, pointer) = classify_blob(&path, data.data)?;
     }
 
     Ok(Some(BaseNode {
@@ -661,6 +671,15 @@ where
         pointer,
         size,
     }))
+}
+
+fn classify_blob(path: &str, blob: &[u8]) -> Result<(u64, Option<Pointer>)> {
+    if !is_pointer(blob) {
+        return Ok((blob.len() as u64, None));
+    }
+    let pointer = Pointer::parse(blob)
+        .map_err(|error| CrabError::Internal(format!("invalid Crab pointer at {path}: {error}")))?;
+    Ok((pointer.size, Some(pointer)))
 }
 
 struct SnapshotTreeVisitor<F> {
@@ -1179,10 +1198,8 @@ mod tests {
         assert_eq!(retrieved.size, 1_048_576);
     }
 
-    // --- update_node_size tests ---
-
     #[test]
-    fn update_node_size_backfills_zero_size() {
+    fn update_node_from_blob_backfills_ordinary_blob_size() {
         let (_dir, store) = temp_store();
         let node = make_file_node("readme.md", 0);
         store
@@ -1194,9 +1211,11 @@ mod tests {
         assert_eq!(before.size, 0);
 
         // Backfill with actual size.
-        store.update_node_size(1, "readme.md", 1234).unwrap();
+        let blob = vec![b'x'; 1234];
+        let result = store.update_node_from_blob(1, "readme.md", &blob).unwrap();
 
         let after = store.get_node(1, "readme.md").unwrap().unwrap();
+        assert_eq!(result, (1234, None));
         assert_eq!(after.size, 1234);
         // Other fields unchanged.
         assert_eq!(after.node_type, NodeType::File);
@@ -1205,30 +1224,58 @@ mod tests {
     }
 
     #[test]
-    fn update_node_size_missing_node_is_noop() {
+    fn update_node_from_blob_records_pointer_logical_size() {
+        let (_dir, store) = temp_store();
+        let node = make_file_node("model.bin", 0);
+        store
+            .publish_generation("aabb", "refs/heads/main", &[node])
+            .unwrap();
+        let pointer = Pointer {
+            file_hash: [7; 32],
+            size: 1_048_576,
+            shard_hint: None,
+        };
+        let blob = pointer.serialize();
+
+        let result = store.update_node_from_blob(1, "model.bin", &blob).unwrap();
+
+        let after = store.get_node(1, "model.bin").unwrap().unwrap();
+        assert_eq!(result, (pointer.size, Some(pointer.clone())));
+        assert_eq!(after.size, pointer.size);
+        assert_eq!(after.pointer, Some(pointer));
+    }
+
+    #[test]
+    fn update_node_from_blob_missing_node_returns_classification() {
         let (_dir, store) = temp_store();
         store
             .publish_generation("aabb", "refs/heads/main", &[make_file_node("a.txt", 10)])
             .unwrap();
 
         // Updating a non-existent path succeeds silently.
-        store.update_node_size(1, "nonexistent.txt", 999).unwrap();
+        let result = store
+            .update_node_from_blob(1, "nonexistent.txt", b"content")
+            .unwrap();
 
         // Original node unchanged.
+        assert_eq!(result, (7, None));
         let node = store.get_node(1, "a.txt").unwrap().unwrap();
         assert_eq!(node.size, 10);
     }
 
     #[test]
-    fn update_node_size_wrong_generation_is_noop() {
+    fn update_node_from_blob_wrong_generation_is_noop() {
         let (_dir, store) = temp_store();
         store
             .publish_generation("aabb", "refs/heads/main", &[make_file_node("a.txt", 0)])
             .unwrap();
 
         // Wrong generation — no update.
-        store.update_node_size(99, "a.txt", 500).unwrap();
+        let result = store
+            .update_node_from_blob(99, "a.txt", &vec![b'x'; 500])
+            .unwrap();
 
+        assert_eq!(result, (500, None));
         let node = store.get_node(1, "a.txt").unwrap().unwrap();
         assert_eq!(node.size, 0);
     }

--- a/packages/web/components/blog/mount-visuals.tsx
+++ b/packages/web/components/blog/mount-visuals.tsx
@@ -1,0 +1,453 @@
+"use client"
+
+import {
+  ArrowDown,
+  ArrowRight,
+  CheckCircle2,
+  Cloud,
+  FileCheck2,
+  FileWarning,
+  GitBranch,
+  HardDrive,
+  Layers3,
+  LockKeyhole,
+  Network,
+  RefreshCcw,
+  ServerCog,
+  UsersRound,
+} from "lucide-react"
+import { useState, type ComponentType } from "react"
+
+import { cn } from "@/lib/utils"
+
+type MountStage = {
+  label: string
+  detail: string
+  state: string
+  changed?: boolean
+}
+
+type MountScene = {
+  id: "read" | "write" | "commit" | "retry"
+  label: string
+  eyebrow: string
+  headline: string
+  command: string
+  note: string
+  stages: MountStage[]
+}
+
+const MOUNT_SCENES: MountScene[] = [
+  {
+    id: "read",
+    label: "Cold read",
+    eyebrow: "01 / RESOLVE",
+    headline: "The first read fetches only the ranges the process asks for.",
+    command: "head -c 65536 /mnt/vision/models/encoder.safetensors",
+    note: "A second read can reuse the verified local range. The Git snapshot never changes.",
+    stages: [
+      { label: "Snapshot", detail: "commit 4f2c", state: "immutable" },
+      { label: "Mounted view", detail: "pointer → recipe", state: "resolve" },
+      {
+        label: "Local state",
+        detail: "+ 64 KiB verified",
+        state: "cache",
+        changed: true,
+      },
+      { label: "Publish", detail: "no transaction", state: "idle" },
+      { label: "Remote", detail: "xorb ranges", state: "unchanged" },
+    ],
+  },
+  {
+    id: "write",
+    label: "First write",
+    eyebrow: "02 / PROMOTE",
+    headline:
+      "The first mutation promotes the whole file into the local overlay.",
+    command: "model-editor /mnt/vision/models/encoder.safetensors",
+    note: "A one-byte edit to a 40 GB file needs room for a coherent 40 GB writable backing file.",
+    stages: [
+      { label: "Snapshot", detail: "commit 4f2c", state: "immutable" },
+      {
+        label: "Mounted view",
+        detail: "overlay wins",
+        state: "write",
+        changed: true,
+      },
+      {
+        label: "Local state",
+        detail: "40 GB backing",
+        state: "dirty",
+        changed: true,
+      },
+      { label: "Publish", detail: "not started", state: "idle" },
+      { label: "Remote", detail: "commit 4f2c", state: "unchanged" },
+    ],
+  },
+  {
+    id: "commit",
+    label: "Commit + push",
+    eyebrow: "03 / PUBLISH",
+    headline:
+      "The barrier freezes a reviewed overlay before Git and Xet move together.",
+    command:
+      'crab mount commit --mountpoint /mnt/vision -m "Regenerate vision index" --push',
+    note: "Xorbs and reconstruction metadata become durable before the remote ref advances.",
+    stages: [
+      { label: "Snapshot", detail: "base checked", state: "4f2c" },
+      { label: "Mounted view", detail: "writers paused", state: "stable" },
+      {
+        label: "Local state",
+        detail: "commit 7ad1",
+        state: "recorded",
+        changed: true,
+      },
+      {
+        label: "Publish",
+        detail: "xet then ref",
+        state: "committed",
+        changed: true,
+      },
+      {
+        label: "Remote",
+        detail: "4f2c → 7ad1",
+        state: "advanced",
+        changed: true,
+      },
+    ],
+  },
+  {
+    id: "retry",
+    label: "Failure / retry",
+    eyebrow: "04 / RECOVER",
+    headline:
+      "A failed push preserves a transaction you can inspect and retry.",
+    command:
+      'crab mount commit --mountpoint /mnt/vision -m "Regenerate vision index" --push',
+    note: "Do not clean the overlay. Fix credentials or ref state, then retry the recorded publication.",
+    stages: [
+      { label: "Snapshot", detail: "base retained", state: "4f2c" },
+      { label: "Mounted view", detail: "hold writers", state: "review" },
+      {
+        label: "Local state",
+        detail: "commit 7ad1",
+        state: "recoverable",
+        changed: true,
+      },
+      {
+        label: "Publish",
+        detail: "retry record",
+        state: "pending",
+        changed: true,
+      },
+      { label: "Remote", detail: "still 4f2c", state: "unchanged" },
+    ],
+  },
+]
+
+const STAGE_ICONS = [GitBranch, Layers3, HardDrive, ServerCog, Cloud]
+
+export function MountLifecycleConsole() {
+  const [sceneId, setSceneId] = useState<MountScene["id"]>("read")
+  const scene =
+    MOUNT_SCENES.find((item) => item.id === sceneId) ?? MOUNT_SCENES[0]
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(68rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] border border-[#34515b] bg-[#142831] text-[#f8f2e8] shadow-[0_24px_70px_rgba(20,40,49,0.24)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(68rem,calc(100vw-2rem))] lg:w-[min(68rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-white/15 px-5 py-6 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.22em] text-[#efa66f]">
+            MOUNT OPERATIONS CONSOLE / ONE SNAPSHOT / ONE OVERLAY
+          </p>
+          <h3 className="m-0 mt-2 max-w-2xl text-2xl font-black tracking-[-0.04em] text-white sm:text-3xl">
+            Follow one file from cold read to durable remote commit.
+          </h3>
+        </div>
+        <div
+          className="flex flex-wrap gap-2"
+          aria-label="Mount lifecycle scene"
+        >
+          {MOUNT_SCENES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={scene.id === item.id}
+              onClick={() => setSceneId(item.id)}
+              className={cn(
+                "min-h-11 rounded-full border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#efa66f] focus-visible:ring-offset-2 focus-visible:ring-offset-[#142831]",
+                scene.id === item.id
+                  ? "border-[#efa66f] bg-[#efa66f] text-[#142831]"
+                  : "border-white/25 bg-white/5 text-white/70 hover:border-white/60 hover:text-white"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid gap-6 p-5 sm:p-7">
+        <div className="grid gap-3 md:grid-cols-5">
+          {scene.stages.map((stage, index) => {
+            const Icon = STAGE_ICONS[index] as ComponentType<{
+              className?: string
+            }>
+            return (
+              <div key={stage.label} className="relative">
+                <div
+                  className={cn(
+                    "h-full min-h-32 rounded-2xl border p-4 transition-colors duration-300 motion-reduce:transition-none",
+                    stage.changed
+                      ? "border-[#efa66f]/70 bg-[#efa66f]/10"
+                      : "border-white/15 bg-white/[0.04]"
+                  )}
+                >
+                  <div className="flex items-center justify-between">
+                    <Icon
+                      className={cn(
+                        "size-5",
+                        stage.changed ? "text-[#efa66f]" : "text-[#76aa91]"
+                      )}
+                    />
+                    <span className="font-mono text-[9px] font-black tracking-[0.16em] text-white/45">
+                      0{index + 1}
+                    </span>
+                  </div>
+                  <p className="m-0 mt-5 text-xs font-black tracking-[0.08em] text-white/55 uppercase">
+                    {stage.label}
+                  </p>
+                  <p className="m-0 mt-1 text-sm font-bold text-white">
+                    {stage.detail}
+                  </p>
+                  <p
+                    className={cn(
+                      "m-0 mt-1 font-mono text-[10px]",
+                      stage.changed ? "text-[#efa66f]" : "text-[#76aa91]"
+                    )}
+                  >
+                    {stage.state}
+                  </p>
+                </div>
+                {index < scene.stages.length - 1 ? (
+                  <ArrowRight className="absolute top-1/2 -right-[18px] z-10 hidden size-5 -translate-y-1/2 text-white/25 md:block" />
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="grid overflow-hidden rounded-2xl border border-white/15 bg-[#0d1d24] lg:grid-cols-[0.72fr_1.28fr]">
+          <div className="border-b border-white/15 p-5 lg:border-r lg:border-b-0">
+            <p className="m-0 font-mono text-[10px] font-black tracking-[0.18em] text-[#76aa91]">
+              {scene.eyebrow}
+            </p>
+            <p className="m-0 mt-2 text-lg leading-snug font-black text-white">
+              {scene.headline}
+            </p>
+          </div>
+          <div className="p-5">
+            <div className="flex items-start gap-3 rounded-xl bg-black/25 px-4 py-3">
+              <span className="font-mono text-sm text-[#efa66f] select-none">
+                $
+              </span>
+              <code className="font-mono text-xs leading-relaxed break-all text-white/85">
+                {scene.command}
+              </code>
+            </div>
+            <p className="m-0 mt-3 text-xs leading-relaxed text-white/60">
+              {scene.note}
+            </p>
+          </div>
+        </div>
+      </div>
+      <figcaption className="border-t border-white/15 px-5 py-3 text-xs leading-relaxed text-white/55 sm:px-7">
+        Choose an operation to see which state changes. Orange marks the state
+        mutated by that step; the base snapshot remains an explicit reference
+        point.
+      </figcaption>
+    </figure>
+  )
+}
+
+type WriterMode = {
+  id: "paths" | "ranges" | "mounts"
+  label: string
+  title: string
+  description: string
+  verdict: string
+  verdictDetail: string
+  tone: "safe" | "coordinate" | "boundary"
+  targets: string[]
+}
+
+const WRITER_MODES: WriterMode[] = [
+  {
+    id: "paths",
+    label: "Independent files",
+    title: "Four workers, four owned outputs",
+    description:
+      "Metadata stays consistent while independent backing files make progress in parallel.",
+    verdict: "Concurrent by design",
+    verdictDetail: "Best fit for shards, partitions, and per-worker artifacts.",
+    tone: "safe",
+    targets: [
+      "shard-000.bin",
+      "shard-001.bin",
+      "shard-002.bin",
+      "shard-003.bin",
+    ],
+  },
+  {
+    id: "ranges",
+    label: "Same file",
+    title: "Four workers, one checkpoint",
+    description:
+      "Crab serializes the path, but it cannot invent record boundaries or merge application writes.",
+    verdict: "Coordinate in the application",
+    verdictDetail:
+      "Use a single writer, a real file-lock protocol, or atomic replacement.",
+    tone: "coordinate",
+    targets: ["bytes 0–4K", "bytes 4–8K", "bytes 8–12K", "header + index"],
+  },
+  {
+    id: "mounts",
+    label: "Separate mounts",
+    title: "Two working trees, one remote ref",
+    description:
+      "Each mount has its own snapshot and overlay. NFS locks do not cross machines or reconcile Git history.",
+    verdict: "Coordinate at the Git boundary",
+    verdictDetail:
+      "Give jobs separate refs or serialize publication against the remote ref.",
+    tone: "boundary",
+    targets: ["host-a / main", "host-b / main", "overlay A", "overlay B"],
+  },
+]
+
+const WRITER_COLORS = ["#315e70", "#d67d45", "#6e9e85", "#816d91"]
+
+export function MountWriterOwnershipLab() {
+  const [modeId, setModeId] = useState<WriterMode["id"]>("paths")
+  const mode =
+    WRITER_MODES.find((item) => item.id === modeId) ?? WRITER_MODES[0]
+  const VerdictIcon =
+    mode.tone === "safe"
+      ? CheckCircle2
+      : mode.tone === "coordinate"
+        ? LockKeyhole
+        : RefreshCcw
+
+  return (
+    <figure className="wide-article-visual not-prose relative left-1/2 my-10 w-[min(64rem,calc(100vw-1rem))] max-w-none -translate-x-1/2 overflow-hidden rounded-[1.75rem] border border-[#a6afa8] bg-[#f3f0e7] text-[#192a33] shadow-[0_20px_60px_rgba(25,42,51,0.13)] min-[1400px]:-translate-x-[calc(50%+1.75rem)] sm:w-[min(64rem,calc(100vw-2rem))] lg:w-[min(64rem,calc(100vw-24.5rem))]">
+      <header className="grid gap-5 border-b border-[#b9b7ac] px-5 py-6 sm:px-7 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="m-0 font-mono text-[10px] font-black tracking-[0.2em] text-[#315e70]">
+            WRITER OWNERSHIP LAB / LOCAL NFS CLIENT
+          </p>
+          <h3 className="m-0 mt-2 text-2xl font-black tracking-[-0.04em] sm:text-3xl">
+            Concurrency follows ownership, not writer count.
+          </h3>
+        </div>
+        <div
+          className="flex flex-wrap gap-2"
+          aria-label="Writer ownership scenario"
+        >
+          {WRITER_MODES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={mode.id === item.id}
+              onClick={() => setModeId(item.id)}
+              className={cn(
+                "min-h-11 rounded-full border px-3 py-2 font-mono text-[10px] font-black transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#315e70] focus-visible:ring-offset-2 focus-visible:ring-offset-[#f3f0e7]",
+                mode.id === item.id
+                  ? "border-[#192a33] bg-[#192a33] text-white"
+                  : "border-[#9ba39c] bg-white/60 text-[#53626a] hover:border-[#192a33] hover:text-[#192a33]"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid gap-5 p-5 sm:p-7 lg:grid-cols-[1.35fr_0.65fr]">
+        <div className="rounded-2xl border border-[#c7c5ba] bg-white/55 p-4 sm:p-5">
+          <div className="flex items-start gap-3">
+            <UsersRound className="mt-0.5 size-5 shrink-0 text-[#315e70]" />
+            <div>
+              <p className="m-0 text-base font-black">{mode.title}</p>
+              <p className="m-0 mt-1 text-xs leading-relaxed text-[#5d696c]">
+                {mode.description}
+              </p>
+            </div>
+          </div>
+          <div className="mt-5 grid gap-2">
+            {mode.targets.map((target, index) => (
+              <div
+                key={target}
+                className="grid grid-cols-[5.5rem_1fr] items-center gap-2 sm:grid-cols-[7rem_1fr]"
+              >
+                <div className="flex min-h-11 items-center gap-2 rounded-xl border border-[#d0cec3] bg-[#f3f0e7] px-3">
+                  <span
+                    className="size-2.5 rounded-full"
+                    style={{ backgroundColor: WRITER_COLORS[index] }}
+                  />
+                  <span className="font-mono text-[10px] font-black">
+                    worker {index + 1}
+                  </span>
+                </div>
+                <div className="flex min-h-11 items-center gap-2 overflow-hidden rounded-xl border border-[#d0cec3] bg-white px-3">
+                  <ArrowRight className="size-4 shrink-0 text-[#8c9694]" />
+                  <span className="truncate font-mono text-[10px] font-bold text-[#45565c]">
+                    {target}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div
+          className={cn(
+            "flex min-h-52 flex-col justify-between rounded-2xl border p-5",
+            mode.tone === "safe" && "border-[#6e9e85] bg-[#dfe9df]",
+            mode.tone === "coordinate" && "border-[#d67d45] bg-[#f3dfcd]",
+            mode.tone === "boundary" && "border-[#816d91] bg-[#e7e0e9]"
+          )}
+        >
+          <div>
+            <VerdictIcon className="size-7" />
+            <p className="m-0 mt-5 font-mono text-[10px] font-black tracking-[0.16em]">
+              VERDICT
+            </p>
+            <p className="m-0 mt-2 text-xl leading-tight font-black">
+              {mode.verdict}
+            </p>
+            <p className="m-0 mt-3 text-xs leading-relaxed text-[#4d5c60]">
+              {mode.verdictDetail}
+            </p>
+          </div>
+          <div className="mt-6 flex items-center gap-2 border-t border-current/15 pt-4 font-mono text-[9px] font-black tracking-[0.12em]">
+            {mode.id === "mounts" ? (
+              <Network className="size-4" />
+            ) : mode.id === "ranges" ? (
+              <FileWarning className="size-4" />
+            ) : (
+              <FileCheck2 className="size-4" />
+            )}
+            {mode.id === "paths"
+              ? "PATH OWNERSHIP IS CLEAR"
+              : mode.id === "ranges"
+                ? "BYTES HAVE SHARED OWNERSHIP"
+                : "REF HAS SHARED OWNERSHIP"}
+          </div>
+        </div>
+      </div>
+      <figcaption className="flex items-start gap-2 border-t border-[#b9b7ac] px-5 py-3 text-xs leading-relaxed text-[#5d696c] sm:px-7">
+        <ArrowDown className="mt-0.5 size-4 shrink-0" />
+        Switch scenarios to identify where coordination belongs: the output
+        path, the application record, or the Git ref.
+      </figcaption>
+    </figure>
+  )
+}

--- a/packages/web/content/docs/cli/reference/crab-mount.mdx
+++ b/packages/web/content/docs/cli/reference/crab-mount.mdx
@@ -64,6 +64,12 @@ crab unmount [OPTIONS]
 Writable mounts use a local copy-on-write overlay. Changes stay local until you
 run an explicit publish command.
 
+Independent paths on one mount may be written concurrently. Same-path and
+intersecting subtree mutations are serialized, while commit, export, and reset
+wait for in-flight mutations before taking an exclusive overlay snapshot.
+Separate mounts remain independent working trees and do not share advisory
+file locks.
+
 ```bash
 crab mount diff --mountpoint /mnt/models
 crab mount export --mountpoint /mnt/models --to /tmp/models-overlay

--- a/packages/web/content/docs/cli/reference/crab-mount.mdx
+++ b/packages/web/content/docs/cli/reference/crab-mount.mdx
@@ -15,9 +15,9 @@ so you can browse a large repository without hydrating everything first.
 server plus the operating system NFS client; `--backend=fuse` uses the FUSE
 adapter and requires fuse3 or macFUSE.
 
-This is the default coordinator-style mount workflow: the CLI starts or
-contacts a local coordinator process, and active mounts are managed by
-mountpoint. For the persistent named-repo service workflow, see
+This is the interactive mount workflow: the CLI starts the selected local
+backend helper or contacts the FUSE coordinator, and active mounts are managed
+by mountpoint. For the persistent named-repo service workflow, see
 [crab daemon](/docs/cli/reference/crab-daemon). For a comparison, see
 [Mount Modes](/docs/cli/virtual-filesystem/mount-modes).
 
@@ -27,6 +27,43 @@ mountpoint. For the persistent named-repo service workflow, see
 crab mount [OPTIONS] [COMMAND]
 crab unmount [OPTIONS]
 ```
+
+A new mount requires both a repository source and a mountpoint. Management
+subcommands address an existing mount by mountpoint.
+
+```bash
+crab mount --repo <source> --mountpoint <path> [--ref <branch>]
+crab mount <status|diff|export|commit|reset|refresh|switch> --mountpoint <path>
+```
+
+## Recommended First Mount
+
+Start read-only, keep the mountpoint outside another Git working tree, and let
+Crab select the available backend:
+
+```bash
+crab mount doctor --backend=auto --mountpoint /tmp/crab-models
+
+crab mount \
+  --repo crab://team-data/ml-models \
+  --mountpoint /tmp/crab-models \
+  --ref main \
+  --read-only
+
+crab mount status --mountpoint /tmp/crab-models --live-only
+head -c 64 /tmp/crab-models/models/encoder.safetensors >/dev/null
+crab unmount --mountpoint /tmp/crab-models
+```
+
+`crab mount doctor` checks the native client, mountpoint, loopback server,
+control endpoint, and privileges needed by the selected backend. A successful
+`status --live-only` proves that the active NFS helper or FUSE coordinator
+responded; ordinary status may fall back to persisted metadata.
+
+Do not put the mountpoint inside the source repository or another Git working
+tree. Crab rejects this by default because Git would see virtual files as
+untracked content. `--allow-nested` is an explicit override for controlled
+environments, not a normal setup step.
 
 ## Mount Options
 
@@ -42,6 +79,19 @@ crab unmount [OPTIONS]
 | `--no-refresh` | Disable automatic remote polling. |
 | `--allow-nested` | Allow mounting inside a Git or Crab working tree. |
 | `--clean-overlay` | Discard existing overlay changes before mounting. |
+
+## Choose the Backend
+
+Use `--backend=auto` unless an operational requirement selects a backend.
+
+| Backend | Use it when | Host requirement |
+| --- | --- | --- |
+| `auto` | You want the supported default. | Prefers NFS when compiled and ready; otherwise uses FUSE when available. |
+| `nfs` | You want the native OS NFS client or do not want a FUSE extension. | NFS client and local mount privileges. Windows uses a drive target such as `Z:`. |
+| `fuse` | You explicitly need the FUSE adapter. | fuse3 on Linux or approved macFUSE on macOS. |
+
+NFS is a local loopback export, not a shared network file server. The helper,
+overlay, snapshot, and cache remain on the machine running Crab.
 
 ## Management Subcommands
 
@@ -70,6 +120,11 @@ wait for in-flight mutations before taking an exclusive overlay snapshot.
 Separate mounts remain independent working trees and do not share advisory
 file locks.
 
+Pause application writers and close or flush open files before inspecting or
+publishing. The publish barrier drains mutations already in flight, but a
+process that keeps issuing writes during commit can receive filesystem errors
+while the exclusive snapshot is held.
+
 ```bash
 crab mount diff --mountpoint /mnt/models
 crab mount export --mountpoint /mnt/models --to /tmp/models-overlay
@@ -83,6 +138,102 @@ the mounted base ref has not moved, creates a Git commit, refreshes the mounted
 snapshot, and clears the overlay after a successful local commit. If `--push`
 fails, the transaction record preserves the local commit OID and leaves the
 overlay in place for recovery.
+
+The command without `--push` creates the commit locally. Run the command again
+with `--push` to publish that recorded commit when the overlay is already clean:
+
+```bash
+crab mount commit --mountpoint /mnt/models -m "Update generated artifacts"
+crab mount commit --mountpoint /mnt/models -m "Push generated artifacts" --push
+```
+
+If a combined commit and push fails, do not use `--clean-overlay` or reset the
+mount. Stop further edits, inspect status, then retry the same publish path:
+
+```bash
+crab mount status --mountpoint /mnt/models --verbose
+crab mount diff --mountpoint /mnt/models
+crab mount commit --mountpoint /mnt/models -m "Update generated artifacts" --push
+```
+
+Crab reuses a matching recorded transaction. If the overlay changed after the
+failure or the mounted base ref moved, Crab rejects the retry instead of
+silently publishing a different tree.
+
+## Safe Writable Workflow
+
+Use this sequence for applications that edit files through the mount:
+
+1. Confirm `git config user.name` and `git config user.email` are set. Mount
+   commit cannot create a Git commit without an author identity.
+2. Mount the intended branch without `--read-only`.
+3. Run the application. Independent paths may be written concurrently; the
+   application must coordinate overlapping writes to the same file.
+4. Stop writers and close their files.
+5. Review `crab mount status --verbose` and `crab mount diff`.
+6. Optionally export the overlay to a normal directory for external review.
+7. Commit locally, or add `--push` for one commit-and-push transaction.
+8. Verify the live mount is clean before unmounting.
+
+```bash
+crab mount \
+  --repo crab://team-data/ml-models \
+  --mountpoint /mnt/models \
+  --ref main
+
+# Run the writer, then stop it before publishing.
+./generate-models --output /mnt/models/generated
+
+crab mount status --mountpoint /mnt/models --verbose
+crab mount diff --mountpoint /mnt/models
+crab mount export --mountpoint /mnt/models --to /tmp/models-review
+crab mount commit \
+  --mountpoint /mnt/models \
+  -m "Regenerate model artifacts" \
+  --push
+crab mount status --mountpoint /mnt/models --live-only --verbose
+crab unmount --mountpoint /mnt/models
+```
+
+The first write to an existing Crab-backed file promotes the complete file into
+the local overlay. Budget local disk for the full promoted file, new files,
+temporary application output, and the read cache—not only for the bytes the
+application expects to change.
+
+## Read-Only and Static Snapshots
+
+Use `--read-only` for browsers, evaluation jobs, and consumers that must never
+create overlay state. Writes return `EROFS`.
+
+Use `--no-refresh` when the process must keep the initial snapshot until an
+operator explicitly refreshes or switches it. Otherwise Crab polls the remote
+and refreshes when it can safely adopt a newer snapshot.
+
+```bash
+crab mount \
+  --repo crab://team-data/releases \
+  --mountpoint /mnt/release-v2 \
+  --ref release-v2 \
+  --read-only \
+  --no-refresh
+```
+
+One repository cache has one active mount owner. To view another ref of the
+same source, use `crab mount switch` or unmount before mounting it elsewhere.
+Different repositories can be mounted at the same time.
+
+## Automation
+
+Use JSON output and live-only status in health checks:
+
+```bash
+crab mount status --mountpoint /mnt/models --live-only --json
+crab mount diff --mountpoint /mnt/models --json
+crab mount commit --mountpoint /mnt/models -m "Automated update" --push --json
+```
+
+Treat a nonzero exit as authoritative. Do not infer mount health from a
+persisted status record, mountpoint directory, or helper PID alone.
 
 DaemonService mode uses the same publish model through
 `crab daemon commit --name <name> -m <message>`.
@@ -108,4 +259,5 @@ evidence that must fail instead of using persisted fallback.
 
 For workflow guidance, see [Virtual Filesystem Mount](/docs/cli/virtual-filesystem/fuse-mount),
 [Mount Modes](/docs/cli/virtual-filesystem/mount-modes), and
-[Mount Management](/docs/cli/virtual-filesystem/mount-management).
+[Mount Management](/docs/cli/virtual-filesystem/mount-management). For the full
+operational model, see [How do you operate a Crab mount safely end to end?](/library/crab-mount-end-to-end).

--- a/packages/web/content/docs/cli/virtual-filesystem/index.mdx
+++ b/packages/web/content/docs/cli/virtual-filesystem/index.mdx
@@ -39,21 +39,22 @@ Use a mount when you need to:
 Mount the current repository, read one managed file, then inspect mount state:
 
 ```bash
-crab mount ./mnt
-head -c 64 ./mnt/models/weights.safetensors >/dev/null
-crab mount status
-crab unmount ./mnt
+crab mount --repo . --mountpoint /tmp/crab-view --read-only
+head -c 64 /tmp/crab-view/models/weights.safetensors >/dev/null
+crab mount status --mountpoint /tmp/crab-view --live-only
+crab unmount --mountpoint /tmp/crab-view
 ```
 
 The first read may fetch remote ranges. A repeated read can use verified cache entries when they remain available.
 
 ## Choose the next mount topic
 
-- [FUSE Mount](/docs/cli/virtual-filesystem/fuse-mount) — mount a Crab repository on macOS or Linux.
+- [Virtual Filesystem Mount](/docs/cli/virtual-filesystem/fuse-mount) — choose NFS or FUSE and mount a Crab repository.
 - [Mount Modes](/docs/cli/virtual-filesystem/mount-modes) — choose between default coordinator-style mounts and DaemonService mode.
 - [Local Mount](/docs/cli/virtual-filesystem/local-mount) — expose an existing local repository through the virtual filesystem.
 - [Mount Management](/docs/cli/virtual-filesystem/mount-management) — list, refresh, switch, and unmount active mounts.
 - [LFS Compatibility](/docs/cli/virtual-filesystem/lfs-compatibility) — work with repositories that still contain Git LFS pointers.
+- [Complete mount workflow](/library/crab-mount-end-to-end) — operate reads, concurrent writes, publishing, and recovery end to end.
 
 ## Keep mount and hydration responsibilities separate
 

--- a/packages/web/content/docs/cli/virtual-filesystem/local-mount.mdx
+++ b/packages/web/content/docs/cli/virtual-filesystem/local-mount.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Local Mount"
-description: "Mount a local repository at another path or branch without creating a separate checkout or requiring remote reads."
+description: "Mount local Git metadata at another path or branch while hydrating Crab-backed content on demand."
 meta:
   contentType: How-to
   goal: "Use Local Mount in an existing Crab repository and verify the result."
@@ -10,8 +10,9 @@ meta:
 # Local Mount
 
 A local mount uses an existing `.git` directory on disk to present a
-repository (or a different branch of it) as a virtual filesystem. No clone, no
-network — reads are served directly from the local object database.
+repository (or a different branch of it) as a virtual filesystem. It does not
+clone Git metadata. Ordinary Git blobs are served from the local object
+database; Crab-backed pointer files can still require object-storage reads.
 
 ## Use Case
 
@@ -93,19 +94,22 @@ crab unmount --mountpoint /tmp/pr-review
 ### Mount for side-by-side comparison
 
 ```bash
-# Mount both branches
-crab mount --repo . --mountpoint /tmp/main --ref=main
-crab mount --repo . --mountpoint /tmp/feature --ref=feature-branch
+# Compare the current working tree with a read-only main snapshot
+crab mount --repo . --mountpoint /tmp/main --ref=main --read-only
 
 # Compare
-diff -r /tmp/main/src/ /tmp/feature/src/
+diff -r /tmp/main/src/ ./src/
 
 # Or use a visual diff tool
-meld /tmp/main/src/ /tmp/feature/src/
+meld /tmp/main/src/ ./src/
 
 # Clean up
-crab unmount --all
+crab unmount --mountpoint /tmp/main
 ```
+
+Crab permits one active mount per repository cache. To compare two committed
+refs without a working tree, mount one ref, export or inspect it, then use
+`crab mount switch` for the second ref.
 
 ### Mount a bare repository
 

--- a/packages/web/content/docs/cli/virtual-filesystem/mount-modes.mdx
+++ b/packages/web/content/docs/cli/virtual-filesystem/mount-modes.mdx
@@ -17,10 +17,13 @@ Crab has two supported ways to run virtual filesystem mounts:
 - **DaemonService mode**: the `crab daemon` workflow. Use this when you want a
   long-running service to manage a named set of repositories.
 
-Both modes expose repositories through FUSE, fetch file content on demand, and
-use a local copy-on-write overlay for writes. The difference is ownership:
-coordinator-style mounts are mountpoint-oriented and ephemeral; DaemonService is
-repo-name-oriented and persistent.
+Both modes can expose repositories through NFS or FUSE, fetch file content on
+demand, and use a local copy-on-write overlay for writes. Coordinator-style
+`crab mount` uses automatic backend selection unless you choose one explicitly;
+DaemonService stores the configured backend with each named repository. The
+other difference is ownership: coordinator-style mounts are
+mountpoint-oriented and ephemeral; DaemonService is repo-name-oriented and
+persistent.
 
 ## Choose a mount mode
 
@@ -28,7 +31,7 @@ repo-name-oriented and persistent.
 | --- | --- |
 | Mount one repo for exploration, review, notebooks, or local development | Coordinator-style `crab mount` |
 | Mount several repos temporarily | Coordinator-style `crab mount` |
-| View another local branch without changing your working tree | Coordinator-style `crab mount --repo . --ref <branch>` |
+| View another local branch without changing your working tree | Coordinator-style `crab mount --repo . --mountpoint <path> --ref <branch>` |
 | Keep a stable fleet of repos mounted on a workstation or shared host | DaemonService mode |
 | Manage repos by name with `list`, `status`, `fetch`, `enable`, `disable`, and `remount` | DaemonService mode |
 | Integrate Crab mounts into an agent environment or service supervisor | DaemonService mode |
@@ -41,17 +44,17 @@ when the mount set itself becomes something you want to manage.
 ```mermaid
 flowchart TB
     subgraph C["Coordinator-style mounts"]
-        C1["crab mount --repo ... --mountpoint ..."] --> C2["Auto-start coordinator"]
-        C2 --> C3["Mount request over IPC"]
+        C1["crab mount --repo ... --mountpoint ..."] --> C2["Start local backend owner"]
+        C2 --> C3["FUSE coordinator or NFS helper"]
         C3 --> C4["Per-mount pipeline"]
-        C4 --> C5["FUSE mount at requested path"]
+        C4 --> C5["NFS or FUSE mount at requested path"]
     end
 
     subgraph D["DaemonService mode"]
         D1["crab daemon add-repo --name ..."] --> D2["Persistent repo registry"]
         D2 --> D3["crab daemon service loop"]
         D3 --> D4["Reconcile registered repos"]
-        D4 --> D5["FUSE mounts at mount-root/name"]
+        D4 --> D5["Configured mounts at mount-root/name"]
     end
 
     C4 --> S["Snapshot + COW overlay + hydration cache"]
@@ -67,10 +70,10 @@ you do not pass `--foreground`.
 crab mount --repo crab://bucket/ml-models --mountpoint /mnt/models
 ```
 
-The CLI validates the request, creates the mountpoint if needed, then sends the
-mount request to a local coordinator process. If the coordinator is not running,
-Crab starts it automatically. The coordinator owns active FUSE sessions, shared
-chunk cache access, hydration workers, and runtime mount state.
+The CLI validates the request and creates the mountpoint if needed. FUSE
+background mounts send the request to a shared coordinator, which Crab starts
+when needed. NFS background mounts start one local helper per mount. Both use
+the same repository cache, hydration, snapshot, and overlay contracts.
 
 ### State and Paths
 
@@ -89,13 +92,14 @@ local path can reuse local state.
 ### Lifecycle
 
 1. User runs `crab mount`.
-2. The CLI sends an IPC request to the coordinator.
-3. The coordinator runs the mount pipeline: clone or open git metadata, build a
-   snapshot, open the overlay, create the resolver, start hydration workers, and
-   mount FUSE.
+2. The CLI resolves and validates the backend and mountpoint.
+3. A FUSE coordinator, NFS helper, or foreground CLI runs the mount pipeline:
+   clone or open git metadata, build a snapshot, open the overlay, create the
+   resolver, start hydration workers, and mount the selected backend.
 4. The CLI returns after the mount is ready.
 5. `crab unmount --mountpoint <path>` removes the mount.
-6. When the last mount is removed, the coordinator shuts down.
+6. An NFS helper exits with its mount; the FUSE coordinator exits after its last
+   mount is removed.
 
 Use `--foreground` when you want the CLI process itself to own the mount:
 

--- a/packages/web/content/library/crab-mount-end-to-end.mdx
+++ b/packages/web/content/library/crab-mount-end-to-end.mdx
@@ -12,7 +12,7 @@ order: 6
 concepts: ["virtual filesystem", "copy-on-write overlay", "publish barrier", "range hydration", "concurrent writers", "commit recovery"]
 prerequisites: ["How do you work with a repository larger than your disk?"]
 outcome: "Run a read-only or writable Crab mount, publish overlay changes safely, and diagnose the common failure modes without losing work."
-diagramType: "Mount read, write, and publish lifecycle"
+diagramType: "Interactive mount state and writer ownership labs"
 knowledgeCheck:
   question: "What should an operator do immediately before publishing a busy writable mount?"
   options:
@@ -49,6 +49,12 @@ predictable production interface and treating it like a magical network disk.
   Reads can be lazy. Writes stay local. Nothing reaches the remote branch until
   you run a mount commit, and the commit is still governed by Git ref state.
 </TakeawayBox>
+
+Use the console below as a map for the rest of the guide. Switch between a cold
+read, the first write, a successful publication, and a recoverable failure to
+see which state changes at each boundary.
+
+<MountLifecycleConsole />
 
 ## Start by choosing the operating mode
 
@@ -155,6 +161,12 @@ blob is a Crab pointer, the hydration path finds the file recipe, fetches the
 needed xorb ranges, verifies them, and returns reconstructed bytes. A later read
 can reuse verified cache data.
 
+The cutaway below follows a single request across the mounted namespace. Change
+the operation to compare metadata-only work, cold and warm reads, and a write
+that crosses into the overlay.
+
+<MountedReadCutaway />
+
 Test the access pattern the real application uses. A sequential copy, random
 seek workload, memory map, and thousands of small opens exercise different
 parts of the stack. A single warm `cat` is not a capacity result.
@@ -181,6 +193,12 @@ Do not place an overlay on a nearly full system disk and assume Xet
 deduplication will make the local write cheap. Deduplication reduces canonical
 upload and storage after Crab classifies the resulting bytes. It does not
 replace the writable local file.
+
+Use the capacity workbench to model how the read cache and writable overlay
+compete for local disk. The promotion scenario is the important production
+case: remote deduplication does not shrink the local writable copy.
+
+<DiskBudgetWorkbench />
 
 ## Move to a writable mount deliberately
 
@@ -246,6 +264,12 @@ output paths, or a single writer for that case.
 
 Native NFS advisory locking coordinates processes using the same local mounted
 client. It should not be treated as a lock service shared by separate machines.
+
+The ownership lab makes that boundary concrete. Compare independent output
+files, byte ranges inside one file, and separate mounts publishing the same
+remote ref.
+
+<MountWriterOwnershipLab />
 
 ## Stop writers before reviewing
 
@@ -518,3 +542,6 @@ After publish:
 For exact syntax, backend options, and machine-readable commands, use the
 [`crab mount` reference](/docs/cli/reference/crab-mount). For choosing between
 mounting and selective hydration, continue with [How do you work with a repository larger than your disk?](/library/lazy-checkout-fuse).
+
+The knowledge check below closes the guide at the most important operational
+boundary: turning a busy writable overlay into a stable, reviewable commit.

--- a/packages/web/content/library/crab-mount-end-to-end.mdx
+++ b/packages/web/content/library/crab-mount-end-to-end.mdx
@@ -1,0 +1,520 @@
+---
+title: "How do you operate a Crab mount safely end to end?"
+description: "Mount a large Xet-backed repository, understand reads and overlay writes, publish a verified commit, and recover without losing local changes."
+date: "2026-08-27"
+author: "Crab Team"
+category: "tutorial"
+tags: ["mount", "nfs", "fuse", "xet", "overlay", "concurrency", "operations"]
+excerpt: "Treat a Crab mount as a stable Git snapshot plus an explicit local write overlay, then make read, edit, review, commit, push, and recovery decisions at the right boundary."
+level: "deep-dive"
+path: "advanced-operations"
+order: 6
+concepts: ["virtual filesystem", "copy-on-write overlay", "publish barrier", "range hydration", "concurrent writers", "commit recovery"]
+prerequisites: ["How do you work with a repository larger than your disk?"]
+outcome: "Run a read-only or writable Crab mount, publish overlay changes safely, and diagnose the common failure modes without losing work."
+diagramType: "Mount read, write, and publish lifecycle"
+knowledgeCheck:
+  question: "What should an operator do immediately before publishing a busy writable mount?"
+  options:
+    - "Delete the overlay so the commit starts clean"
+    - "Pause writers, close or flush files, inspect the overlay, then commit"
+    - "Start a second mount of the same repository and push from it"
+  answer: 1
+  explanation: "The exclusive publish barrier drains in-flight mutations, but pausing writers prevents new application writes from racing the snapshot and makes the reviewed diff match the intended commit."
+meta:
+  contentType: "Tutorial"
+  goal: "Teach the complete operational workflow and safety model for Crab mounts."
+  audience: "Developers and operators using large Crab repositories through native filesystem paths."
+---
+
+A Crab mount makes a Git repository look like an ordinary directory without
+materializing every large file first. An editor can open a source file, a model
+server can seek into a checkpoint, and a pipeline can create output under a
+normal filesystem path. Crab resolves the Git snapshot and retrieves the
+required Xet-backed ranges only when an application reads them.
+
+That convenience does not turn the object store into a general-purpose shared
+filesystem. The mount is a local view with explicit Git semantics:
+
+- A **base snapshot** represents one Git commit and ref.
+- A **read cache** holds verified remote ranges used by this machine.
+- A **copy-on-write overlay** holds local filesystem mutations.
+- A **publish transaction** turns the reviewed overlay into a Git commit and,
+  optionally, pushes it to the Crab remote.
+
+Understanding those four states is the difference between using a mount as a
+predictable production interface and treating it like a magical network disk.
+
+<TakeawayBox title="A mount is a working tree with an explicit publish boundary">
+  Reads can be lazy. Writes stay local. Nothing reaches the remote branch until
+  you run a mount commit, and the commit is still governed by Git ref state.
+</TakeawayBox>
+
+## Start by choosing the operating mode
+
+Make three decisions before running a command.
+
+### Read-only or writable
+
+Use a read-only mount when the workload consumes repository state but should
+not change it. Examples include evaluation jobs, asset browsers, code review,
+and serving a released model. The kernel returns `EROFS` for write attempts, so
+an accidental application save cannot create hidden local state.
+
+Use a writable mount when an application must edit or generate repository
+paths through filesystem calls. Writes enter the local overlay. They do not
+modify the mounted base snapshot, source working tree, or remote branch.
+
+### Remote or local source
+
+A remote source such as `crab://team-data/vision-search` creates or reuses a
+blobless cached repository. Git trees and pointer blobs define the namespace;
+large payloads remain in object storage until read.
+
+A local source such as `--repo .` reuses the existing Git object database. It
+is useful for viewing another branch without checking it out. Crab-backed
+pointer files can still require object-storage access even though ordinary Git
+blobs are local.
+
+### Interactive mount or named service
+
+Use `crab mount` for an interactive, mountpoint-oriented lifecycle. Use
+DaemonService mode when a supervisor should maintain a registry of named
+repositories across a longer-running host lifecycle. Both use snapshots,
+on-demand hydration, and overlays, but their management commands and ownership
+models differ.
+
+This guide follows the interactive `crab mount` workflow. The same publish
+principles apply to `crab daemon commit`.
+
+## Preflight the machine and mountpoint
+
+Crab defaults to `--backend=auto`, which prefers NFS when the binary and host
+support it. The NFS backend starts a loopback NFSv3 server and uses the native
+operating-system NFS client. It is local to the machine; it does not export the
+repository to other hosts.
+
+FUSE remains available when installed and explicitly selected. Linux requires
+fuse3. macOS requires approved macFUSE. Windows uses the NFS client and a drive
+target rather than FUSE.
+
+Run the preflight before debugging an application:
+
+```bash
+crab mount doctor --backend=auto --mountpoint /tmp/vision-search
+```
+
+The check covers backend availability, the native client, local control
+transport, mountpoint suitability, and privileges. Fix a failed preflight at
+the host boundary rather than repeatedly starting the mount.
+
+Choose a dedicated mountpoint outside every Git working tree. If a mount sits
+inside a checkout, Git can discover the virtual namespace as untracked files,
+tools can recurse into themselves, and cleanup commands can target the wrong
+tree. Crab rejects nested mountpoints by default. `--allow-nested` exists for
+controlled integrations that have already addressed those risks.
+
+## Prove a read-only mount first
+
+Start with the smallest safe topology:
+
+```bash
+crab mount \
+  --repo crab://team-data/vision-search \
+  --mountpoint /tmp/vision-search \
+  --ref main \
+  --read-only
+```
+
+Confirm the active helper, not merely a persisted registry entry:
+
+```bash
+crab mount status \
+  --mountpoint /tmp/vision-search \
+  --live-only \
+  --json
+```
+
+Without `--live-only`, status can fall back to persisted metadata when the
+backend control endpoint is unavailable. That fallback is useful to a human
+cleaning up a stale mount. It is not proof that an application can issue a
+filesystem operation now.
+
+Read both metadata and content during qualification:
+
+```bash
+find /tmp/vision-search/models -maxdepth 1 -type f | head
+head -c 65536 \
+  /tmp/vision-search/models/encoder.safetensors \
+  >/dev/null
+```
+
+A directory listing resolves snapshot metadata. It does not download every
+file in that directory. The first content read resolves the Git blob. If the
+blob is a Crab pointer, the hydration path finds the file recipe, fetches the
+needed xorb ranges, verifies them, and returns reconstructed bytes. A later read
+can reuse verified cache data.
+
+Test the access pattern the real application uses. A sequential copy, random
+seek workload, memory map, and thousands of small opens exercise different
+parts of the stack. A single warm `cat` is not a capacity result.
+
+## Know what consumes local disk
+
+Lazy reads reduce initial materialization, but they do not eliminate local
+capacity planning. A host can hold four different forms of data:
+
+| Local state | Why it grows |
+| --- | --- |
+| Cached Git metadata | Commits, trees, pointer blobs, and fetched Git objects define the snapshot. |
+| Verified read cache | Applications populate remote file ranges as they read. |
+| Overlay backing | New files and promoted base files hold writable content. |
+| Application scratch | Temporary outputs, checkpoints, logs, and atomic-save copies live outside Crab policy. |
+
+The important surprise is promotion. The first write to an existing
+Crab-backed file creates a complete writable backing file in the overlay. A
+one-byte edit to a 40 GB checkpoint therefore needs space for the full 40 GB
+file, plus application and temporary headroom. Reads can remain range-based;
+writes need a coherent local file that normal filesystem calls can modify.
+
+Do not place an overlay on a nearly full system disk and assume Xet
+deduplication will make the local write cheap. Deduplication reduces canonical
+upload and storage after Crab classifies the resulting bytes. It does not
+replace the writable local file.
+
+## Move to a writable mount deliberately
+
+Unmount the qualification view, then start the intended branch without
+`--read-only`:
+
+```bash
+crab unmount --mountpoint /tmp/vision-search
+
+crab mount \
+  --repo crab://team-data/vision-search \
+  --mountpoint /mnt/vision-search \
+  --ref main
+```
+
+Before the application writes, confirm the Git author identity used to create
+the future commit:
+
+```bash
+git config --global user.name
+git config --global user.email
+```
+
+Set missing values according to team policy. `crab mount commit` refuses to
+invent an author identity.
+
+The base snapshot remains immutable while the mount is active. Reads consult
+the overlay first and fall back to the snapshot. Creates, writes, truncates,
+mode changes, symlinks, deletions, and directory renames are represented as
+overlay mutations.
+
+This means an application can work normally while Crab retains a reviewable
+boundary between “visible on this mount” and “part of Git history.”
+
+## Use concurrent writers within the actual contract
+
+Processes on one mount may write independent paths concurrently. Crab keeps
+metadata operations consistent while allowing independent backing files to
+make progress in parallel.
+
+Ordering becomes stricter when paths overlap:
+
+- Mutations to the same path are serialized by the VFS engine.
+- Directory operations serialize with intersecting descendants.
+- Overlapping byte-range writes to the same file still require application
+  coordination. Crab does not invent record locks or merge semantics for the
+  application.
+- Separate mounts are separate working trees and overlays. They are not a
+  distributed writer-coordination mechanism.
+
+This fits build and data pipelines that assign one output path per worker:
+
+```text
+/mnt/vision-search/generated/shard-000.bin
+/mnt/vision-search/generated/shard-001.bin
+/mnt/vision-search/generated/shard-002.bin
+/mnt/vision-search/generated/shard-003.bin
+```
+
+It does not make two uncoordinated processes safely patch the same checkpoint
+header. Use application-level file locks, atomic replacement, partitioned
+output paths, or a single writer for that case.
+
+Native NFS advisory locking coordinates processes using the same local mounted
+client. It should not be treated as a lock service shared by separate machines.
+
+## Stop writers before reviewing
+
+When the job finishes, stop every process that can write beneath the
+mountpoint. Close files or make the application flush and `fsync` them. Then
+inspect the overlay:
+
+```bash
+crab mount status --mountpoint /mnt/vision-search --verbose
+crab mount diff --mountpoint /mnt/vision-search
+```
+
+The diff reports creates, modifications, deletes, renames, modes, and an
+estimated upload size. It describes the mounted overlay, not unrelated scratch
+files elsewhere on the host.
+
+For an external scanner, reviewer, or backup step, export a normal directory:
+
+```bash
+crab mount export \
+  --mountpoint /mnt/vision-search \
+  --to /tmp/vision-search-review
+```
+
+Export takes a stable overlay view and includes deletion metadata. It does not
+publish a commit or clear the live overlay.
+
+Why stop writers if Crab has a barrier? Commit, export, and reset acquire an
+exclusive publish lease and wait for mutations already in flight. New
+filesystem writes issued while that exclusive operation runs can fail. Pausing
+writers makes the reviewed diff stable, prevents application-visible errors,
+and ensures the intended batch matches the committed batch.
+
+## Commit locally or commit and push
+
+Create a local commit when review and remote publication are separate steps:
+
+```bash
+crab mount commit \
+  --mountpoint /mnt/vision-search \
+  -m "Regenerate vision index"
+```
+
+The operation:
+
+1. Flushes and stabilizes the mounted view.
+2. Takes the exclusive overlay publish lease.
+3. Checks that the mounted base ref has not moved.
+4. Builds the Git tree in an isolated publish worktree.
+5. Streams stable Crab-tracked overlay files into Crab staging and writes
+   pointer blobs into the Git index.
+6. Creates the Git commit and refreshes the mounted snapshot.
+7. Clears the overlay after the local commit succeeds.
+
+The mount now represents the new local commit, but the remote ref has not moved.
+Publish that recorded commit with:
+
+```bash
+crab mount commit \
+  --mountpoint /mnt/vision-search \
+  -m "Push vision index" \
+  --push
+```
+
+If review and publication are one operation, include `--push` on the first
+commit:
+
+```bash
+crab mount commit \
+  --mountpoint /mnt/vision-search \
+  -m "Regenerate vision index" \
+  --push
+```
+
+Crab flushes staged xorbs and publishes the metadata required to reconstruct
+every managed file before moving the remote ref. Git history contains compact
+pointer blobs; object storage contains the Xet data and reconstruction
+metadata. Both describe one commit.
+
+## Recover from a failed push without deleting work
+
+A network, credential, or ref publication failure after commit is not a reason
+to reset the overlay. Crab records the transaction, including the local commit
+identity, and preserves recovery state.
+
+First, stop further edits and inspect:
+
+```bash
+crab mount status --mountpoint /mnt/vision-search --verbose
+crab mount diff --mountpoint /mnt/vision-search
+```
+
+Fix the external cause, then retry the same publish path:
+
+```bash
+crab mount commit \
+  --mountpoint /mnt/vision-search \
+  -m "Regenerate vision index" \
+  --push
+```
+
+When the overlay still matches the recorded transaction, Crab can finish the
+existing publication instead of creating a different commit. If files changed
+after the failure, Crab rejects that recovery path. Review the new overlay as a
+new change set rather than forcing it into the earlier transaction.
+
+Avoid these reactions:
+
+- Do not remount with `--clean-overlay`; it discards local modifications before
+  mounting.
+- Do not run `crab mount reset --overlay --yes`; that command is explicitly
+  destructive.
+- Do not edit directly inside the cached bare or blobless repository.
+- Do not push a guessed object ID outside the recorded workflow.
+
+If another writer moved the remote ref, Crab rejects the stale base. The
+overlay remains local. Inspect the remote change, refresh or remount as directed
+by the error, reconcile the intended output, and publish a newly reviewed
+transaction.
+
+## Refresh and switch only at clear boundaries
+
+Automatic refresh lets a clean mount adopt remote progress. Use
+`--no-refresh` when a job requires the original snapshot for its entire run:
+
+```bash
+crab mount \
+  --repo crab://team-data/vision-search \
+  --mountpoint /mnt/vision-search \
+  --ref release-v2 \
+  --read-only \
+  --no-refresh
+```
+
+An operator can explicitly refresh a suitable mount:
+
+```bash
+crab mount refresh --mountpoint /mnt/vision-search
+```
+
+Switch the existing mount to another branch instead of opening a second mount
+of the same repository cache:
+
+```bash
+crab mount switch \
+  --mountpoint /mnt/vision-search \
+  --ref experiment-v3
+```
+
+One active owner per repository cache avoids two local snapshots and overlays
+competing for the same cached checkout. Different repository sources can be
+mounted concurrently and share higher-level host resources where supported.
+
+Do not switch or refresh casually while a workload expects a fixed data set.
+Treat the mounted commit identity as an input to the job, just as you would
+treat a checked-out Git commit.
+
+## Reset only when loss is intentional
+
+To discard every overlay change, Crab requires both an operation selector and
+confirmation:
+
+```bash
+crab mount reset \
+  --mountpoint /mnt/vision-search \
+  --overlay \
+  --yes
+```
+
+Stop writers first. Run `diff`, and export if any part of the overlay might be
+needed later. Reset takes the exclusive barrier, removes the local mutations,
+and restores the mounted base view. It does not create a compensating commit.
+
+`--clean-overlay` performs a similar discard before a new mount starts. Use it
+only when the operator has already established that retained overlay state is
+unwanted.
+
+## Monitor the live service, not filesystem appearance
+
+A mountpoint directory can exist after a helper exits. A registry record can
+describe the last known state. Neither proves the backend currently handles
+requests.
+
+Use live JSON status for health checks:
+
+```bash
+crab mount status \
+  --mountpoint /mnt/vision-search \
+  --live-only \
+  --json
+```
+
+Use regular status for human diagnostics when the live endpoint might be gone.
+Use `crab mount list --json` to inventory active registrations, not as a
+substitute for a per-mount live probe.
+
+Unmount through Crab so the helper, native client mount, registry, and control
+state can shut down in order:
+
+```bash
+crab unmount --mountpoint /mnt/vision-search
+```
+
+If unmount reports a busy filesystem, close shells and processes whose current
+directory or open file is under the mountpoint, then retry. Do not delete the
+mountpoint or cache while it is active.
+
+## Qualify the real workload before calling it production-ready
+
+Correctness and performance depend on more than one large sequential copy. A
+useful qualification matrix includes:
+
+| Dimension | Evidence to collect |
+| --- | --- |
+| Cold reads | Range and full-file hashes after an empty cache. |
+| Warm reads | Cache hit behavior and repeated-read latency. |
+| Namespace scale | Large directory enumeration and metadata-heavy tools. |
+| Independent writers | Overlap intervals, aggregate throughput, and final hashes. |
+| Publish barrier | Writers drain before diff, export, commit, and reset snapshots. |
+| Git representation | Managed files are pointers in Git, not accidental full blobs. |
+| Fresh consumer | A new clone reconstructs byte-identical files. |
+| Failure recovery | A forced push failure preserves state and succeeds on retry. |
+| Capacity | Peak cache, overlay, temporary, and application disk usage. |
+| Operations | Restart, unmount, stale-state cleanup, and monitoring behavior. |
+
+Also test host-specific NFS or FUSE policy, credentials, real object-store
+latency, network interruption, crash recovery, and a soak long enough to expose
+resource leaks. A benchmark on one laptop proves that topology and workload;
+it does not establish universal shared-filesystem semantics.
+
+Crab mount is strongest when the workload follows Git-shaped ownership:
+immutable base input, independent output paths, an explicit review boundary,
+and a deliberate commit. It is not intended to replace a multi-host database,
+distributed lock manager, or arbitrarily concurrent in-place editor for one
+large file.
+
+## Use this operator checklist
+
+Before mount:
+
+- Choose read-only unless writes are required.
+- Select the exact ref and decide whether refresh is allowed.
+- Use a dedicated mountpoint outside Git working trees.
+- Run `crab mount doctor` on the intended backend and mountpoint.
+- Budget cache, overlay, promotion, and application scratch space.
+- Confirm Git author identity before a writable run.
+
+Before publish:
+
+- Stop application writers and close or flush their files.
+- Check live status.
+- Review the verbose status and overlay diff.
+- Export when external review or recovery evidence is required.
+- Decide whether to commit locally or commit with `--push`.
+
+After publish:
+
+- Confirm the command succeeded and record its commit identity.
+- Verify live status and that the intended overlay is clean.
+- On failure, preserve state and retry the recorded transaction after fixing
+  the cause.
+- Unmount through Crab after readers and writers exit.
+
+<TakeawayBox title="Keep the boundaries explicit">
+  The snapshot answers what commit you are reading. The cache answers what this
+  machine has fetched. The overlay answers what changed locally. Mount commit
+  is the only step that turns those reviewed local changes into Git history.
+</TakeawayBox>
+
+For exact syntax, backend options, and machine-readable commands, use the
+[`crab mount` reference](/docs/cli/reference/crab-mount). For choosing between
+mounting and selective hydration, continue with [How do you work with a repository larger than your disk?](/library/lazy-checkout-fuse).

--- a/packages/web/mdx-components.tsx
+++ b/packages/web/mdx-components.tsx
@@ -43,6 +43,10 @@ import {
   MaterializationPackingDesk,
   MountedReadCutaway,
 } from "@/components/blog/lazy-checkout-visuals"
+import {
+  MountLifecycleConsole,
+  MountWriterOwnershipLab,
+} from "@/components/blog/mount-visuals"
 import { GcObjectEvidenceLab, GcRaceReplay } from "@/components/blog/gc-visuals"
 import { GcRunPermit } from "@/components/blog/gc-run-permit"
 import { CostReceiptMixer } from "@/components/blog/cost-ledger-visual"
@@ -187,6 +191,8 @@ export function getMDXComponents(components?: MDXComponents) {
     DiskBudgetWorkbench,
     MaterializationPackingDesk,
     MountedReadCutaway,
+    MountLifecycleConsole,
+    MountWriterOwnershipLab,
     GcObjectEvidenceLab,
     GcRaceReplay,
     GcRunPermit,


### PR DESCRIPTION
## Summary

- allow Git partial-clone promisor fetches to retrieve exact reachable objects while retaining visible-ref closure authorization
- classify lazily fetched Crab pointers before NFS size, read, and promotion decisions
- replace the global overlay mutation mutex with shared local and cross-process publish leases so independent paths write concurrently
- retain same-path and intersecting-subtree serialization in the VFS engine
- make commit, export, and reset take an exclusive lease that drains in-flight mutations before snapshotting the overlay
- record post-start mount publish failures and preserve the overlay for retry
- extend the native macOS RustFS/NFS smoke with deterministic concurrent writer processes and end-to-end hash and pointer verification

## Why this is the best fix

This keeps mutation ordering at the existing VFS ownership boundary and changes only the overlay publish barrier. Independent backing files no longer contend on one global mutex, while publish still gets one stable snapshot across threads, store handles, and processes. It does not add another mount mode, fallback path, compatibility shim, or configuration surface.

The Git hardening restores the canonical promisor-object path instead of adding a clone or hydration fallback. Exact-object requests remain authorized against the generation-pinned visible-ref catalog, and arbitrary unfiltered SHA wants remain denied.

## Exact rebased live proof

Native macOS NFS against isolated RustFS, bucket `crabbuild`:

- remote: `crab://crabbuild/mount-large-macos/nfs-concurrent-20260827-rebased`
- published commit: `f893b0aea0411fc3cab2f517ddcc098fba27c594`
- three identical 256 MiB seed files backed by Xet; 768 MiB logical stored as 268,624,156 xorb bytes
- four independent 64 MiB writer processes overlapped for 1.447 seconds
- concurrent aggregate throughput: 172.67 MiB/s through the native mount
- 320 MiB created file, 48 MiB sparse file, truncate, rename, delete, symlink, chmod, diff, export, and reset
- 10,000 ordinary directory entries enumerated
- forced post-commit push failure retained the commit and overlay; retry pushed and cleared the overlay
- every concurrent file hash matched after export, fresh clone, and cold rehydration
- Git blobs and dehydrated worktree files were verified as Crab pointers before hydration
- full scenario completed in 143.01 seconds
- emitted `macos_mount_large_e2e=ok` and `macos_mount_large_rustfs_smoke=ok`

A separate pre-rebase run also passed with 3.839 seconds of writer overlap and 66.23 MiB/s aggregate throughput.

## Focused validation

- `cargo test -p crab-vfs --features nfs`: 458 passed
- `cargo clippy -p crab-vfs --features nfs --lib -- -D warnings`
- `cargo check -p crab --no-default-features --features nfs --locked`
- `cargo fmt --all --check`
- concurrent writer probe self-test and Python compile check
- macOS RustFS/NFS smoke passed twice, including once after rebasing onto current `origin/main`
- Next.js production build passed
- docs link crawl checked 314 HTML pages and 3,192 fragments
- shell syntax and `git diff --check`

## Remaining Level 5 gates

This now proves concurrent independent-path writers on one native macOS NFS mount and a stable commit/export/reset barrier. Same-file overlapping byte-range writes still require application coordination. Separate mounts remain independent working trees. Linux NFS, real cloud providers, crash and reboot recovery, network partitions, longer soak tests, and security qualification remain separate production gates. The cold hydration run also emitted recoverable file-index repair warnings; correctness passed, but eliminating that repair path remains operational follow-up.