### PR TITLE
fix(add): harden renamed staging and dehydrate

### DIFF
--- a/crab/src/cmd/dehydrate.rs
+++ b/crab/src/cmd/dehydrate.rs
@@ -201,6 +201,18 @@ pub fn run_dehydrate_in(
     // that will be invalidated lazily on the next clean (stat
     // mismatch detection).
     if summary.dehydrated > 0 {
+        let dehydrated_paths = to_dehydrate
+            .iter()
+            .filter(|path| is_working_tree_pointer(path).unwrap_or(false))
+            .cloned()
+            .collect::<Vec<_>>();
+        if let Err(error) = crate::git::worktree::refresh_index_stats(root, &dehydrated_paths) {
+            warn!(
+                files = dehydrated_paths.len(),
+                error = %error,
+                "failed to refresh dehydrated file index stat metadata"
+            );
+        }
         let invalidations: Vec<String> = to_dehydrate
             .iter()
             .map(|path| {

--- a/crab/src/cmd/hydrate.rs
+++ b/crab/src/cmd/hydrate.rs
@@ -40,7 +40,7 @@ use crate::engine::pointer::is_working_tree_pointer;
 use crate::git::progress::{format_rate, is_tty, render_bar};
 use crate::git::smudge::SmudgeSession;
 use crate::git::worktree::{
-    WorktreeContext, normalize_identity_path, parse_worktree_list_porcelain,
+    WorktreeContext, normalize_identity_path, parse_worktree_list_porcelain, refresh_index_stats,
 };
 use crate::git::worktree_hydration::{
     WorktreeHydrationMode, WorktreeHydrationPolicyFile, WorktreeHydrationPolicyStatus,
@@ -3583,82 +3583,13 @@ fn refresh_hydrated_index_entries(root: &Path, entries: &[(PathBuf, Pointer)]) {
             (!is_working_tree_pointer(path).unwrap_or(true)).then_some(path.clone())
         })
         .collect::<Vec<_>>();
-    if let Err(e) = refresh_hydrated_index_entries_once(root, &paths) {
+    if let Err(e) = refresh_index_stats(root, &paths) {
         debug!(
             files = paths.len(),
             error = %e,
             "failed to refresh hydrated file index stat metadata"
         );
     }
-}
-
-fn refresh_hydrated_index_entries_once(root: &Path, paths: &[PathBuf]) -> Result<usize> {
-    use bstr::ByteSlice;
-
-    if paths.is_empty() {
-        return Ok(0);
-    }
-    let mut updates = HashMap::with_capacity(paths.len());
-    for path in paths {
-        let rel = path.strip_prefix(root).unwrap_or(path);
-        let metadata =
-            gix_index::fs::Metadata::from_path_no_follow(path).map_err(error::CrabError::Io)?;
-        let stat = gix_index::entry::Stat::from_fs(&metadata)
-            .map_err(|e| error::CrabError::Internal(format!("read hydrated file stat: {e}")))?;
-        updates.insert(hydrate_index_path_bytes(rel), stat);
-    }
-
-    let index_path = WorktreeContext::resolve_from_path(root)?.index_path();
-    let lock = gix_lock::File::acquire_to_update_resource(
-        &index_path,
-        gix_lock::acquire::Fail::Immediately,
-        None,
-    )
-    .map_err(|e| error::CrabError::Internal(format!("lock Git index: {e}")))?;
-    let mut index = gix_index::File::at(
-        &index_path,
-        gix_hash::Kind::Sha1,
-        true,
-        gix_index::decode::Options::default(),
-    )
-    .map_err(|e| error::CrabError::Internal(format!("read Git index: {e}")))?;
-    let mut updated = 0usize;
-    for (entry, entry_path) in index.entries_mut_with_paths() {
-        if entry.stage() != gix_index::entry::Stage::Unconflicted {
-            continue;
-        }
-        let Some(stat) = updates.get(entry_path.as_bytes()) else {
-            continue;
-        };
-        entry.stat = *stat;
-        updated += 1;
-    }
-    if updated == 0 {
-        return Ok(0);
-    }
-
-    let mut writer = std::io::BufWriter::with_capacity(64 * 1024, lock);
-    index
-        .write_to(&mut writer, gix_index::write::Options::default())
-        .map_err(|e| error::CrabError::Internal(format!("write Git index: {e}")))?;
-    let lock = writer
-        .into_inner()
-        .map_err(|e| error::CrabError::Io(e.into_error()))?;
-    lock.commit()
-        .map_err(|e| error::CrabError::Internal(format!("commit Git index: {e}")))?;
-    Ok(updated)
-}
-
-#[cfg(unix)]
-fn hydrate_index_path_bytes(path: &Path) -> Vec<u8> {
-    use std::os::unix::ffi::OsStrExt;
-
-    path.as_os_str().as_bytes().to_vec()
-}
-
-#[cfg(not(unix))]
-fn hydrate_index_path_bytes(path: &Path) -> Vec<u8> {
-    path.to_string_lossy().into_owned().into_bytes()
 }
 
 pub fn resolve_git_pointer_prefetch_candidates(
@@ -4824,7 +4755,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn refresh_hydrated_index_entry_clears_filtered_status_dirty_bit() {
+    fn refresh_index_entry_clears_filtered_status_after_hydrate_and_dehydrate() {
         use std::os::unix::fs::PermissionsExt;
 
         let _git_env = ScopedGitDir::acquire();
@@ -4866,7 +4797,7 @@ mod tests {
         assert!(git_stdout(&repo, &["status", "--porcelain=v1"]).contains(" M model.bin"));
 
         assert_eq!(
-            refresh_hydrated_index_entries_once(&repo, &[repo.join("model.bin")]).unwrap(),
+            refresh_index_stats(&repo, &[repo.join("model.bin")]).unwrap(),
             1
         );
 
@@ -4886,6 +4817,14 @@ mod tests {
             gix_index::fs::Metadata::from_path_no_follow(&repo.join("model.bin")).unwrap();
         let expected_stat = gix_index::entry::Stat::from_fs(&metadata).unwrap();
         assert_eq!(entry.stat, expected_stat);
+        assert_eq!(git_stdout(&repo, &["status", "--porcelain=v1"]), "");
+
+        std::fs::write(repo.join("model.bin"), "POINTER\n").unwrap();
+        assert!(git_stdout(&repo, &["status", "--porcelain=v1"]).contains(" M model.bin"));
+        assert_eq!(
+            refresh_index_stats(&repo, &[repo.join("model.bin")]).unwrap(),
+            1
+        );
         assert_eq!(git_stdout(&repo, &["status", "--porcelain=v1"]), "");
     }
 
@@ -4932,11 +4871,8 @@ mod tests {
         std::fs::write(repo.join("model.bin"), "hydrated model bytes\n").unwrap();
         std::fs::write(repo.join("adapter.bin"), "hydrated adapter bytes\n").unwrap();
         assert_eq!(
-            refresh_hydrated_index_entries_once(
-                &repo,
-                &[repo.join("model.bin"), repo.join("adapter.bin")],
-            )
-            .unwrap(),
+            refresh_index_stats(&repo, &[repo.join("model.bin"), repo.join("adapter.bin")],)
+                .unwrap(),
             2
         );
 

--- a/crab/src/git/worktree.rs
+++ b/crab/src/git/worktree.rs
@@ -139,6 +139,75 @@ pub fn committed_pointers_for_paths(
     Ok(pointers)
 }
 
+/// Refresh Git index stat entries after Crab replaces worktree file contents.
+pub(crate) fn refresh_index_stats(root: &Path, paths: &[PathBuf]) -> Result<usize> {
+    use bstr::ByteSlice;
+
+    if paths.is_empty() {
+        return Ok(0);
+    }
+    let mut updates = HashMap::with_capacity(paths.len());
+    for path in paths {
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        let metadata = gix_index::fs::Metadata::from_path_no_follow(path).map_err(CrabError::Io)?;
+        let stat = gix_index::entry::Stat::from_fs(&metadata)
+            .map_err(|error| CrabError::Internal(format!("read worktree file stat: {error}")))?;
+        updates.insert(index_path_bytes(rel), stat);
+    }
+
+    let index_path = WorktreeContext::resolve_from_path(root)?.index_path();
+    let lock = gix_lock::File::acquire_to_update_resource(
+        &index_path,
+        gix_lock::acquire::Fail::Immediately,
+        None,
+    )
+    .map_err(|error| CrabError::Internal(format!("lock Git index: {error}")))?;
+    let mut index = gix_index::File::at(
+        &index_path,
+        gix_hash::Kind::Sha1,
+        true,
+        gix_index::decode::Options::default(),
+    )
+    .map_err(|error| CrabError::Internal(format!("read Git index: {error}")))?;
+    let mut updated = 0usize;
+    for (entry, entry_path) in index.entries_mut_with_paths() {
+        if entry.stage() != gix_index::entry::Stage::Unconflicted {
+            continue;
+        }
+        let Some(stat) = updates.get(entry_path.as_bytes()) else {
+            continue;
+        };
+        entry.stat = *stat;
+        updated += 1;
+    }
+    if updated == 0 {
+        return Ok(0);
+    }
+
+    let mut writer = std::io::BufWriter::with_capacity(64 * 1024, lock);
+    index
+        .write_to(&mut writer, gix_index::write::Options::default())
+        .map_err(|error| CrabError::Internal(format!("write Git index: {error}")))?;
+    let lock = writer
+        .into_inner()
+        .map_err(|error| CrabError::Io(error.into_error()))?;
+    lock.commit()
+        .map_err(|error| CrabError::Internal(format!("commit Git index: {error}")))?;
+    Ok(updated)
+}
+
+#[cfg(unix)]
+fn index_path_bytes(path: &Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+
+    path.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(not(unix))]
+fn index_path_bytes(path: &Path) -> Vec<u8> {
+    path.to_string_lossy().into_owned().into_bytes()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorktreeContext {
     pub current_worktree_root: PathBuf,

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -667,8 +667,21 @@ async fn stage_file_streaming_inner(
         });
     }
 
-    if let Err(err) = staging.adopt_staged_file(&provisional_merkle, &file_merkle, stage_stats.size)
-    {
+    // A renamed or copied path can resolve entirely to proven remote chunks
+    // while the same canonical recipe is still indexed locally. Its partial
+    // provisional rows are redundant; comparing them with the complete
+    // canonical recipe would falsely report divergent content.
+    let adopt_result = if staging.has_verified_local_recipe(&recipe)? {
+        staging
+            .retire_file(&provisional_merkle)
+            .and_then(|_| staging.unregister_file(&provisional_merkle))
+            .map(|_| ())
+    } else {
+        staging
+            .adopt_staged_file(&provisional_merkle, &file_merkle, stage_stats.size)
+            .map(|_| ())
+    };
+    if let Err(err) = adopt_result {
         fail_stream_preparation(staging, xorb_builder.as_ref(), owned_preparation.as_ref());
         cleanup_staged_file(
             staging,
@@ -2491,6 +2504,53 @@ mod tests {
             .collect::<std::collections::HashSet<_>>();
         assert_eq!(indexed_remote_chunks, unique_recipe_chunks);
         assert!(plan.prepared_xorbs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn restaging_identical_recipe_with_remote_authority_reuses_canonical_recipe() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        let source = repo.join("source.bin");
+        write_pattern_file(&source, 2 * 1024 * 1024);
+        let staging = StagingArea::open(dir.path().join(".crab/staging"))
+            .await
+            .unwrap();
+
+        let first = stage_file_streaming_as(
+            &source,
+            &repo,
+            Path::new("models/original.bin"),
+            &staging,
+            StreamStageProgress::default(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        staging.mark_batch_published(&first.batch_id).unwrap();
+
+        let renamed = stage_file_streaming_as(
+            &source,
+            &repo,
+            Path::new("models/renamed.bin"),
+            &staging,
+            StreamStageProgress {
+                existing_lookup: Some(Arc::new(BatchRemoteLookup { first_only: false })),
+                ..StreamStageProgress::default()
+            },
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(renamed.recipe, first.recipe);
+        staging.mark_batch_published(&renamed.batch_id).unwrap();
+        assert_eq!(
+            staging
+                .published_recipe_for_file(&MerkleHash::from(renamed.file_hash))
+                .unwrap(),
+            Some(first.recipe)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- reuse an exact verified canonical recipe when a renamed or copied file resolves through remote chunk authority
- refresh Git index stat metadata after both hydration and dehydration
- prevent false divergent-recipe failures and false dirty worktrees after dehydrate

## Proof
- 24 x 64 MiB versioned model files (1.5 GiB) across three commits
- 300, 320, and 340 small source files across versions
- add, commit, push, lazy clone, incremental pull, hydrate, dehydrate, fresh clone, historical checkout
- complete SHA-256 manifest equality at every hydrated version
- focused regression tests and strict crab-staging Clippy