### PR TITLE
ci: consolidate shared builds

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -99,10 +99,12 @@ jobs:
         working-directory: crab
         run: make architecture-check
 
-  crate-interfaces:
-    name: Split-crate interface checks
+  # Split-crate checks reuse library artifacts; binary and integration checks share
+  # executable builds. Two cohorts retain parallel feedback without duplicate targets.
+  split-crate-contracts:
+    name: Split-crate contracts
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
@@ -111,62 +113,46 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Linux system dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y libfuse3-dev
+
       - name: Run split-crate interface checks
+        id: crate_interfaces
+        continue-on-error: true
         working-directory: crab
         run: make crate-interface-check
 
-  crate-behavior:
-    name: Split-crate behavior checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Run split-crate behavior checks
+        id: crate_behavior
+        continue-on-error: true
         working-directory: crab
         run: make crate-behavior-check
 
-  split-crate-clippy:
-    name: Split-crate clippy checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Run split-crate clippy checks
+        id: split_crate_clippy
+        continue-on-error: true
         working-directory: crab
         run: make split-crate-clippy-check
 
-  split-crate-tests:
-    name: Split-crate test checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Run split-crate test checks
+        id: split_crate_tests
+        continue-on-error: true
         working-directory: crab
         run: make split-crate-test-check
 
-  shipped-binary-versions:
-    name: Shipped binary version checks
+      - name: Fail when a split-crate contract failed
+        if: >-
+          always() &&
+          (steps.crate_interfaces.outcome != 'success' ||
+           steps.crate_behavior.outcome != 'success' ||
+           steps.split_crate_clippy.outcome != 'success' ||
+           steps.split_crate_tests.outcome != 'success')
+        run: exit 1
+
+  binary-contracts:
+    name: Binary and integration contracts
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -179,27 +165,30 @@ jobs:
         run: sudo apt-get update -y && sudo apt-get install -y libfuse3-dev
 
       - name: Run shipped binary version checks
+        id: shipped_binary_versions
+        continue-on-error: true
         working-directory: crab
         run: make shipped-binary-version-check
 
-  install-layout:
-    name: Install layout check
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Linux system dependencies
-        run: sudo apt-get update -y && sudo apt-get install -y libfuse3-dev
-
       - name: Run install layout check
+        id: install_layout
+        continue-on-error: true
         working-directory: crab
         run: make install-layout-check
+
+      - name: Run final integration checks
+        id: final_integration
+        continue-on-error: true
+        working-directory: crab
+        run: make final-integration-check
+
+      - name: Fail when a binary or integration contract failed
+        if: >-
+          always() &&
+          (steps.shipped_binary_versions.outcome != 'success' ||
+           steps.install_layout.outcome != 'success' ||
+           steps.final_integration.outcome != 'success')
+        run: exit 1
 
   auth-helper-packaging:
     name: Auth helper packaging check
@@ -248,22 +237,3 @@ jobs:
       - name: Run release archive contents check
         working-directory: crab
         run: make release-archive-contents-check
-
-  final-integration:
-    name: Final integration checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Linux system dependencies
-        run: sudo apt-get update -y && sudo apt-get install -y libfuse3-dev
-
-      - name: Run final integration checks
-        working-directory: crab
-        run: make final-integration-check

--- a/.github/workflows/cache-service.yml
+++ b/.github/workflows/cache-service.yml
@@ -1,7 +1,7 @@
 name: Cache Service Tests
 
-# Build and test the cache service on pushes to main and PRs that touch
-# cache service source, client code, or deployment configs.
+# Build, test, and smoke the cache service on pushes to main and PRs that
+# touch cache service source, client code, or deployment configs.
 on:
   push:
     branches: [main]
@@ -67,48 +67,9 @@ concurrency:
 
 jobs:
   test:
