### PR TITLE
fix: verify and harden Linux NFS Xet parity

### DIFF
--- a/.github/workflows/nfs-mount.yml
+++ b/.github/workflows/nfs-mount.yml
@@ -10,6 +10,7 @@ on:
       - "crab/Cargo.toml"
       - "crab/Makefile"
       - "crab/scripts/release/dispatch-nfs-release-evidence.sh"
+      - "crab/scripts/docker/run-mount-large-rustfs-smoke.sh"
       - "crab/scripts/docker/run-mount-nfs-linux-smoke.sh"
       - "crab/scripts/nfs-evidence-summary.py"
       - "crab/scripts/nfs-read-path-bench-report.py"
@@ -20,6 +21,7 @@ on:
       - "crab/src/cmd/mount.rs"
       - "crab/src/vfs/**"
       - "crab/tests/prop_coordinator.rs"
+      - "crates/crab-vfs/**"
   pull_request:
     paths:
       - ".github/workflows/nfs-mount.yml"
@@ -28,6 +30,7 @@ on:
       - "crab/Cargo.toml"
       - "crab/Makefile"
       - "crab/scripts/release/dispatch-nfs-release-evidence.sh"
+      - "crab/scripts/docker/run-mount-large-rustfs-smoke.sh"
       - "crab/scripts/docker/run-mount-nfs-linux-smoke.sh"
       - "crab/scripts/nfs-evidence-summary.py"
       - "crab/scripts/nfs-read-path-bench-report.py"
@@ -38,6 +41,7 @@ on:
       - "crab/src/cmd/mount.rs"
       - "crab/src/vfs/**"
       - "crab/tests/prop_coordinator.rs"
+      - "crates/crab-vfs/**"
   workflow_dispatch:
     inputs:
       nfs_smoke_baseline_run_id:
@@ -141,6 +145,34 @@ jobs:
         with:
           name: nfs-smoke-linux-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ env.CRAB_NFS_SMOKE_ROOT }}/${{ env.CRAB_NFS_SMOKE_RUN_ID }}
+          if-no-files-found: warn
+          retention-days: 14
+
+  linux-rustfs-xet-smoke:
+    name: Linux NFS RustFS/Xet E2E
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: feature-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      CRAB_MOUNT_SMOKE_ROOT: ${{ github.workspace }}/.ci/crab-nfs-rustfs
+      CRAB_MOUNT_SMOKE_RUN_ID: mount-large-nfs-linux-${{ github.run_id }}-${{ github.run_attempt }}
+      CRAB_MOUNT_SMOKE_BUCKET: crabbuild
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Linux NFS RustFS/Xet E2E
+        working-directory: crab
+        run: make mount-large-rustfs-smoke
+
+      - name: Upload Linux NFS RustFS/Xet evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nfs-rustfs-xet-linux-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.CRAB_MOUNT_SMOKE_ROOT }}/${{ env.CRAB_MOUNT_SMOKE_RUN_ID }}
           if-no-files-found: warn
           retention-days: 14
 

--- a/crab/Makefile
+++ b/crab/Makefile
@@ -64,8 +64,8 @@
 #                     NFS_THRESHOLD_REQUIRE_CALIBRATION_READY=1
 #                     NFS_THRESHOLD_REQUIRE_RELEASE_GRADE=1
 #   make mount-large-rustfs-smoke
-#                     Verify large-file `crab mount` read-only and writable
-#                     overlay writeback against Docker RustFS/S3.
+#                     Verify native Linux NFS large-file reads, concurrent
+#                     overlay writes, and Git/Xet writeback against RustFS/S3.
 #   make mount-nfs-linux-smoke
 #                     Verify native Linux NFS `crab mount` through Docker.
 #   make mount-nfs-macos-smoke
@@ -513,6 +513,7 @@ nfs-smoke-report-verify-self-test:
 	@$(PYTHON) scripts/verify-nfs-smoke-report.py self-test
 
 nfs-smoke-script-check:
