### PR TITLE
perf(add): cache verified indexed content

### DIFF
--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -37,6 +37,7 @@ The important ownership boundaries are:
 | Surface | Responsibility |
 | --- | --- |
 | `crab/src/cmd/add.rs` | CLI orchestration, candidate discovery, progress, rollback, pointer publication |
+| `crab/src/cache/add_validation.rs` | Per-worktree v1 proof cache for already-verified indexed content |
 | `crates/crab-staging/src/stream.rs` | Bounded file streaming, Blake3 hashing, CDC chunking, preparation-wide claims, provisional staging adoption |
 | `crates/crab-staging/src/lib.rs` | Segment writes, SQLite rows, flush/promotion, staged-file adoption and retirement |
 | `crates/crab-staging/src/add_push_plan.rs` | Add-time push-plan construction from staged chunk rows |
@@ -246,7 +247,17 @@ Worker durations can exceed wall time because files execute concurrently.
 Independent `crab add` processes queue for up to 30 minutes on the staging
 flock. A later process does not fail merely because an earlier large add is
 still preparing or publishing, and rechecks Git's index after ownership so it
-does not repeat work the preceding process just published.
+does not repeat work the preceding process just published. After verified
+content and its pointer are published, add records a per-worktree token in
+`.crab/worktrees/<identity>/add-validations-v1.sqlite`. The token binds raw Git
+path bytes, pointer OID and bytes, mode, exact filesystem stat, and full u64
+length. An exact token issued after a verified read can resolve Git's racy-stat
+ambiguity. Without one, a racy entry takes one descriptor-safe full-file hash
+instead of repeating CDC and staging, then refreshes the row only after the
+content matches the current indexed pointer. Any other cache or token mismatch
+also falls back to that full hash. Cache hits are disabled when high-resolution
+Unix change-time semantics are unavailable; those platforms retain the
+full-hash behavior.
 For `--skip-git-add`, ordinary `git add` verifies the Git-provided stream
 against bounded pages of the retained recipe while buffering at most one
 expected chunk. An exact match promotes the recipe without CDC, payload reads,
@@ -327,6 +338,10 @@ stat fields. Crab updates those fields after publication so a later
 
 - Git index publication happens only after the chunks referenced by every
   pointer are staged and flushable.
+- An add-validation cache hit is accepted only when the indexed pointer's exact
+  path, pointer, mode, stat, and full size match a token issued after Crab
+  verified the content. A racy entry without a token and every cache failure
+  always fall back to hashing.
 - Rollback retires unpublished staging rows on file errors, cancellation before
   publication, and push-plan preparation errors.
 - Push plans are validated against the exact staged chunk sequence before a
@@ -356,11 +371,12 @@ segment write is removed from `crab add`.
 
 ## Improvement Ideas
 
-1. **Stronger concurrent mutation exclusion.** Clean indexed files are hashed
-   before Crab reuses their pointer, and streamed files compare descriptor and
-   path stat before publication. A malicious writer that changes bytes after a
-   verified read while preserving every observed stat field still requires
-   cooperative file locking or filesystem snapshots to exclude completely.
+1. **Stronger concurrent mutation exclusion.** Cache misses hash clean indexed
+   files before Crab reuses their pointer, cache hits require the exact stat
+   captured by an earlier verified read, and streamed files compare descriptor
+   and path stat before publication. A malicious writer that changes bytes
+   while preserving every observed stat field still requires cooperative file
+   locking or filesystem snapshots to exclude completely.
 2. **Plan progress inside large single files.** The planning phase reports per
    completed file. If one file packs many chunks, an additional per-batch
    callback from `prepare_one_file_plan` would make `push-plan` progress more

--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -257,7 +257,10 @@ instead of repeating CDC and staging, then refreshes the row only after the
 content matches the current indexed pointer. Any other cache or token mismatch
 also falls back to that full hash. Cache hits are disabled when high-resolution
 Unix change-time semantics are unavailable; those platforms retain the
-full-hash behavior.
+full-hash behavior. Successful hydrate, staging recovery, and verified sibling
+CoW publication seed the same token from the exact post-rename descriptor stat,
+so the first subsequent add does not reread content. A file or index pointer
+changed before token publication is rejected rather than inheriting the proof.
 For `--skip-git-add`, ordinary `git add` verifies the Git-provided stream
 against bounded pages of the retained recipe while buffering at most one
 expected chunk. An exact match promotes the recipe without CDC, payload reads,

--- a/crab/docs/design/overview.md
+++ b/crab/docs/design/overview.md
@@ -591,8 +591,9 @@ crab dehydrate "data/old-experiments/**"
 - **Progress reporting.** Long hydrations show per-file progress bars
   with ETA, bytes downloaded, and dedup savings.
 - **Resumable.** If hydration is interrupted (Ctrl-C, network failure),