-    name: Build & test cache service
+    name: Build, test & smoke cache service
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
-
-      - name: Install Linux system dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y \
-            libfuse3-dev \
-            prometheus
-
-      - name: Validate cache service manifests
-        working-directory: crab
-        run: make cache-service-validate-manifests
-
-      - name: Build crab-cache-server
-        run: cargo build --release -p crab-cache-server --bin crab-cache-server
-
-      - name: Run cache service tests
-        run: |
-          cargo test -p crab-cache-server --lib
-          cargo test -p crab --lib cache_service
-          cargo test -p crab-cache-server --test cache_service_integration
-          cargo test -p crab-cache-server --test cache_server_preflight_cli
-
-  rustfs-smoke:
-    name: RustFS cache-service smoke
-    runs-on: ubuntu-latest
-    needs: test
-    timeout-minutes: 45
+    timeout-minutes: 90
     env:
       CACHE_SERVICE_RUSTFS_ACCESS_KEY: crab
       CACHE_SERVICE_RUSTFS_BUCKET: crab
@@ -136,7 +97,8 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             curl \
-            libfuse3-dev
+            libfuse3-dev \
+            prometheus
           if ! command -v aws >/dev/null 2>&1; then
             sudo apt-get install -y pipx
             pipx install awscli
@@ -144,6 +106,20 @@ jobs:
           fi
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           aws --version
+
+      - name: Validate cache service manifests
+        working-directory: crab
+        run: make cache-service-validate-manifests
+
+      - name: Build crab-cache-server
+        run: cargo build --release -p crab-cache-server --bin crab-cache-server
+
+      - name: Run cache service tests
+        run: |
+          cargo test -p crab-cache-server --lib
+          cargo test -p crab --lib cache_service
+          cargo test -p crab-cache-server --test cache_service_integration
+          cargo test -p crab-cache-server --test cache_server_preflight_cli
 
       - name: Start RustFS
         run: |

--- a/.github/workflows/git-protocol-v2-partial-clone.yml
+++ b/.github/workflows/git-protocol-v2-partial-clone.yml
@@ -84,6 +84,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_TARGET_DIR: ${{ github.workspace }}/target/crab-protocol-v2
+  CRAB_RELEASE_ARCHIVE: crab-protocol-v2-linux-x86_64.tar.gz
+  CRAB_RELEASE_ARTIFACT: crab-protocol-v2-linux-x86_64-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   unit-and-transcript:
@@ -126,10 +128,44 @@ jobs:
             crates/crab-remote-git/src/reader.rs \
             crates/crab-remote-git/src/repository.rs
 
+  release-build:
+    name: Build shared protocol release artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux system dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y libfuse3-dev
+
+      - name: Build release artifact with source provenance
+        run: |
+          GIT_SHA="$(git rev-parse HEAD)" \
+            cargo build -p crab --release --locked --features gix-transport
+          test -x "${CARGO_TARGET_DIR}/release/crab"
+          # Artifact upload normalizes file modes, so tar preserves the executable bit.
+          tar -C "${CARGO_TARGET_DIR}/release" \
+            -czf "${RUNNER_TEMP}/${CRAB_RELEASE_ARCHIVE}" crab
+
+      - name: Upload shared release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.CRAB_RELEASE_ARTIFACT }}
+          path: ${{ runner.temp }}/${{ env.CRAB_RELEASE_ARCHIVE }}
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   real-git-version-matrix:
     name: Real Git compatibility (${{ matrix.label }})
     runs-on: ubuntu-latest
-    needs: unit-and-transcript
+    needs: [unit-and-transcript, release-build]
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -158,9 +194,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Install compatibility dependencies
         run: |
           sudo apt-get update -y
@@ -171,10 +204,19 @@ jobs:
           pipx install awscli
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Build release artifact with source provenance
+      - name: Download shared release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.CRAB_RELEASE_ARTIFACT }}
+          path: ${{ runner.temp }}/crab-protocol-v2-release
+
+      - name: Extract shared release artifact
         run: |
-          GIT_SHA="$(git rev-parse HEAD)" \
-            cargo build -p crab --release --locked --features gix-transport
+          mkdir -p "${CARGO_TARGET_DIR}/release"
+          tar -xzf "${RUNNER_TEMP}/crab-protocol-v2-release/${CRAB_RELEASE_ARCHIVE}" \
+            -C "${CARGO_TARGET_DIR}/release"
+          test -x "${CARGO_TARGET_DIR}/release/crab"
+          "${CARGO_TARGET_DIR}/release/crab" version | grep -F "$(git rev-parse HEAD)"
 
       - name: Install selected Git
         shell: bash
