### PR TITLE
docs: explain S3-compatible provider setup

### DIFF
--- a/packages/web/content/docs/cli/authentication/static-credentials.mdx
+++ b/packages/web/content/docs/cli/authentication/static-credentials.mdx
@@ -48,9 +48,9 @@ credentials in this order:
 Earlier sources win. Crab only fills in missing variables from later `.env`
 files, so an explicit shell export overrides project and user-global files.
 
-## Common AWS/S3 Variables
+## Amazon S3
 
-For AWS S3 or an S3-compatible service, the usual static setup is:
+For Amazon S3, the usual static setup is:
 
 ```bash
 export AWS_ACCESS_KEY_ID=...
@@ -64,13 +64,6 @@ For temporary credentials, also set:
 export AWS_SESSION_TOKEN=...
 ```
 
-For S3-compatible endpoints such as MinIO, R2, or RustFS, set:
-
-```bash
-export AWS_ENDPOINT_URL=http://localhost:9000
-export AWS_ALLOW_HTTP=true
-```
-
 For production and CI, prefer web identity or an attached ECS/EC2 role:
 
 ```bash
@@ -82,6 +75,78 @@ The current S3 provider does not read `AWS_PROFILE`, `~/.aws/config`, or
 `~/.aws/credentials`. If an SSO/profile workflow produces temporary
 credentials, export `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
 `AWS_SESSION_TOKEN` into the Crab process.
+
+## S3-Compatible Storage
+
+Crab connects to MinIO, Cloudflare R2, RustFS, Ceph, and other S3-compatible
+services through the `s3` provider. There is no separate provider value such
+as `r2` or `minio`.
+
+Set the access key, secret key, region expected by the service, and its S3 API
+endpoint:
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
+export AWS_ENDPOINT_URL=https://s3.example.com
+export AWS_VIRTUAL_HOSTED_STYLE_REQUEST=false
+```
+
+`AWS_ENDPOINT_URL` must be the service's S3 API endpoint, not a bucket's public
+download URL or web dashboard URL. Path-style addressing is the default;
+setting `AWS_VIRTUAL_HOSTED_STYLE_REQUEST=false` makes that choice explicit for
+services whose TLS certificate does not cover bucket-prefixed hostnames.
+
+Use `AWS_ALLOW_HTTP=true` only for a trusted development endpoint that uses
+plain HTTP:
+
+```bash
+export AWS_ENDPOINT_URL=http://127.0.0.1:9000
+export AWS_ALLOW_HTTP=true
+```
+
+Do not enable `AWS_ALLOW_HTTP` for HTTPS services such as Cloudflare R2.
+
+### Cloudflare R2 example
+
+Create an R2 API token with object read and write access to the target bucket,
+then use the S3 credentials and endpoint shown by Cloudflare:
+
+```bash
+export AWS_ACCESS_KEY_ID=<R2_ACCESS_KEY_ID>
+export AWS_SECRET_ACCESS_KEY=<R2_SECRET_ACCESS_KEY>
+export AWS_REGION=auto
+export AWS_ENDPOINT_URL=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+export AWS_VIRTUAL_HOSTED_STYLE_REQUEST=false
+
+mkdir my-project && cd my-project
+crab configure crab://<BUCKET>/<REPOSITORY> --provider s3
+crab doctor
+```
+
+For a jurisdiction-restricted bucket, use the endpoint Cloudflare provides,
+such as `https://<ACCOUNT_ID>.eu.r2.cloudflarestorage.com`. If Cloudflare issues
+temporary credentials, export their session token as `AWS_SESSION_TOKEN` too.
+
+### MinIO or RustFS example
+
+For a service running locally on port 9000:
+
+```bash
+export AWS_ACCESS_KEY_ID=<ACCESS_KEY_ID>
+export AWS_SECRET_ACCESS_KEY=<SECRET_ACCESS_KEY>
+export AWS_REGION=us-east-1
+export AWS_ENDPOINT_URL=http://127.0.0.1:9000
+export AWS_VIRTUAL_HOSTED_STYLE_REQUEST=false
+export AWS_ALLOW_HTTP=true
+
+crab configure crab://my-bucket/my-project --provider s3
+crab doctor
+```
+
+Use the region, endpoint, and TLS policy configured by your deployment when
+they differ from this local example.
 
 ## GCS and Azure Variables
 