+	@bash -n scripts/docker/run-mount-large-rustfs-smoke.sh
 	@bash -n scripts/docker/run-mount-nfs-linux-smoke.sh
 	@bash -n scripts/run-mount-nfs-macos-smoke.sh
 	@$(PYTHON) scripts/check-nfs-smoke-scripts.py --self-test

--- a/crab/scripts/docker/run-mount-large-rustfs-smoke.sh
+++ b/crab/scripts/docker/run-mount-large-rustfs-smoke.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #
-# Run an end-to-end Crab mount smoke against Docker RustFS.
+# Run an end-to-end native Linux NFS mount smoke against Docker RustFS.
 #
 # The smoke builds Crab inside a Linux container, starts a local RustFS S3
 # endpoint, seeds a Crab repo with a large tracked file, verifies read-only
-# mount behavior, verifies writable overlay writeback for large files, pushes
-# the overlay commit, then performs a fresh eager clone and byte-for-byte checks.
+# native NFS mount behavior, verifies concurrent writable overlay writeback for
+# large files, pushes the overlay commit, then performs a fresh eager clone and
+# byte-for-byte checks.
 
 set -euo pipefail
 
@@ -89,7 +90,6 @@ printf "rustfs=ready\n"
 "$DOCKER" run --rm -i \
     --name "$RUNNER" \
     --network "$NET" \
-    --device /dev/fuse \
     --cap-add SYS_ADMIN \
     --security-opt apparmor:unconfined \
     -v "$REPO_ROOT:/src" \
@@ -107,10 +107,9 @@ printf "rustfs=ready\n"
     -e AWS_VIRTUAL_HOSTED_STYLE_REQUEST=false \
     -e VIRTUAL_HOSTED_STYLE_REQUEST=false \
     -e CARGO_HOME=/cargo \
+    -e CARGO_INCREMENTAL=0 \
+    -e CARGO_PROFILE_DEV_DEBUG=0 \
     -e CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=cc \
-    -e CARGO_PROFILE_RELEASE_LTO=false \
-    -e CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
-    -e CARGO_PROFILE_RELEASE_DEBUG=0 \
     "$RUST_IMAGE" bash -s -- "$RUN_ID" "$BUCKET" "$SEED_MIB" "$NEW_MIB" <<'INNER'
 set -euo pipefail
 
@@ -120,7 +119,7 @@ SEED_MIB="$3"
 NEW_MIB="$4"
 
 export HOME=/e2e/home
-export PATH="$HOME/.cargo/bin:/usr/local/cargo/bin:$PATH"
+export PATH="/src/target/debug:$HOME/.cargo/bin:/usr/local/cargo/bin:$PATH"
 export CRAB_CACHE_DIR=/e2e/crab-cache
 export GIT_TERMINAL_PROMPT=0
 
@@ -162,16 +161,16 @@ cleanup_mounts() {
         crab unmount --mountpoint /e2e/run/mnt-rw-refresh >/e2e/logs/unmount-rw-refresh.log 2>&1
         crab unmount --mountpoint /e2e/run/mnt-rw >/e2e/logs/unmount-rw.log 2>&1
     fi
-    fusermount3 -u /e2e/run/mnt-ro >/dev/null 2>&1
-    fusermount3 -u /e2e/run/mnt-rw-refresh >/dev/null 2>&1
-    fusermount3 -u /e2e/run/mnt-rw >/dev/null 2>&1
+    umount /e2e/run/mnt-ro >/dev/null 2>&1
+    umount /e2e/run/mnt-rw-refresh >/dev/null 2>&1
+    umount /e2e/run/mnt-rw >/dev/null 2>&1
 }
 trap cleanup_mounts EXIT
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update >/e2e/logs/apt-update.log
 apt-get install -y --no-install-recommends \
-    fuse3 libfuse3-dev pkg-config make git ca-certificates python3 procps \
+    nfs-common util-linux pkg-config git ca-certificates python3 procps \
     >/e2e/logs/apt-install.log
 
 git config --global --add safe.directory /src
