### PR TITLE
feat(replica): auto-discover and route replica clones

### DIFF
--- a/crab/docs/architecture/git-protocol-v2.md
+++ b/crab/docs/architecture/git-protocol-v2.md
@@ -179,3 +179,8 @@ locator and visibility coverage separately. `crab fsck --store` checks current
 and historical proof roots; `crab fsck --store --repair` verifies the historical
 pack closure and idempotently backfills missing roots. Until repair completes,
 v2 stays disabled for that repository.
+
+When replication is configured, protocol-v2 capability admission and the
+terminal `stateless-connect` upload-pack session bind to the same selected
+store and repository prefix. The helper does not reselect between advertising
+and serving the immutable repository view.

--- a/crab/docs/guides/replica.md
+++ b/crab/docs/guides/replica.md
@@ -117,6 +117,12 @@ verified. Use `crab replica backfill status` to inspect that gate directly.
 In read-replica mode, the `[remote]` URL remains the write authority.
 `[replication]` only augments read routing.
 
+Git protocol v2 clone and fetch select a ready replica before capability
+advertisement, then pin that replica's store and repository prefix for the
+upload-pack session. A fresh clone can use replica routing when `.crab.toml` is
+discoverable in the clone directory or one of its ancestors; the copy inside
+the repository is not available until after the initial Git fetch.
+
 Active-active mode adds coordinator and writer-region config:
 
 ```toml

--- a/crab/docs/guides/replica.md
+++ b/crab/docs/guides/replica.md
@@ -119,9 +119,18 @@ In read-replica mode, the `[remote]` URL remains the write authority.
 
 Git protocol v2 clone and fetch select a ready replica before capability
 advertisement, then pin that replica's store and repository prefix for the
-upload-pack session. A fresh clone can use replica routing when `.crab.toml` is
-discoverable in the clone directory or one of its ancestors; the copy inside
-the repository is not available until after the initial Git fetch.
+upload-pack session. `crab replica add`, read enable/disable, removal, and
+primary-change operations publish the read-routing subset to
+`{repo}/metadata/replica-discovery.json` in the primary object store. A fresh
+direct-bucket clone reads this bounded, versioned document before its initial
+fetch, so the clone directory does not need an ancestor `.crab.toml`. Explicit
+local replication config wins when both sources exist.
+
+Discovery still needs the primary endpoint. The metadata object can remain
+available while missing Git packs or Crab payloads are served from a verified
+replica, but Crab cannot infer an unknown replica when the entire primary
+object-store endpoint is unreachable. That case requires an external service
+or preconfigured local routing.
 
 Active-active mode adds coordinator and writer-region config:
 

--- a/crab/src/cmd/hydrate.rs
+++ b/crab/src/cmd/hydrate.rs
@@ -3184,7 +3184,7 @@ pub async fn run_hydrate_in(
     let filter = if manifest_entries.is_some() {
         // Manifest mode: match everything — filtering is done by the
         // manifest entries themselves during the walk.
-        Some(build_filter(&["**/*".to_owned()], &[])?)
+        Some(build_filter(&["*".to_owned()], &[])?)
     } else {
         resolve_patterns(args, config)?
     };
@@ -3663,7 +3663,7 @@ pub fn resolve_git_pointer_prefetch_candidates(
 ) -> Result<Vec<(PathBuf, Pointer)>> {
     let manifest_entries = resolve_manifest(args, root)?;
     let filter = if manifest_entries.is_some() {
-        build_filter(&["**/*".to_owned()], &[])?
+        build_filter(&["*".to_owned()], &[])?
     } else {
         let Some(filter) = resolve_patterns(args, config)? else {
             return Ok(Vec::new());
@@ -3699,7 +3699,7 @@ pub fn resolve_all_ref_pointer_prefetch_candidates(
     cancel: &CancellationToken,
 ) -> Result<Vec<(PathBuf, Pointer)>> {
     let include = if include.is_empty() {
-        vec!["**/*".to_owned()]
+        vec!["*".to_owned()]
     } else {
         include.to_vec()
     };
@@ -4402,7 +4402,7 @@ fn build_manifest_filter(
 fn resolve_patterns(args: &HydrateArgs, config: &Config) -> Result<Option<PatternFilter>> {
     // --all: match everything.
     if args.all {
-        let filter = build_filter(&["**/*".to_owned()], &[])?;
+        let filter = build_filter(&["*".to_owned()], &[])?;
         return Ok(Some(filter));
     }
 
@@ -4415,7 +4415,7 @@ fn resolve_patterns(args: &HydrateArgs, config: &Config) -> Result<Option<Patter
     // Explicit --include/--exclude flags.
     if !args.include.is_empty() || !args.exclude.is_empty() {
         let include = if args.include.is_empty() {
-            vec!["**/*".to_owned()]
+            vec!["*".to_owned()]
         } else {
             args.include.clone()
         };
@@ -4426,7 +4426,7 @@ fn resolve_patterns(args: &HydrateArgs, config: &Config) -> Result<Option<Patter
     // Fall back to persistent config patterns.
     if !config.hydrate.include.is_empty() || !config.hydrate.exclude.is_empty() {
         let include = if config.hydrate.include.is_empty() {
-            vec!["**/*".to_owned()]
+            vec!["*".to_owned()]
         } else {
             config.hydrate.include.clone()
         };
@@ -5314,6 +5314,7 @@ mod tests {
         };
         let config = Config::default();
         let filter = resolve_patterns(&args, &config).unwrap().unwrap();
+        assert!(filter.matches("file.bin"));
         assert!(filter.matches("any/path/file.bin"));
     }
 

--- a/crab/src/cmd/replica.rs
+++ b/crab/src/cmd/replica.rs
@@ -36,6 +36,7 @@ use crate::replication::{
     replica_statuses_with_options, resume_active_active_writes, sync_readiness_cache_control_plane,
     validate_active_active_config, validate_replica_url_provider,
 };
+use crate::storage::StoreLayout;
 #[cfg(feature = "coordinator-cosmosdb")]
 use crab_coordination::cosmosdb_coordinator::AzureCosmosDbCoordinatorBackend;
 #[cfg(feature = "coordinator-dynamodb")]
@@ -1722,7 +1723,7 @@ pub struct RemovePayload {
 pub async fn exec(command: ReplicaCommand, cancel: &CancellationToken) -> Result<()> {
     check_cancelled(cancel)?;
     match command {
-        ReplicaCommand::Add(args) => run_add(&args).await,
+        ReplicaCommand::Add(args) => run_add_with_cancel(&args, cancel).await,
         ReplicaCommand::Export(args) => run_export(&args),
         ReplicaCommand::Cost(args) => run_cost(&args),
         ReplicaCommand::Runbook(args) => run_runbook(&args),
@@ -1730,24 +1731,30 @@ pub async fn exec(command: ReplicaCommand, cancel: &CancellationToken) -> Result
         ReplicaCommand::Verify(args) => run_verify(&args, cancel).await,
         ReplicaCommand::Backfill(BackfillCommand::Status(args)) => run_backfill_status(&args).await,
         ReplicaCommand::Enable(args) => run_replica_enable(&args, cancel).await,
-        ReplicaCommand::Disable(args) => run_replica_toggle(&args.name, false, args.json),
+        ReplicaCommand::Disable(args) => {
+            run_replica_toggle(&args.name, false, args.json, cancel).await
+        }
         ReplicaCommand::Mode(args) => run_mode(&args),
         ReplicaCommand::Writers(command) => run_writers(command),
         ReplicaCommand::Coordinator(command) => run_coordinator(command).await,
         ReplicaCommand::Failover(command) => run_failover(command).await,
         ReplicaCommand::Repair(args) => run_repair(&args, cancel).await,
-        ReplicaCommand::Promote(args) => run_promote(&args).await,
-        ReplicaCommand::SetPrimary(args) => run_set_primary(&args).await,
+        ReplicaCommand::Promote(args) => run_promote(&args, cancel).await,
+        ReplicaCommand::SetPrimary(args) => run_set_primary(&args, cancel).await,
         ReplicaCommand::Diagnostics(args) => run_diagnostics(&args, cancel).await,
         ReplicaCommand::Certify(args) => run_certify(&args, cancel).await,
         ReplicaCommand::Evidence(command) => run_evidence_with_cancel(&command, cancel),
         ReplicaCommand::Status(args) => run_status(&args, cancel).await,
         ReplicaCommand::Doctor(args) => run_doctor(&args, cancel).await,
-        ReplicaCommand::Remove(args) => run_remove(&args).await,
+        ReplicaCommand::Remove(args) => run_remove(&args, cancel).await,
     }
 }
 
 pub async fn run_add(args: &AddArgs) -> Result<()> {
+    run_add_with_cancel(args, &CancellationToken::new()).await
+}
+
+async fn run_add_with_cancel(args: &AddArgs, cancel: &CancellationToken) -> Result<()> {
     let provider: ReplicationProviderKind = args.provider.into();
     let rpo: ReplicationRpo = args.rpo.into();
     validate_replica_url_provider(provider, &args.replica)?;
@@ -1771,6 +1778,7 @@ pub async fn run_add(args: &AddArgs) -> Result<()> {
         let cwd = std::env::current_dir()?;
         let path = project_config_path(&cwd);
         add_replica_to_project_config(&path, args, provider, rpo)?;
+        publish_project_replica_discovery(&cwd, cancel).await?;
     }
 
     let payload = AddPayload {
@@ -1880,6 +1888,7 @@ pub async fn run_wait(args: &WaitArgs, cancel: &CancellationToken) -> Result<()>
 
     if ready && args.enable_read {
         set_replica_read_enabled(&project_config_path(&cwd), &args.name, true)?;
+        publish_project_replica_discovery(&cwd, cancel).await?;
     }
 
     let payload = WaitPayload {
@@ -1978,9 +1987,15 @@ pub async fn run_verify(args: &VerifyArgs, cancel: &CancellationToken) -> Result
     })
 }
 
-pub fn run_replica_toggle(name: &str, enabled: bool, json: bool) -> Result<()> {
+pub async fn run_replica_toggle(
+    name: &str,
+    enabled: bool,
+    json: bool,
+    cancel: &CancellationToken,
+) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let changed = set_replica_read_enabled(&project_config_path(&cwd), name, enabled)?;
+    publish_project_replica_discovery(&cwd, cancel).await?;
     let payload = TogglePayload {
         name: name.to_owned(),
         enabled,
@@ -2040,7 +2055,9 @@ async fn enable_replica_reads_after_cutover_check(
             origin: format!("replica {name} cannot be enabled for reads: {reason}"),
         });
     }
-    set_replica_read_enabled(&project_config_path(root), name, true)
+    let changed = set_replica_read_enabled(&project_config_path(root), name, true)?;
+    publish_project_replica_discovery(root, cancel).await?;
+    Ok(changed)
 }
 
 pub async fn run_backfill_status(args: &BackfillStatusArgs) -> Result<()> {
@@ -3502,7 +3519,7 @@ fn validate_repair_args(args: &RepairArgs) -> Result<()> {
     Ok(())
 }
 
-pub async fn run_promote(args: &PromoteArgs) -> Result<()> {
+pub async fn run_promote(args: &PromoteArgs, cancel: &CancellationToken) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let path = project_config_path(&cwd);
     let mut config = ProjectConfig::load(&path)?;
@@ -3582,6 +3599,7 @@ pub async fn run_promote(args: &PromoteArgs) -> Result<()> {
             replication.primary = Some(new_primary);
         }
         ProjectConfig::write(&path, &config)?;
+        publish_project_replica_discovery(&cwd, cancel).await?;
         let audit_root = path.parent().unwrap_or(cwd.as_path());
         if let Err(err) = record_replica_promote_audit(audit_root, &payload) {
             warn!(%err, "failed to append replica promotion audit event");
@@ -3612,7 +3630,7 @@ fn record_replica_promote_audit(repo_root: &Path, payload: &PromotePayload) -> R
     append_event(&repo_root.join(default_log_path()), &event)
 }
 
-pub async fn run_set_primary(args: &SetPrimaryArgs) -> Result<()> {
+pub async fn run_set_primary(args: &SetPrimaryArgs, cancel: &CancellationToken) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let path = project_config_path(&cwd);
     let mut config = ProjectConfig::load(&path)?;
@@ -3684,6 +3702,7 @@ pub async fn run_set_primary(args: &SetPrimaryArgs) -> Result<()> {
             plan_ready,
         )?;
         write_primary_to_project_config(&path, &mut config, &new_primary)?;
+        publish_project_replica_discovery(&cwd, cancel).await?;
         payload.applied = true;
     }
 
@@ -8609,7 +8628,7 @@ fn collect_sensitive(values: &mut Vec<String>, value: &str) {
     values.push(trimmed.to_owned());
 }
 
-pub async fn run_remove(args: &RemoveArgs) -> Result<()> {
+pub async fn run_remove(args: &RemoveArgs, cancel: &CancellationToken) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let path = project_config_path(&cwd);
     let apply_status = if args.apply {
@@ -8639,6 +8658,7 @@ pub async fn run_remove(args: &RemoveArgs) -> Result<()> {
         None
     };
     let removed = remove_replica_from_project_config(&path, &args.name)?;
+    publish_project_replica_discovery(&cwd, cancel).await?;
     let payload = RemovePayload {
         removed,
         name: args.name.clone(),
@@ -11818,6 +11838,32 @@ fn resolved_replication_context(root: &Path) -> Result<(Option<String>, Config)>
         .and_then(|replication| replication.primary.clone())
         .or_else(|| config.remote_url.clone());
     Ok((primary, config))
+}
+
+async fn publish_project_replica_discovery(root: &Path, cancel: &CancellationToken) -> Result<()> {
+    let (primary, config) = resolved_replication_context(root)?;
+    let primary = primary.ok_or_else(|| CrabError::Configuration {
+        key: "replication.primary".into(),
+        origin: "replica discovery publication requires a configured primary remote".into(),
+    })?;
+    let Some(replication) = config.replication.as_ref() else {
+        return Ok(());
+    };
+    let cache_dir = crab_auth::token_cache::expand_token_cache_path(&config.auth.token_cache_path);
+    let resolver = crab_auth_store::ManagedRepositoryResolver::new(cache_dir);
+    let locator = resolver.classify(&primary)?;
+    if matches!(&locator, crab_git::RepositoryLocator::Managed(_)) {
+        return Ok(());
+    }
+    let resolved = crate::auth::build_repository_store(
+        &config,
+        locator,
+        crab_auth::TransferOperation::PushUpload,
+        cancel,
+    )
+    .await?;
+    let layout = StoreLayout::new(resolved.store.clone(), resolved.repository_prefix);
+    crate::replication::discovery::publish(&resolved.store, &layout, &primary, replication).await
 }
 
 fn select_configured_replica<'a>(

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -752,6 +752,9 @@ async fn run_remote_helper_with_context(
         managed_repository,
         caching_store,
     } = context;
+    // Protocol v2 advertises and serves one immutable repository view. Keep
+    // the selected store and layout together so the handoff cannot drift.
+    let mut pinned_read_store = None;
 
     loop {
         let Some(batch) = read_batch(
@@ -773,11 +776,20 @@ async fn run_remote_helper_with_context(
             let hidden_ref_patterns = cache.config().transfer_hide_refs.clone();
             let fetch_policy = fetch_admission_policy(cache.config());
             let result = if service == "git-upload-pack" {
+                let (read_store, read_router) = pinned_read_store_for_batch(
+                    &mut pinned_read_store,
+                    &store,
+                    &prefix,
+                    Some(invocation_url.as_str()),
+                    cache.config(),
+                    &cancel,
+                )
+                .await;
                 crate::git::upload_pack_wire::serve(
                     &mut reader,
                     &mut writer,
-                    store.as_storage(),
-                    &prefix,
+                    read_store.as_storage(),
+                    read_router.repo_prefix(),
                     &hidden_ref_patterns,
                     &fetch_policy,
                     options.progress,
@@ -796,6 +808,20 @@ async fn run_remote_helper_with_context(
                 tracing::warn!(error = %error, "failed to save push state");
             }
             return result;
+        }
+        if matches!(batch, Batch::Capabilities) {
+            let (read_store, read_router) = pinned_read_store_for_batch(
+                &mut pinned_read_store,
+                &store,
+                &prefix,
+                Some(invocation_url.as_str()),
+                cache.config(),
+                &cancel,
+            )
+            .await;
+            dispatch_capabilities(&mut writer, &read_store, &read_router, &mut cache, &cancel)
+                .await?;
+            continue;
         }
         dispatch_batch(
             &batch,
@@ -1132,6 +1158,35 @@ async fn handle_option<W: tokio::io::AsyncWrite + Unpin>(
     Ok(())
 }
 
+async fn dispatch_capabilities<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    store: &crate::storage::store::Store,
+    router: &StoreLayout,
+    cache: &mut SessionCache,
+    cancel: &tokio_util::sync::CancellationToken,
+) -> Result<()> {
+    tracing::debug!("responding to capabilities");
+    let has_graph =
+        has_commit_graph_summary(Some(store), router.repo_prefix(), Some(router), cache).await;
+    let v2_ready = if crate::git::upload_pack_wire::hidden_ref_patterns_are_valid(
+        &cache.config().transfer_hide_refs,
+    ) {
+        crate::git::upload_pack_wire::snapshot_available(
+            store.as_storage(),
+            router.repo_prefix(),
+            cancel,
+        )
+        .await
+    } else {
+        tracing::warn!("invalid transfer.hideRefs pattern; protocol-v2 remains unavailable");
+        false
+    };
+    let caps = format_capabilities_with_v2(has_graph, v2_ready);
+    writer.write_all(caps.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
 /// Dispatch a collected batch and write the response.
 #[expect(
     clippy::too_many_arguments,
@@ -1161,31 +1216,14 @@ async fn dispatch_batch<W: tokio::io::AsyncWrite + Unpin>(
             ));
         }
         Batch::Capabilities => {
-            tracing::debug!("responding to capabilities");
-            let router = store.map(|s| StoreLayout::new(s.clone(), prefix.to_owned()));
-            let has_graph = has_commit_graph_summary(store, prefix, router.as_ref(), cache).await;
-            let v2_ready = if let Some(store) = store {
-                if crate::git::upload_pack_wire::hidden_ref_patterns_are_valid(
-                    &cache.config().transfer_hide_refs,
-                ) {
-                    crate::git::upload_pack_wire::snapshot_available(
-                        store.as_storage(),
-                        prefix,
-                        cancel,
-                    )
-                    .await
-                } else {
-                    tracing::warn!(
-                        "invalid transfer.hideRefs pattern; protocol-v2 remains unavailable"
-                    );
-                    false
-                }
+            if let Some(store) = store {
+                let router = StoreLayout::new(store.clone(), prefix.to_owned());
+                dispatch_capabilities(writer, store, &router, cache, cancel).await?;
             } else {
-                false
-            };
-            let caps = format_capabilities_with_v2(has_graph, v2_ready);
-            writer.write_all(caps.as_bytes()).await?;
-            writer.flush().await?;
+                let caps = format_capabilities_with_v2(false, false);
+                writer.write_all(caps.as_bytes()).await?;
+                writer.flush().await?;
+            }
         }
         Batch::List { for_push } => {
             tracing::debug!(for_push, "list requested");
@@ -1770,6 +1808,62 @@ where
             primary_store_for_batch(primary_store, prefix)
         }
     }
+}
+
+async fn pinned_read_store_for_batch(
+    pinned: &mut Option<(crate::storage::store::Store, StoreLayout)>,
+    primary_store: &crate::storage::store::Store,
+    prefix: &str,
+    remote_url: Option<&str>,
+    config: &crate::core::config::Config,
+    cancel: &tokio_util::sync::CancellationToken,
+) -> (crate::storage::store::Store, StoreLayout) {
+    pinned_read_store_for_batch_with_selector(
+        pinned,
+        primary_store,
+        prefix,
+        remote_url,
+        config,
+        cancel,
+        |config, parsed, cancel| async move {
+            crate::replication::select_read_store(&config, &parsed, "fetch", &cancel).await
+        },
+    )
+    .await
+}
+
+async fn pinned_read_store_for_batch_with_selector<F, Fut>(
+    pinned: &mut Option<(crate::storage::store::Store, StoreLayout)>,
+    primary_store: &crate::storage::store::Store,
+    prefix: &str,
+    remote_url: Option<&str>,
+    config: &crate::core::config::Config,
+    cancel: &tokio_util::sync::CancellationToken,
+    select_read: F,
+) -> (crate::storage::store::Store, StoreLayout)
+where
+    F: FnOnce(
+        crate::core::config::Config,
+        crate::git::url::CrabUrl,
+        tokio_util::sync::CancellationToken,
+    ) -> Fut,
+    Fut: Future<Output = Result<crate::replication::ReadStoreSelection>>,
+{
+    if let Some((store, router)) = pinned {
+        return (store.clone(), router.clone());
+    }
+
+    let selected = read_store_for_batch_with_selector(
+        primary_store,
+        prefix,
+        remote_url,
+        config,
+        cancel,
+        select_read,
+    )
+    .await;
+    *pinned = Some(selected.clone());
+    selected
 }
 
 /// Check whether the committed manifest pins a split commit graph.
@@ -3040,7 +3134,8 @@ mod tests {
             "1111111111111111111111111111111111111111",
         )
         .await;
-        let (replica_store, replica_router) = memory_store_with_manifest(
+        let (replica_store, replica_router) = memory_store_with_manifest_at_prefix(
+            "replica/repo",
             "refs/heads/main",
             "2222222222222222222222222222222222222222",
         )
@@ -3195,6 +3290,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn protocol_v2_read_store_is_selected_once_and_pinned() {
+        let (primary_store, _primary_router) = memory_store_with_manifest(
+            "refs/heads/main",
+            "1111111111111111111111111111111111111111",
+        )
+        .await;
+        let (replica_store, replica_router) = memory_store_with_manifest_at_prefix(
+            "replica/repo",
+            "refs/heads/main",
+            "2222222222222222222222222222222222222222",
+        )
+        .await;
+        let config = config_with_read_replica();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let selector_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut pinned = None;
+
+        for _ in 0..2 {
+            let selector_calls = std::sync::Arc::clone(&selector_calls);
+            let replica_store = replica_store.clone();
+            let replica_router = replica_router.clone();
+            let (read_store, router) = pinned_read_store_for_batch_with_selector(
+                &mut pinned,
+                &primary_store,
+                "org/repo",
+                Some("crab://primary/org/repo"),
+                &config,
+                &cancel,
+                move |_, _, _| async move {
+                    selector_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(crate::replication::ReadStoreSelection {
+                        store: replica_store,
+                        router: replica_router,
+                        source: crate::replication::ReadSource::Replica {
+                            name: "west".into(),
+                        },
+                    })
+                },
+            )
+            .await;
+            let output = read_remote_refs(&read_store, &router, &[])
+                .await
+                .expect("read pinned replica refs");
+            assert_eq!(
+                output.refs[0].sha,
+                "2222222222222222222222222222222222222222"
+            );
+            assert_eq!(router.repo_prefix(), "replica/repo");
+        }
+
+        assert_eq!(selector_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn fetch_batch_accepts_refs_from_selected_replica_manifest() {
         let _guard = GitWorktreeGuard::new();
         let replica_tip = TEST_GIT_REPO.commit_sha.clone();
@@ -3302,6 +3451,14 @@ mod tests {
         ref_name: &str,
         sha: &str,
     ) -> (crate::storage::store::Store, StoreLayout) {
+        memory_store_with_manifest_at_prefix("org/repo", ref_name, sha).await
+    }
+
+    async fn memory_store_with_manifest_at_prefix(
+        prefix: &str,
+        ref_name: &str,
+        sha: &str,
+    ) -> (crate::storage::store::Store, StoreLayout) {
         use crate::metadata::manifest::{Manifest, create_manifest};
         use crate::storage::store::Store;
         use object_store::memory::InMemory;
@@ -3310,7 +3467,7 @@ mod tests {
 
         let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
         let store = Store::new(inner);
-        let router = StoreLayout::new(store.clone(), "org/repo".to_string());
+        let router = StoreLayout::new(store.clone(), prefix.to_owned());
         let refs = BTreeMap::from([(ref_name.to_owned(), sha.to_owned())]);
         let mut manifest = Manifest {
             version: 2,

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -662,7 +662,7 @@ pub async fn run_remote_helper(
         };
 
     // Resolve config early — needed for store construction and CachingStore.
-    let config = resolve_remote_helper_config()?;
+    let mut config = resolve_remote_helper_config()?;
 
     // Classify before constructing any store. A corrupt configured profile is
     // an error, never a reason to reinterpret a logical authority as a bucket.
@@ -681,6 +681,18 @@ pub async fn run_remote_helper(
         &cancel,
     )
     .await?;
+
+    if managed_repository.is_none() && config.replication.is_none() {
+        let layout = StoreLayout::new(resolved.store.clone(), resolved.repository_prefix.clone());
+        let discovered =
+            crate::replication::discovery::load(&resolved.store, &layout, &invocation_url).await?;
+        if crate::replication::discovery::apply_if_unconfigured(&mut config, discovered) {
+            tracing::debug!(
+                discovery_path = %layout.replica_discovery_path(),
+                "loaded replica routing from primary discovery"
+            );
+        }
+    }
 
     // Wrap with CachingStore when a cache service is configured.
     // The caching store routes immutable reads (packs, shards) through

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -512,7 +512,7 @@ fn finalize_batch(
 /// fetches, and commit-graph probes within a single `run_remote_helper`
 /// invocation.
 struct SessionCache {
-    /// Config resolved before any remote operation starts.
+    /// Session config, augmented once by replica discovery before the first read operation.
     config: crate::core::config::Config,
     /// PackList from the most recent fetch, reused by `check_repack_threshold`.
     pack_list: Option<crab_metadata::manifests::PackList>,
@@ -662,7 +662,7 @@ pub async fn run_remote_helper(
         };
 
     // Resolve config early — needed for store construction and CachingStore.
-    let mut config = resolve_remote_helper_config()?;
+    let config = resolve_remote_helper_config()?;
 
     // Classify before constructing any store. A corrupt configured profile is
     // an error, never a reason to reinterpret a logical authority as a bucket.
@@ -682,17 +682,9 @@ pub async fn run_remote_helper(
     )
     .await?;
 
-    if managed_repository.is_none() && config.replication.is_none() {
-        let layout = StoreLayout::new(resolved.store.clone(), resolved.repository_prefix.clone());
-        let discovered =
-            crate::replication::discovery::load(&resolved.store, &layout, &invocation_url).await?;
-        if crate::replication::discovery::apply_if_unconfigured(&mut config, discovered) {
-            tracing::debug!(
-                discovery_path = %layout.replica_discovery_path(),
-                "loaded replica routing from primary discovery"
-            );
-        }
-    }
+    // Protocol parsing and option handling do not depend on storage. Defer the
+    // optional discovery read until Git requests repository data.
+    let replica_discovery_pending = managed_repository.is_none() && config.replication.is_none();
 
     // Wrap with CachingStore when a cache service is configured.
     // The caching store routes immutable reads (packs, shards) through
@@ -723,6 +715,7 @@ pub async fn run_remote_helper(
         invocation_url,
         managed_repository,
         caching_store,
+        replica_discovery_pending,
     };
 
     run_remote_helper_with_context(remote_name, io, context, cancel).await
@@ -740,6 +733,7 @@ struct RemoteHelperContext {
     invocation_url: String,
     managed_repository: Option<crab_git::ManagedRepository>,
     caching_store: Option<crab_cache_store::CachingStore>,
+    replica_discovery_pending: bool,
 }
 
 async fn run_remote_helper_with_context(
@@ -763,6 +757,7 @@ async fn run_remote_helper_with_context(
         invocation_url,
         managed_repository,
         caching_store,
+        mut replica_discovery_pending,
     } = context;
     // Protocol v2 advertises and serves one immutable repository view. Keep
     // the selected store and layout together so the handoff cannot drift.
@@ -784,6 +779,16 @@ async fn run_remote_helper_with_context(
             }
             return Ok(());
         };
+        let uses_read_routing = match &batch {
+            Batch::Capabilities | Batch::List { for_push: false } | Batch::Fetch(_) => true,
+            Batch::StatelessConnect { service } => service == "git-upload-pack",
+            Batch::List { for_push: true } | Batch::Push(_) => false,
+        };
+        if replica_discovery_pending && uses_read_routing {
+            replica_discovery_pending = false;
+            load_replica_discovery_for_session(&store, &prefix, &invocation_url, &mut cache.config)
+                .await?;
+        }
         if let Batch::StatelessConnect { service } = &batch {
             let hidden_ref_patterns = cache.config().transfer_hide_refs.clone();
             let fetch_policy = fetch_admission_policy(cache.config());
@@ -854,6 +859,44 @@ async fn run_remote_helper_with_context(
         )
         .await?;
     }
+}
+
+async fn load_replica_discovery_for_session(
+    store: &crate::storage::store::Store,
+    prefix: &str,
+    invocation_url: &str,
+    config: &mut crate::core::config::Config,
+) -> Result<()> {
+    let layout = StoreLayout::new(store.clone(), prefix.to_owned());
+    let discovered = match crate::replication::discovery::load(store, &layout, invocation_url).await
+    {
+        Ok(discovered) => discovered,
+        Err(
+            error @ (CrabError::NetworkTransient(_)
+            | CrabError::Throttled { .. }
+            | CrabError::Forbidden { .. }
+            | CrabError::NoCredentials
+            | CrabError::AuthFailed { .. }
+            | CrabError::AuthExpired { .. }
+            | CrabError::Io(_)
+            | CrabError::Storage(_)),
+        ) => {
+            tracing::debug!(
+                error = %error,
+                discovery_path = %layout.replica_discovery_path(),
+                "replica discovery unavailable; using primary"
+            );
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
+    if crate::replication::discovery::apply_if_unconfigured(config, discovered) {
+        tracing::debug!(
+            discovery_path = %layout.replica_discovery_path(),
+            "loaded replica routing from primary discovery"
+        );
+    }
+    Ok(())
 }
 
 /// Open the staging area for the push pipeline (read-only).
@@ -3043,6 +3086,7 @@ mod tests {
             invocation_url: format!("crab://bucket/{prefix}"),
             managed_repository: None,
             caching_store: None,
+            replica_discovery_pending: false,
         }
     }
 

--- a/crab/src/replication/discovery.rs
+++ b/crab/src/replication/discovery.rs
@@ -1,0 +1,257 @@
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+use super::{ReplicaConfig, ReplicationConfig, validate_replica_url_provider};
+use crate::core::config::Config;
+use crate::core::error::{CrabError, Result};
+use crate::git::url::CrabUrl;
+use crate::storage::StoreLayout;
+use crate::storage::store::Store;
+
+const REPLICA_DISCOVERY_VERSION: u32 = 1;
+const MAX_REPLICA_DISCOVERY_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct ReplicaDiscoveryDocument {
+    version: u32,
+    primary: String,
+    replicas: Vec<ReplicaConfig>,
+}
+
+/// Publish the read-routing subset needed to bootstrap a fresh clone.
+pub(crate) async fn publish(
+    store: &Store,
+    layout: &StoreLayout,
+    primary: &str,
+    replication: &ReplicationConfig,
+) -> Result<()> {
+    let document = ReplicaDiscoveryDocument {
+        version: REPLICA_DISCOVERY_VERSION,
+        primary: canonical_primary(primary)?,
+        replicas: replication.replicas.clone(),
+    };
+    for replica in &document.replicas {
+        validate_replica_url_provider(replica.provider, &replica.url)?;
+    }
+
+    let path = layout.replica_discovery_path();
+    let body = serde_json::to_vec(&document).map_err(|error| CrabError::CorruptObject {
+        path: path.to_string(),
+        reason: format!("failed to serialize replica discovery: {error}"),
+    })?;
+    if body.len() as u64 > MAX_REPLICA_DISCOVERY_BYTES {
+        return Err(CrabError::Configuration {
+            key: "replication.replicas".into(),
+            origin: format!(
+                "replica discovery exceeds the {MAX_REPLICA_DISCOVERY_BYTES}-byte limit"
+            ),
+        });
+    }
+    store.put_overwrite(&path, Bytes::from(body)).await
+}
+
+/// Load replica routing from the authoritative primary before Git fetches config.
+pub(crate) async fn load(
+    store: &Store,
+    layout: &StoreLayout,
+    expected_primary: &str,
+) -> Result<Option<ReplicationConfig>> {
+    let path = layout.replica_discovery_path();
+    let (body, _) = match store
+        .get_with_etag_bounded(&path, MAX_REPLICA_DISCOVERY_BYTES)
+        .await
+    {
+        Ok(result) => result,
+        Err(CrabError::NotFound { path: missing }) if missing == path.as_ref() => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let document: ReplicaDiscoveryDocument =
+        serde_json::from_slice(&body).map_err(|error| CrabError::CorruptObject {
+            path: path.to_string(),
+            reason: format!("invalid replica discovery document: {error}"),
+        })?;
+    if document.version != REPLICA_DISCOVERY_VERSION {
+        return Err(CrabError::IncompatibleFormat {
+            required: format!("replica discovery v{REPLICA_DISCOVERY_VERSION}"),
+            found: format!("replica discovery v{}", document.version),
+        });
+    }
+
+    let expected_primary = canonical_primary(expected_primary)?;
+    let discovered_primary =
+        canonical_primary(&document.primary).map_err(|error| CrabError::CorruptObject {
+            path: path.to_string(),
+            reason: format!("invalid discovery primary: {error}"),
+        })?;
+    if discovered_primary != expected_primary {
+        return Err(CrabError::CorruptObject {
+            path: path.to_string(),
+            reason: format!(
+                "discovery primary {discovered_primary} does not match requested {expected_primary}"
+            ),
+        });
+    }
+    for replica in &document.replicas {
+        validate_replica_url_provider(replica.provider, &replica.url).map_err(|error| {
+            CrabError::CorruptObject {
+                path: path.to_string(),
+                reason: format!("invalid replica {}: {error}", replica.name),
+            }
+        })?;
+    }
+
+    Ok(Some(ReplicationConfig {
+        primary: Some(discovered_primary),
+        replicas: document.replicas,
+        ..ReplicationConfig::default()
+    }))
+}
+
+/// Apply discovered routing only when no explicit local routing is available.
+pub(crate) fn apply_if_unconfigured(
+    config: &mut Config,
+    discovered: Option<ReplicationConfig>,
+) -> bool {
+    if config.replication.is_some() {
+        return false;
+    }
+    let Some(discovered) = discovered else {
+        return false;
+    };
+    config.replication = Some(discovered);
+    true
+}
+
+fn canonical_primary(primary: &str) -> Result<String> {
+    let parsed = CrabUrl::parse(primary)?;
+    Ok(format!("crab://{}/{}", parsed.bucket, parsed.repo_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use object_store::memory::InMemory;
+
+    use super::*;
+    use crate::replication::{ReplicationProviderKind, ReplicationRpo};
+
+    fn store_and_layout() -> (Store, StoreLayout) {
+        let store = Store::new(Arc::new(InMemory::new()));
+        let layout = StoreLayout::new(store.clone(), "org/repo".to_owned());
+        (store, layout)
+    }
+
+    fn replication() -> ReplicationConfig {
+        ReplicationConfig {
+            primary: Some("crab://primary/org/repo".to_owned()),
+            replicas: vec![ReplicaConfig {
+                name: "west".to_owned(),
+                provider: ReplicationProviderKind::S3,
+                url: "crab://replica/replicated/org/repo".to_owned(),
+                region: "us-west-2".to_owned(),
+                backfill: true,
+                read: true,
+                rpo: ReplicationRpo::Standard,
+            }],
+            ..ReplicationConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn published_discovery_round_trips_read_routing() {
+        let (store, layout) = store_and_layout();
+        let expected = replication();
+
+        publish(
+            &store,
+            &layout,
+            expected.primary.as_deref().unwrap(),
+            &expected,
+        )
+        .await
+        .unwrap();
+        let loaded = load(&store, &layout, "crab://primary/org/repo/")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(loaded, expected);
+    }
+
+    #[tokio::test]
+    async fn missing_discovery_keeps_primary_only_routing() {
+        let (store, layout) = store_and_layout();
+
+        let loaded = load(&store, &layout, "crab://primary/org/repo")
+            .await
+            .unwrap();
+
+        assert!(loaded.is_none());
+    }
+
+    #[tokio::test]
+    async fn discovery_is_bound_to_requested_primary() {
+        let (store, layout) = store_and_layout();
+        let replication = replication();
+        publish(
+            &store,
+            &layout,
+            replication.primary.as_deref().unwrap(),
+            &replication,
+        )
+        .await
+        .unwrap();
+
+        let error = load(&store, &layout, "crab://other/org/repo")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, CrabError::CorruptObject { .. }));
+    }
+
+    #[tokio::test]
+    async fn unsupported_discovery_version_fails_closed() {
+        let (store, layout) = store_and_layout();
+        let path = layout.replica_discovery_path();
+        store
+            .put_overwrite(
+                &path,
+                Bytes::from_static(
+                    br#"{"version":2,"primary":"crab://primary/org/repo","replicas":[]}"#,
+                ),
+            )
+            .await
+            .unwrap();
+
+        let error = load(&store, &layout, "crab://primary/org/repo")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, CrabError::IncompatibleFormat { .. }));
+    }
+
+    #[test]
+    fn discovery_populates_unconfigured_session() {
+        let mut config = Config::default();
+        let expected = replication();
+
+        let changed = apply_if_unconfigured(&mut config, Some(expected.clone()));
+
+        assert!(changed);
+        assert_eq!(config.replication, Some(expected));
+    }
+
+    #[test]
+    fn explicit_local_replication_wins_over_discovery() {
+        let mut config = Config {
+            replication: Some(ReplicationConfig::default()),
+            ..Config::default()
+        };
+
+        let changed = apply_if_unconfigured(&mut config, Some(replication()));
+
+        assert!(!changed);
+        assert_eq!(config.replication, Some(ReplicationConfig::default()));
+    }
+}

--- a/crab/src/replication/mod.rs
+++ b/crab/src/replication/mod.rs
@@ -4,6 +4,8 @@
 //! only, selected after their manifest generation and referenced immutable
 //! objects are known to be present.
 
+pub(crate) mod discovery;
+
 use std::collections::{BTreeSet, HashSet};
 use std::fmt;
 use std::io::Write;

--- a/crates/crab-storage/src/layout.rs
+++ b/crates/crab-storage/src/layout.rs
@@ -170,6 +170,12 @@ impl<S> StoreLayout<S> {
         self.repo_path("manifest")
     }
 
+    /// Path to the fresh-clone replica discovery document.
+    #[must_use]
+    pub fn replica_discovery_path(&self) -> ObjectPath {
+        self.repo_path("metadata/replica-discovery.json")
+    }
+
     /// Prefix containing immutable historical manifest roots.
     #[must_use]
     pub fn manifest_history_prefix(&self) -> ObjectPath {
@@ -536,6 +542,15 @@ mod tests {
     fn manifest_path_is_per_repo() {
         let layout = test_layout();
         assert_eq!(layout.manifest_path().as_ref(), "org/models/manifest");
+    }
+
+    #[test]
+    fn replica_discovery_path_is_per_repo() {
+        let layout = test_layout();
+        assert_eq!(
+            layout.replica_discovery_path().as_ref(),
+            "org/models/metadata/replica-discovery.json"
+        );
     }
 
     #[test]

--- a/packages/web/content/docs/cli/reference/crab-replica.mdx
+++ b/packages/web/content/docs/cli/reference/crab-replica.mdx
@@ -43,5 +43,12 @@ Use `crab replica doctor` for configuration and readiness diagnostics. Use
 `promote` or `set-primary` only as guarded disaster-recovery operations after
 reviewing the generated plan and provider state.
 
+Read-enabled replicas participate in both legacy Git fetches and protocol-v2
+clone/fetch sessions. Protocol v2 selects the ready replica before capability
+advertisement and pins its storage location for the upload-pack session. For a
+fresh clone, make the replica-bearing `.crab.toml` discoverable in the clone
+directory or one of its ancestors because the repository's committed config is
+not available until the initial fetch completes.
+
 Run `crab replica <subcommand> --help` for the exact provider, active-active,
 failover, and evidence options available in the installed CLI.

--- a/packages/web/content/docs/cli/reference/crab-replica.mdx
+++ b/packages/web/content/docs/cli/reference/crab-replica.mdx
@@ -45,10 +45,16 @@ reviewing the generated plan and provider state.
 
 Read-enabled replicas participate in both legacy Git fetches and protocol-v2
 clone/fetch sessions. Protocol v2 selects the ready replica before capability
-advertisement and pins its storage location for the upload-pack session. For a
-fresh clone, make the replica-bearing `.crab.toml` discoverable in the clone
-directory or one of its ancestors because the repository's committed config is
-not available until the initial fetch completes.
+advertisement and pins its storage location for the upload-pack session.
+Replica configuration changes also publish a bounded discovery document under
+the primary repository prefix. A fresh direct-bucket clone reads that document
+before its initial fetch, so it does not need an ancestor `.crab.toml`.
+
+The primary endpoint remains the discovery trust anchor. Its discovery object
+must be reachable even when Git packs or Crab payloads are unavailable there;
+if the entire primary endpoint is unreachable, a client that knows only the
+primary URL cannot discover an unknown replica without an external registry.
+An explicit local replication config takes precedence over discovered routing.
 
 Run `crab replica <subcommand> --help` for the exact provider, active-active,
 failover, and evidence options available in the installed CLI.

--- a/packages/web/content/docs/cli/reference/crab-replica.mdx
+++ b/packages/web/content/docs/cli/reference/crab-replica.mdx
@@ -54,7 +54,10 @@ The primary endpoint remains the discovery trust anchor. Its discovery object
 must be reachable even when Git packs or Crab payloads are unavailable there;
 if the entire primary endpoint is unreachable, a client that knows only the
 primary URL cannot discover an unknown replica without an external registry.
-An explicit local replication config takes precedence over discovered routing.
+When the optional discovery read is unavailable, Crab continues against the
+primary; a discovery object that is readable but malformed or incompatible
+still fails closed. An explicit local replication config takes precedence over
+discovered routing.
 
 Run `crab replica <subcommand> --help` for the exact provider, active-active,
 failover, and evidence options available in the installed CLI.


### PR DESCRIPTION
## Summary

- publish a bounded, versioned replica-discovery document at `{repo}/metadata/replica-discovery.json` whenever direct-bucket replica routing changes
- load that document from the authoritative primary before a fresh clone's initial fetch, while preserving explicit local-config precedence and leaving managed-service resolution unchanged
- select and pin a ready replica before protocol-v2 capability admission, then use the same store and repository prefix throughout terminal `stateless-connect` upload-pack
- keep the primary as the write authority and discovery trust anchor; absence falls back to primary-only routing, while malformed, mismatched, or unsupported discovery fails closed
- make hydrate match-all selectors include repository-root files with `gix-pathmatch`
- document the bootstrap contract and the irreducible requirement that the small primary discovery object remain reachable without an external registry

## Why this is the bounded fix

The committed `.crab.toml` cannot bootstrap its own initial fetch. Publishing only the read-routing subset beside the primary repository metadata solves that ordering problem without introducing a Crab data server, exposing write-coordinator configuration, or adding a second remote-resolution authority. The object-store owner remains the trust boundary, and explicit local configuration still wins.

## Verification

- `cargo test -p crab --lib replication::discovery::tests --locked`: 6 passed
- `cargo test -p crab-storage replica_discovery_path_is_per_repo --locked`: passed
- `cargo test -p crab --lib git::remote_helper::tests::protocol_v2_read_store_is_selected_once_and_pinned --locked`: passed
- `cargo test -p crab --lib git::remote_helper::tests::stateless_connect_dispatches_before_protocol_payload --locked`: passed
- existing `gix-pathmatch` root match-all regression tests: 2 passed
- `cargo check -p crab --locked`: passed
- `cargo fmt --all` and `git diff --check`: passed
- `npm run build`: passed, 235 static pages generated
- `npm run check:links`: passed, 323 HTML pages and 3,282 fragments
- `cargo clippy -p crab --lib --locked`: exits successfully; current checkout reports the existing warning backlog, with no warning on the changed discovery/publication/remote-helper/layout lines

## Docker RustFS E2E

- initialized and pushed a repository containing a 2 MiB Crab-managed payload
- `crab replica add` created the primary discovery object; `crab replica wait west --enable-read` republished it with `read=true`
- manually synchronized the replica under a different repository prefix and passed exhaustive readiness at zero generation lag
- removed all primary Git pack bodies and the primary xorb payload while retaining the primary manifest and discovery object
- ran `crab clone --no-lazy` from an empty directory with no `.crab.toml` in any ancestor
- trace confirmed `loaded replica routing from primary discovery` followed by `selected read replica ... west`
- clone completed at the expected commit; `git fsck --strict`, 2 MiB size, and SHA-256 identity for the payload, README, and `.crab.toml` all passed

The first manual-copy attempt was intentionally not counted as green: plain `aws s3 sync` did not propagate deletion of a compacted `refs/journal/active` marker, and protocol-v2 admission failed closed after observing locator generation 2 with generation 3 required. Propagating that deletion, as provider replication must do for Crab's mutable repository state, made the fresh clone pass.

## Scope and limitation

Auto-discovery currently applies to direct object-store repositories. If the entire primary endpoint is unreachable, a client that knows only its primary URL cannot learn an unknown replica endpoint; that scenario still requires managed-service resolution or preconfigured local routing.