--- a/packages/web/content/docs/cli/getting-started/first-repository.mdx
+++ b/packages/web/content/docs/cli/getting-started/first-repository.mdx
@@ -150,14 +150,28 @@ credential discovery. Its values are case-insensitive:
 
 ### S3-Compatible Endpoints
 
-For S3-compatible stores like MinIO, Cloudflare R2, or Ceph, use the standard `crab://` URL (no prefix) and set the custom endpoint via environment variable:
+For S3-compatible stores like MinIO, Cloudflare R2, or Ceph, select the `s3`
+provider and set the service's S3 API endpoint and credentials before running
+`crab configure`:
 
 ```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
 export AWS_ENDPOINT_URL=https://s3.example.com
-crab init crab://my-bucket/my-project
+export AWS_VIRTUAL_HOSTED_STYLE_REQUEST=false
+
+crab configure crab://my-bucket/my-project --provider s3
+crab doctor
 ```
 
-The S3 builder picks up `AWS_ENDPOINT_URL` automatically — no URL-level distinction is needed.
+Use the region required by the service; Cloudflare R2 uses `auto`. For a trusted
+plain-HTTP development endpoint, also set `AWS_ALLOW_HTTP=true`. Crab reads the
+endpoint from `AWS_ENDPOINT_URL`, so credentials and endpoint URLs do not
+belong in `.crab.toml`.
+
+See [Static Credentials](/docs/cli/authentication/static-credentials#s3-compatible-storage)
+for complete Cloudflare R2 and local MinIO/RustFS examples.
 
 ## After Initialization
 

--- a/packages/web/content/docs/cli/reference/crab-configure.mdx
+++ b/packages/web/content/docs/cli/reference/crab-configure.mdx
@@ -52,8 +52,11 @@ Amazon S3 is the default choice.
 Use flags in scripts or when you already know the remote:
 
 ```bash
-# Amazon S3 or S3-compatible storage
-crab configure s3://team-data/models --provider s3
+# Amazon S3
+crab configure s3://team-data/models
+
+# S3-compatible storage (after exporting credentials and AWS_ENDPOINT_URL)
+crab configure crab://team-data/models --provider s3
 
 # Google Cloud Storage
 crab configure gs://team-data/models --provider gcs
@@ -65,6 +68,11 @@ crab configure azure://team-data/models --provider azure
 Provider-prefixed URLs let Crab infer the provider, so `--provider` is optional
 in those examples. Use it with a canonical `crab://` URL when the provider is
 not S3.
+
+S3-compatible services use the `s3` provider. Export the service's access key,
+secret key, region, and `AWS_ENDPOINT_URL` before configuration; do not put
+credentials in the remote URL. See [Static Credentials](/docs/cli/authentication/static-credentials#s3-compatible-storage)
+for Cloudflare R2 and local MinIO/RustFS examples.
 
 Choose the local bucket-GC listing policy during setup when desired:
 


### PR DESCRIPTION
## Summary

- document the complete S3-compatible credential and endpoint contract
- add Cloudflare R2 and local MinIO/RustFS setup examples
- distinguish native Amazon S3 URLs from canonical `crab://` S3-compatible remotes
- add `crab doctor` verification and HTTP/TLS guidance

## Testing

- `npm run build`
- `npm run check:links` (398 pages, 4,292 fragments)
- `npm run typecheck`
- `npm run lint` (passes with 17 existing warnings)
- `npm run test` (9 tests)