@@ -179,10 +178,13 @@ git config --global user.name "Crab Mount E2E"
 git config --global user.email "mount-e2e@example.invalid"
 
 cd /src/crab
-make install >/e2e/logs/make-install.log 2>&1
+cargo build -p crab --bin crab --no-default-features --features nfs \
+    >/e2e/logs/cargo-build-nfs.log 2>&1
+ln -sf crab /src/target/debug/crab-nfs-mount
+ln -sf crab /src/target/debug/git-remote-crab
 crab --version | tee /e2e/crab-version.txt
-sed -n '/name = "fuser"/,/dependencies =/s/version = "\(.*\)"/dependency=fuser-\1/p' \
-    /src/Cargo.lock | head -n1 | tee /e2e/fuser-version.txt
+crab-nfs-mount --version | tee /e2e/crab-nfs-mount-version.txt
+command -v mount.nfs >/e2e/mount-nfs-path.txt
 crab mount --help >/e2e/logs/mount-help.txt
 SCENARIO_START_MS="$(now_ms)"
 
@@ -240,14 +242,17 @@ echo "seed_push=ok"
 
 RO=/e2e/run/mnt-ro
 mkdir -p "$RO"
+crab mount doctor --backend nfs --mountpoint "$RO" --json >/e2e/mount-doctor.json
 phase_start_ms="$(now_ms)"
-crab mount --repo "$REMOTE_URL" --mountpoint "$RO" --ref main --read-only --no-refresh \
+crab mount --repo "$REMOTE_URL" --mountpoint "$RO" --ref main --backend nfs --read-only --no-refresh \
     >/e2e/logs/mount-ro.log 2>&1
 for _ in $(seq 1 60); do
     [[ -e "$RO/models/model.bin" ]] && break
     sleep 1
 done
 [[ -e "$RO/models/model.bin" ]]
+mountpoint -q "$RO"
+grep -F "127.0.0.1:/crab $RO nfs" /proc/mounts >/e2e/mount-ro-native.txt
 record_duration_since ro_mount_ready_ms "$phase_start_ms"
 phase_start_ms="$(now_ms)"
 sha256sum "$RO/models/model.bin" | awk '{print $1}' > /e2e/ro-model.sha256
@@ -332,13 +337,15 @@ echo "read_only_mount=ok"
 RWR=/e2e/run/mnt-rw-refresh
 mkdir -p "$RWR"
 phase_start_ms="$(now_ms)"
-crab mount --repo "$REMOTE_URL" --mountpoint "$RWR" --ref main \
+crab mount --repo "$REMOTE_URL" --mountpoint "$RWR" --ref main --backend nfs \
     >/e2e/logs/mount-rw-refresh.log 2>&1
 for _ in $(seq 1 60); do
     [[ -e "$RWR/models/ro-refresh.bin" ]] && break
     sleep 1
 done
 [[ -e "$RWR/models/ro-refresh.bin" ]]
+mountpoint -q "$RWR"
+grep -F "127.0.0.1:/crab $RWR nfs" /proc/mounts >/e2e/mount-rw-refresh-native.txt
 record_duration_since rw_refresh_mount_ready_ms "$phase_start_ms"
 
 phase_start_ms="$(now_ms)"
@@ -389,13 +396,15 @@ echo "read_write_auto_refresh=ok"
 RW=/e2e/run/mnt-rw
 mkdir -p "$RW"
 phase_start_ms="$(now_ms)"
-crab mount --repo "$REMOTE_URL" --mountpoint "$RW" --ref main --no-refresh \
+crab mount --repo "$REMOTE_URL" --mountpoint "$RW" --ref main --backend nfs --no-refresh \
     >/e2e/logs/mount-rw.log 2>&1
 for _ in $(seq 1 60); do
     [[ -e "$RW/models/model.bin" ]] && break
     sleep 1
 done
 [[ -e "$RW/models/model.bin" ]]