-  re-running the same command skips already-hydrated files (detected by
-  comparing file size against the pointer's `size` field).
+  re-running the same command discovers only remaining pointer files. A file
+  hydrated concurrently after discovery is skipped only after full BLAKE3
+  verification.
 - **Include/exclude composability.** Multiple `--include` and `--exclude`
   flags compose like Git-LFS: includes are evaluated first, then excludes
   subtract from the result.

--- a/crab/docs/guides/add.md
+++ b/crab/docs/guides/add.md
@@ -71,7 +71,9 @@ instead of needlessly repeating CDC and staging. Cache hits require
 high-resolution Unix change-time semantics; unsupported or coarse stat
 implementations keep using the full hash. On a supported filesystem, same-size
 replacements with restored mtimes still change ctime and cannot reuse a stale
-pointer through the cache.
+pointer through the cache. Successful hydration seeds the same proof from the
+verified post-rename descriptor stat, making the first subsequent add a cache
+hit without trusting a later metadata snapshot.
 
 Only files that match patterns listed in `.gitattributes` with `filter=crab`
 are processed. If a file matches the command-line glob but is not tracked by

--- a/crab/docs/guides/add.md
+++ b/crab/docs/guides/add.md
@@ -59,10 +59,19 @@ size, and modification time are checked again before publication. Pointer and
 `.gitattributes` deltas are applied to a freshly reread Git index under its
 lock, so unrelated concurrent index entries are preserved. `--dry-run` performs
 discovery only and does not create staging, object, attribute, or index state.
-When an indexed pointer appears clean by Git's stat cache, Crab hashes the
-working-tree bytes and compares the Blake3 identity before skipping CDC and
-staging. This keeps same-size, same-stat replacements from reusing a stale
-pointer.
+When an indexed pointer appears clean by Git's stat cache, Crab first checks a
+per-worktree v1 validation token written only after Crab verified those bytes.
+The token binds literal path bytes, exact indexed pointer identity and payload,
+mode, full size, and every captured filesystem stat field. A hit skips the
+redundant file read, including when Git conservatively marks the matching stat
+entry as racy. A missing, stale, or corrupt token falls back to a
+descriptor-safe full Blake3 hash before skipping CDC and staging, then refreshes
+the token. A racy entry without an exact token takes the same one-time hash
+instead of needlessly repeating CDC and staging. Cache hits require
+high-resolution Unix change-time semantics; unsupported or coarse stat
+implementations keep using the full hash. On a supported filesystem, same-size
+replacements with restored mtimes still change ctime and cannot reuse a stale
+pointer through the cache.
 
 Only files that match patterns listed in `.gitattributes` with `filter=crab`
 are processed. If a file matches the command-line glob but is not tracked by
@@ -160,6 +169,8 @@ Supports `--json` and `--jsonl`.
   "data": {
     "files_staged": 5,
     "files_skipped": 0,
+    "validation_cache_hits": 0,
+    "validation_cache_hit_bytes": 0,
     "files_failed": 0,
     "chunks_staged": 847,
     "bytes_processed": 2469606195,
@@ -184,13 +195,16 @@ Each line is a complete JSON object:
 ```
 {"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.100Z","type":"progress","data":{"operation":"staging","current":3,"total":5,"bytes":1572864000,"total_bytes":2469606195,"rate_bytes_per_sec":45000000.0}}
 {"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.450Z","type":"file_done","data":{"path":"models/weights.bin","bytes":1288490188,"duration_ms":340,"status":"ok"}}
-{"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.500Z","type":"result","data":{"files_staged":5,"files_skipped":0,"files_failed":0,"chunks_staged":847,"bytes_processed":2469606195,"lock_wait_duration_ms":2,"chunking_worker_duration_ms":1800,"remote_lookup_duration_ms":120,"compression_worker_duration_ms":2100,"payload_write_duration_ms":640,"staging_duration_ms":3400,"planning_duration_ms":420,"flushing_duration_ms":25,"indexing_duration_ms":80,"duration_ms":3925}}
+{"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.500Z","type":"result","data":{"files_staged":5,"files_skipped":0,"validation_cache_hits":0,"validation_cache_hit_bytes":0,"files_failed":0,"chunks_staged":847,"bytes_processed":2469606195,"lock_wait_duration_ms":2,"chunking_worker_duration_ms":1800,"remote_lookup_duration_ms":120,"compression_worker_duration_ms":2100,"payload_write_duration_ms":640,"staging_duration_ms":3400,"planning_duration_ms":420,"flushing_duration_ms":25,"indexing_duration_ms":80,"duration_ms":3925}}
 ```
 
 The worker-duration fields are cumulative across parallel file tasks and can
 therefore exceed the command's wall-clock `duration_ms`.
 `lock_wait_duration_ms` covers staging-owner acquisition and publication
 recovery before file work starts.
+`validation_cache_hits` and `validation_cache_hit_bytes` report clean indexed
+files that were accepted from v1 verification tokens without rereading their
+contents.
 
 See [Structured Output](structured-output.md) for envelope details, event types,
 and error handling.

--- a/crab/docs/guides/hydrate.md
+++ b/crab/docs/guides/hydrate.md
@@ -16,8 +16,8 @@ is the primary way to "check out" large files after a lazy clone or after
 switching branches.
 
 Hydration is selective: you can hydrate specific files by glob pattern, or use
-`--all` to hydrate everything. Files that are already hydrated (full content on
-disk matching the expected size) are skipped automatically.
+`--all` to hydrate everything. Files already replaced with full content are not
+selected again.
 
 ## Arguments
 
@@ -42,11 +42,13 @@ disk matching the expected size) are skipped automatically.
    b. Resolves the file index from the shard metadata.
    c. Downloads the required xorb chunks from the remote store (or local cache).
    d. Reconstructs the original file content from chunks.
-   e. Atomically writes the full content, replacing the pointer.
+   e. Verifies the full BLAKE3 hash and atomically replaces the pointer.
+   f. Refreshes Git's stat entry and records the exact verified stat for the
+      first subsequent `crab add`.
 4. Prints a summary of hydrated files, bytes downloaded, and elapsed time.
 
-Files that are already hydrated (file size matches the pointer's declared size
-and the content is not a pointer) are skipped.
+If another process hydrates a selected pointer during the run, Crab skips it
+only after its size and full BLAKE3 hash match the pointer.
 
 ## Examples
 

--- a/crab/docs/guides/structured-output.md
+++ b/crab/docs/guides/structured-output.md
@@ -167,7 +167,7 @@ The final event is always `type: "result"`. Its `data` field matches what
 {"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.100Z","type":"progress","data":{"operation":"staging","current":3,"total":10,"bytes":15728640,"total_bytes":52428800,"rate_bytes_per_sec":45000000.0}}
 {"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.450Z","type":"file_done","data":{"path":"data/train.parquet","bytes":52428800,"duration_ms":340,"status":"ok"}}
 {"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.460Z","type":"file_done","data":{"path":"data/val.parquet","bytes":10485760,"duration_ms":120,"status":"ok"}}
-{"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.500Z","type":"result","data":{"files_staged":10,"files_skipped":0,"files_failed":0,"chunks_staged":42,"bytes_processed":524288000,"lock_wait_duration_ms":1,"chunking_worker_duration_ms":180,"remote_lookup_duration_ms":20,"compression_worker_duration_ms":150,"payload_write_duration_ms":55,"staging_duration_ms":300,"planning_duration_ms":0,"flushing_duration_ms":20,"indexing_duration_ms":80,"duration_ms":400}}
+{"schema":"add.event","version":"1.0","timestamp":"2026-04-24T18:32:17.500Z","type":"result","data":{"files_staged":10,"files_skipped":0,"validation_cache_hits":0,"validation_cache_hit_bytes":0,"files_failed":0,"chunks_staged":42,"bytes_processed":524288000,"lock_wait_duration_ms":1,"chunking_worker_duration_ms":180,"remote_lookup_duration_ms":20,"compression_worker_duration_ms":150,"payload_write_duration_ms":55,"staging_duration_ms":300,"planning_duration_ms":0,"flushing_duration_ms":20,"indexing_duration_ms":80,"duration_ms":400}}
 ```
 
 ### Rate Limiting

--- a/crab/schemas/add.json
+++ b/crab/schemas/add.json
@@ -76,6 +76,16 @@
       "format": "uint64",
       "minimum": 0.0,
       "type": "integer"
+    },
+    "validation_cache_hit_bytes": {
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "validation_cache_hits": {
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
     }
   },
   "required": [
@@ -93,7 +103,9 @@
     "payload_write_duration_ms",
     "planning_duration_ms",
     "remote_lookup_duration_ms",
-    "staging_duration_ms"
+    "staging_duration_ms",
+    "validation_cache_hit_bytes",
+    "validation_cache_hits"
   ],
   "title": "AddSummary",
   "type": "object"

--- a/crab/src/cache/add_validation.rs
+++ b/crab/src/cache/add_validation.rs
@@ -1,0 +1,234 @@
+//! Per-worktree proof cache for content already verified by `crab add`.
+//!
+//! A row is only a shortcut for a descriptor-safe content hash. The token
+//! binds the literal Git path, indexed pointer identity and bytes, file mode,
+//! and every filesystem stat field captured during verification. An exact
+//! token can resolve Git's racy-stat ambiguity; a miss must hash the file.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::core::error::{CrabError, Result};
+
+pub(crate) const ADD_VALIDATIONS_FILENAME: &str = "add-validations-v1.sqlite";
+const SCHEMA_VERSION: i64 = 1;
+
+pub(crate) struct AddValidationCache {
+    connection: Connection,
+}
+
+impl AddValidationCache {
+    pub(crate) fn open(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(CrabError::Io)?;
+        }
+        let connection = Connection::open(path)
+            .map_err(|error| database_error("open add validation cache", error))?;
+        connection
+            .busy_timeout(Duration::from_millis(250))
+            .map_err(|error| database_error("configure add validation cache timeout", error))?;
+        connection
+            .execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")
+            .map_err(|error| database_error("configure add validation cache", error))?;
+
+        let version = connection
+            .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+            .map_err(|error| database_error("read add validation cache version", error))?;
+        if version == 0 {
+            connection
+                .execute_batch(
+                    "BEGIN IMMEDIATE;
+                     CREATE TABLE add_validations (
+                         path BLOB PRIMARY KEY NOT NULL,
+                         token BLOB NOT NULL CHECK(length(token) = 32)
+                     ) WITHOUT ROWID;
+                     PRAGMA user_version = 1;
+                     COMMIT;",
+                )
+                .map_err(|error| database_error("initialize add validation cache", error))?;
+        } else if version != SCHEMA_VERSION {
+            return Err(CrabError::Internal(format!(
+                "unsupported add validation cache schema {version}; expected v{SCHEMA_VERSION}"
+            )));
+        }
+
+        Ok(Self { connection })
+    }
+
+    pub(crate) fn contains(&self, path: &[u8], token: &[u8; 32]) -> Result<bool> {
+        self.connection
+            .prepare_cached("SELECT 1 FROM add_validations WHERE path = ?1 AND token = ?2")
+            .map_err(|error| database_error("prepare add validation cache query", error))?
+            .query_row(params![path, token.as_slice()], |_| Ok(()))
+            .optional()
+            .map(|row| row.is_some())
+            .map_err(|error| database_error("query add validation cache", error))
+    }
+
+    pub(crate) fn upsert(&mut self, rows: &[(Vec<u8>, [u8; 32])]) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let transaction = self
+            .connection
+            .transaction()
+            .map_err(|error| database_error("begin add validation cache update", error))?;
+        {
+            let mut statement = transaction
+                .prepare_cached(
+                    "INSERT INTO add_validations(path, token) VALUES (?1, ?2)
+                     ON CONFLICT(path) DO UPDATE SET token = excluded.token",
+                )
+                .map_err(|error| database_error("prepare add validation cache update", error))?;
+            for (path, token) in rows {
+                statement
+                    .execute(params![path, token.as_slice()])
+                    .map_err(|error| database_error("write add validation cache row", error))?;
+            }
+        }
+        transaction
+            .commit()
+            .map_err(|error| database_error("commit add validation cache update", error))
+    }
+}
+
+pub(crate) fn cache_path_for_context(context: &crate::git::worktree::WorktreeContext) -> PathBuf {
+    context.per_worktree_crab_dir.join(ADD_VALIDATIONS_FILENAME)
+}
+
+pub(crate) fn validation_token(
+    path: &[u8],
+    pointer_oid: &[u8],
+    pointer_bytes: &[u8],
+    mode: u32,
+    stat: &gix_index::entry::Stat,
+    len: u64,
+) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"crab add validation v1\0");
+    update_sized(&mut hasher, path);
+    update_sized(&mut hasher, pointer_oid);
+    update_sized(&mut hasher, pointer_bytes);
+    hasher.update(&mode.to_le_bytes());
+    hasher.update(&stat.mtime.secs.to_le_bytes());
+    hasher.update(&stat.mtime.nsecs.to_le_bytes());
+    hasher.update(&stat.ctime.secs.to_le_bytes());
+    hasher.update(&stat.ctime.nsecs.to_le_bytes());
+    hasher.update(&stat.dev.to_le_bytes());
+    hasher.update(&stat.ino.to_le_bytes());
+    hasher.update(&stat.uid.to_le_bytes());
+    hasher.update(&stat.gid.to_le_bytes());
+    hasher.update(&stat.size.to_le_bytes());
+    hasher.update(&len.to_le_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+#[cfg(unix)]
+pub(crate) fn stat_is_cacheable(stat: &gix_index::entry::Stat) -> bool {
+    // Unix ctime changes on content mutation. Requiring non-zero nanoseconds
+    // rejects coarse filesystems where a same-second rewrite could alias.
+    stat.ctime.nsecs != 0
+}
+
+#[cfg(not(unix))]
+pub(crate) fn stat_is_cacheable(_stat: &gix_index::entry::Stat) -> bool {
+    // Windows exposes creation time in this field, not Unix change time.
+    false
+}
+
+fn update_sized(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+fn database_error(action: &str, error: rusqlite::Error) -> CrabError {
+    CrabError::Internal(format!("{action}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stat() -> gix_index::entry::Stat {
+        gix_index::entry::Stat {
+            mtime: gix_index::entry::stat::Time { secs: 1, nsecs: 2 },
+            ctime: gix_index::entry::stat::Time { secs: 3, nsecs: 4 },
+            dev: 5,
+            ino: 6,
+            uid: 7,
+            gid: 8,
+            size: 9,
+        }
+    }
+
+    #[test]
+    fn cache_round_trip_preserves_literal_path_bytes() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(ADD_VALIDATIONS_FILENAME);
+        let literal_path = b"model-\xff.bin".to_vec();
+        let token = validation_token(&literal_path, b"oid", b"pointer", 0o100_644, &stat(), 9);
+        let mut cache = AddValidationCache::open(&path).unwrap();
+
+        cache.upsert(&[(literal_path.clone(), token)]).unwrap();
+
+        assert!(cache.contains(&literal_path, &token).unwrap());
+        assert!(!cache.contains(b"model.bin", &token).unwrap());
+    }
+
+    #[test]
+    fn validation_token_binds_exact_stat_and_pointer() {
+        let base = stat();
+        let token = validation_token(b"model.bin", b"oid", b"pointer", 0o100_644, &base, 9);
+        let mut changed = base;
+        changed.ctime.nsecs += 1;
+
+        assert_ne!(
+            token,
+            validation_token(b"model.bin", b"oid", b"pointer", 0o100_644, &changed, 9)
+        );
+        assert_ne!(
+            token,
+            validation_token(b"model.bin", b"oid", b"other", 0o100_644, &base, 9)
+        );
+        assert_ne!(
+            token,
+            validation_token(b"other.bin", b"oid", b"pointer", 0o100_644, &base, 9)
+        );
+    }
+
+    #[test]
+    fn cache_requires_supported_change_time() {
+        let mut supported = stat();
+        supported.ctime.nsecs = 4;
+        let mut coarse = supported;
+        coarse.ctime.nsecs = 0;
+
+        #[cfg(unix)]
+        {
+            assert!(stat_is_cacheable(&supported));
+            assert!(!stat_is_cacheable(&coarse));
+        }
+        #[cfg(not(unix))]
+        {
+            assert!(!stat_is_cacheable(&supported));
+            assert!(!stat_is_cacheable(&coarse));
+        }
+    }
+
+    #[test]
+    fn cache_rejects_non_v1_schema() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(ADD_VALIDATIONS_FILENAME);
+        let connection = Connection::open(&path).unwrap();
+        connection.pragma_update(None, "user_version", 2).unwrap();
+        drop(connection);
+
+        let error = AddValidationCache::open(&path)
+            .err()
+            .expect("non-v1 cache must be rejected");
+
+        assert!(error.to_string().contains("expected v1"));
+    }
+}

--- a/crab/src/cache/add_validation.rs
+++ b/crab/src/cache/add_validation.rs
@@ -1,4 +1,4 @@
-//! Per-worktree proof cache for content already verified by `crab add`.
+//! Per-worktree proof cache for worktree content verified against indexed Crab pointers.
 //!
 //! A row is only a shortcut for a descriptor-safe content hash. The token
 //! binds the literal Git path, indexed pointer identity and bytes, file mode,
@@ -8,6 +8,8 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use bstr::ByteSlice;
+use crab_types::pointer::Pointer;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::core::error::{CrabError, Result};
@@ -17,6 +19,14 @@ const SCHEMA_VERSION: i64 = 1;
 
 pub(crate) struct AddValidationCache {
     connection: Connection,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct VerifiedPath {
+    pub path: PathBuf,
+    pub file_hash: [u8; 32],
+    pub size: u64,
+    pub index_stat: crate::cmd::stream_stage::VerifiedIndexStat,
 }
 
 impl AddValidationCache {
@@ -96,6 +106,75 @@ impl AddValidationCache {
 
 pub(crate) fn cache_path_for_context(context: &crate::git::worktree::WorktreeContext) -> PathBuf {
     context.per_worktree_crab_dir.join(ADD_VALIDATIONS_FILENAME)
+}
+
+pub(crate) fn record_verified_paths(repo_root: &Path, paths: &[VerifiedPath]) -> Result<usize> {
+    if paths.is_empty() {
+        return Ok(0);
+    }
+    let context = crate::git::worktree::WorktreeContext::resolve_from_path(repo_root)?;
+    let index = gix_index::File::at(
+        context.index_path(),
+        gix_hash::Kind::Sha1,
+        true,
+        gix_index::decode::Options::default(),
+    )
+    .map_err(|error| {
+        CrabError::Internal(format!(
+            "read Git index while recording add validations: {error}"
+        ))
+    })?;
+    let repo = gix::open(repo_root).map_err(|error| {
+        CrabError::Internal(format!(
+            "open Git repository while recording add validations: {error}"
+        ))
+    })?;
+    let mut rows = Vec::with_capacity(paths.len());
+    for verified in paths {
+        if !stat_is_cacheable(&verified.index_stat.stat)
+            || crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&verified.path)
+                != Some(verified.index_stat)
+        {
+            continue;
+        }
+        let Ok(rel_path) = verified.path.strip_prefix(repo_root) else {
+            continue;
+        };
+        let path_bytes = crate::git::worktree::index_path_bytes(rel_path);
+        let Some(entry) = index.entry_by_path_and_stage(
+            path_bytes.as_slice().as_bstr(),
+            gix_index::entry::Stage::Unconflicted,
+        ) else {
+            continue;
+        };
+        if entry.stat != verified.index_stat.stat {
+            continue;
+        }
+        let Ok(blob) = repo.find_blob(entry.id) else {
+            continue;
+        };
+        let Ok(pointer) = Pointer::parse(&blob.data) else {
+            continue;
+        };
+        if pointer.file_hash != verified.file_hash || pointer.size != verified.size {
+            continue;
+        }
+        rows.push((
+            path_bytes.clone(),
+            validation_token(
+                &path_bytes,
+                entry.id.as_bytes(),
+                &blob.data,
+                entry.mode.bits(),
+                &verified.index_stat.stat,
+                verified.index_stat.len,
+            ),
+        ));
+    }
+
+    let mut cache = AddValidationCache::open(&cache_path_for_context(&context))?;
+    cache.upsert(&rows)?;
+    Ok(rows.len())
 }
 
 pub(crate) fn validation_token(

--- a/crab/src/cache/mod.rs
+++ b/crab/src/cache/mod.rs
@@ -24,6 +24,7 @@ use crab_types::storage::StorageProviderKind;
 pub mod chunks {
     pub use crab_vfs::chunk_cache::*;
 }
+pub(crate) mod add_validation;
 pub mod hydrated_pointer;
 pub mod shard_hints {
     pub use crab_cache::shard_hints::*;

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -29,6 +29,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use crate::cache::add_validation::VerifiedPath;
 use crate::cmd::stream_stage::cleanup_stream_prepared_xorbs;
 use crate::core::error::{self, CrabError, Result};
 use crate::core::output::event_payloads::{FileDonePayload, ProgressPayload};
@@ -202,11 +203,6 @@ struct CleanIndexPointer {
     path_bytes: Vec<u8>,
     validation_token: Option<[u8; 32]>,
     verified_stat: crate::cmd::stream_stage::VerifiedIndexStat,
-}
-
-struct VerifiedCleanIndexPath {
-    abs_path: PathBuf,
-    size: u64,
 }
 
 struct AddFileProgressSpec {
@@ -1487,12 +1483,16 @@ async fn execute_add(
         publication_staging.publish_publication_intent(&publication_intent)?;
         let verified_paths = staged_entries
             .iter()
-            .map(|entry| VerifiedCleanIndexPath {
-                abs_path: entry.abs_path.clone(),
-                size: entry.size,
+            .filter_map(|entry| {
+                entry.index_stat.map(|index_stat| VerifiedPath {
+                    path: entry.abs_path.clone(),
+                    file_hash: entry.file_hash,
+                    size: entry.size,
+                    index_stat,
+                })
             })
             .collect::<Vec<_>>();
-        match remember_verified_clean_index_paths(&repo_root, &verified_paths) {
+        match crate::cache::add_validation::record_verified_paths(&repo_root, &verified_paths) {
             Ok(validations) => {
                 debug!(validations, "recorded verified add validations");
             }
@@ -1875,15 +1875,13 @@ async fn process_duplicate_candidate(
 
     file_progress.set_state(AddFileState::Running);
     let start = Instant::now();
-    let before_hash_stat =
-        crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(abs_path);
     let hash_result = crate::cmd::stream_stage::stream_hash_file(
         abs_path,
         Some(&file_progress.bytes_done),
         cancel,
     )
     .await;
-    let (file_hash, size) = match hash_result {
+    let verified = match hash_result {
         Ok(result) => result,
         Err(err) => {
             file_progress.set_state(AddFileState::Failed);
@@ -1891,24 +1889,8 @@ async fn process_duplicate_candidate(
             return Err(err.into());
         }
     };
-    let after_hash_stat =
-        crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(abs_path);
-
-    if let (Some(before), Some(after)) = (before_hash_stat, after_hash_stat)
-        && before != after
-    {
-        let (second_hash, second_size) =
-            crate::cmd::stream_stage::stream_hash_file(abs_path, None, cancel).await?;
-        file_progress.set_state(AddFileState::Failed);
-        progress.files_done.fetch_add(1, Relaxed);
-        return Err(CrabError::FileChangedDuringStaging {
-            path: abs_path.display().to_string(),
-            first_hash: MerkleHash::from(file_hash).hex(),
-            second_hash: MerkleHash::from(second_hash).hex(),
-            first_size: size,
-            second_size,
-        });
-    }
+    let file_hash = verified.hash;
+    let size = verified.size;
 
     if file_hash != reusable.file_hash || size != reusable.size {
         file_progress.bytes_done.store(0, Relaxed);
@@ -1974,7 +1956,7 @@ async fn process_duplicate_candidate(
         file_hash,
         recipe,
         prepared_xorbs: Vec::new(),
-        index_stat: after_hash_stat.filter(|stat| stat.len == size),
+        index_stat: Some(verified.index_stat),
         timings: crab_staging::stream::StreamStageTimings::default(),
         duration_ms: start.elapsed().as_millis() as u64,
     })
@@ -2698,24 +2680,31 @@ async fn filter_clean_indexed_candidates(
     }
     let mut checks = futures_util::stream::iter(prepared)
         .map(|(abs_path, size, indexed, cache_hit)| async move {
-            let matches = if cache_hit {
-                crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&abs_path)
-                    == indexed.as_ref().map(|indexed| indexed.verified_stat)
+            let (matches, verified) = if cache_hit {
+                (
+                    crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&abs_path)
+                        == indexed.as_ref().map(|indexed| indexed.verified_stat),
+                    None,
+                )
             } else {
                 match indexed {
                     Some(indexed) => {
-                        worktree_content_matches_pointer(
+                        let verified = worktree_content_matches_pointer(
                             &abs_path,
                             size,
                             indexed.expected_hash,
                             cancel,
                         )
-                        .await?
+                        .await?;
+                        (
+                            verified.is_some(),
+                            verified.map(|stat| (indexed.expected_hash, stat)),
+                        )
                     }
-                    None => false,
+                    None => (false, None),
                 }
             };
-            Ok::<_, CrabError>((abs_path, size, matches, cache_hit))
+            Ok::<_, CrabError>((abs_path, size, matches, cache_hit, verified))
         })
         .buffered(jobs.max(1));
 
@@ -2723,17 +2712,19 @@ async fn filter_clean_indexed_candidates(
     let mut skipped = CleanIndexedSkipSummary::default();
     let mut newly_verified = Vec::new();
     while let Some(result) = checks.next().await {
-        let (abs_path, size, matches, cache_hit) = result?;
+        let (abs_path, size, matches, cache_hit, verified) = result?;
         if matches {
             skipped.files += 1;
             skipped.bytes += size;
             if cache_hit {
                 skipped.validation_cache_hits += 1;
                 skipped.validation_cache_hit_bytes += size;
-            } else {
-                newly_verified.push(VerifiedCleanIndexPath {
-                    abs_path: abs_path.clone(),
+            } else if let Some((file_hash, index_stat)) = verified {
+                newly_verified.push(VerifiedPath {
+                    path: abs_path.clone(),
+                    file_hash,
                     size,
+                    index_stat,
                 });
             }
         } else {
@@ -2742,7 +2733,8 @@ async fn filter_clean_indexed_candidates(
     }
 
     if !newly_verified.is_empty()
-        && let Err(error) = remember_verified_clean_index_paths(repo_root, &newly_verified)
+        && let Err(error) =
+            crate::cache::add_validation::record_verified_paths(repo_root, &newly_verified)
     {
         debug!(
             path = %cache_path.display(),
@@ -2769,10 +2761,12 @@ async fn worktree_content_matches_pointer(
     expected_size: u64,
     expected_hash: [u8; 32],
     cancel: &CancellationToken,
-) -> Result<bool> {
-    let (actual_hash, actual_size) =
-        crate::cmd::stream_stage::stream_hash_file(path, None, cancel).await?;
-    Ok(actual_size == expected_size && actual_hash == expected_hash)
+) -> Result<Option<crate::cmd::stream_stage::VerifiedIndexStat>> {
+    let verified = crate::cmd::stream_stage::stream_hash_file(path, None, cancel).await?;
+    Ok(
+        (verified.size == expected_size && verified.hash == expected_hash)
+            .then_some(verified.index_stat),
+    )
 }
 
 fn clean_index_pointer(
@@ -2839,56 +2833,6 @@ fn clean_index_pointer(
         validation_token,
         verified_stat: current_stat,
     })
-}
-
-fn remember_verified_clean_index_paths(
-    repo_root: &Path,
-    paths: &[VerifiedCleanIndexPath],
-) -> Result<usize> {
-    if paths.is_empty() {
-        return Ok(0);
-    }
-    let context = crate::git::worktree::WorktreeContext::resolve_from_path(repo_root)?;
-    let index = gix_index::File::at(
-        context.index_path(),
-        gix_hash::Kind::Sha1,
-        true,
-        gix_index::decode::Options::default(),
-    )
-    .map_err(|error| {
-        CrabError::Internal(format!(
-            "read Git index while recording add validations: {error}"
-        ))
-    })?;
-    let repo = gix::open(repo_root).map_err(|error| {
-        CrabError::Internal(format!(
-            "open Git repository while recording add validations: {error}"
-        ))
-    })?;
-    let honor_filemode = git_honors_filemode(repo_root);
-    let rows = paths
-        .iter()
-        .filter_map(|path| {
-            clean_index_pointer(
-                repo_root,
-                &repo,
-                &index,
-                &path.abs_path,
-                path.size,
-                honor_filemode,
-            )
-            .and_then(|pointer| {
-                pointer
-                    .validation_token
-                    .map(|token| (pointer.path_bytes, token))
-            })
-        })
-        .collect::<Vec<_>>();
-    let mut cache = crate::cache::add_validation::AddValidationCache::open(
-        &crate::cache::add_validation::cache_path_for_context(&context),
-    )?;
-    cache.upsert(&rows)?;
-    Ok(rows.len())
 }
 
 /// Recursive directory walker that collects `(abs_path, file_size)` pairs.
@@ -4987,11 +4931,14 @@ mod tests {
             || {},
         )
         .unwrap();
-        remember_verified_clean_index_paths(
+        crate::cache::add_validation::record_verified_paths(
             dir.path(),
-            &[VerifiedCleanIndexPath {
-                abs_path: path.clone(),
+            &[VerifiedPath {
+                path: path.clone(),
+                file_hash: *blake3::hash(payload).as_bytes(),
                 size: payload.len() as u64,
+                index_stat: crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&path)
+                    .unwrap(),
             }],
         )
         .unwrap();
@@ -5009,6 +4956,98 @@ mod tests {
         assert_eq!(skipped.files, 1);
         assert_eq!(skipped.validation_cache_hits, 1);
         assert_eq!(skipped.validation_cache_hit_bytes, payload.len() as u64);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn add_validation_rejects_file_changed_after_verified_read() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("SKIP: git init failed");
+            return;
+        }
+
+        let path = dir.path().join("model.bin");
+        let original = b"original payload";
+        let replacement = b"replaced payload";
+        assert_eq!(original.len(), replacement.len());
+        std::fs::write(&path, original).unwrap();
+        make_file_mtime_old(&path);
+        let file_hash = *blake3::hash(original).as_bytes();
+        let index_stat =
+            crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&path).unwrap();
+        write_pointers_to_git_index(
+            &[staged_entry(path.clone(), file_hash, original.len() as u64)],
+            dir.path(),
+            &crate::cache::ShardHintCache::new(),
+            || {},
+        )
+        .unwrap();
+
+        std::fs::write(&path, replacement).unwrap();
+        crate::git::worktree::refresh_index_stats(dir.path(), std::slice::from_ref(&path)).unwrap();
+
+        assert_eq!(
+            crate::cache::add_validation::record_verified_paths(
+                dir.path(),
+                &[VerifiedPath {
+                    path,
+                    file_hash,
+                    size: original.len() as u64,
+                    index_stat,
+                }],
+            )
+            .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn add_validation_rejects_index_pointer_changed_after_verified_read() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("SKIP: git init failed");
+            return;
+        }
+
+        let path = dir.path().join("model.bin");
+        let payload = b"model payload";
+        std::fs::write(&path, payload).unwrap();
+        make_file_mtime_old(&path);
+        let file_hash = *blake3::hash(payload).as_bytes();
+        let index_stat =
+            crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&path).unwrap();
+        write_pointers_to_git_index(
+            &[staged_entry(path.clone(), file_hash, payload.len() as u64)],
+            dir.path(),
+            &crate::cache::ShardHintCache::new(),
+            || {},
+        )
+        .unwrap();
+        let mut other_hash = file_hash;
+        other_hash[0] ^= 0xff;
+        write_pointers_to_git_index(
+            &[staged_entry(path.clone(), other_hash, payload.len() as u64)],
+            dir.path(),
+            &crate::cache::ShardHintCache::new(),
+            || {},
+        )
+        .unwrap();
+
+        assert_eq!(
+            crate::cache::add_validation::record_verified_paths(
+                dir.path(),
+                &[VerifiedPath {
+                    path,
+                    file_hash,
+                    size: payload.len() as u64,
+                    index_stat,
+                }],
+            )
+            .unwrap(),
+            0
+        );
     }
 
     #[tokio::test]
@@ -5037,11 +5076,14 @@ mod tests {
             || {},
         )
         .unwrap();
-        remember_verified_clean_index_paths(
+        crate::cache::add_validation::record_verified_paths(
             dir.path(),
-            &[VerifiedCleanIndexPath {
-                abs_path: path.clone(),
+            &[VerifiedPath {
+                path: path.clone(),
+                file_hash: *blake3::hash(original).as_bytes(),
                 size: original.len() as u64,
+                index_stat: crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&path)
+                    .unwrap(),
             }],
         )
         .unwrap();

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -69,6 +69,8 @@ pub struct AddArgs {
 pub struct AddSummary {
     pub files_staged: u64,
     pub files_skipped: u64,
+    pub validation_cache_hits: u64,
+    pub validation_cache_hit_bytes: u64,
     pub files_failed: u64,
     pub chunks_staged: u64,
     pub bytes_processed: u64,
@@ -191,6 +193,20 @@ struct ReusableStagedFile {
 struct CleanIndexedSkipSummary {
     files: u64,
     bytes: u64,
+    validation_cache_hits: u64,
+    validation_cache_hit_bytes: u64,
+}
+
+struct CleanIndexPointer {
+    expected_hash: [u8; 32],
+    path_bytes: Vec<u8>,
+    validation_token: Option<[u8; 32]>,
+    verified_stat: crate::cmd::stream_stage::VerifiedIndexStat,
+}
+
+struct VerifiedCleanIndexPath {
+    abs_path: PathBuf,
+    size: u64,
 }
 
 struct AddFileProgressSpec {
@@ -1123,6 +1139,8 @@ async fn execute_add(
     let mut summary = AddSummary {
         files_staged: 0,
         files_skipped: clean_skipped.files,
+        validation_cache_hits: clean_skipped.validation_cache_hits,
+        validation_cache_hit_bytes: clean_skipped.validation_cache_hit_bytes,
         files_failed: 0,
         chunks_staged: 0,
         bytes_processed: 0,
@@ -1467,6 +1485,24 @@ async fn execute_add(
             CrabError::Internal("Git index publication intent was not recorded".to_owned())
         })?;
         publication_staging.publish_publication_intent(&publication_intent)?;
+        let verified_paths = staged_entries
+            .iter()
+            .map(|entry| VerifiedCleanIndexPath {
+                abs_path: entry.abs_path.clone(),
+                size: entry.size,
+            })
+            .collect::<Vec<_>>();
+        match remember_verified_clean_index_paths(&repo_root, &verified_paths) {
+            Ok(validations) => {
+                debug!(validations, "recorded verified add validations");
+            }
+            Err(error) => {
+                debug!(
+                    error = %error,
+                    "failed to persist verified add validations; later add will rehash"
+                );
+            }
+        }
         summary.indexing_duration_ms = indexing_start.elapsed().as_millis() as u64;
     }
 
@@ -1499,6 +1535,13 @@ async fn execute_add(
                         "  {} skipped (already staged and clean)",
                         summary.files_skipped
                     );
+                    if summary.validation_cache_hits > 0 {
+                        println!(
+                            "    {} validation-cache hit(s), {} of file reads avoided",
+                            summary.validation_cache_hits,
+                            format_bytes(summary.validation_cache_hit_bytes)
+                        );
+                    }
                 }
                 if summary.files_failed > 0 {
                     println!("  {} failed", summary.files_failed);
@@ -2611,42 +2654,109 @@ async fn filter_clean_indexed_candidates(
         }
     };
     let honor_filemode = git_honors_filemode(repo_root);
-    let candidates = candidates
-        .into_iter()
-        .map(|(abs_path, size)| {
-            let expected_hash =
-                clean_index_pointer_hash(repo_root, &repo, &index, &abs_path, size, honor_filemode);
-            (abs_path, size, expected_hash)
-        })
-        .collect::<Vec<_>>();
-    let mut checks = futures_util::stream::iter(candidates)
-        .map(|(abs_path, size, expected_hash)| async move {
-            let matches = match expected_hash {
-                Some(expected_hash) => {
-                    worktree_content_matches_pointer(&abs_path, size, expected_hash, cancel).await?
+    let cache_path = crate::cache::add_validation::cache_path_for_context(&ctx);
+    let mut validation_cache =
+        match crate::cache::add_validation::AddValidationCache::open(&cache_path) {
+            Ok(cache) => Some(cache),
+            Err(error) => {
+                debug!(
+                    path = %cache_path.display(),
+                    error = %error,
+                    "clean-index add validation cache unavailable; hashing candidates"
+                );
+                None
+            }
+        };
+    let mut prepared = Vec::with_capacity(candidates.len());
+    for (abs_path, size) in candidates {
+        let indexed =
+            clean_index_pointer(repo_root, &repo, &index, &abs_path, size, honor_filemode);
+        let cache_hit = match (
+            validation_cache.as_ref(),
+            indexed.as_ref(),
+            indexed
+                .as_ref()
+                .and_then(|indexed| indexed.validation_token.as_ref()),
+        ) {
+            (Some(cache), Some(indexed), Some(token)) => {
+                match cache.contains(&indexed.path_bytes, token) {
+                    Ok(hit) => hit,
+                    Err(error) => {
+                        debug!(
+                            path = %cache_path.display(),
+                            error = %error,
+                            "clean-index add validation cache query failed; hashing candidates"
+                        );
+                        validation_cache = None;
+                        false
+                    }
                 }
-                None => false,
+            }
+            _ => false,
+        };
+        prepared.push((abs_path, size, indexed, cache_hit));
+    }
+    let mut checks = futures_util::stream::iter(prepared)
+        .map(|(abs_path, size, indexed, cache_hit)| async move {
+            let matches = if cache_hit {
+                crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&abs_path)
+                    == indexed.as_ref().map(|indexed| indexed.verified_stat)
+            } else {
+                match indexed {
+                    Some(indexed) => {
+                        worktree_content_matches_pointer(
+                            &abs_path,
+                            size,
+                            indexed.expected_hash,
+                            cancel,
+                        )
+                        .await?
+                    }
+                    None => false,
+                }
             };
-            Ok::<_, CrabError>((abs_path, size, matches))
+            Ok::<_, CrabError>((abs_path, size, matches, cache_hit))
         })
         .buffered(jobs.max(1));
 
     let mut to_process = Vec::new();
     let mut skipped = CleanIndexedSkipSummary::default();
+    let mut newly_verified = Vec::new();
     while let Some(result) = checks.next().await {
-        let (abs_path, size, matches) = result?;
+        let (abs_path, size, matches, cache_hit) = result?;
         if matches {
             skipped.files += 1;
             skipped.bytes += size;
+            if cache_hit {
+                skipped.validation_cache_hits += 1;
+                skipped.validation_cache_hit_bytes += size;
+            } else {
+                newly_verified.push(VerifiedCleanIndexPath {
+                    abs_path: abs_path.clone(),
+                    size,
+                });
+            }
         } else {
             to_process.push((abs_path, size));
         }
+    }
+
+    if !newly_verified.is_empty()
+        && let Err(error) = remember_verified_clean_index_paths(repo_root, &newly_verified)
+    {
+        debug!(
+            path = %cache_path.display(),
+            error = %error,
+            "failed to persist content-verified add validations"
+        );
     }
 
     if skipped.files > 0 {
         debug!(
             files = skipped.files,
             bytes = skipped.bytes,
+            validation_cache_hits = skipped.validation_cache_hits,
+            validation_cache_hit_bytes = skipped.validation_cache_hit_bytes,
             "skipped content-verified indexed files during add"
         );
     }
@@ -2665,14 +2775,14 @@ async fn worktree_content_matches_pointer(
     Ok(actual_size == expected_size && actual_hash == expected_hash)
 }
 
-fn clean_index_pointer_hash(
+fn clean_index_pointer(
     repo_root: &Path,
     repo: &gix::Repository,
     index: &gix_index::File,
     abs_path: &Path,
     size: u64,
     honor_filemode: bool,
-) -> Option<[u8; 32]> {
+) -> Option<CleanIndexPointer> {
     use bstr::ByteSlice;
     use gix_index::entry;
 
@@ -2691,14 +2801,12 @@ fn clean_index_pointer_hash(
     }
 
     let stat_options = gix_index::entry::stat::Options::default();
-    if !current_stat.stat.matches(&entry.stat, stat_options)
-        || current_stat.stat.is_racy(index.timestamp(), stat_options)
-    {
+    if !current_stat.stat.matches(&entry.stat, stat_options) {
         return None;
     }
 
-    let pointer = match repo.find_blob(entry.id) {
-        Ok(blob) => Pointer::parse(&blob.data).ok(),
+    let blob = match repo.find_blob(entry.id) {
+        Ok(blob) => Some(blob),
         Err(e) => {
             debug!(
                 path = %rel_path.display(),
@@ -2709,7 +2817,78 @@ fn clean_index_pointer_hash(
             None
         }
     }?;
-    (pointer.size == size).then_some(pointer.file_hash)
+    let pointer = Pointer::parse(&blob.data).ok()?;
+    if pointer.size != size {
+        return None;
+    }
+    let path_bytes = rel_bstr.as_bytes().to_vec();
+    let validation_token = crate::cache::add_validation::stat_is_cacheable(&current_stat.stat)
+        .then(|| {
+            crate::cache::add_validation::validation_token(
+                &path_bytes,
+                entry.id.as_bytes(),
+                &blob.data,
+                entry.mode.bits(),
+                &current_stat.stat,
+                current_stat.len,
+            )
+        });
+    Some(CleanIndexPointer {
+        expected_hash: pointer.file_hash,
+        path_bytes,
+        validation_token,
+        verified_stat: current_stat,
+    })
+}
+
+fn remember_verified_clean_index_paths(
+    repo_root: &Path,
+    paths: &[VerifiedCleanIndexPath],
+) -> Result<usize> {
+    if paths.is_empty() {
+        return Ok(0);
+    }
+    let context = crate::git::worktree::WorktreeContext::resolve_from_path(repo_root)?;
+    let index = gix_index::File::at(
+        context.index_path(),
+        gix_hash::Kind::Sha1,
+        true,
+        gix_index::decode::Options::default(),
+    )
+    .map_err(|error| {
+        CrabError::Internal(format!(
+            "read Git index while recording add validations: {error}"
+        ))
+    })?;
+    let repo = gix::open(repo_root).map_err(|error| {
+        CrabError::Internal(format!(
+            "open Git repository while recording add validations: {error}"
+        ))
+    })?;
+    let honor_filemode = git_honors_filemode(repo_root);
+    let rows = paths
+        .iter()
+        .filter_map(|path| {
+            clean_index_pointer(
+                repo_root,
+                &repo,
+                &index,
+                &path.abs_path,
+                path.size,
+                honor_filemode,
+            )
+            .and_then(|pointer| {
+                pointer
+                    .validation_token
+                    .map(|token| (pointer.path_bytes, token))
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut cache = crate::cache::add_validation::AddValidationCache::open(
+        &crate::cache::add_validation::cache_path_for_context(&context),
+    )?;
+    cache.upsert(&rows)?;
+    Ok(rows.len())
 }
 
 /// Recursive directory walker that collects `(abs_path, file_size)` pairs.
@@ -4781,6 +4960,187 @@ mod tests {
         assert!(to_process.is_empty());
         assert_eq!(skipped.files, 1);
         assert_eq!(skipped.bytes, payload.len() as u64);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn clean_index_filter_reuses_verified_add_validation() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("SKIP: git init failed");
+            return;
+        }
+
+        let path = dir.path().join("model.bin");
+        let payload = b"model payload";
+        std::fs::write(&path, payload).unwrap();
+        make_file_mtime_old(&path);
+
+        write_pointers_to_git_index(
+            &[staged_entry(
+                path.clone(),
+                *blake3::hash(payload).as_bytes(),
+                payload.len() as u64,
+            )],
+            dir.path(),
+            &crate::cache::ShardHintCache::new(),
+            || {},
+        )
+        .unwrap();
+        remember_verified_clean_index_paths(
+            dir.path(),
+            &[VerifiedCleanIndexPath {
+                abs_path: path.clone(),
+                size: payload.len() as u64,
+            }],
+        )
+        .unwrap();
+
+        let (to_process, skipped) = filter_clean_indexed_candidates(
+            dir.path(),
+            vec![(path, payload.len() as u64)],
+            1,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(to_process.is_empty());
+        assert_eq!(skipped.files, 1);
+        assert_eq!(skipped.validation_cache_hits, 1);
+        assert_eq!(skipped.validation_cache_hit_bytes, payload.len() as u64);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn clean_index_filter_rehashes_same_size_same_mtime_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("SKIP: git init failed");
+            return;
+        }
+
+        let path = dir.path().join("model.bin");
+        let original = b"original payload";
+        let replacement = b"replaced payload";
+        assert_eq!(original.len(), replacement.len());
+        std::fs::write(&path, original).unwrap();
+        make_file_mtime_old(&path);
+        write_pointers_to_git_index(
+            &[staged_entry(
+                path.clone(),
+                *blake3::hash(original).as_bytes(),
+                original.len() as u64,
+            )],
+            dir.path(),
+            &crate::cache::ShardHintCache::new(),
+            || {},
+        )
+        .unwrap();
+        remember_verified_clean_index_paths(
+            dir.path(),
+            &[VerifiedCleanIndexPath {
+                abs_path: path.clone(),
+                size: original.len() as u64,
+            }],
+        )
+        .unwrap();
+
+        std::fs::write(&path, replacement).unwrap();
+        make_file_mtime_old(&path);
+        let (to_process, skipped) = filter_clean_indexed_candidates(
+            dir.path(),
+            vec![(path, replacement.len() as u64)],
+            1,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(to_process.len(), 1);
+        assert_eq!(skipped.files, 0);
+        assert_eq!(skipped.validation_cache_hits, 0);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn clean_index_filter_hashes_racy_pointer_once_then_uses_validation() {
+        use bstr::ByteSlice;
+
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("SKIP: git init failed");
+            return;
+        }
+
+        let path = dir.path().join("model.bin");
+        let payload = b"model payload";
+        std::fs::write(&path, payload).unwrap();
+        make_file_mtime_old(&path);
+        write_pointers_to_git_index(
+            &[staged_entry(
+                path.clone(),
+                *blake3::hash(payload).as_bytes(),
+                payload.len() as u64,
+            )],
+            dir.path(),
+            &crate::cache::ShardHintCache::new(),
+            || {},
+        )
+        .unwrap();
+
+        let future = filetime::FileTime::from_system_time(
+            std::time::SystemTime::now() + Duration::from_secs(60),
+        );
+        filetime::set_file_mtime(&path, future).unwrap();
+        assert_eq!(
+            crate::git::worktree::refresh_index_stats(dir.path(), std::slice::from_ref(&path))
+                .unwrap(),
+            1
+        );
+        let context = crate::git::worktree::WorktreeContext::resolve_from_path(dir.path()).unwrap();
+        let index = gix_index::File::at(
+            context.index_path(),
+            gix_hash::Kind::Sha1,
+            true,
+            gix_index::decode::Options::default(),
+        )
+        .unwrap();
+        let entry = index
+            .entry_by_path_and_stage(
+                git_index_path_bstring(Path::new("model.bin")).as_bstr(),
+                gix_index::entry::Stage::Unconflicted,
+            )
+            .unwrap();
+        assert!(
+            entry.stat.is_racy(
+                index.timestamp(),
+                gix_index::entry::stat::Options::default()
+            ),
+            "fixture must exercise Git's racy-stat path"
+        );
+
+        let (_, first) = filter_clean_indexed_candidates(
+            dir.path(),
+            vec![(path.clone(), payload.len() as u64)],
+            1,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        let (to_process, second) = filter_clean_indexed_candidates(
+            dir.path(),
+            vec![(path, payload.len() as u64)],
+            1,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(first.files, 1);
+        assert_eq!(first.validation_cache_hits, 0);
+        assert!(to_process.is_empty());
+        assert_eq!(second.validation_cache_hits, 1);
     }
 
     #[tokio::test]

--- a/crab/src/cmd/dehydrate.rs
+++ b/crab/src/cmd/dehydrate.rs
@@ -1893,7 +1893,12 @@ mod tests {
         let ptr = sample_pointer(4096);
         std::fs::write(dir.path().join("ptr.bin"), ptr.serialize()).unwrap();
 
-        let filter = build_filter(&["**/*".to_owned()], &[]).unwrap();
+        let filter = resolve_patterns(&DehydrateArgs {
+            all: true,
+            ..default_args()
+        })
+        .unwrap()
+        .unwrap();
         let tracked = TrackedClassifier::open(dir.path()).unwrap();
         let cancel = CancellationToken::new();
         let mut out = Vec::new();

--- a/crab/src/cmd/hydrate.rs
+++ b/crab/src/cmd/hydrate.rs
@@ -40,7 +40,8 @@ use crate::engine::pointer::is_working_tree_pointer;
 use crate::git::progress::{format_rate, is_tty, render_bar};
 use crate::git::smudge::SmudgeSession;
 use crate::git::worktree::{
-    WorktreeContext, normalize_identity_path, parse_worktree_list_porcelain, refresh_index_stats,
+    WorktreeContext, normalize_identity_path, parse_worktree_list_porcelain,
+    refresh_verified_index_stats,
 };
 use crate::git::worktree_hydration::{
     WorktreeHydrationMode, WorktreeHydrationPolicyFile, WorktreeHydrationPolicyStatus,
@@ -191,6 +192,27 @@ pub struct HydrateSummary {
     /// Bytes materialized through verified sibling-worktree CoW clones.
     /// Subset of `bytes_written`.
     pub bytes_cow_cloned: u64,
+    /// Exact post-publication stats for content verified during this run.
+    pub(crate) verified_paths: Vec<crate::cache::add_validation::VerifiedPath>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct VerifiedWrite {
+    bytes: u64,
+    index_stat: crate::cmd::stream_stage::VerifiedIndexStat,
+}
+
+fn verified_path(
+    path: &Path,
+    pointer: &Pointer,
+    write: VerifiedWrite,
+) -> crate::cache::add_validation::VerifiedPath {
+    crate::cache::add_validation::VerifiedPath {
+        path: path.to_owned(),
+        file_hash: pointer.file_hash,
+        size: write.bytes,
+        index_stat: write.index_stat,
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -464,7 +486,7 @@ impl Hydrator for SmudgeSessionHydrator {
 
                 let file_start = Instant::now();
 
-                if is_already_hydrated(path, ptr) {
+                if is_already_hydrated(path, ptr, cancel)? {
                     debug!(path = %path.display(), "already hydrated, skipping");
                     summary.skipped += 1;
                     summary.bytes_skipped += ptr.size;
@@ -483,7 +505,14 @@ impl Hydrator for SmudgeSessionHydrator {
 
                 let pointer_bytes = ptr.serialize();
                 let result = match self.session.smudge_file(&pointer_bytes).await {
-                    Ok(content) => atomic_write(path, &content).map(|()| content.len() as u64),
+                    Ok(content) => {
+                        atomic_write_with_progress(path, &content, None).map(|index_stat| {
+                            VerifiedWrite {
+                                bytes: content.len() as u64,
+                                index_stat,
+                            }
+                        })
+                    }
                     Err(remote_error) => match try_hydrate_from_staging(path, ptr, cancel).await {
                         Ok(Some(bytes)) => Ok(bytes),
                         Ok(None) => Err(remote_error),
@@ -498,17 +527,18 @@ impl Hydrator for SmudgeSessionHydrator {
                     },
                 };
                 match result {
-                    Ok(bytes) => {
+                    Ok(write) => {
                         summary.hydrated += 1;
-                        summary.bytes_written += bytes;
+                        summary.bytes_written += write.bytes;
+                        summary.verified_paths.push(verified_path(path, ptr, write));
                         if let Some(p) = progress {
                             p.files_done.fetch_add(1, Relaxed);
-                            p.bytes_done.fetch_add(bytes, Relaxed);
+                            p.bytes_done.fetch_add(write.bytes, Relaxed);
                             p.send_file_result(HydrateFileResult {
                                 path: path.clone(),
                                 outcome: HydrateFileOutcome::Hydrated,
                                 duration: file_start.elapsed(),
-                                bytes,
+                                bytes: write.bytes,
                             });
                         }
                     }
@@ -1467,7 +1497,7 @@ impl ShardHydrator {
         progress: Option<Arc<HydrateProgress>>,
         file_index_lookup: Option<&SharedFileIndexLookup>,
         cancel: CancellationToken,
-    ) -> Result<u64> {
+    ) -> Result<VerifiedWrite> {
         error::check_cancelled(&cancel)?;
         let parent = dest.parent().unwrap_or(Path::new("."));
         ensure_atomic_reconstruction_space(parent, ptr.size)?;
@@ -1485,10 +1515,7 @@ impl ShardHydrator {
             )
             .await?;
         error::check_cancelled(&cancel)?;
-        preserve_destination_permissions(dest, tmp.as_file())?;
-        tmp.persist(dest)
-            .map_err(|e| error::CrabError::Io(e.error))?;
-        Ok(bytes)
+        persist_verified_temp(tmp, dest, bytes)
     }
 
     async fn reconstruct_to_open_file(
@@ -1951,7 +1978,7 @@ impl ShardHydrator {
         cancel: &CancellationToken,
         progress: Option<&Arc<HydrateProgress>>,
         file_index_lookup: &SharedFileIndexLookup,
-    ) -> Result<HydrateFileResult> {
+    ) -> Result<HydrateOneResult> {
         error::check_cancelled(cancel)?;
 
         if let Some(progress) = progress {
@@ -1963,7 +1990,7 @@ impl ShardHydrator {
         }
 
         let file_start = Instant::now();
-        if is_already_hydrated(path, ptr) {
+        if is_already_hydrated(path, ptr, cancel)? {
             tracing::debug!(path = %path.display(), "already hydrated, skipping");
             let result = HydrateFileResult {
                 path: path.to_owned(),
@@ -1976,7 +2003,10 @@ impl ShardHydrator {
                 progress.bytes_done.fetch_add(ptr.size, Relaxed);
                 progress.send_file_result(result.clone());
             }
-            return Ok(result);
+            return Ok(HydrateOneResult {
+                result,
+                verified_path: None,
+            });
         }
 
         let result = match self
@@ -1985,7 +2015,8 @@ impl ShardHydrator {
         {
             Ok(content) => {
                 let bytes = content.len() as u64;
-                atomic_write_with_progress(path, &content, progress).map(|()| bytes)
+                atomic_write_with_progress(path, &content, progress)
+                    .map(|index_stat| VerifiedWrite { bytes, index_stat })
             }
             Err(e) => {
                 tracing::debug!(
@@ -2007,11 +2038,11 @@ impl ShardHydrator {
         let result = match result {
             Ok(bytes) => Ok(bytes),
             Err(remote_error) => match try_hydrate_from_staging(path, ptr, cancel).await {
-                Ok(Some(bytes)) => {
+                Ok(Some(write)) => {
                     if let Some(progress) = progress {
-                        progress.add_bytes_done(bytes);
+                        progress.add_bytes_done(write.bytes);
                     }
-                    Ok(bytes)
+                    Ok(write)
                 }
                 Ok(None) => Err(remote_error),
                 Err(staging_error) => {
@@ -2025,13 +2056,14 @@ impl ShardHydrator {
             },
         };
 
-        let (outcome, bytes) = match result {
-            Ok(bytes) => (HydrateFileOutcome::Hydrated, bytes),
+        let (outcome, write) = match result {
+            Ok(write) => (HydrateFileOutcome::Hydrated, Some(write)),
             Err(e) => {
                 tracing::warn!(path = %path.display(), err = %e, "reconstruction failed");
-                (HydrateFileOutcome::Failed, 0)
+                (HydrateFileOutcome::Failed, None)
             }
         };
+        let bytes = write.map_or(0, |write| write.bytes);
         let result = HydrateFileResult {
             path: path.to_owned(),
             outcome,
@@ -2042,8 +2074,16 @@ impl ShardHydrator {
             progress.files_done.fetch_add(1, Relaxed);
             progress.send_file_result(result.clone());
         }
-        Ok(result)
+        Ok(HydrateOneResult {
+            result,
+            verified_path: write.map(|write| verified_path(path, ptr, write)),
+        })
     }
+}
+
+struct HydrateOneResult {
+    result: HydrateFileResult,
+    verified_path: Option<crate::cache::add_validation::VerifiedPath>,
 }
 
 impl Hydrator for ShardHydrator {
@@ -2067,14 +2107,17 @@ impl Hydrator for ShardHydrator {
                 // leave download slots idle behind one large straggler.
                 while let Some(result) = results.next().await {
                     let result = result?;
-                    match result.outcome {
+                    match result.result.outcome {
                         HydrateFileOutcome::Hydrated => {
                             summary.hydrated += 1;
-                            summary.bytes_written += result.bytes;
+                            summary.bytes_written += result.result.bytes;
+                            if let Some(verified) = result.verified_path {
+                                summary.verified_paths.push(verified);
+                            }
                         }
                         HydrateFileOutcome::Skipped => {
                             summary.skipped += 1;
-                            summary.bytes_skipped += result.bytes;
+                            summary.bytes_skipped += result.result.bytes;
                         }
                         HydrateFileOutcome::Failed => {
                             summary.failed += 1;
@@ -2363,7 +2406,7 @@ impl Hydrator for StubHydrator {
 
                 let file_start = Instant::now();
 
-                if is_already_hydrated(path, ptr) {
+                if is_already_hydrated(path, ptr, cancel)? {
                     debug!(path = %path.display(), "already hydrated, skipping");
                     summary.skipped += 1;
                     summary.bytes_skipped += ptr.size;
@@ -2418,31 +2461,21 @@ impl Hydrator for StubHydrator {
     }
 }
 
-/// Check whether a file is already hydrated: its size matches the pointer's
-/// declared size and it is not itself a pointer blob.
-///
-/// This is a size-only heuristic — it does **not** re-hash the file. A
-/// file that happens to match the pointer's declared size but contains
-/// different content would be misclassified as hydrated and skipped.
-/// In practice the scenario requires both exact-size and not-a-pointer
-/// content, which is unlikely enough that reading and hashing every
-/// candidate file is not worth the I/O cost on large repos. See
-/// finding CR2-F18.
-///
-/// Callers that need a strict guarantee (e.g., post-corruption recovery)
-/// should re-run hydration with a fresh working tree; a `--force` flag
-/// that bypasses this check is tracked in the backlog.
-fn is_already_hydrated(path: &Path, ptr: &Pointer) -> bool {
+/// Verify a file that became hydrated after pointer discovery.
+fn is_already_hydrated(path: &Path, ptr: &Pointer, cancel: &CancellationToken) -> Result<bool> {
     let Ok(meta) = std::fs::metadata(path) else {
-        return false;
+        return Ok(false);
     };
 
     if meta.len() != ptr.size {
-        return false;
+        return Ok(false);
     }
 
     // If the file parses as a pointer it hasn't been hydrated yet.
-    matches!(is_working_tree_pointer(path), Ok(false))
+    if !matches!(is_working_tree_pointer(path), Ok(false)) {
+        return Ok(false);
+    }
+    Ok(hash_file_blake3_cancellable(path, cancel)? == ptr.file_hash)
 }
 
 /// Write `content` to `dest` atomically via a sibling tempfile and rename.
@@ -2455,14 +2488,14 @@ fn is_already_hydrated(path: &Path, ptr: &Pointer) -> bool {
 /// The final path is only updated by `persist()` (an atomic rename), so
 /// a signal can never leave a half-written file at `dest`.
 fn atomic_write(dest: &Path, content: &[u8]) -> Result<()> {
-    atomic_write_with_progress(dest, content, None)
+    atomic_write_with_progress(dest, content, None).map(|_| ())
 }
 
 fn atomic_write_with_progress(
     dest: &Path,
     content: &[u8],
     progress: Option<&Arc<HydrateProgress>>,
-) -> Result<()> {
+) -> Result<crate::cmd::stream_stage::VerifiedIndexStat> {
     let parent = dest.parent().unwrap_or(Path::new("."));
     let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
     for chunk in content.chunks(1024 * 1024) {
@@ -2471,10 +2504,37 @@ fn atomic_write_with_progress(
             p.add_bytes_done(chunk.len() as u64);
         }
     }
+    persist_verified_temp(tmp, dest, content.len() as u64).map(|write| write.index_stat)
+}
+
+fn persist_verified_temp(
+    mut tmp: tempfile::NamedTempFile,
+    dest: &Path,
+    bytes: u64,
+) -> Result<VerifiedWrite> {
     tmp.flush()?;
     preserve_destination_permissions(dest, tmp.as_file())?;
-    tmp.persist(dest).map_err(|e| e.error)?;
-    Ok(())
+    let file = tmp.persist(dest).map_err(|e| e.error)?;
+    let verified_stat = crate::cmd::stream_stage::VerifiedIndexStat::from_file(&file)
+        .ok_or_else(|| error::CrabError::Internal("stat published hydration file".to_owned()))?;
+    if verified_stat.len != bytes {
+        return Err(error::CrabError::Internal(format!(
+            "verified hydration size mismatch for {}: expected {bytes}, got {}",
+            dest.display(),
+            verified_stat.len
+        )));
+    }
+    if crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(dest) != Some(verified_stat)
+    {
+        return Err(error::CrabError::Internal(format!(
+            "hydrated file changed during atomic publication: {}",
+            dest.display()
+        )));
+    }
+    Ok(VerifiedWrite {
+        bytes,
+        index_stat: verified_stat,
+    })
 }
 
 fn preserve_destination_permissions(dest: &Path, temporary: &std::fs::File) -> Result<()> {
@@ -2499,7 +2559,7 @@ async fn try_hydrate_from_staging(
     dest: &Path,
     ptr: &Pointer,
     cancel: &CancellationToken,
-) -> Result<Option<u64>> {
+) -> Result<Option<VerifiedWrite>> {
     let Some(start) = dest.parent() else {
         return Ok(None);
     };
@@ -2562,11 +2622,9 @@ async fn try_hydrate_from_staging(
             file_hash.hex()
         )));
     }
-    tmp.flush()?;
-    preserve_destination_permissions(dest, tmp.as_file())?;
-    tmp.persist(dest).map_err(|error| error.error)?;
+    let verified = persist_verified_temp(tmp, dest, written)?;
     debug!(path = %dest.display(), bytes = written, "hydrated unpushed pointer from local staging");
-    Ok(Some(written))
+    Ok(Some(verified))
 }
 
 /// Result of attempting to recover a single pointer from a local source.
@@ -2574,7 +2632,7 @@ async fn try_hydrate_from_staging(
 enum RecoverOutcome {
     /// Candidate found and matched the pointer's blake3 hash. Bytes
     /// have already been written to `dest` (atomic rename completed).
-    Recovered { bytes: u64 },
+    Recovered { write: VerifiedWrite },
     /// No candidate file at the resolved path — fall through to remote.
     NoCandidate,
     /// Candidate was found but its content does not match the pointer's
@@ -2601,27 +2659,6 @@ fn resolve_recover_candidate(recover_from: &Path, dest: &Path) -> Option<PathBuf
     } else {
         None
     }
-}
-
-/// Stream-hash the candidate file with blake3 to verify against the
-/// pointer's `file_hash` without loading the whole content twice.
-///
-/// Reads in 1 MiB blocks so memory stays bounded regardless of file
-/// size. The same buffer is reused for the subsequent atomic write,
-/// avoiding a redundant pass over the file when the hash matches.
-fn hash_file_blake3(path: &Path) -> std::io::Result<[u8; 32]> {
-    use std::io::Read;
-    let mut file = std::fs::File::open(path)?;
-    let mut hasher = blake3::Hasher::new();
-    let mut buf = vec![0u8; 1024 * 1024];
-    loop {
-        let n = file.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    Ok(*hasher.finalize().as_bytes())
 }
 
 /// Try to recover a single pointer from a local source path.
@@ -2653,29 +2690,38 @@ fn try_recover_one(recover_from: &Path, dest: &Path, ptr: &Pointer) -> Result<Re
         return Ok(RecoverOutcome::HashMismatch);
     }
 
-    let actual_hash = hash_file_blake3(&candidate).map_err(error::CrabError::Io)?;
-    if actual_hash != ptr.file_hash {
+    // Copy and hash the exact published bytes in one bounded pass. Hashing the
+    // source first and reopening it for copy leaves a TOCTOU window and doubles
+    // source I/O for large recovery files.
+    use std::io::Read;
+    let parent = dest.parent().unwrap_or(Path::new("."));
+    let mut src = std::fs::File::open(&candidate).map_err(error::CrabError::Io)?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(error::CrabError::Io)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = vec![0u8; 1024 * 1024];
+    let mut bytes = 0u64;
+    loop {
+        let read = src.read(&mut buffer).map_err(error::CrabError::Io)?;
+        if read == 0 {
+            break;
+        }
+        tmp.write_all(&buffer[..read])?;
+        hasher.update(&buffer[..read]);
+        bytes = bytes
+            .checked_add(read as u64)
+            .ok_or_else(|| error::CrabError::Internal("recovery size overflow".to_owned()))?;
+    }
+    let actual_hash = *hasher.finalize().as_bytes();
+    if bytes != ptr.size || actual_hash != ptr.file_hash {
         debug!(
             candidate = %candidate.display(),
             expected_hash = %crab_types::pointer::hex_encode(&ptr.file_hash),
             actual_hash = %crab_types::pointer::hex_encode(&actual_hash),
-            "recover-from: candidate hash mismatch"
+            "recover-from: candidate changed or hash mismatched during copy"
         );
         return Ok(RecoverOutcome::HashMismatch);
     }
-
-    // Hash verified. Stream the candidate to a sibling tempfile and
-    // rename atomically. Avoids `std::fs::copy` because it doesn't
-    // give us the tempfile-then-rename ordering, and a crash mid-copy
-    // would leave a half-written `dest`.
-    let parent = dest.parent().unwrap_or(Path::new("."));
-    let mut src = std::fs::File::open(&candidate).map_err(error::CrabError::Io)?;
-    let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(error::CrabError::Io)?;
-    let bytes = std::io::copy(&mut src, tmp.as_file_mut()).map_err(error::CrabError::Io)?;
-    tmp.flush().map_err(error::CrabError::Io)?;
-    preserve_destination_permissions(dest, tmp.as_file())?;
-    tmp.persist(dest)
-        .map_err(|e| error::CrabError::Io(e.error))?;
+    let write = persist_verified_temp(tmp, dest, bytes)?;
 
     debug!(
         candidate = %candidate.display(),
@@ -2683,7 +2729,7 @@ fn try_recover_one(recover_from: &Path, dest: &Path, ptr: &Pointer) -> Result<Re
         bytes,
         "recover-from: hash verified and copied to working tree"
     );
-    Ok(RecoverOutcome::Recovered { bytes })
+    Ok(RecoverOutcome::Recovered { write })
 }
 
 /// Walk the to-hydrate list, attempting `--recover-from` recovery for
@@ -2711,7 +2757,7 @@ fn run_recover_phase(
     for (path, ptr) in to_hydrate {
         error::check_cancelled(cancel)?;
 
-        if is_already_hydrated(&path, &ptr) {
+        if is_already_hydrated(&path, &ptr, cancel)? {
             // Defer to the normal hydrator's skip path so the summary
             // accounting stays in one place.
             residual.push((path, ptr));
@@ -2727,22 +2773,23 @@ fn run_recover_phase(
 
         let file_start = Instant::now();
         match try_recover_one(recover_from, &path, &ptr)? {
-            RecoverOutcome::Recovered { bytes } => {
+            RecoverOutcome::Recovered { write } => {
                 stats.recovered += 1;
-                stats.bytes_recovered += bytes;
+                stats.bytes_recovered += write.bytes;
+                stats.verified_paths.push(verified_path(&path, &ptr, write));
                 if let Some(p) = progress {
                     p.files_done.fetch_add(1, Relaxed);
-                    p.bytes_done.fetch_add(bytes, Relaxed);
+                    p.bytes_done.fetch_add(write.bytes, Relaxed);
                     p.send_file_result(HydrateFileResult {
                         path: path.clone(),
                         outcome: HydrateFileOutcome::Hydrated,
                         duration: file_start.elapsed(),
-                        bytes,
+                        bytes: write.bytes,
                     });
                 }
                 info!(
                     path = %path.display(),
-                    bytes,
+                    bytes = write.bytes,
                     "recovered from local source"
                 );
             }
@@ -2759,6 +2806,7 @@ fn run_recover_phase(
 struct RecoverPhaseStats {
     recovered: u64,
     bytes_recovered: u64,
+    verified_paths: Vec<crate::cache::add_validation::VerifiedPath>,
 }
 
 const MAX_COW_CANDIDATES_PER_POINTER: usize = 8;
@@ -2936,7 +2984,7 @@ fn try_cow_clone_candidate(
     dest: &Path,
     pointer: &Pointer,
     cancel: &CancellationToken,
-) -> Result<Option<u64>> {
+) -> Result<Option<VerifiedWrite>> {
     error::check_cancelled(cancel)?;
     let parent = dest.parent().unwrap_or(Path::new("."));
     let reservation = match tempfile::Builder::new()
@@ -2987,31 +3035,63 @@ fn try_cow_clone_candidate(
         }
     }
 
-    let publish = (|| -> Result<()> {
+    let prepare = (|| -> Result<std::fs::File> {
         let temporary_file = std::fs::OpenOptions::new().write(true).open(&temporary)?;
         preserve_destination_permissions(dest, &temporary_file)?;
-        error::check_cancelled(cancel)?;
-        std::fs::rename(&temporary, dest)?;
-        Ok(())
+        let pre_publish_stat =
+            crate::cmd::stream_stage::VerifiedIndexStat::from_file(&temporary_file).ok_or_else(
+                || error::CrabError::Internal("stat verified CoW hydration tempfile".to_owned()),
+            )?;
+        if pre_publish_stat.len != pointer.size {
+            return Err(error::CrabError::Internal(format!(
+                "verified CoW hydration size mismatch for {}",
+                dest.display()
+            )));
+        }
+        Ok(temporary_file)
     })();
-    match publish {
-        Ok(()) => Ok(Some(pointer.size)),
+    let temporary_file = match prepare {
+        Ok(temporary_file) => temporary_file,
         Err(error::CrabError::Cancelled) => {
             remove_file_if_present(&temporary);
-            Err(error::CrabError::Cancelled)
+            return Err(error::CrabError::Cancelled);
         }
         Err(error) => {
             remove_file_if_present(&temporary);
             debug!(source = %source.display(), path = %dest.display(), error = %error, "CoW clone publication failed; falling back to hydration");
-            Ok(None)
+            return Ok(None);
         }
+    };
+    if let Err(error) = error::check_cancelled(cancel) {
+        remove_file_if_present(&temporary);
+        return Err(error);
     }
+    if let Err(error) = std::fs::rename(&temporary, dest) {
+        remove_file_if_present(&temporary);
+        debug!(source = %source.display(), path = %dest.display(), error = %error, "CoW clone publication failed; falling back to hydration");
+        return Ok(None);
+    }
+    let index_stat = crate::cmd::stream_stage::VerifiedIndexStat::from_file(&temporary_file)
+        .ok_or_else(|| {
+            error::CrabError::Internal("stat published CoW hydration file".to_owned())
+        })?;
+    if crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(dest) != Some(index_stat) {
+        return Err(error::CrabError::Internal(format!(
+            "CoW hydrated file changed during publication: {}",
+            dest.display()
+        )));
+    }
+    Ok(Some(VerifiedWrite {
+        bytes: pointer.size,
+        index_stat,
+    }))
 }
 
 #[derive(Debug, Default)]
 struct CowPhaseStats {
     cloned: u64,
     bytes_cloned: u64,
+    verified_paths: Vec<crate::cache::add_validation::VerifiedPath>,
 }
 
 async fn run_cow_phase(
@@ -3025,7 +3105,7 @@ async fn run_cow_phase(
 
     for (path, pointer) in to_hydrate {
         error::check_cancelled(cancel)?;
-        if is_already_hydrated(&path, &pointer) {
+        if is_already_hydrated(&path, &pointer, cancel)? {
             residual.push((path, pointer));
             continue;
         }
@@ -3049,23 +3129,26 @@ async fn run_cow_phase(
             .map_err(|error| {
                 error::CrabError::Internal(format!("CoW hydration worker failed: {error}"))
             })??;
-            let Some(bytes) = outcome else {
+            let Some(write) = outcome else {
                 continue;
             };
 
             stats.cloned += 1;
-            stats.bytes_cloned += bytes;
+            stats.bytes_cloned += write.bytes;
+            stats
+                .verified_paths
+                .push(verified_path(&path, &pointer, write));
             if let Some(progress) = progress {
                 progress.files_done.fetch_add(1, Relaxed);
-                progress.bytes_done.fetch_add(bytes, Relaxed);
+                progress.bytes_done.fetch_add(write.bytes, Relaxed);
                 progress.send_file_result(HydrateFileResult {
                     path: path.clone(),
                     outcome: HydrateFileOutcome::Hydrated,
                     duration: file_start.elapsed(),
-                    bytes,
+                    bytes: write.bytes,
                 });
             }
-            info!(path = %path.display(), bytes, "hydrated through sibling-worktree CoW clone");
+            info!(path = %path.display(), bytes = write.bytes, "hydrated through sibling-worktree CoW clone");
             cloned = true;
             break;
         }
@@ -3387,10 +3470,12 @@ pub async fn run_hydrate_in(
     summary.bytes_written += recover_stats.bytes_recovered;
     summary.recovered = recover_stats.recovered;
     summary.bytes_recovered = recover_stats.bytes_recovered;
+    summary.verified_paths.extend(recover_stats.verified_paths);
     summary.hydrated += cow_stats.cloned;
     summary.bytes_written += cow_stats.bytes_cloned;
     summary.cow_cloned = cow_stats.cloned;
     summary.bytes_cow_cloned = cow_stats.bytes_cloned;
+    summary.verified_paths.extend(cow_stats.verified_paths);
     let elapsed = start.elapsed();
 
     if let Some(pending) = pending_hydration.as_ref()
@@ -3446,7 +3531,7 @@ pub async fn run_hydrate_in(
                 }
             }
         }
-        refresh_hydrated_index_entries(root, &selected_to_hydrate);
+        refresh_hydrated_index_entries(root, &summary.verified_paths);
     }
 
     // In non-manifest JSONL mode, emit retroactive file_done events.
@@ -3576,19 +3661,40 @@ pub async fn run_hydrate_in(
     Ok(())
 }
 
-fn refresh_hydrated_index_entries(root: &Path, entries: &[(PathBuf, Pointer)]) {
-    let paths = entries
+fn refresh_hydrated_index_entries(
+    root: &Path,
+    verified_paths: &[crate::cache::add_validation::VerifiedPath],
+) {
+    let paths = verified_paths
         .iter()
-        .filter_map(|(path, _)| {
-            (!is_working_tree_pointer(path).unwrap_or(true)).then_some(path.clone())
+        .map(|verified| {
+            (
+                verified.path.clone(),
+                verified.index_stat.stat,
+                verified.index_stat.len,
+                verified.file_hash,
+                verified.size,
+            )
         })
         .collect::<Vec<_>>();
-    if let Err(e) = refresh_index_stats(root, &paths) {
+    if let Err(e) = refresh_verified_index_stats(root, &paths) {
         debug!(
             files = paths.len(),
             error = %e,
             "failed to refresh hydrated file index stat metadata"
         );
+        return;
+    }
+    match crate::cache::add_validation::record_verified_paths(root, verified_paths) {
+        Ok(validations) => {
+            debug!(validations, "recorded verified hydrate validations");
+        }
+        Err(error) => {
+            debug!(
+                error = %error,
+                "failed to persist verified hydrate validations; later add will rehash"
+            );
+        }
     }
 }
 
@@ -4797,7 +4903,7 @@ mod tests {
         assert!(git_stdout(&repo, &["status", "--porcelain=v1"]).contains(" M model.bin"));
 
         assert_eq!(
-            refresh_index_stats(&repo, &[repo.join("model.bin")]).unwrap(),
+            crate::git::worktree::refresh_index_stats(&repo, &[repo.join("model.bin")]).unwrap(),
             1
         );
 
@@ -4822,7 +4928,7 @@ mod tests {
         std::fs::write(repo.join("model.bin"), "POINTER\n").unwrap();
         assert!(git_stdout(&repo, &["status", "--porcelain=v1"]).contains(" M model.bin"));
         assert_eq!(
-            refresh_index_stats(&repo, &[repo.join("model.bin")]).unwrap(),
+            crate::git::worktree::refresh_index_stats(&repo, &[repo.join("model.bin")]).unwrap(),
             1
         );
         assert_eq!(git_stdout(&repo, &["status", "--porcelain=v1"]), "");
@@ -4871,8 +4977,11 @@ mod tests {
         std::fs::write(repo.join("model.bin"), "hydrated model bytes\n").unwrap();
         std::fs::write(repo.join("adapter.bin"), "hydrated adapter bytes\n").unwrap();
         assert_eq!(
-            refresh_index_stats(&repo, &[repo.join("model.bin"), repo.join("adapter.bin")],)
-                .unwrap(),
+            crate::git::worktree::refresh_index_stats(
+                &repo,
+                &[repo.join("model.bin"), repo.join("adapter.bin")],
+            )
+            .unwrap(),
             2
         );
 
@@ -4895,6 +5004,198 @@ mod tests {
                 gix_index::entry::Stat::from_fs(&metadata).unwrap()
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hydrate_proof_seeds_first_add_validation() {
+        use bstr::ByteSlice;
+
+        let _git_env = ScopedGitDir::acquire();
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        run_git(&repo, &["init", "--initial-branch=main"]);
+
+        let content = b"verified hydrated bytes";
+        let pointer = Pointer {
+            file_hash: *blake3::hash(content).as_bytes(),
+            size: content.len() as u64,
+            shard_hint: None,
+        };
+        let path = repo.join("model.bin");
+        std::fs::write(&path, pointer.serialize()).unwrap();
+        run_git(&repo, &["add", "model.bin"]);
+        let index_stat = atomic_write_with_progress(&path, content, None).unwrap();
+        if !crate::cache::add_validation::stat_is_cacheable(&index_stat.stat) {
+            eprintln!("SKIP: filesystem change-time precision cannot support validation cache");
+            return;
+        }
+        let verified = crate::cache::add_validation::VerifiedPath {
+            path: path.clone(),
+            file_hash: pointer.file_hash,
+            size: pointer.size,
+            index_stat,
+        };
+
+        refresh_hydrated_index_entries(&repo, std::slice::from_ref(&verified));
+
+        let context = WorktreeContext::resolve_from_path(&repo).unwrap();
+        let index = gix_index::File::at(
+            context.index_path(),
+            gix_hash::Kind::Sha1,
+            true,
+            gix_index::decode::Options::default(),
+        )
+        .unwrap();
+        let entry = index
+            .entry_by_path_and_stage(
+                b"model.bin".as_bstr(),
+                gix_index::entry::Stage::Unconflicted,
+            )
+            .unwrap();
+        let git_repo = gix::open(&repo).unwrap();
+        let blob = git_repo.find_blob(entry.id).unwrap();
+        let token = crate::cache::add_validation::validation_token(
+            b"model.bin",
+            entry.id.as_bytes(),
+            &blob.data,
+            entry.mode.bits(),
+            &index_stat.stat,
+            index_stat.len,
+        );
+        let cache_path = crate::cache::add_validation::cache_path_for_context(&context);
+        let cache = crate::cache::add_validation::AddValidationCache::open(&cache_path).unwrap();
+
+        assert!(cache.contains(b"model.bin", &token).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hydrate_proof_rejects_content_changed_before_index_refresh() {
+        use bstr::ByteSlice;
+
+        let _git_env = ScopedGitDir::acquire();
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        run_git(&repo, &["init", "--initial-branch=main"]);
+
+        let content = b"verified hydrated bytes";
+        let replacement = b"modified hydrated bytes";
+        assert_eq!(content.len(), replacement.len());
+        let pointer = Pointer {
+            file_hash: *blake3::hash(content).as_bytes(),
+            size: content.len() as u64,
+            shard_hint: None,
+        };
+        let path = repo.join("model.bin");
+        std::fs::write(&path, pointer.serialize()).unwrap();
+        run_git(&repo, &["add", "model.bin"]);
+        let index_stat = atomic_write_with_progress(&path, content, None).unwrap();
+        let verified = crate::cache::add_validation::VerifiedPath {
+            path: path.clone(),
+            file_hash: pointer.file_hash,
+            size: pointer.size,
+            index_stat,
+        };
+        std::fs::write(&path, replacement).unwrap();
+
+        refresh_hydrated_index_entries(&repo, std::slice::from_ref(&verified));
+
+        let context = WorktreeContext::resolve_from_path(&repo).unwrap();
+        let index = gix_index::File::at(
+            context.index_path(),
+            gix_hash::Kind::Sha1,
+            true,
+            gix_index::decode::Options::default(),
+        )
+        .unwrap();
+        let entry = index
+            .entry_by_path_and_stage(
+                b"model.bin".as_bstr(),
+                gix_index::entry::Stage::Unconflicted,
+            )
+            .unwrap();
+        let current =
+            crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&path).unwrap();
+        assert_ne!(entry.stat, current.stat);
+        let cache_path = crate::cache::add_validation::cache_path_for_context(&context);
+        let connection = rusqlite::Connection::open(cache_path).unwrap();
+        let rows: u64 = connection
+            .query_row("SELECT COUNT(*) FROM add_validations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hydrate_proof_rejects_pointer_changed_before_index_refresh() {
+        use bstr::ByteSlice;
+
+        let _git_env = ScopedGitDir::acquire();
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        run_git(&repo, &["init", "--initial-branch=main"]);
+
+        let content = b"verified hydrated bytes";
+        let pointer = pointer_for_content(content);
+        let path = repo.join("model.bin");
+        std::fs::write(&path, pointer.serialize()).unwrap();
+        run_git(&repo, &["add", "model.bin"]);
+        let index_stat = atomic_write_with_progress(&path, content, None).unwrap();
+        let verified = crate::cache::add_validation::VerifiedPath {
+            path: path.clone(),
+            file_hash: pointer.file_hash,
+            size: pointer.size,
+            index_stat,
+        };
+
+        let mut other_hash = pointer.file_hash;
+        other_hash[0] ^= 0xff;
+        let other_pointer = Pointer {
+            file_hash: other_hash,
+            size: pointer.size,
+            shard_hint: None,
+        };
+        let pointer_file = repo.join("other.pointer");
+        std::fs::write(&pointer_file, other_pointer.serialize()).unwrap();
+        let oid = git_stdout(&repo, &["hash-object", "-w", "other.pointer"])
+            .trim()
+            .to_owned();
+        let cache_info = format!("100644,{oid},model.bin");
+        run_git(&repo, &["update-index", "--cacheinfo", &cache_info]);
+        assert_eq!(
+            crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&path),
+            Some(index_stat)
+        );
+
+        refresh_hydrated_index_entries(&repo, std::slice::from_ref(&verified));
+
+        let context = WorktreeContext::resolve_from_path(&repo).unwrap();
+        let index = gix_index::File::at(
+            context.index_path(),
+            gix_hash::Kind::Sha1,
+            true,
+            gix_index::decode::Options::default(),
+        )
+        .unwrap();
+        let entry = index
+            .entry_by_path_and_stage(
+                b"model.bin".as_bstr(),
+                gix_index::entry::Stage::Unconflicted,
+            )
+            .unwrap();
+        assert_eq!(entry.id.to_hex().to_string(), oid);
+        assert_ne!(entry.stat, index_stat.stat);
+
+        let cache_path = crate::cache::add_validation::cache_path_for_context(&context);
+        let connection = rusqlite::Connection::open(cache_path).unwrap();
+        let rows: u64 = connection
+            .query_row("SELECT COUNT(*) FROM add_validations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 0);
     }
 
     fn run_git_without_crab_filter(cwd: &Path, args: &[&str]) {
@@ -5050,7 +5351,7 @@ mod tests {
             .await
             .expect("staging fallback");
 
-        assert_eq!(restored, Some(pointer.size));
+        assert_eq!(restored.map(|write| write.bytes), Some(pointer.size));
         assert_eq!(std::fs::read(path).expect("read restored file"), content);
     }
 
@@ -5991,6 +6292,50 @@ mod tests {
         }
     }
 
+    #[test]
+    fn recover_from_hashes_the_exact_published_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.bin");
+        let dest = dir.path().join("dest.bin");
+        let content = b"verified recovery content".repeat(4096);
+        let pointer = pointer_for_content(&content);
+        std::fs::write(&source, &content).unwrap();
+        std::fs::write(&dest, pointer.serialize()).unwrap();
+
+        let RecoverOutcome::Recovered { write } =
+            try_recover_one(&source, &dest, &pointer).unwrap()
+        else {
+            panic!("matching recovery source must be published");
+        };
+
+        assert_eq!(write.bytes, pointer.size);
+        assert_eq!(
+            crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&dest),
+            Some(write.index_stat)
+        );
+        assert_eq!(std::fs::read(dest).unwrap(), content);
+    }
+
+    #[test]
+    fn recover_from_mismatch_leaves_pointer_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.bin");
+        let dest = dir.path().join("dest.bin");
+        let expected = b"expected recovery bytes";
+        let pointer = pointer_for_content(expected);
+        let pointer_bytes = pointer.serialize();
+        let mut incorrect = expected.to_vec();
+        incorrect[0] ^= 0xff;
+        std::fs::write(&source, incorrect).unwrap();
+        std::fs::write(&dest, &pointer_bytes).unwrap();
+
+        assert!(matches!(
+            try_recover_one(&source, &dest, &pointer).unwrap(),
+            RecoverOutcome::HashMismatch
+        ));
+        assert_eq!(std::fs::read(dest).unwrap(), pointer_bytes);
+    }
+
     #[cfg(unix)]
     #[test]
     fn cow_clone_candidate_verifies_content_preserves_mode_and_is_independent() {
@@ -6276,8 +6621,10 @@ mod tests {
         let ptr = sample_pointer(4096);
         std::fs::write(dir.path().join("model.bin"), ptr.serialize()).unwrap();
 
-        let filter = build_filter(&["**/*".to_owned()], &[]).unwrap();
+        let filter = build_all_filter().unwrap();
         let tracked = TrackedClassifier::open(dir.path()).unwrap();
+        assert!(filter.matches("model.bin"));
+        assert!(tracked.is_tracked(Path::new("model.bin")));
         let cancel = CancellationToken::new();
         let mut out = Vec::new();
         walk_and_parse_pointers(dir.path(), dir.path(), &tracked, &filter, &cancel, &mut out)
@@ -6493,8 +6840,8 @@ mod tests {
     async fn hydrate_batch_skips_already_hydrated_files() {
         let dir = tempfile::tempdir().unwrap();
 
-        // Pointer declares size = 4096.
-        let ptr = sample_pointer(4096);
+        let hydrated = vec![0xAB; 4096];
+        let ptr = pointer_for_content(&hydrated);
 
         // File A: still a pointer on disk — should be hydrated.
         let path_a = dir.path().join("a.bin");
@@ -6503,7 +6850,7 @@ mod tests {
         // File B: already hydrated — non-pointer content whose size
         // matches ptr.size. The hydrator should skip it.
         let path_b = dir.path().join("b.bin");
-        std::fs::write(&path_b, vec![0xAB; 4096]).unwrap();
+        std::fs::write(&path_b, hydrated).unwrap();
 
         let items = vec![(path_a.clone(), ptr.clone()), (path_b.clone(), ptr.clone())];
         let cancel = CancellationToken::new();
@@ -6524,16 +6871,20 @@ mod tests {
         let ptr = sample_pointer(4096);
         let path = dir.path().join("ptr.bin");
         std::fs::write(&path, ptr.serialize()).unwrap();
-        assert!(!is_already_hydrated(&path, &ptr));
+        assert!(!is_already_hydrated(&path, &ptr, &CancellationToken::new()).unwrap());
     }
 
     #[test]
-    fn is_already_hydrated_returns_true_for_matching_size_non_pointer() {
+    fn is_already_hydrated_requires_matching_hash() {
         let dir = tempfile::tempdir().unwrap();
-        let ptr = sample_pointer(512);
+        let content = vec![0xCD; 512];
+        let ptr = pointer_for_content(&content);
         let path = dir.path().join("data.bin");
-        std::fs::write(&path, vec![0xCD; 512]).unwrap();
-        assert!(is_already_hydrated(&path, &ptr));
+        std::fs::write(&path, &content).unwrap();
+        assert!(is_already_hydrated(&path, &ptr, &CancellationToken::new()).unwrap());
+
+        std::fs::write(&path, vec![0xCE; 512]).unwrap();
+        assert!(!is_already_hydrated(&path, &ptr, &CancellationToken::new()).unwrap());
     }
 
     #[test]
@@ -6542,16 +6893,20 @@ mod tests {
         let ptr = sample_pointer(4096);
         let path = dir.path().join("data.bin");
         std::fs::write(&path, vec![0xCD; 9999]).unwrap();
-        assert!(!is_already_hydrated(&path, &ptr));
+        assert!(!is_already_hydrated(&path, &ptr, &CancellationToken::new()).unwrap());
     }
 
     #[test]
     fn is_already_hydrated_returns_false_for_missing_file() {
         let ptr = sample_pointer(4096);
-        assert!(!is_already_hydrated(
-            Path::new("/nonexistent/file.bin"),
-            &ptr
-        ));
+        assert!(
+            !is_already_hydrated(
+                Path::new("/nonexistent/file.bin"),
+                &ptr,
+                &CancellationToken::new()
+            )
+            .unwrap()
+        );
     }
 
     // --- format_bytes and format_elapsed tests ---
@@ -6690,15 +7045,16 @@ mod tests {
     #[tokio::test]
     async fn hydrate_summary_tracks_bytes_skipped() {
         let dir = tempfile::tempdir().unwrap();
-        let ptr = sample_pointer(4096);
+        let content = vec![0xAB; 4096];
+        let ptr = pointer_for_content(&content);
 
         // File A: still a pointer — will be hydrated.
         let path_a = dir.path().join("a.bin");
         std::fs::write(&path_a, ptr.serialize()).unwrap();
 
-        // File B: already hydrated (non-pointer, size matches).
+        // File B: already hydrated with the exact pointer content.
         let path_b = dir.path().join("b.bin");
-        std::fs::write(&path_b, vec![0xAB; 4096]).unwrap();
+        std::fs::write(&path_b, content).unwrap();
 
         let items = vec![(path_a, ptr.clone()), (path_b, ptr.clone())];
         let cancel = CancellationToken::new();
@@ -6942,13 +7298,14 @@ mod tests {
     #[tokio::test]
     async fn hydrate_file_result_channel_sends_per_file_results() {
         let dir = tempfile::tempdir().unwrap();
-        let ptr = sample_pointer(4096);
+        let content = vec![0xAB; 4096];
+        let ptr = pointer_for_content(&content);
 
         let path_a = dir.path().join("a.bin");
         let path_b = dir.path().join("b.bin");
         std::fs::write(&path_a, ptr.serialize()).unwrap();
-        // b.bin is already hydrated (non-pointer, matching size).
-        std::fs::write(&path_b, vec![0xAB; 4096]).unwrap();
+        // b.bin is already hydrated with the exact pointer content.
+        std::fs::write(&path_b, content).unwrap();
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<HydrateFileResult>();
         let total_bytes = ptr.size * 2;

--- a/crab/src/git/worktree.rs
+++ b/crab/src/git/worktree.rs
@@ -141,8 +141,6 @@ pub fn committed_pointers_for_paths(
 
 /// Refresh Git index stat entries after Crab replaces worktree file contents.
 pub(crate) fn refresh_index_stats(root: &Path, paths: &[PathBuf]) -> Result<usize> {
-    use bstr::ByteSlice;
-
     if paths.is_empty() {
         return Ok(0);
     }
@@ -152,7 +150,62 @@ pub(crate) fn refresh_index_stats(root: &Path, paths: &[PathBuf]) -> Result<usiz
         let metadata = gix_index::fs::Metadata::from_path_no_follow(path).map_err(CrabError::Io)?;
         let stat = gix_index::entry::Stat::from_fs(&metadata)
             .map_err(|error| CrabError::Internal(format!("read worktree file stat: {error}")))?;
-        updates.insert(index_path_bytes(rel), stat);
+        updates.insert(
+            index_path_bytes(rel),
+            IndexStatUpdate {
+                stat,
+                expected_pointer: None,
+            },
+        );
+    }
+
+    write_index_stats(root, &updates)
+}
+
+/// Refresh only paths that still have the exact stat captured by a verified read.
+pub(crate) fn refresh_verified_index_stats(
+    root: &Path,
+    paths: &[(PathBuf, gix_index::entry::Stat, u64, [u8; 32], u64)],
+) -> Result<usize> {
+    let mut updates = HashMap::with_capacity(paths.len());
+    for (path, verified_stat, verified_len, file_hash, size) in paths {
+        let Ok(metadata) = gix_index::fs::Metadata::from_path_no_follow(path) else {
+            continue;
+        };
+        let Ok(current_stat) = gix_index::entry::Stat::from_fs(&metadata) else {
+            continue;
+        };
+        if current_stat != *verified_stat || metadata.len() != *verified_len {
+            continue;
+        }
+        let Ok(rel) = path.strip_prefix(root) else {
+            continue;
+        };
+        // Write the captured stat, not a fresh one: a rewrite after this check
+        // then differs from the index instead of being accidentally marked clean.
+        updates.insert(
+            index_path_bytes(rel),
+            IndexStatUpdate {
+                stat: *verified_stat,
+                expected_pointer: Some((*file_hash, *size)),
+            },
+        );
+    }
+
+    write_index_stats(root, &updates)
+}
+
+#[derive(Clone, Copy)]
+struct IndexStatUpdate {
+    stat: gix_index::entry::Stat,
+    expected_pointer: Option<([u8; 32], u64)>,
+}
+
+fn write_index_stats(root: &Path, updates: &HashMap<Vec<u8>, IndexStatUpdate>) -> Result<usize> {
+    use bstr::ByteSlice;
+
+    if updates.is_empty() {
+        return Ok(0);
     }
 
     let index_path = WorktreeContext::resolve_from_path(root)?.index_path();
@@ -169,15 +222,37 @@ pub(crate) fn refresh_index_stats(root: &Path, paths: &[PathBuf]) -> Result<usiz
         gix_index::decode::Options::default(),
     )
     .map_err(|error| CrabError::Internal(format!("read Git index: {error}")))?;
+    let repo = updates
+        .values()
+        .any(|update| update.expected_pointer.is_some())
+        .then(|| {
+            gix::open(root)
+                .map_err(|error| CrabError::Internal(format!("open Git repository: {error}")))
+        })
+        .transpose()?;
     let mut updated = 0usize;
     for (entry, entry_path) in index.entries_mut_with_paths() {
         if entry.stage() != gix_index::entry::Stage::Unconflicted {
             continue;
         }
-        let Some(stat) = updates.get(entry_path.as_bytes()) else {
+        let Some(update) = updates.get(entry_path.as_bytes()) else {
             continue;
         };
-        entry.stat = *stat;
+        if let Some((expected_hash, expected_size)) = update.expected_pointer {
+            let Some(repo) = repo.as_ref() else {
+                continue;
+            };
+            let Ok(blob) = repo.find_blob(entry.id) else {
+                continue;
+            };
+            let Ok(pointer) = Pointer::parse(&blob.data) else {
+                continue;
+            };
+            if pointer.file_hash != expected_hash || pointer.size != expected_size {
+                continue;
+            }
+        }
+        entry.stat = update.stat;
         updated += 1;
     }
     if updated == 0 {
@@ -197,14 +272,14 @@ pub(crate) fn refresh_index_stats(root: &Path, paths: &[PathBuf]) -> Result<usiz
 }
 
 #[cfg(unix)]
-fn index_path_bytes(path: &Path) -> Vec<u8> {
+pub(crate) fn index_path_bytes(path: &Path) -> Vec<u8> {
     use std::os::unix::ffi::OsStrExt;
 
     path.as_os_str().as_bytes().to_vec()
 }
 
 #[cfg(not(unix))]
-fn index_path_bytes(path: &Path) -> Vec<u8> {
+pub(crate) fn index_path_bytes(path: &Path) -> Vec<u8> {
     path.to_string_lossy().into_owned().into_bytes()
 }
 

--- a/crab/src/lfs/migrate.rs
+++ b/crab/src/lfs/migrate.rs
@@ -3191,16 +3191,16 @@ mod tests {
     }
 
     #[test]
-    fn glob_matches_exact() {
+    fn glob_matches_exact_root_path() {
         let matcher = glob_matches_factory("README.md");
         assert!(matcher("README.md"));
-        assert!(matcher("docs/README.md"));
+        assert!(!matcher("docs/README.md"));
         assert!(!matcher("README.txt"));
     }
 
     #[test]
     fn path_matcher_applies_include_and_exclude() {
-        let matcher = PathMatcher::new(Some("*.bin"), Some("skip.bin"));
+        let matcher = PathMatcher::new(Some("*.bin"), Some("data/skip.bin"));
 
         assert!(matcher.matches("data/keep.bin"));
         assert!(!matcher.matches("data/skip.bin"));

--- a/crab/tests/schema_validate.rs
+++ b/crab/tests/schema_validate.rs
@@ -208,6 +208,8 @@ fn validate_add() {
         &AddSummary {
             files_staged: 3,
             files_skipped: 1,
+            validation_cache_hits: 1,
+            validation_cache_hit_bytes: 1024,
             files_failed: 0,
             chunks_staged: 12,
             bytes_processed: 65536,

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -395,6 +395,14 @@ pub struct VerifiedIndexStat {
     pub len: u64,
 }
 
+/// Whole-file hash and stat captured by one descriptor-safe verified read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VerifiedFileHash {
+    pub hash: [u8; 32],
+    pub size: u64,
+    pub index_stat: VerifiedIndexStat,
+}
+
 impl VerifiedIndexStat {
     pub fn from_path_no_follow(path: &Path) -> Option<Self> {
         let metadata = gix_index::fs::Metadata::from_path_no_follow(path).ok()?;
@@ -655,15 +663,15 @@ async fn stage_file_streaming_inner(
         );
         cleanup_stream_prepared_xorb_dir(staging.root(), &provisional_merkle, abs_path);
         let _ = staging.rollback_batch(&batch_id);
-        let (second_hash, second_size) = stream_hash_file(abs_path, None, cancel)
+        let second = stream_hash_file(abs_path, None, cancel)
             .await
             .map_err(|e| with_path(abs_path, e))?;
         return Err(CrabError::FileChangedDuringStaging {
             path: abs_path.display().to_string(),
             first_hash: file_merkle.hex(),
-            second_hash: MerkleHash::from(second_hash).hex(),
+            second_hash: MerkleHash::from(second.hash).hex(),
             first_size: stage_stats.size,
-            second_size,
+            second_size: second.size,
         });
     }
 
@@ -848,7 +856,7 @@ pub async fn stream_hash_file(
     path: &Path,
     bytes_done: Option<&Arc<AtomicU64>>,
     cancel: &CancellationToken,
-) -> Result<([u8; 32], u64)> {
+) -> Result<VerifiedFileHash> {
     let descriptor = open_regular_file_no_follow(path).await?;
     let before = VerifiedIndexStat::from_file(&descriptor);
     if VerifiedIndexStat::from_path_no_follow(path) != before {
@@ -885,7 +893,15 @@ pub async fn stream_hash_file(
             second_size: after.map_or(0, |stat| stat.len),
         });
     }
-    Ok((*hasher.finalize().as_bytes(), total))
+    let index_stat = after.ok_or_else(|| CrabError::Configuration {
+        key: path.display().to_string(),
+        origin: "file stat unavailable after descriptor-safe hash".to_owned(),
+    })?;
+    Ok(VerifiedFileHash {
+        hash: *hasher.finalize().as_bytes(),
+        size: total,
+        index_stat,
+    })
 }
 
 #[expect(

--- a/packages/web/content/docs/cli/reference/crab-hydrate.mdx
+++ b/packages/web/content/docs/cli/reference/crab-hydrate.mdx
@@ -25,8 +25,9 @@ is the primary way to "check out" large files after a lazy clone or after
 switching branches.
 
 Hydration is selective: you can hydrate specific files by glob pattern, or use
-`--all` to hydrate everything. Files that are already hydrated (full content on
-disk matching the expected size) are skipped automatically.
+`--all` to hydrate everything. Files already replaced with full content are not
+selected again. If a selected pointer is hydrated concurrently, Crab skips it
+only after its size and full BLAKE3 hash match the pointer.
 
 For conceptual background on hydration and lazy checkout, see [Hydrating Files](/docs/cli/daily-workflow/hydrating-files).
 


### PR DESCRIPTION
## Summary

- add a per-worktree v1 SQLite proof cache for content verified against the exact indexed Crab pointer
- bind each token to literal Git path bytes, pointer OID and payload, mode, full u64 length, and every captured filesystem stat field
- propagate descriptor-safe proofs from `crab add`, remote/staging hydration, recovery, and sibling-worktree CoW publication
- seed the add cache from the exact post-rename descriptor stat so the first post-hydrate add performs metadata checks instead of rereading large content
- copy and hash `--recover-from` candidates in one bounded pass, eliminating the previous second source read and reopen race
- require a full BLAKE3 match before skipping a file hydrated concurrently after discovery
- expose cache-hit counts and avoided bytes in the v1 add summary schema, text output, and docs

## Correctness

- proof publication requires the current path, indexed stat, and indexed pointer hash/size to match the exact verified read
- Git index refresh writes only the captured stat and refuses a file or pointer changed before publication
- same-size one-byte replacement with restored mtime invalidates through ctime and is restaged
- corrupt or unavailable cache state falls back to descriptor-safe hashing without trusting content
- recovery hashes the exact bytes written to its tempfile before atomic publication
- non-UTF8 Git paths round-trip as raw bytes
- the cache schema remains a hard v1 contract; unknown versions are rejected

## Verification

- `cargo test -p crab --lib --locked` — 3,840 passed, 0 failed, 2 ignored
- `cargo test -p crab-staging --lib stream --locked` — 29 passed, 1 manual test ignored
- focused add/hydrate/dehydrate/LFS migrate suites — 58 + 75 + 41 + 77 passed
- `cargo test -p crab --test schema_drift schemas_up_to_date --locked -- --exact` — passed
- CI-equivalent correctness Clippy invocation — passed
- `cargo build --release -p crab --bin crab --locked` — passed
- fresh RustFS 512 MiB lifecycle: add/commit/push/lazy-clone/hydrate/dehydrate/re-hydrate completed with byte-identical content
- first post-hydrate add: 0.21 s, one 512 MiB cache hit, zero bytes reprocessed, zero chunks staged, and zero payload writes
- repeated dehydrate/hydrate first add: 0.21 s with the same metadata-only result
- live one-byte mutation: stale proof rejected, 512 MiB reprocessed, 8,349 chunks staged, zero cache hits
- earlier RustFS 100 GiB logical qualification: repeat add 0.2–0.4 s with 100 GiB of reads avoided; one edited GiB was restaged while 99 GiB stayed cached
- isolated RustFS buckets, qualification trees, and the temporary 1.1 GiB Cargo home were removed after verification