@@ -255,7 +297,7 @@ jobs:
   rustfs-lifecycle:
     name: Released-shape RustFS partial-clone lifecycle
     runs-on: ubuntu-latest
-    needs: unit-and-transcript
+    needs: [unit-and-transcript, release-build]
     timeout-minutes: 45
     env:
       CRAB_E2E_BUCKET: crab
@@ -273,9 +315,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Install smoke dependencies
         run: |
           sudo apt-get update -y
@@ -283,10 +322,19 @@ jobs:
           pipx install awscli
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Build release artifact with source provenance
+      - name: Download shared release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.CRAB_RELEASE_ARTIFACT }}
+          path: ${{ runner.temp }}/crab-protocol-v2-release
+
+      - name: Extract shared release artifact
         run: |
-          GIT_SHA="$(git rev-parse HEAD)" \
-            cargo build -p crab --release --locked --features gix-transport
+          mkdir -p "${CARGO_TARGET_DIR}/release"
+          tar -xzf "${RUNNER_TEMP}/crab-protocol-v2-release/${CRAB_RELEASE_ARCHIVE}" \
+            -C "${CARGO_TARGET_DIR}/release"
+          test -x "${CARGO_TARGET_DIR}/release/crab"
+          "${CARGO_TARGET_DIR}/release/crab" version | grep -F "$(git rev-parse HEAD)"
 
       - name: Start RustFS
         run: |

--- a/packages/web/content/docs/cli/cache-service/monitoring.mdx
+++ b/packages/web/content/docs/cli/cache-service/monitoring.mdx
@@ -208,7 +208,7 @@ workflow before starting a release:
 
 1. Run `.github/workflows/cache-service.yml` with `workflow_dispatch` on the
    release commit.
-2. Wait for the `RustFS cache-service smoke` job to pass.
+2. Wait for the `Build, test & smoke cache service` job to pass.
 3. Keep the workflow run ID. Release CI derives the expected report run ID as
    `gha-<run-id>-<attempt>` and downloads the default artifact
    `cache-service-rustfs-smoke-<run-id>-<attempt>`.


### PR DESCRIPTION
## Summary

- build the protocol-v2 Linux release binary once, then fan the exact run-scoped artifact out to the four Git compatibility jobs and the RustFS lifecycle
- run cache-service build, tests, and RustFS smoke on one runner so the serial path reuses its live Cargo target without artifact transfer
- consolidate seven overlapping Architecture Cargo jobs into two balanced shared-target cohorts while retaining every original verification command and aggregating failures
- keep Rust target caches off the new protocol, architecture, and native boundaries so the workflows do not churn the repository cache quota
- update cache-service release instructions for the consolidated job name

## Expected impact

The motivating protocol run spent 97m34s across five identical release builds. Keeping one producer removes roughly 78 runner-minutes from that workflow. Starting the producer alongside unit tests also shortens the compatibility critical path.

The cache-service workflow removes its second checkout, toolchain setup, dependency install, cache restore, and queue boundary. Architecture keeps two-way parallelism: split-crate library checks share one target, while shipped-binary, install-layout, and final-integration checks share executable builds in the other cohort.

A repository-wide universal Crab binary is intentionally not introduced: crash-injection, NFS-only, minimal workflow, FUSE/no-FUSE, cross-compiled release, and native platform jobs have different executable contracts.

## Validation

- rebased on current `main`
- `git diff --check origin/main...HEAD`
- `actionlint` v1.7.11 on all changed workflows
- workflow graph and command ownership assertions for protocol producer/consumers, cache-service consolidation, and architecture cohorts
- `python3 crab/scripts/release/check-release-archive-contents.py`
- `npm run lint` (passes with 17 pre-existing warnings)
- `npm run build`
- `npm run check:links` (398 pages and 4,292 fragments)