+mountpoint -q "$RW"
+grep -F "127.0.0.1:/crab $RW nfs" /proc/mounts >/e2e/mount-rw-native.txt
 record_duration_since rw_mount_ready_ms "$phase_start_ms"
 
 phase_start_ms="$(now_ms)"
@@ -434,6 +443,54 @@ cmp /e2e/seed-model.sha256 /e2e/reset-model.sha256
 cmp /e2e/delete-me.sha256 /e2e/reset-delete-me.sha256
 [[ ! -e "$RW/models/reset-new.bin" ]]
 record_duration_since reset_ms "$phase_start_ms"
+
+phase_start_ms="$(now_ms)"
+python3 <<'PY'
+import concurrent.futures
+import hashlib
+import json
+import os
+import pathlib
+import threading
+import time
+
+root = pathlib.Path("/e2e/run/mnt-rw/generated")
+root.mkdir()
+barrier = threading.Barrier(4)
+
+
+def writer(index):
+    path = root / f"worker-{index}.bin"
+    block = hashlib.sha256(f"linux-nfs-writer-{index}".encode()).digest() * 8192
+    digest = hashlib.sha256()
+    barrier.wait()
+    started_ns = time.monotonic_ns()
+    with path.open("wb") as handle:
+        for _ in range(16):
+            handle.write(block)
+            digest.update(block)
+        handle.flush()
+        os.fsync(handle.fileno())
+    finished_ns = time.monotonic_ns()
+    return {
+        "path": path.relative_to(root.parent).as_posix(),
+        "bytes": path.stat().st_size,
+        "sha256": digest.hexdigest(),
+        "started_ns": started_ns,
+        "finished_ns": finished_ns,
+    }
+
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+    results = list(pool.map(writer, range(4)))
+
+if max(item["started_ns"] for item in results) >= min(item["finished_ns"] for item in results):
+    raise SystemExit("independent Linux NFS writers did not overlap")
+pathlib.Path("/e2e/concurrent-writers.json").write_text(
+    json.dumps({"writers": results}, indent=2, sort_keys=True) + "\n"
+)
+PY
+record_duration_since concurrent_writers_ms "$phase_start_ms"
 
 phase_start_ms="$(now_ms)"
 cp /e2e/run/seed/models/model.bin /e2e/run/expected-model.bin
@@ -584,6 +641,9 @@ if [[ -d "$MOUNT_CACHE/.git" ]]; then
 fi
 [[ -f "$MOUNT_GIT_DIR/HEAD" ]]
 git --git-dir "$MOUNT_GIT_DIR" rev-parse refs/heads/main > /e2e/local-ref-before-push-failure.txt
+# Keep the lazy base's compact Git blobs local so the broken origin is first
+# used by `git push`, after Crab has recorded the candidate commit for retry.
+git --git-dir "$MOUNT_GIT_DIR" archive refs/heads/main >/dev/null
 git --git-dir "$MOUNT_GIT_DIR" config remote.origin.url /e2e/run/missing-origin.git
 if crab mount commit --mountpoint "$RW" --message "mount large writeback should retry" --push --json \
     > /e2e/rw-commit-push-failure.json 2>/e2e/logs/rw-commit-push-failure.err; then
@@ -661,6 +721,27 @@ grep -q "directory rename content" "$CLONE/dir-after/nested/note.txt"
 [[ ! -e "$CLONE/dir-before/nested/note.txt" ]]
 [[ ! -e "$CLONE/archive/base-move.bin" ]]
 [[ ! -e "$CLONE/models/delete-me.bin" ]]
