### PR TITLE
fix(web): widen feature blog visuals

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -539,12 +539,20 @@ details.faq-item[open] .faq-chevron {
 }
 
 @media (min-width: 64rem) {
-  /* Sticky rails own the outer columns, so wide visuals cannot cover navigation. */
+  /* Wide media fills the center canvas without inheriting viewport breakout offsets. */
   [data-feature-article] .wide-article-visual {
     left: auto;
     width: 100%;
     translate: 0 0 !important;
     transform: none;
+  }
+}
+
+@media (min-width: 90rem) {
+  /* Keep narrative measure focused while diagrams and tables use the wider canvas. */
+  [data-feature-article] .feature-blog-prose > :not(.wide-article-visual, table) {
+    max-width: 48rem;
+    margin-inline: auto;
   }
 }
 

--- a/packages/web/components/blog/blog-detail-diagrams.tsx
+++ b/packages/web/components/blog/blog-detail-diagrams.tsx
@@ -253,7 +253,7 @@ function ReachabilityMarker() {
       markerHeight="8"
       orient="auto"
     >
-      <path d="M1 1 9 5 1 9 3.5 5Z" fill="#64748b" />
+      <path d="M1 1 9 5 1 9Z" fill="#64748b" />
     </marker>
   )
 }

--- a/packages/web/components/blog/blog-diagrams.tsx
+++ b/packages/web/components/blog/blog-diagrams.tsx
@@ -48,7 +48,7 @@ export function DiagramFrame({
   return (
     <figure
       className={cn(
-        "not-prose my-10 overflow-hidden rounded-xl border border-border bg-card shadow-sm",
+        "wide-article-visual not-prose my-10 overflow-hidden rounded-xl border border-border bg-card shadow-sm",
         className
       )}
     >
@@ -90,7 +90,7 @@ function ArrowMarker({
       markerHeight="8"
       orient="auto-start-reverse"
     >
-      <path d="M1 1 9 5 1 9 3.5 5Z" fill={color} />
+      <path d="M1 1 9 5 1 9Z" fill={color} />
     </marker>
   )
 }

--- a/packages/web/components/blog/feature-blog-article.tsx
+++ b/packages/web/components/blog/feature-blog-article.tsx
@@ -90,7 +90,7 @@ export function FeatureBlogArticle({
 
         <div
           data-feature-article
-          className="mx-auto grid w-full max-w-[88rem] gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[13rem_minmax(0,48rem)] lg:items-start lg:justify-center lg:gap-10 lg:px-8 lg:py-24 xl:grid-cols-[14rem_minmax(0,48rem)_14rem] xl:justify-between 2xl:px-12"
+          className="mx-auto grid w-full max-w-[100rem] gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[13rem_minmax(0,48rem)] lg:items-start lg:justify-center lg:gap-10 lg:px-8 lg:py-24 min-[90rem]:grid-cols-[14rem_minmax(0,62rem)_14rem] min-[90rem]:justify-between min-[90rem]:gap-8 2xl:gap-10 2xl:px-12"
         >
           <aside className="min-w-0 lg:sticky lg:top-24 lg:self-start">
             <FeatureArticleRail items={toc} />
@@ -102,7 +102,7 @@ export function FeatureBlogArticle({
             </div>
           </div>
 
-          <aside className="hidden min-w-0 justify-self-end xl:sticky xl:top-24 xl:right-0 xl:col-start-3 xl:row-start-1 xl:block xl:self-start">
+          <aside className="hidden min-w-0 justify-self-end min-[90rem]:sticky min-[90rem]:top-24 min-[90rem]:right-0 min-[90rem]:col-start-3 min-[90rem]:row-start-1 min-[90rem]:block min-[90rem]:self-start">
             <div className="w-56 space-y-5">
               <div className="border-t-2 border-primary pt-4">
                 <div className="flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.16em] text-primary uppercase">


### PR DESCRIPTION
## Summary

- keep the feature article prose at a focused 48rem measure while giving interactive components, tables, and SVG frames a wider center canvas
- move the sticky table of contents and premise into edge rails on spacious desktop layouts
- replace concave diagram arrowheads with conventional filled triangles

## Verification

- npm run typecheck
- npm run test (9 tests)
- npm run build
- npm run lint (0 errors; 17 pre-existing warnings outside the changed surface)
- browser checks at 1557px, 1024px, and 390px with no page-level horizontal overflow or console errors