+python3 - "$CLONE" <<'PY'
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+
+root = pathlib.Path(sys.argv[1])
+evidence = json.loads(pathlib.Path("/e2e/concurrent-writers.json").read_text())
+for writer in evidence["writers"]:
+    path = root / writer["path"]
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    if path.stat().st_size != writer["bytes"] or digest != writer["sha256"]:
+        raise SystemExit(f"fresh clone mismatch for {writer['path']}")
+    pointer = subprocess.check_output(
+        ["git", "-C", str(root), "show", f"HEAD:{writer['path']}"],
+        text=True,
+    )
+    if "version https://crab.dev/spec/v1" not in pointer or len(pointer) >= 1000:
+        raise SystemExit(f"fresh clone did not retain a compact pointer for {writer['path']}")
+PY
 
 cd "$CLONE"
 git show HEAD:models/model.bin > /e2e/clone-model-pointer.txt
@@ -727,6 +808,7 @@ def read_timings(path):
 summary = {
     "run_id": run_id,
     "remote_url": remote_url,
+    "backend": "nfs",
     "seed_mib": int(seed_mib),
     "new_large_mib": int(new_mib),
     "sparse_extend_mib": 48,
@@ -751,6 +833,7 @@ summary = {
     "renamed_dir_note": pathlib.Path("/e2e/clone-renamed-dir-note.txt").read_text().strip(),
     "symlink_mode": pathlib.Path("/e2e/clone-model-link-mode.txt").read_text().strip(),
     "symlink_target": pathlib.Path("/e2e/run/clone/models/model-link.bin").readlink().as_posix(),
+    "concurrent_writers": json.loads(pathlib.Path("/e2e/concurrent-writers.json").read_text()),
 }
 pathlib.Path("/e2e/summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
 print(json.dumps(summary, sort_keys=True))

--- a/crab/scripts/docker/run-mount-nfs-linux-smoke.sh
+++ b/crab/scripts/docker/run-mount-nfs-linux-smoke.sh
@@ -29,6 +29,7 @@ trap cleanup EXIT
 
 command -v "$DOCKER" >/dev/null 2>&1 || die "docker is required"
 "$DOCKER" info >/dev/null 2>&1 || die "Docker daemon is not running"
+GIT_COMMIT="$(git -C "$REPO_ROOT" rev-parse HEAD)" || die "could not resolve checkout commit"
 
 mkdir -p "$RUN_ROOT" "$HOST_TARGET" "$HOST_CARGO"
 
@@ -44,6 +45,9 @@ printf "artifact_root=%s\n" "$RUN_ROOT"
     -v "$HOST_CARGO:/cargo" \
     -v "$RUN_ROOT:/e2e" \
     -e CARGO_HOME=/cargo \
+    -e CARGO_INCREMENTAL=0 \
+    -e CARGO_PROFILE_DEV_DEBUG=0 \
+    -e GIT_COMMIT="$GIT_COMMIT" \
     -e CRAB_NFS_SMOKE_RUN_ID="$RUN_ID" \
     -e CRAB_NFS_SMOKE_REPORT="$RUN_ROOT/nfs-smoke-report.json" \
     "$RUST_IMAGE" bash -s <<'INNER'
@@ -108,12 +112,6 @@ apt-get update >/e2e/logs/apt-update.log
 apt-get install -y --no-install-recommends \
     ca-certificates git make nfs-common pkg-config procps python3 util-linux \
     >/e2e/logs/apt-install.log
-
-# The checkout is bind-mounted from the host and may have a different owner.
-# Mark this exact path trusted so Git can read the revision used in evidence.
-git config --global --add safe.directory /src
-GIT_COMMIT="$(git -C /src rev-parse HEAD)"
-export GIT_COMMIT
 
 cd /src/crab
 cargo build -p crab --bin crab --no-default-features --features nfs \

--- a/crab/src/cmd/mount.rs
+++ b/crab/src/cmd/mount.rs
@@ -659,6 +659,8 @@ pub async fn run_mount_with_new_cli(opts: NewMountOpts) -> Result<()> {
                         .cache_dir
                         .join("nfs-exclusive-verifiers.json"),
                     read_only: opts.read_only,
+                    auto_refresh_interval: (!opts.read_only && !opts.no_refresh)
+                        .then_some(Duration::from_secs(30)),
                     control_endpoint_override: None,
                 };
                 nfs_mount::install_signal_handler(opts.cancel.clone());

--- a/crates/crab-vfs/src/daemon.rs
+++ b/crates/crab-vfs/src/daemon.rs
@@ -1063,6 +1063,7 @@ impl DaemonService {
                             .repo_dir
                             .join("nfs-exclusive-verifiers.json"),
                         read_only: config.read_only,
+                        auto_refresh_interval: None,
                         control_endpoint_override: control_endpoint.clone(),
                     };
                     crate::nfs_mount::preflight_for_config(&mount_config).ensure_ready()?;

--- a/crates/crab-vfs/src/mount_runtime.rs
+++ b/crates/crab-vfs/src/mount_runtime.rs
@@ -30,6 +30,14 @@ pub fn refresh_mount_runtime(
         resolve_refresh_head(git_dir, &config.source, config.ref_name.as_deref())?;
     info!(head_oid = %head_oid, head_ref = %head_ref, "resolved new HEAD after fetch");
 
+    if output.head_oid == head_oid && output.head_ref == head_ref {
+        return Ok(MountRuntimeUpdate {
+            head_oid,
+            head_ref,
+            generation: output.resolver.generation(),
+        });
+    }
+
     let update = publish_runtime_snapshot(output, config, &head_oid, &head_ref)?;
     info!(
         mountpoint = %mountpoint.display(),
@@ -103,6 +111,7 @@ fn publish_runtime_snapshot(
     output.engine.invalidate_read_source_cache();
     output.head_oid = head_oid.to_owned();
     output.head_ref = head_ref.to_owned();
+    output.generation = generation;
     run_read_tree_head(&config.git_dir);
 
     Ok(MountRuntimeUpdate {

--- a/crates/crab-vfs/src/nfs_control.rs
+++ b/crates/crab-vfs/src/nfs_control.rs
@@ -1157,6 +1157,29 @@ async fn refresh_runtime(state: &NfsControlState) -> Result<NfsControlUpdate> {
     .map_err(|error| CrabError::Internal(format!("NFS refresh task failed: {error}")))?
 }
 
+pub(crate) fn spawn_auto_refresh(
+    state: NfsControlState,
+    interval: Duration,
+    cancel: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => return,
+                () = tokio::time::sleep(interval) => {}
+            }
+            match refresh_runtime(&state).await {
+                Ok(update) => debug!(
+                    generation = update.generation,
+                    head_oid = %update.head_oid,
+                    "NFS mount auto-refresh completed"
+                ),
+                Err(error) => warn!(error = %error, "NFS mount auto-refresh failed"),
+            }
+        }
+    })
+}
+
 async fn switch_runtime(state: &NfsControlState, new_ref: String) -> Result<NfsControlUpdate> {
     let runtime = state
         .runtime

--- a/crates/crab-vfs/src/nfs_mount.rs
+++ b/crates/crab-vfs/src/nfs_mount.rs
@@ -38,6 +38,9 @@ pub struct NfsMountConfig {
     pub exclusive_verifiers_path: PathBuf,
     /// Whether to expose a read-only NFS export.
     pub read_only: bool,
+    /// Poll interval for interactive remote refreshes. Daemon-managed mounts
+    /// leave this unset because the daemon owns their refresh task.
+    pub auto_refresh_interval: Option<Duration>,
     /// Explicit control endpoint. When absent, derive it from the mountpoint
     /// or the helper-provided environment override.
     pub control_endpoint_override: Option<String>,
@@ -144,6 +147,7 @@ pub struct NfsMountedSession {
     protocol_stats: Arc<NfsProtocolStats>,
     control_endpoint: Option<String>,
     read_only: bool,
+    auto_refresh_interval: Option<Duration>,
     runtime: Option<Arc<Mutex<NfsMountRuntime>>>,
     lifecycle: NfsMountLifecycleStatus,
 }
@@ -240,6 +244,7 @@ pub async fn mount(
         protocol_stats,
         control_endpoint,
         read_only: config.read_only,
+        auto_refresh_interval: config.auto_refresh_interval,
         runtime: runtime.map(|runtime| Arc::new(Mutex::new(runtime))),
         lifecycle,
     })
@@ -250,11 +255,15 @@ pub async fn run_until_cancelled(
     mut session: NfsMountedSession,
     cancel: CancellationToken,
 ) -> Result<()> {
+    let control_state = session.control_state();
     let control_handle = nfs_control::spawn_server(
         session.control_endpoint.clone(),
-        session.control_state(),
+        control_state.clone(),
         cancel.clone(),
     );
+    let refresh_handle = session
+        .auto_refresh_interval
+        .map(|interval| nfs_control::spawn_auto_refresh(control_state, interval, cancel.clone()));
     let mut server_error = None;
     loop {
         tokio::select! {
@@ -299,6 +308,10 @@ pub async fn run_until_cancelled(
     }
 
     let shutdown_start = Instant::now();
+    cancel.cancel();
+    if let Some(handle) = refresh_handle {
+        handle.abort();
+    }
     if let Some(handle) = control_handle {
         handle.abort();
     }
@@ -458,6 +471,7 @@ pub fn preflight_for_mountpoint(mountpoint: &Path) -> NfsPreflightReport {
         git_dir: String::new(),
         exclusive_verifiers_path: PathBuf::new(),
         read_only: true,
+        auto_refresh_interval: None,
         control_endpoint_override: None,
     };
     preflight_for_config(&config)
@@ -1113,6 +1127,7 @@ mod tests {
             git_dir: ".git".to_owned(),
             exclusive_verifiers_path: tmp.path().join("verifiers.json"),
             read_only: false,
+            auto_refresh_interval: None,
             control_endpoint_override: None,
         };
 
@@ -1137,6 +1152,7 @@ mod tests {
             git_dir: ".git".to_owned(),
             exclusive_verifiers_path: tmp.path().join("verifiers.json"),
             read_only: false,
+            auto_refresh_interval: None,
             control_endpoint_override: None,
         };
 


### PR DESCRIPTION
## Summary

- make interactive native NFS mounts run the existing cache-aware remote refresh path and avoid publishing duplicate generations when the remote ref is unchanged
- turn the large RustFS/Xet smoke into an explicit native Linux NFS qualification with mount-table proof, read-only/manual refresh, automatic refresh, writable overlay reset/export, four overlapping independent writers, push-failure recovery, commit/push, and fresh eager-clone verification
- fix the Docker worktree revision probe and add retained Linux RustFS/Xet evidence on the NFS workflow

## End-to-end proof

Executed locally in a privileged Linux arm64 Docker container against RustFS with access key/secret `crab` and bucket `crabbuild`:

- native mount confirmed as `127.0.0.1:/crab ... nfs`
- 32 MiB seeded Xet file read byte-for-byte through NFS
- manual read-only refresh and 30-second writable automatic refresh succeeded
- four writers overlapped while each wrote and fsynced an independent 4 MiB file
- writable overlay covered modify/create/delete/rename/symlink/sparse-extension operations
- injected post-commit push failure retained the local commit and dirty overlay; retry pushed successfully
- fresh eager clone reproduced every SHA-256 and retained compact 122-byte Git pointers
- RustFS object count: 181
- scenario time after build/setup: 87.885 seconds

Evidence run: `mount-large-nfs-linux-20260828-proof`

## Validation

- `cargo fmt --all --check`
- `cargo test -p crab-vfs --features nfs` — 458 passed
- `cargo check -p crab --bin crab --no-default-features --features nfs`
- `make nfs-smoke-script-check`
- native Linux NFS smoke and report verification
- full Docker Linux NFS + RustFS/Xet E2E

## Concurrency boundary

This qualifies Crab's same-host loopback NFS contract. Independent paths can be written concurrently. Applications still need to coordinate same-file or intersecting-subtree writes, and separate mounts are independent Git working trees rather than a distributed lock service.
