### PR TITLE
perf: harden hydrated cache and add preparation

### DIFF
--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -162,6 +162,9 @@ parallel files and later adds cannot assign the same chunk to different local
 xorbs. Only the claim winner feeds its builder. Other recipe occurrences wait
 for and then lease the winner's placement. The coordination is disk-backed and
 batch-bounded; it does not require a repository-sized in-memory hash map.
+Direct preparation classifies up to 32 MiB per remote-index query. Files still
+chunk and classify concurrently, while prepared-payload promotion is serialized
+within the add preparation to avoid competing durability flushes on one disk.
 
 ```mermaid
 flowchart LR

--- a/crab/docs/guides/worktree.md
+++ b/crab/docs/guides/worktree.md
@@ -153,8 +153,11 @@ directory:
 .crab/worktrees/<linked-worktree-id>/
 ```
 
-Each worktree has its own hydrated-pointer cache and hydration policy. A
-linked worktree never treats another worktree's cache as authoritative state.
+Each worktree has its own `hydrated-pointers-v1.sqlite` cache and hydration
+policy. Cache rows use the exact no-follow stat captured from a verified
+published file descriptor. WAL transactions preserve unrelated rows from
+concurrent hydrators and update only changed paths. A linked worktree never
+treats another worktree's cache as authoritative state.
 
 ## Copy-on-Write Hydration
 
@@ -172,14 +175,21 @@ fall through to the normal chunk/Xorb hydration path. This optimization does
 not change Crab's CDC, chunk deduplication, Xorb storage, push, or remote
 reconstruction format.
 
+The cache is never used to bypass clean-filter input verification. Git permits
+the pathname supplied to a clean filter to name a worktree file whose bytes
+differ from the filter's standard input. Crab therefore hashes the supplied
+bytes whenever Git invokes the filter; exact Git index-stat refresh after
+hydrate prevents unchanged files from invoking it during ordinary status and
+diff operations.
+
 After a CoW clone, worktrees are independent: editing one file does not alter
 the sibling file. Both files initially share physical extents only where the
 filesystem supports that behavior. This is distinct from writable VFS overlay
 CoW, which keeps changes in a mount overlay instead of publishing a normal
 working-tree file.
 
-The legacy shared `.crab/hydrated-pointers.json` cache is not read, migrated,
-or rewritten.
+Legacy JSON hydrated-pointer caches, including the shared
+`.crab/hydrated-pointers.json` path, are not read, migrated, or rewritten.
 
 ## JSON Listing
 

--- a/crab/scripts/e2e/run_add_commit_push_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_add_commit_push_rustfs_smoke.py
@@ -1949,6 +1949,19 @@ class AddCommitPushSmoke:
             timeout=self.args.push_timeout,
         )
         self.head_key(f"{repo_prefix}/manifest")
+        fsck_record = self.run_crab(
+            repo,
+            ["fsck", "--json"],
+            name=f"{case_name} full store fsck",
+        )
+        fsck_data = json.loads(self.read_stdout(fsck_record))["data"]
+        self.check(
+            f"{case_name}-publishes-complete-acceleration-metadata",
+            fsck_data["passed"]
+            and fsck_data["errors"] == 0
+            and fsck_data["repair_failures"] == 0,
+            fsck_data,
+        )
 
         after_push_record = self.run_crab(
             repo,

--- a/crab/src/cache/hydrated_pointer.rs
+++ b/crab/src/cache/hydrated_pointer.rs
@@ -1,217 +1,187 @@
-//! Per-worktree cache mapping working-tree paths to the pointer bytes that
-//! produced their current content.
+//! Per-worktree cache of verified hydrated files.
 //!
-//! After `crab hydrate` reconstructs a file, the working-tree copy
-//! is full content (not a pointer) — but git has a pointer blob in
-//! the index, so `git status` / `git diff` / `git pull` all invoke
-//! the clean filter on the hydrated bytes to decide whether the
-//! file changed. Without this cache, every such invocation would
-//! re-hash and re-chunk the entire file (slow on multi-GiB files)
-//! and require acquiring `LOCK_EX` on `.crab/staging` — which
-//! fails as [`CrabError::StagingLocked`] whenever another crab
-//! process (e.g. a shell-prompt `git status`) is mid-flight, leaving
-//! the user unable to `git diff` or `git pull` hydrated files.
+//! Hydration records the exact no-follow filesystem stat captured from the
+//! published file descriptor together with the Crab pointer that produced the
+//! content. Sibling worktrees use these rows only as candidate locators and
+//! still hash candidates before cloning them.
 //!
-//! The cache is keyed on a **stat fingerprint** (`mtime_ns`, `size`)
-//! so concurrent modifications invalidate the entry correctly — a
-//! `touch` or partial write produces a different mtime, so the clean
-//! filter falls through to the normal CDC pipeline.
-//!
-//! Concurrency: writes use tempfile + atomic rename. Concurrent
-//! hydrators may overwrite each other's additions, but the last
-//! writer wins with a consistent file. A corrupt or missing cache
-//! degrades gracefully to the slow path — nothing in the protocol
-//! depends on it.
+//! Rows live in a v1 SQLite database. WAL transactions make concurrent
+//! hydrators composable, and updates touch only changed rows instead of
+//! rewriting the full cache.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
+use crab_types::pointer::Pointer;
+use rusqlite::{Connection, OpenFlags, params};
 use tracing::{debug, warn};
 
 use crate::core::error::{CrabError, Result};
 
 /// Filename inside `.crab/` holding the hydrated-pointer cache.
-pub const HYDRATED_POINTERS_FILENAME: &str = "hydrated-pointers.json";
+pub const HYDRATED_POINTERS_FILENAME: &str = "hydrated-pointers-v1.sqlite";
+const SCHEMA_VERSION: i64 = 1;
 
-/// Stat fingerprint plus the pointer blob that a hydrated working-tree
-/// file reconstructs back into. Used by the clean filter to skip
-/// CDC/hashing/staging for files whose content matches a known pointer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Exact stat proof plus the pointer blob for a hydrated working-tree file.
+#[derive(Debug, Clone)]
 pub struct HydratedEntry {
-    /// File modification time in nanoseconds since the UNIX epoch.
-    pub mtime_ns: i128,
-    /// File size in bytes, as observed by `fs::metadata` after hydrate.
+    stat_token: [u8; 32],
+    /// File size captured from the verified published descriptor.
     pub size: u64,
-    /// Hex-encoded pointer blob bytes. Stored hex-encoded to keep the
-    /// JSON file human-inspectable and avoid base64 quirks.
-    pub pointer_hex: String,
+    pointer_bytes: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-struct OnDiskFile {
-    /// Map from repo-relative path (forward-slashes) to entry.
-    #[serde(default)]
-    entries: HashMap<String, HydratedEntry>,
-}
-
-/// In-memory cache. Cheap to clone (map of small strings) and safe to
-/// mutate from a single thread — concurrent writers arbitrate at the
-/// filesystem level via atomic rename.
+/// In-memory snapshot used while discovering sibling-worktree candidates.
 #[derive(Debug, Clone, Default)]
 pub struct HydratedPointerCache {
     entries: HashMap<String, HydratedEntry>,
 }
 
 impl HydratedPointerCache {
-    /// Create an empty cache.
+    /// Create an empty cache snapshot.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Load the cache from `path`, synchronously.
-    ///
-    /// Returns an empty cache if the file is missing or corrupt. A
-    /// corrupt cache is logged at `warn!` and treated as empty so a
-    /// bad file can never block the clean filter.
+    /// Load a cache snapshot. Missing or invalid databases degrade to empty.
     #[must_use]
     pub fn load_sync(path: &Path) -> Self {
-        let bytes = match std::fs::read(path) {
-            Ok(b) => b,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                debug!(
-                    path = %path.display(),
-                    "hydrated-pointer cache missing, starting empty"
-                );
-                return Self::new();
-            }
-            Err(e) => {
+        match load_entries(path) {
+            Ok(entries) => Self { entries },
+            Err(error) => {
                 warn!(
                     path = %path.display(),
-                    error = %e,
-                    "hydrated-pointer cache unreadable, treating as empty"
-                );
-                return Self::new();
-            }
-        };
-        match serde_json::from_slice::<OnDiskFile>(&bytes) {
-            Ok(parsed) => Self {
-                entries: parsed.entries,
-            },
-            Err(e) => {
-                warn!(
-                    path = %path.display(),
-                    error = %e,
-                    "hydrated-pointer cache corrupt, treating as empty"
+                    error = %error,
+                    "hydrated-pointer cache unavailable, treating as empty"
                 );
                 Self::new()
             }
         }
     }
 
-    /// Number of entries currently in the cache.
+    /// Number of entries in this snapshot.
     #[must_use]
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
-    /// Whether the cache has any entries.
+    /// Whether this snapshot has no entries.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 
-    /// Look up the entry for `rel_path`, if any. The caller is
-    /// responsible for validating the stat fingerprint via
-    /// [`matches_stat`](Self::matches_stat).
+    /// Count rows without loading pointer blobs.
+    #[must_use]
+    pub(crate) fn count_on_disk(path: &Path) -> usize {
+        match count_entries(path) {
+            Ok(entries) => entries,
+            Err(error) => {
+                warn!(
+                    path = %path.display(),
+                    error = %error,
+                    "hydrated-pointer cache count unavailable"
+                );
+                0
+            }
+        }
+    }
+
+    /// Look up a snapshot entry.
     #[must_use]
     pub fn get(&self, rel_path: &str) -> Option<&HydratedEntry> {
         self.entries.get(rel_path)
     }
 
-    /// Iterate over advisory entries without exposing mutation.
+    /// Iterate over advisory sibling-worktree candidates.
     pub(crate) fn entries(&self) -> impl Iterator<Item = (&str, &HydratedEntry)> {
         self.entries
             .iter()
             .map(|(path, entry)| (path.as_str(), entry))
     }
 
-    /// Insert (or overwrite) an entry. Overwrites are common: every
-    /// successful `crab hydrate` refreshes the fingerprint.
-    pub fn insert(&mut self, rel_path: String, entry: HydratedEntry) {
-        self.entries.insert(rel_path, entry);
-    }
-
-    /// Remove an entry. Returns `true` if a row was removed. Used when
-    /// the caller observes a stale entry (stat mismatch) and wants to
-    /// avoid re-checking it on every subsequent clean.
-    pub fn remove(&mut self, rel_path: &str) -> bool {
-        self.entries.remove(rel_path).is_some()
-    }
-
-    /// Atomically save the cache to `path` via tempfile + rename.
-    ///
-    /// Creates the parent directory if needed. A failure to save is
-    /// surfaced so callers can log it; writers treat save errors as
-    /// best-effort (the cache will simply be re-populated on the next
-    /// hydrate).
-    pub fn save_sync(&self, path: &Path) -> Result<()> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(CrabError::Io)?;
-        }
-
-        let on_disk = OnDiskFile {
-            entries: self.entries.clone(),
-        };
-        let body = serde_json::to_vec(&on_disk).map_err(|e| {
-            CrabError::Internal(format!("failed to serialize hydrated-pointer cache: {e}"))
-        })?;
-
-        let tmp = tmp_path(path);
-        std::fs::write(&tmp, &body).map_err(CrabError::Io)?;
-        std::fs::rename(&tmp, path).map_err(CrabError::Io)?;
-        debug!(
-            path = %path.display(),
-            entries = self.entries.len(),
-            "saved hydrated-pointer cache"
-        );
-        Ok(())
-    }
-
-    /// Merge `updates` into the on-disk cache at `path` and rewrite
-    /// atomically. Load-modify-save so a concurrent writer's entries
-    /// for unrelated keys are preserved (last writer wins per key).
+    /// Transactionally upsert only the supplied rows.
     pub fn update_on_disk<I>(path: &Path, updates: I) -> Result<()>
     where
         I: IntoIterator<Item = (String, HydratedEntry)>,
     {
-        let mut cache = Self::load_sync(path);
-        for (k, v) in updates {
-            cache.insert(k, v);
+        let updates = updates.into_iter().collect::<Vec<_>>();
+        if updates.is_empty() {
+            return Ok(());
         }
-        cache.save_sync(path)
+        let mut connection = open_connection(path)?;
+        let transaction = connection
+            .transaction()
+            .map_err(|error| database_error("begin hydrated-pointer cache update", error))?;
+        {
+            let mut statement = transaction
+                .prepare_cached(
+                    "INSERT INTO hydrated_pointers(path, stat_token, size, pointer)
+                     VALUES (?1, ?2, ?3, ?4)
+                     ON CONFLICT(path) DO UPDATE SET
+                         stat_token = excluded.stat_token,
+                         size = excluded.size,
+                         pointer = excluded.pointer",
+                )
+                .map_err(|error| database_error("prepare hydrated-pointer cache update", error))?;
+            for (relative, entry) in &updates {
+                let size = i64::try_from(entry.size).map_err(|error| {
+                    CrabError::Internal(format!(
+                        "hydrated-pointer cache size {} exceeds SQLite range: {error}",
+                        entry.size
+                    ))
+                })?;
+                statement
+                    .execute(params![
+                        relative,
+                        entry.stat_token.as_slice(),
+                        size,
+                        &entry.pointer_bytes
+                    ])
+                    .map_err(|error| database_error("write hydrated-pointer cache row", error))?;
+            }
+        }
+        transaction
+            .commit()
+            .map_err(|error| database_error("commit hydrated-pointer cache update", error))?;
+        debug!(
+            path = %path.display(),
+            entries = updates.len(),
+            "updated hydrated-pointer cache"
+        );
+        Ok(())
     }
 
-    /// Remove entries for each path in `paths` and rewrite the cache
-    /// atomically. Used when the caller invalidates stale entries
-    /// (stat mismatch during clean) so the next session doesn't re-do
-    /// the lookup only to fall through again.
+    /// Transactionally remove the supplied paths without rewriting other rows.
     pub fn invalidate_on_disk<I>(path: &Path, paths: I) -> Result<()>
     where
         I: IntoIterator<Item = String>,
     {
-        let mut cache = Self::load_sync(path);
-        let mut touched = false;
-        for p in paths {
-            touched |= cache.remove(&p);
+        let paths = paths.into_iter().collect::<Vec<_>>();
+        if paths.is_empty() || !path.exists() {
+            return Ok(());
         }
-        if touched {
-            cache.save_sync(path)
-        } else {
-            Ok(())
+        let mut connection = open_connection(path)?;
+        let transaction = connection
+            .transaction()
+            .map_err(|error| database_error("begin hydrated-pointer cache invalidation", error))?;
+        {
+            let mut statement = transaction
+                .prepare_cached("DELETE FROM hydrated_pointers WHERE path = ?1")
+                .map_err(|error| {
+                    database_error("prepare hydrated-pointer cache invalidation", error)
+                })?;
+            for relative in &paths {
+                statement
+                    .execute([relative])
+                    .map_err(|error| database_error("delete hydrated-pointer cache row", error))?;
+            }
         }
+        transaction
+            .commit()
+            .map_err(|error| database_error("commit hydrated-pointer cache invalidation", error))
     }
 }
 
@@ -227,102 +197,202 @@ pub fn cache_path_for_worktree_root(worktree_root: &Path) -> Result<PathBuf> {
     Ok(cache_path_for_context(&ctx))
 }
 
-/// Construct a stat-fingerprinted [`HydratedEntry`] for `path`.
-///
-/// Reads metadata once; returns an IO error if the file is missing or
-/// its metadata cannot be read. `mtime_ns` may saturate to `i128::MIN`
-/// for timestamps before the UNIX epoch, which is fine — those are
-/// never observed on hydrated files in practice.
-pub fn entry_for_path(path: &Path, pointer_bytes: &[u8]) -> Result<HydratedEntry> {
-    let meta = std::fs::metadata(path).map_err(CrabError::Io)?;
-    let size = meta.len();
-    let mtime_ns = systemtime_to_nanos(meta.modified().ok());
-    Ok(HydratedEntry {
-        mtime_ns,
-        size,
-        pointer_hex: hex_encode(pointer_bytes),
+/// Construct an entry from a descriptor-safe post-publication stat.
+#[must_use]
+pub fn entry_for_verified_stat(
+    index_stat: crate::cmd::stream_stage::VerifiedIndexStat,
+    pointer_bytes: &[u8],
+) -> Option<HydratedEntry> {
+    let stat_token = stat_token(index_stat)?;
+    let pointer = Pointer::parse(pointer_bytes).ok()?;
+    if pointer.size != index_stat.len {
+        return None;
+    }
+    Some(HydratedEntry {
+        stat_token,
+        size: index_stat.len,
+        pointer_bytes: pointer_bytes.to_vec(),
     })
 }
 
-/// Compare a cached entry's fingerprint against the current stat of
-/// `path`. Returns `true` when `mtime_ns` and `size` match exactly.
-/// A false result means the file has been modified since hydrate and
-/// the caller must fall back to the normal clean pipeline.
+/// Construct an entry from the current no-follow path stat.
+pub fn entry_for_path(path: &Path, pointer_bytes: &[u8]) -> Result<HydratedEntry> {
+    let index_stat = crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(path)
+        .ok_or_else(|| {
+            CrabError::Internal(format!(
+                "could not capture exact hydrated-file stat for {}",
+                path.display()
+            ))
+        })?;
+    entry_for_verified_stat(index_stat, pointer_bytes).ok_or_else(|| {
+        CrabError::Internal(format!(
+            "hydrated file or pointer is not cacheable for {}",
+            path.display()
+        ))
+    })
+}
+
+/// Compare an entry with the current exact no-follow filesystem stat.
 #[must_use]
 pub fn matches_stat(path: &Path, entry: &HydratedEntry) -> bool {
-    let Ok(meta) = std::fs::metadata(path) else {
-        return false;
-    };
-    if meta.len() != entry.size {
-        return false;
-    }
-    systemtime_to_nanos(meta.modified().ok()) == entry.mtime_ns
+    crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(path)
+        .and_then(stat_token)
+        .is_some_and(|token| token == entry.stat_token)
 }
 
-/// Decode the hex-encoded pointer bytes from a cache entry.
-///
-/// A corrupt hex string returns `None`; callers treat that as a cache
-/// miss and fall through to the CDC pipeline.
+/// Return validated pointer bytes from an entry.
 #[must_use]
 pub fn decode_pointer(entry: &HydratedEntry) -> Option<Vec<u8>> {
-    hex_decode(&entry.pointer_hex)
+    Pointer::parse(&entry.pointer_bytes)
+        .ok()
+        .filter(|pointer| pointer.size == entry.size)
+        .map(|_| entry.pointer_bytes.clone())
 }
 
-/// Encode bytes as a lowercase ASCII hex string.
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for &b in bytes {
-        out.push(HEX[(b >> 4) as usize] as char);
-        out.push(HEX[(b & 0x0f) as usize] as char);
-    }
-    out
-}
-
-/// Decode a lowercase/uppercase ASCII hex string. Returns `None` on
-/// odd length or non-hex characters.
-fn hex_decode(s: &str) -> Option<Vec<u8>> {
-    if !s.len().is_multiple_of(2) {
+fn stat_token(index_stat: crate::cmd::stream_stage::VerifiedIndexStat) -> Option<[u8; 32]> {
+    if !crate::cache::add_validation::stat_is_cacheable(&index_stat.stat) {
         return None;
     }
-    let bytes = s.as_bytes();
-    let mut out = Vec::with_capacity(s.len() / 2);
-    for pair in bytes.chunks_exact(2) {
-        let hi = hex_nibble(pair[0])?;
-        let lo = hex_nibble(pair[1])?;
-        out.push((hi << 4) | lo);
-    }
-    Some(out)
+    let stat = index_stat.stat;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"crab hydrated pointer stat v1\0");
+    hasher.update(&stat.mtime.secs.to_le_bytes());
+    hasher.update(&stat.mtime.nsecs.to_le_bytes());
+    hasher.update(&stat.ctime.secs.to_le_bytes());
+    hasher.update(&stat.ctime.nsecs.to_le_bytes());
+    hasher.update(&stat.dev.to_le_bytes());
+    hasher.update(&stat.ino.to_le_bytes());
+    hasher.update(&stat.uid.to_le_bytes());
+    hasher.update(&stat.gid.to_le_bytes());
+    hasher.update(&stat.size.to_le_bytes());
+    hasher.update(&index_stat.len.to_le_bytes());
+    Some(*hasher.finalize().as_bytes())
 }
 
-fn hex_nibble(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        _ => None,
+fn load_entries(path: &Path) -> Result<HashMap<String, HydratedEntry>> {
+    if !path.exists() {
+        return Ok(HashMap::new());
     }
+    let connection = open_read_connection(path)?;
+    let mut statement = connection
+        .prepare("SELECT path, stat_token, size, pointer FROM hydrated_pointers")
+        .map_err(|error| database_error("prepare hydrated-pointer cache load", error))?;
+    let mut rows = statement
+        .query([])
+        .map_err(|error| database_error("query hydrated-pointer cache", error))?;
+    let mut entries = HashMap::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| database_error("read hydrated-pointer cache row", error))?
+    {
+        let relative = row
+            .get::<_, String>(0)
+            .map_err(|error| database_error("read hydrated-pointer cache path", error))?;
+        let token = row
+            .get::<_, Vec<u8>>(1)
+            .map_err(|error| database_error("read hydrated-pointer cache token", error))?;
+        let stat_token = <[u8; 32]>::try_from(token.as_slice()).map_err(|_| {
+            CrabError::Internal("hydrated-pointer cache contains an invalid stat token".to_owned())
+        })?;
+        let size = row
+            .get::<_, i64>(2)
+            .map_err(|error| database_error("read hydrated-pointer cache size", error))?;
+        let size = u64::try_from(size).map_err(|error| {
+            CrabError::Internal(format!(
+                "hydrated-pointer cache contains an invalid size: {error}"
+            ))
+        })?;
+        let pointer_bytes = row
+            .get::<_, Vec<u8>>(3)
+            .map_err(|error| database_error("read hydrated-pointer cache pointer", error))?;
+        entries.insert(
+            relative,
+            HydratedEntry {
+                stat_token,
+                size,
+                pointer_bytes,
+            },
+        );
+    }
+    Ok(entries)
 }
 
-fn systemtime_to_nanos(t: Option<SystemTime>) -> i128 {
-    // Duration since UNIX_EPOCH; negate if the time is before epoch
-    // (exceptionally rare on hydrated files, but harmless to handle).
-    match t {
-        Some(st) => match st.duration_since(SystemTime::UNIX_EPOCH) {
-            Ok(d) => i128::try_from(d.as_nanos()).unwrap_or(i128::MAX),
-            Err(e) => {
-                let before = e.duration();
-                -i128::try_from(before.as_nanos()).unwrap_or(i128::MAX)
-            }
-        },
-        None => 0,
+fn count_entries(path: &Path) -> Result<usize> {
+    if !path.exists() {
+        return Ok(0);
     }
+    let connection = open_read_connection(path)?;
+    let count = connection
+        .query_row("SELECT COUNT(*) FROM hydrated_pointers", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(|error| database_error("count hydrated-pointer cache rows", error))?;
+    usize::try_from(count).map_err(|error| {
+        CrabError::Internal(format!(
+            "hydrated-pointer cache row count exceeds memory range: {error}"
+        ))
+    })
 }
 
-fn tmp_path(path: &Path) -> PathBuf {
-    let mut tmp = path.as_os_str().to_os_string();
-    tmp.push(".tmp");
-    PathBuf::from(tmp)
+fn open_read_connection(path: &Path) -> Result<Connection> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|error| database_error("open hydrated-pointer cache for reading", error))?;
+    verify_schema(&connection)?;
+    Ok(connection)
+}
+
+fn open_connection(path: &Path) -> Result<Connection> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(CrabError::Io)?;
+    }
+    let connection = Connection::open(path)
+        .map_err(|error| database_error("open hydrated-pointer cache", error))?;
+    connection
+        .busy_timeout(Duration::from_secs(5))
+        .map_err(|error| database_error("configure hydrated-pointer cache timeout", error))?;
+    connection
+        .execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")
+        .map_err(|error| database_error("configure hydrated-pointer cache", error))?;
+    let version = connection
+        .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+        .map_err(|error| database_error("read hydrated-pointer cache version", error))?;
+    if version == 0 {
+        connection
+            .execute_batch(
+                "BEGIN IMMEDIATE;
+                 CREATE TABLE IF NOT EXISTS hydrated_pointers (
+                     path TEXT PRIMARY KEY NOT NULL,
+                     stat_token BLOB NOT NULL CHECK(length(stat_token) = 32),
+                     size INTEGER NOT NULL CHECK(size >= 0),
+                     pointer BLOB NOT NULL
+                 ) WITHOUT ROWID;
+                 PRAGMA user_version = 1;
+                 COMMIT;",
+            )
+            .map_err(|error| database_error("initialize hydrated-pointer cache", error))?;
+    } else if version != SCHEMA_VERSION {
+        verify_schema(&connection)?;
+    }
+    Ok(connection)
+}
+
+fn verify_schema(connection: &Connection) -> Result<()> {
+    let version = connection
+        .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+        .map_err(|error| database_error("read hydrated-pointer cache version", error))?;
+    if version != SCHEMA_VERSION {
+        return Err(CrabError::Internal(format!(
+            "unsupported hydrated-pointer cache schema {version}; expected v{SCHEMA_VERSION}"
+        )));
+    }
+    Ok(())
+}
+
+fn database_error(action: &str, error: rusqlite::Error) -> CrabError {
+    CrabError::Internal(format!("{action}: {error}"))
 }
 
 #[cfg(test)]
@@ -332,170 +402,183 @@ mod tests {
     use tempfile::tempdir;
 
     fn write_file(path: &Path, bytes: &[u8]) {
-        let mut f = std::fs::File::create(path).expect("create");
-        f.write_all(bytes).expect("write");
-        f.sync_all().expect("sync");
+        let mut file = std::fs::File::create(path).expect("create");
+        file.write_all(bytes).expect("write");
+        file.sync_all().expect("sync");
+    }
+
+    fn pointer_for(content: &[u8]) -> Vec<u8> {
+        Pointer {
+            file_hash: *blake3::hash(content).as_bytes(),
+            size: content.len() as u64,
+            shard_hint: None,
+        }
+        .serialize()
+    }
+
+    fn entry(path: &Path, content: &[u8]) -> Option<HydratedEntry> {
+        entry_for_path(path, &pointer_for(content)).ok()
     }
 
     #[test]
     fn load_missing_returns_empty() {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("missing.json");
-        let cache = HydratedPointerCache::load_sync(&path);
+        let cache = HydratedPointerCache::load_sync(&dir.path().join("missing.sqlite"));
         assert!(cache.is_empty());
-        assert_eq!(cache.len(), 0);
     }
 
     #[test]
     fn load_corrupt_returns_empty() {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("corrupt.json");
-        write_file(&path, b"{not valid json");
-        let cache = HydratedPointerCache::load_sync(&path);
-        assert!(cache.is_empty());
+        let path = dir.path().join("corrupt.sqlite");
+        write_file(&path, b"not sqlite");
+        assert!(HydratedPointerCache::load_sync(&path).is_empty());
     }
 
+    #[cfg(unix)]
     #[test]
-    fn insert_save_load_roundtrip() {
+    fn update_load_roundtrip() {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("cache.json");
-        let mut cache = HydratedPointerCache::new();
-        cache.insert(
-            "a.zip".to_owned(),
-            HydratedEntry {
-                mtime_ns: 123,
-                size: 456,
-                pointer_hex: "deadbeef".to_owned(),
-            },
-        );
-        cache.save_sync(&path).expect("save");
-
+        let file = dir.path().join("content.bin");
+        let path = dir.path().join("cache.sqlite");
+        write_file(&file, b"content");
+        let expected = entry(&file, b"content").unwrap();
+        HydratedPointerCache::update_on_disk(&path, [("content.bin".to_owned(), expected.clone())])
+            .unwrap();
+        assert_eq!(HydratedPointerCache::count_on_disk(&path), 1);
         let loaded = HydratedPointerCache::load_sync(&path);
-        let e = loaded.get("a.zip").expect("entry");
-        assert_eq!(e.mtime_ns, 123);
-        assert_eq!(e.size, 456);
-        assert_eq!(e.pointer_hex, "deadbeef");
-        assert_eq!(
-            loaded.entries().map(|(path, _)| path).collect::<Vec<_>>(),
-            ["a.zip"]
-        );
+        let actual = loaded.get("content.bin").unwrap();
+        assert_eq!(actual.stat_token, expected.stat_token);
+        assert_eq!(decode_pointer(actual), decode_pointer(&expected));
     }
 
+    #[cfg(unix)]
     #[test]
     fn update_on_disk_preserves_other_entries() {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("cache.json");
-        let mut cache = HydratedPointerCache::new();
-        cache.insert(
-            "keep.bin".to_owned(),
-            HydratedEntry {
-                mtime_ns: 1,
-                size: 1,
-                pointer_hex: "00".to_owned(),
-            },
-        );
-        cache.save_sync(&path).expect("save");
-
-        HydratedPointerCache::update_on_disk(
-            &path,
-            [(
-                "new.bin".to_owned(),
-                HydratedEntry {
-                    mtime_ns: 2,
-                    size: 2,
-                    pointer_hex: "11".to_owned(),
-                },
-            )],
-        )
-        .expect("update");
-
+        let file = dir.path().join("content.bin");
+        let path = dir.path().join("cache.sqlite");
+        write_file(&file, b"content");
+        let entry = entry(&file, b"content").unwrap();
+        HydratedPointerCache::update_on_disk(&path, [("keep.bin".to_owned(), entry.clone())])
+            .unwrap();
+        HydratedPointerCache::update_on_disk(&path, [("new.bin".to_owned(), entry)]).unwrap();
         let loaded = HydratedPointerCache::load_sync(&path);
         assert_eq!(loaded.len(), 2);
         assert!(loaded.get("keep.bin").is_some());
         assert!(loaded.get("new.bin").is_some());
     }
 
+    #[cfg(unix)]
     #[test]
-    fn entry_for_path_reads_metadata() {
+    fn entry_for_path_reads_exact_metadata() {
         let dir = tempdir().unwrap();
-        let p = dir.path().join("f.bin");
-        write_file(&p, b"hello world");
-        let entry = entry_for_path(&p, b"pointer-bytes").expect("entry");
+        let path = dir.path().join("content.bin");
+        write_file(&path, b"hello world");
+        let entry = entry(&path, b"hello world").unwrap();
         assert_eq!(entry.size, 11);
-        assert!(!entry.pointer_hex.is_empty());
-        assert!(matches_stat(&p, &entry));
+        assert!(matches_stat(&path, &entry));
     }
 
+    #[cfg(unix)]
     #[test]
     fn matches_stat_detects_size_change() {
         let dir = tempdir().unwrap();
-        let p = dir.path().join("f.bin");
-        write_file(&p, b"hello");
-        let entry = entry_for_path(&p, b"ptr").expect("entry");
-        write_file(&p, b"hello world"); // size grew
-        assert!(!matches_stat(&p, &entry));
+        let path = dir.path().join("content.bin");
+        write_file(&path, b"hello");
+        let entry = entry(&path, b"hello").unwrap();
+        write_file(&path, b"hello world");
+        assert!(!matches_stat(&path, &entry));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn matches_stat_detects_same_size_rewrite_with_restored_mtime() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("content.bin");
+        write_file(&path, b"original");
+        let original_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&path).unwrap());
+        let entry = entry(&path, b"original").unwrap();
+        write_file(&path, b"modified");
+        filetime::set_file_mtime(&path, original_mtime).unwrap();
+        assert!(!matches_stat(&path, &entry));
+    }
+
+    #[cfg(unix)]
     #[test]
     fn matches_stat_returns_false_for_missing_file() {
         let dir = tempdir().unwrap();
-        let p = dir.path().join("missing.bin");
-        let entry = HydratedEntry {
-            mtime_ns: 0,
-            size: 0,
-            pointer_hex: String::new(),
-        };
-        assert!(!matches_stat(&p, &entry));
+        let path = dir.path().join("content.bin");
+        write_file(&path, b"content");
+        let entry = entry(&path, b"content").unwrap();
+        std::fs::remove_file(&path).unwrap();
+        assert!(!matches_stat(&path, &entry));
     }
 
+    #[cfg(unix)]
     #[test]
-    fn decode_pointer_round_trip() {
-        let entry = HydratedEntry {
-            mtime_ns: 0,
-            size: 0,
-            pointer_hex: hex_encode(b"pointer"),
-        };
-        assert_eq!(decode_pointer(&entry).as_deref(), Some(&b"pointer"[..]));
-    }
-
-    #[test]
-    fn decode_pointer_rejects_invalid_hex() {
-        let entry = HydratedEntry {
-            mtime_ns: 0,
-            size: 0,
-            pointer_hex: "zz".to_owned(),
-        };
+    fn decode_pointer_rejects_invalid_blob() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("content.bin");
+        write_file(&path, b"content");
+        let mut entry = entry(&path, b"content").unwrap();
+        entry.pointer_bytes = b"not a pointer".to_vec();
         assert!(decode_pointer(&entry).is_none());
     }
 
+    #[cfg(unix)]
     #[test]
-    fn invalidate_on_disk_removes_entries() {
+    fn invalidate_on_disk_removes_only_selected_entries() {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("cache.json");
-        let mut cache = HydratedPointerCache::new();
-        cache.insert(
-            "a".to_owned(),
-            HydratedEntry {
-                mtime_ns: 1,
-                size: 1,
-                pointer_hex: "00".to_owned(),
-            },
-        );
-        cache.insert(
-            "b".to_owned(),
-            HydratedEntry {
-                mtime_ns: 2,
-                size: 2,
-                pointer_hex: "11".to_owned(),
-            },
-        );
-        cache.save_sync(&path).expect("save");
-
-        HydratedPointerCache::invalidate_on_disk(&path, ["a".to_owned()]).expect("invalidate");
-
+        let file = dir.path().join("content.bin");
+        let path = dir.path().join("cache.sqlite");
+        write_file(&file, b"content");
+        let entry = entry(&file, b"content").unwrap();
+        HydratedPointerCache::update_on_disk(
+            &path,
+            [("a".to_owned(), entry.clone()), ("b".to_owned(), entry)],
+        )
+        .unwrap();
+        HydratedPointerCache::invalidate_on_disk(&path, ["a".to_owned()]).unwrap();
         let loaded = HydratedPointerCache::load_sync(&path);
         assert_eq!(loaded.len(), 1);
         assert!(loaded.get("a").is_none());
         assert!(loaded.get("b").is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn concurrent_updates_preserve_every_entry() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("content.bin");
+        write_file(&file, b"content");
+        let entry = entry(&file, b"content").unwrap();
+        let path = std::sync::Arc::new(dir.path().join("cache.sqlite"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(16));
+        let mut threads = Vec::new();
+        for index in 0..16 {
+            let path = std::sync::Arc::clone(&path);
+            let barrier = std::sync::Arc::clone(&barrier);
+            let entry = entry.clone();
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                HydratedPointerCache::update_on_disk(&path, [(format!("file-{index}.bin"), entry)])
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap().unwrap();
+        }
+        assert_eq!(HydratedPointerCache::load_sync(&path).len(), 16);
+    }
+
+    #[test]
+    fn cache_rejects_non_v1_schema() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("cache.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        connection.pragma_update(None, "user_version", 2).unwrap();
+        drop(connection);
+        assert!(HydratedPointerCache::load_sync(&path).is_empty());
     }
 }

--- a/crab/src/cmd/dehydrate.rs
+++ b/crab/src/cmd/dehydrate.rs
@@ -1135,6 +1135,7 @@ fn atomic_write(dest: &Path, content: &[u8]) -> Result<()> {
     tmp.write_all(content)?;
     tmp.flush()?;
     preserve_destination_permissions(dest, tmp.as_file())?;
+    crate::git::worktree::age_filter_output_mtime(tmp.as_file());
     tmp.persist(dest).map_err(|e| e.error)?;
     Ok(())
 }
@@ -1826,6 +1827,7 @@ mod tests {
             hydrated_pointer::cache_path_for_worktree_root(&linked).expect("linked cache");
         assert_ne!(main_cache_path, linked_cache_path);
 
+        std::fs::write(root.join("clean.bin"), &clean_content).unwrap();
         let main_entry = hydrated_pointer::entry_for_path(&root.join("clean.bin"), &clean_pointer)
             .expect("main cache entry");
         HydratedPointerCache::update_on_disk(
@@ -2069,6 +2071,17 @@ mod tests {
         let content = b"new content";
         atomic_write(&dest, content).unwrap();
         assert_eq!(std::fs::read(&dest).unwrap(), content);
+    }
+
+    #[test]
+    fn atomic_write_avoids_git_racy_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("output.bin");
+        let before = std::time::SystemTime::now();
+
+        atomic_write(&dest, b"pointer").unwrap();
+
+        assert!(std::fs::metadata(dest).unwrap().modified().unwrap() < before);
     }
 
     #[cfg(unix)]

--- a/crab/src/cmd/hydrate.rs
+++ b/crab/src/cmd/hydrate.rs
@@ -2514,6 +2514,7 @@ fn persist_verified_temp(
 ) -> Result<VerifiedWrite> {
     tmp.flush()?;
     preserve_destination_permissions(dest, tmp.as_file())?;
+    crate::git::worktree::age_filter_output_mtime(tmp.as_file());
     let file = tmp.persist(dest).map_err(|e| e.error)?;
     let verified_stat = crate::cmd::stream_stage::VerifiedIndexStat::from_file(&file)
         .ok_or_else(|| error::CrabError::Internal("stat published hydration file".to_owned()))?;
@@ -3038,6 +3039,7 @@ fn try_cow_clone_candidate(
     let prepare = (|| -> Result<std::fs::File> {
         let temporary_file = std::fs::OpenOptions::new().write(true).open(&temporary)?;
         preserve_destination_permissions(dest, &temporary_file)?;
+        crate::git::worktree::age_filter_output_mtime(&temporary_file);
         let pre_publish_stat =
             crate::cmd::stream_stage::VerifiedIndexStat::from_file(&temporary_file).ok_or_else(
                 || error::CrabError::Internal("stat verified CoW hydration tempfile".to_owned()),
@@ -3484,31 +3486,32 @@ pub async fn run_hydrate_in(
         mark_pending_worktree_hydration_applied(root, &pending.policy)?;
     }
 
-    // Populate the per-worktree hydrated-pointer cache so the clean filter
-    // can short-circuit `git status` / `git diff` / `git pull` on
-    // these files. Each entry records the post-hydrate stat
-    // fingerprint and the pointer bytes the content reconstructs
-    // back into. Best-effort: a write failure here degrades to the
-    // pre-cache behavior (slow CDC-based clean) and must never
-    // break the hydrate command.
+    // Publish only descriptor-safe proofs captured by successful atomic
+    // writes. Sibling worktrees use this cache to locate CoW candidates;
+    // they still hash each candidate before publication. Best-effort: an
+    // unavailable cache only disables that local optimization.
     if summary.hydrated > 0 {
-        let updates: Vec<(String, crate::cache::HydratedEntry)> = selected_to_hydrate
+        let pointers = selected_to_hydrate
             .iter()
-            .filter_map(|(path, ptr)| {
-                // Skip files that didn't end up hydrated (errors or
-                // files that were still pointers). `is_working_tree_pointer`
-                // returns false for reconstructed content.
-                if is_working_tree_pointer(path).unwrap_or(true) {
+            .map(|(path, pointer)| (path.as_path(), pointer))
+            .collect::<HashMap<_, _>>();
+        let updates = summary
+            .verified_paths
+            .iter()
+            .filter_map(|verified| {
+                let pointer = pointers.get(verified.path.as_path())?;
+                if pointer.file_hash != verified.file_hash || pointer.size != verified.size {
                     return None;
                 }
-                let rel = path.strip_prefix(root).unwrap_or(path);
+                let rel = verified.path.strip_prefix(root).unwrap_or(&verified.path);
                 let rel_str = rel.to_string_lossy().replace('\\', "/");
-                let pointer_bytes = ptr.serialize();
-                crate::cache::hydrated_pointer::entry_for_path(path, &pointer_bytes)
-                    .ok()
-                    .map(|e| (rel_str, e))
+                crate::cache::hydrated_pointer::entry_for_verified_stat(
+                    verified.index_stat,
+                    &pointer.serialize(),
+                )
+                .map(|entry| (rel_str, entry))
             })
-            .collect();
+            .collect::<Vec<_>>();
         if !updates.is_empty() {
             match crate::cache::hydrated_pointer::cache_path_for_worktree_root(root) {
                 Ok(cache_path) => {
@@ -4870,9 +4873,13 @@ mod tests {
         std::fs::create_dir(&repo).unwrap();
 
         let clean_script = tmp.path().join("clean.sh");
+        let clean_calls = tmp.path().join("clean-calls");
         std::fs::write(
             &clean_script,
-            "#!/bin/sh\ncat >/dev/null\nprintf 'POINTER\\n'\n",
+            format!(
+                "#!/bin/sh\nprintf x >> '{}'\ncat >/dev/null\nprintf 'POINTER\\n'\n",
+                clean_calls.display()
+            ),
         )
         .unwrap();
         let mut perms = std::fs::metadata(&clean_script).unwrap().permissions();
@@ -4898,9 +4905,10 @@ mod tests {
         run_git(&repo, &["add", ".gitattributes", "model.bin"]);
         run_git(&repo, &["commit", "-m", "init"]);
 
-        std::fs::write(repo.join("model.bin"), "hydrated bytes\n").unwrap();
+        atomic_write_with_progress(&repo.join("model.bin"), b"hydrated bytes\n", None).unwrap();
         assert_eq!(git_stdout(&repo, &["diff", "--name-only"]), "");
         assert!(git_stdout(&repo, &["status", "--porcelain=v1"]).contains(" M model.bin"));
+        std::fs::remove_file(&clean_calls).unwrap();
 
         assert_eq!(
             crate::git::worktree::refresh_index_stats(&repo, &[repo.join("model.bin")]).unwrap(),
@@ -4924,14 +4932,17 @@ mod tests {
         let expected_stat = gix_index::entry::Stat::from_fs(&metadata).unwrap();
         assert_eq!(entry.stat, expected_stat);
         assert_eq!(git_stdout(&repo, &["status", "--porcelain=v1"]), "");
+        assert!(!clean_calls.exists());
 
-        std::fs::write(repo.join("model.bin"), "POINTER\n").unwrap();
+        atomic_write_with_progress(&repo.join("model.bin"), b"POINTER\n", None).unwrap();
         assert!(git_stdout(&repo, &["status", "--porcelain=v1"]).contains(" M model.bin"));
+        let _ = std::fs::remove_file(&clean_calls);
         assert_eq!(
             crate::git::worktree::refresh_index_stats(&repo, &[repo.join("model.bin")]).unwrap(),
             1
         );
         assert_eq!(git_stdout(&repo, &["status", "--porcelain=v1"]), "");
+        assert!(!clean_calls.exists());
     }
 
     #[cfg(unix)]
@@ -5499,14 +5510,20 @@ mod tests {
         ) -> Pin<Box<dyn Future<Output = Result<HydrateSummary>> + Send + 'a>> {
             Box::pin(async move {
                 error::check_cancelled(cancel)?;
-                for (path, _) in items {
-                    atomic_write(path, &self.content)?;
+                let mut summary = HydrateSummary::default();
+                for (path, pointer) in items {
+                    let index_stat = atomic_write_with_progress(path, &self.content, None)?;
+                    let write = VerifiedWrite {
+                        bytes: self.content.len() as u64,
+                        index_stat,
+                    };
+                    summary
+                        .verified_paths
+                        .push(verified_path(path, pointer, write));
                 }
-                Ok(HydrateSummary {
-                    hydrated: items.len() as u64,
-                    bytes_written: self.content.len() as u64 * items.len() as u64,
-                    ..HydrateSummary::default()
-                })
+                summary.hydrated = items.len() as u64;
+                summary.bytes_written = self.content.len() as u64 * items.len() as u64;
+                Ok(summary)
             })
         }
     }

--- a/crab/src/cmd/worktree.rs
+++ b/crab/src/cmd/worktree.rs
@@ -1268,7 +1268,7 @@ fn hydrated_pointer_cache_summary(state_dir: &Path) -> CrabHydratedPointerCacheS
         .filter(|meta| meta.is_file())
         .map(|meta| meta.len());
     let entries = if bytes.is_some() {
-        crate::cache::HydratedPointerCache::load_sync(&path).len()
+        crate::cache::HydratedPointerCache::count_on_disk(&path)
     } else {
         0
     };

--- a/crab/src/git/clean.rs
+++ b/crab/src/git/clean.rs
@@ -1326,18 +1326,6 @@ pub struct CleanSession {
     /// in the session. Resolves `filter=lfs` vs `filter=crab` per file
     /// path with git's "last match wins" semantics.
     filter_attr_cache: Option<crate::git::filter_attr_cache::FilterAttrCache>,
-    /// Per-worktree cache of `path → (mtime, size, pointer_bytes)` populated
-    /// by `crab hydrate`. A cache hit lets the clean filter short-circuit
-    /// CDC + staging for hydrated files — critical for `git status` /
-    /// `git diff` / `git pull` not to either grind through multi-GiB
-    /// content on every invocation or fail with `CRAB-E0081` when a
-    /// concurrent crab process holds `.crab/staging`.
-    hydrated_cache: Option<crate::cache::HydratedPointerCache>,
-    /// Paths observed to have stale hydrated-cache entries during this
-    /// session (stat mismatch). Flushed to disk at session teardown via
-    /// [`persist_hydrated_cache_invalidations`](Self::persist_hydrated_cache_invalidations)
-    /// so the next session doesn't re-do the lookup only to fall through.
-    hydrated_cache_invalidations: Vec<String>,
     /// When `Some`, the backing staging area is unavailable for writes
     /// and the crab-native clean path must fail instead of producing
     /// a pointer that points at chunks we never staged. `None` means
@@ -1380,8 +1368,6 @@ impl CleanSession {
             lfs_attrs: std::sync::OnceLock::new(),
             filter_attr_cache: None,
             shard_hints: ShardHintCache::new(),
-            hydrated_cache: None,
-            hydrated_cache_invalidations: Vec::new(),
             staging_unavailable: None,
         }
     }
@@ -1424,8 +1410,6 @@ impl CleanSession {
             lfs_attrs: std::sync::OnceLock::new(),
             filter_attr_cache: None,
             shard_hints: ShardHintCache::new(),
-            hydrated_cache: None,
-            hydrated_cache_invalidations: Vec::new(),
             staging_unavailable: None,
         }
     }
@@ -1471,29 +1455,6 @@ impl CleanSession {
     /// Install the remote file-index checker used by the clean fast path.
     pub fn set_file_index_checker(&mut self, checker: Box<dyn FileIndexChecker>) {
         self.file_index_checker = checker;
-    }
-
-    /// Peek the hydrated-pointer cache for `pathname` without touching
-    /// staging. Returns `true` when the pathname has a live (stat
-    /// matches on-disk file) cache entry with decodable pointer bytes,
-    /// meaning the upcoming clean will be served from cache — so callers
-    /// can skip acquiring the staging flock entirely.
-    ///
-    /// Non-mutating: if the entry turns out to be stale during the
-    /// actual clean call, the normal invalidation path handles it.
-    #[must_use]
-    pub fn has_live_hydrated_entry(&self, pathname: &str) -> bool {
-        let Some(cache) = self.hydrated_cache.as_ref() else {
-            return false;
-        };
-        let Some(entry) = cache.get(pathname) else {
-            return false;
-        };
-        let Some(root) = self.repo_root.as_ref() else {
-            return false;
-        };
-        crate::cache::hydrated_pointer::matches_stat(&root.join(pathname), entry)
-            && crate::cache::hydrated_pointer::decode_pointer(entry).is_some()
     }
 
     /// If the session knows staging isn't backing writes, return the
@@ -1664,30 +1625,6 @@ impl CleanSession {
         // `FilterAttrCache` instead, so the lazy init keeps `crab init`
         // fast on large working trees.
 
-        // Load the hydrated-pointer cache so we can short-circuit
-        // clean on already-hydrated files. Missing / corrupt caches
-        // degrade to an empty map (no short-circuit) rather than
-        // failing the session.
-        match crate::cache::hydrated_pointer::cache_path_for_worktree_root(&root) {
-            Ok(cache_path) => {
-                let hydrated = crate::cache::HydratedPointerCache::load_sync(&cache_path);
-                tracing::debug!(
-                    path = %cache_path.display(),
-                    entries = hydrated.len(),
-                    "loaded hydrated-pointer cache for clean session"
-                );
-                self.hydrated_cache = Some(hydrated);
-            }
-            Err(e) => {
-                tracing::debug!(
-                    root = %root.display(),
-                    error = %e,
-                    "hydrated-pointer cache unavailable for clean session"
-                );
-                self.hydrated_cache = Some(crate::cache::HydratedPointerCache::new());
-            }
-        }
-
         self.repo_root = Some(root);
     }
 
@@ -1727,148 +1664,6 @@ impl CleanSession {
     #[must_use]
     pub fn should_skip_lfs_download_errors(&self) -> bool {
         self.lfs_skip_download_errors
-    }
-
-    /// Flush pending hydrated-cache invalidations to disk. Called at
-    /// session teardown by the filter-process loop so stale entries
-    /// don't linger across invocations. Non-fatal on failure — the
-    /// cache is purely advisory.
-    pub fn persist_hydrated_cache_invalidations(&mut self) {
-        let paths = std::mem::take(&mut self.hydrated_cache_invalidations);
-        if paths.is_empty() {
-            return;
-        }
-        let Some(root) = self.repo_root.as_ref() else {
-            return;
-        };
-        match crate::cache::hydrated_pointer::cache_path_for_worktree_root(root) {
-            Ok(cache_path) => {
-                if let Err(e) =
-                    crate::cache::HydratedPointerCache::invalidate_on_disk(&cache_path, paths)
-                {
-                    tracing::debug!(
-                        path = %cache_path.display(),
-                        error = %e,
-                        "failed to flush hydrated-pointer cache invalidations"
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::debug!(
-                    root = %root.display(),
-                    error = %e,
-                    "hydrated-pointer cache unavailable for invalidation flush"
-                );
-            }
-        }
-    }
-
-    /// Consult the hydrated-pointer cache for `pathname`. When the
-    /// stat fingerprint still matches, returns the cached pointer
-    /// bytes verbatim so the filter can skip CDC, hashing, and
-    /// staging entirely. A stale entry is queued for invalidation
-    /// and the caller falls back to the normal pipeline.
-    ///
-    /// Returns `None` when the cache is missing, the entry is absent,
-    /// the fingerprint no longer matches, or the pointer bytes are
-    /// corrupt — any of which mean the normal clean path must run.
-    fn try_hydrated_cache_hit(&mut self, pathname: &str) -> Option<Vec<u8>> {
-        let cache = self.hydrated_cache.as_ref()?;
-        let entry = cache.get(pathname)?;
-        let root = self.repo_root.as_ref()?;
-        let full_path = root.join(pathname);
-
-        if !crate::cache::hydrated_pointer::matches_stat(&full_path, entry) {
-            // Fingerprint no longer matches — the user (or a tool)
-            // touched the file after hydrate. Drop the entry so we
-            // don't re-check on every clean in this session, and fall
-            // through to the real pipeline.
-            tracing::debug!(
-                path = %pathname,
-                "hydrated-pointer cache: stat mismatch, invalidating entry"
-            );
-            self.hydrated_cache_invalidations.push(pathname.to_owned());
-            if let Some(cache) = self.hydrated_cache.as_mut() {
-                cache.remove(pathname);
-            }
-            return None;
-        }
-
-        let Some(bytes) = crate::cache::hydrated_pointer::decode_pointer(entry) else {
-            tracing::debug!(
-                path = %pathname,
-                "hydrated-pointer cache: corrupt pointer bytes, invalidating entry"
-            );
-            self.hydrated_cache_invalidations.push(pathname.to_owned());
-            if let Some(cache) = self.hydrated_cache.as_mut() {
-                cache.remove(pathname);
-            }
-            return None;
-        };
-        tracing::debug!(
-            path = %pathname,
-            size = entry.size,
-            "hydrated-pointer cache hit: returning cached pointer without CDC"
-        );
-        Some(bytes)
-    }
-
-    /// Refresh the hydrated-pointer cache entry for `pathname` with
-    /// the current file stat and `pointer_bytes`. Non-fatal on error —
-    /// the cache is advisory and degrades to the slow path when
-    /// absent. No-op when we don't know the repo root or the file is
-    /// missing on disk.
-    ///
-    /// Called after a successful clean so subsequent invocations
-    /// (e.g. the next `git status` in a shell prompt) short-circuit
-    /// without re-running CDC over the same bytes. Also populated by
-    /// `crab hydrate`, but clean-side updates cover the
-    /// clone-then-hydrate-elsewhere path and keep the cache self-healing.
-    fn remember_hydrated_pointer(&mut self, pathname: &str, pointer_bytes: &[u8]) {
-        let Some(root) = self.repo_root.as_ref() else {
-            return;
-        };
-        let full_path = root.join(pathname);
-        let entry = match crate::cache::hydrated_pointer::entry_for_path(&full_path, pointer_bytes)
-        {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::debug!(
-                    path = %pathname,
-                    error = %e,
-                    "hydrated-pointer cache: stat failed, not recording entry"
-                );
-                return;
-            }
-        };
-
-        match crate::cache::hydrated_pointer::cache_path_for_worktree_root(root) {
-            Ok(cache_path) => {
-                if let Err(e) = crate::cache::HydratedPointerCache::update_on_disk(
-                    &cache_path,
-                    [(pathname.to_owned(), entry.clone())],
-                ) {
-                    tracing::debug!(
-                        path = %cache_path.display(),
-                        error = %e,
-                        "hydrated-pointer cache: failed to persist entry"
-                    );
-                    return;
-                }
-            }
-            Err(e) => {
-                tracing::debug!(
-                    root = %root.display(),
-                    error = %e,
-                    "hydrated-pointer cache: unavailable for persist"
-                );
-                return;
-            }
-        }
-
-        if let Some(cache) = self.hydrated_cache.as_mut() {
-            cache.insert(pathname.to_owned(), entry);
-        }
     }
 
     /// Check whether a file is LFS-tracked via `filter=lfs` in `.gitattributes`.
@@ -2121,7 +1916,6 @@ impl CleanSession {
         // pointer verbatim, no staging needed. Works with zero
         // network traffic and regardless of bloom state.
         if let Some(pointer_bytes) = self.try_index_pointer_match(pathname, &file_hash) {
-            self.remember_hydrated_pointer(pathname, &pointer_bytes);
             return Ok(pointer_bytes);
         }
 
@@ -2129,7 +1923,6 @@ impl CleanSession {
         // pointer whose chunks already exist remotely — no staging
         // needed, so this works even when `.crab/staging` is locked.
         if let Some(pointer_bytes) = self.try_fast_path(file_size, &file_hash)? {
-            self.remember_hydrated_pointer(pathname, &pointer_bytes);
             return Ok(pointer_bytes);
         }
 
@@ -2147,7 +1940,6 @@ impl CleanSession {
                 .publish_recipe(Path::new(pathname), &recipe)?;
             let pointer = self.build_pointer(file_hash, file_size, None);
             let pointer_bytes = pointer.serialize();
-            self.remember_hydrated_pointer(pathname, &pointer_bytes);
             return Ok(pointer_bytes);
         }
         let mut provisional = ProvisionalChunkStager::new(pathname);
@@ -2159,7 +1951,6 @@ impl CleanSession {
 
         let pointer = self.build_pointer(file_hash, file_size, None);
         let pointer_bytes = pointer.serialize();
-        self.remember_hydrated_pointer(pathname, &pointer_bytes);
         Ok(pointer_bytes)
     }
 
@@ -2182,24 +1973,6 @@ impl CleanSession {
         pathname: &str,
         reader: &mut crate::git::filter_process::PktLineReader<R>,
     ) -> Result<Vec<u8>> {
-        // Fast-fast path: the file was hydrated in a previous session
-        // and its stat fingerprint still matches. Emit the cached
-        // pointer verbatim without reading any content from the
-        // stream — no CDC, no hashing, no staging lock. Makes
-        // `git status` / `git diff` / `git pull` instant on hydrated
-        // files, even when another crab process holds the staging
-        // lock.
-        //
-        // We must still drain the reader to honor the filter-process
-        // protocol (git expects us to consume the content pkt-lines
-        // up to and including flush).
-        if let Some(bytes) = self.try_hydrated_cache_hit(pathname) {
-            while reader.read_packet()?.is_some() {
-                // discard — we already know the answer
-            }
-            return Ok(bytes);
-        }
-
         // Resolve the filter handler for this path from .gitattributes.
         // This runs BEFORE blob classification so explicit user rules
         // always take precedence over pointer format detection.
@@ -2407,7 +2180,6 @@ impl CleanSession {
             // zero network traffic and no staging lock needed.
             if let Some(pointer_bytes) = self.try_index_pointer_match(pathname, &file_hash) {
                 discard_provisional_stager(&mut provisional_stager, &mut self.chunk_stager)?;
-                self.remember_hydrated_pointer(pathname, &pointer_bytes);
                 return Ok(pointer_bytes);
             }
 
@@ -2418,7 +2190,6 @@ impl CleanSession {
             // hydrated-file workflow depends on this.
             if let Some(pointer_bytes) = self.try_fast_path(file_size, &file_hash)? {
                 discard_provisional_stager(&mut provisional_stager, &mut self.chunk_stager)?;
-                self.remember_hydrated_pointer(pathname, &pointer_bytes);
                 return Ok(pointer_bytes);
             }
 
@@ -2436,7 +2207,6 @@ impl CleanSession {
                     .publish_recipe(Path::new(pathname), &recipe)?;
                 let pointer = self.build_pointer(file_hash, file_size, None);
                 let pointer_bytes = pointer.serialize();
-                self.remember_hydrated_pointer(pathname, &pointer_bytes);
                 return Ok(pointer_bytes);
             }
             if provisional_stager.is_none() {
@@ -2454,7 +2224,6 @@ impl CleanSession {
 
             let pointer = self.build_pointer(file_hash, file_size, None);
             let pointer_bytes = pointer.serialize();
-            self.remember_hydrated_pointer(pathname, &pointer_bytes);
             Ok(pointer_bytes)
         })();
 
@@ -2564,7 +2333,6 @@ impl CleanSession {
                 self.chunk_stager
                     .publish_recipe(Path::new(pathname), &prepared)?;
                 let pointer_bytes = self.build_pointer(file_hash, file_size, None).serialize();
-                self.remember_hydrated_pointer(pathname, &pointer_bytes);
                 tracing::info!(
                     path = %pathname,
                     size = file_size,
@@ -2581,12 +2349,10 @@ impl CleanSession {
 
             if let Some(pointer_bytes) = self.try_index_pointer_match(pathname, &file_hash) {
                 discard_provisional_stager(&mut changed.provisional, &mut self.chunk_stager)?;
-                self.remember_hydrated_pointer(pathname, &pointer_bytes);
                 return Ok(pointer_bytes);
             }
             if let Some(pointer_bytes) = self.try_fast_path(file_size, &file_hash)? {
                 discard_provisional_stager(&mut changed.provisional, &mut self.chunk_stager)?;
-                self.remember_hydrated_pointer(pathname, &pointer_bytes);
                 return Ok(pointer_bytes);
             }
 
@@ -2615,7 +2381,6 @@ impl CleanSession {
             self.chunk_stager
                 .publish_recipe(Path::new(pathname), &recipe)?;
             let pointer_bytes = self.build_pointer(file_hash, file_size, None).serialize();
-            self.remember_hydrated_pointer(pathname, &pointer_bytes);
             tracing::info!(
                 path = %pathname,
                 size = file_size,
@@ -3720,13 +3485,9 @@ mod tests {
         assert_eq!(pointer.size, content.len() as u64);
     }
 
+    #[cfg(unix)]
     #[test]
-    fn hydrated_cache_short_circuits_clean_when_staging_locked() {
-        // Regression guard for the hydrated-file UX bug: once a file
-        // has been hydrated and its pointer recorded in the cache,
-        // subsequent clean-filter invocations (git status, git diff,
-        // git pull) must return the cached pointer without touching
-        // staging — even when staging is locked by another process.
+    fn clean_uses_supplied_content_when_path_cache_differs() {
         use crate::cache::{HydratedPointerCache, hydrated_pointer};
 
         let Some(dir) = git_repo_tempdir() else {
@@ -3734,124 +3495,31 @@ mod tests {
             return;
         };
         let root = dir.path();
-        let rel = "big.zip";
-        let full = root.join(rel);
-        std::fs::write(&full, b"hydrated file content that matches the pointer").unwrap();
+        let relative = "content.bin";
+        let hydrated = b"hydrated bytes";
+        let supplied = b"different bytes";
+        let full_path = root.join(relative);
+        std::fs::write(&full_path, hydrated).unwrap();
+        let hydrated_pointer = Pointer {
+            file_hash: *blake3::hash(hydrated).as_bytes(),
+            size: hydrated.len() as u64,
+            shard_hint: None,
+        }
+        .serialize();
+        let entry = hydrated_pointer::entry_for_path(&full_path, &hydrated_pointer).unwrap();
+        let cache_path = hydrated_pointer::cache_path_for_worktree_root(root).unwrap();
+        HydratedPointerCache::update_on_disk(&cache_path, [(relative.to_owned(), entry)]).unwrap();
 
-        // Seed a cached pointer entry for this file.
-        let fake_pointer = b"\
-version crab/1\nfile-hash 00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\n\
-size 45\n";
-        let entry = hydrated_pointer::entry_for_path(&full, fake_pointer).unwrap();
-        let cache_path = hydrated_pointer::cache_path_for_worktree_root(root).expect("cache path");
-        HydratedPointerCache::update_on_disk(&cache_path, [(rel.to_owned(), entry)]).unwrap();
-
-        let ctx = AppContext::default();
-        let mut session = CleanSession::new(ctx);
+        let mut session = CleanSession::new(AppContext::default());
         session.set_repo_root(root.to_path_buf());
-        // Simulate "another process holds the staging lock". Without
-        // the short-circuit this would immediately return
-        // StagingLocked.
-        session.set_staging_locked(Some(99999));
+        let cleaned = session.clean_file(relative, supplied.to_vec()).unwrap();
+        let pointer = Pointer::parse(&cleaned).unwrap();
 
-        let bytes = session
-            .clean_file(
-                rel,
-                b"hydrated file content that matches the pointer".to_vec(),
-            )
-            .expect("clean must succeed from cached pointer even with staging locked");
-        assert_eq!(bytes, fake_pointer);
+        assert_eq!(pointer.file_hash, *blake3::hash(supplied).as_bytes());
     }
 
     #[test]
-    fn hydrated_cache_corrupt_pointer_does_not_skip_staging_acquire() {
-        use crate::cache::{HydratedPointerCache, hydrated_pointer};
-
-        let Some(dir) = git_repo_tempdir() else {
-            eprintln!("SKIP: git unavailable or fixture setup failed");
-            return;
-        };
-        let root = dir.path();
-        let rel = "corrupt-cache.bin";
-        let full = root.join(rel);
-        let content = b"hydrated file content with corrupt cached pointer";
-        std::fs::write(&full, content).unwrap();
-
-        let mut entry = hydrated_pointer::entry_for_path(
-            &full,
-            b"version crab/1\nfile-hash 00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nsize 48\n",
-        )
-        .unwrap();
-        entry.pointer_hex = "not hex".to_owned();
-        let cache_path = hydrated_pointer::cache_path_for_worktree_root(root).expect("cache path");
-        HydratedPointerCache::update_on_disk(&cache_path, [(rel.to_owned(), entry)]).unwrap();
-
-        let ctx = AppContext::default();
-        let mut session = CleanSession::new(ctx);
-        session.set_repo_root(root.to_path_buf());
-        assert!(
-            !session.has_live_hydrated_entry(rel),
-            "dispatch must acquire staging when the live cache entry cannot decode"
-        );
-
-        session.set_staging_locked(Some(99999));
-        let err = session.clean_file(rel, content.to_vec()).unwrap_err();
-        assert!(matches!(
-            err,
-            CrabError::StagingLocked {
-                holder_pid: Some(99999)
-            }
-        ));
-
-        session.persist_hydrated_cache_invalidations();
-        let reloaded = HydratedPointerCache::load_sync(&cache_path);
-        assert!(
-            reloaded.get(rel).is_none(),
-            "corrupt live entry should be invalidated after the failed slow-path attempt"
-        );
-    }
-
-    #[test]
-    fn hydrated_cache_falls_through_when_file_modified_after_hydrate() {
-        // A hydrated-then-touched file has a stat-mismatched cache
-        // entry. The clean filter must drop the entry and run the
-        // normal pipeline, not hand back a stale pointer.
-        use crate::cache::{HydratedPointerCache, hydrated_pointer};
-
-        let Some(dir) = git_repo_tempdir() else {
-            eprintln!("SKIP: git unavailable or fixture setup failed");
-            return;
-        };
-        let root = dir.path();
-        let rel = "file.bin";
-        let full = root.join(rel);
-        std::fs::write(&full, b"original hydrated content").unwrap();
-
-        let fake_pointer = b"version crab/1\nfile-hash abc\nsize 25\n";
-        let entry = hydrated_pointer::entry_for_path(&full, fake_pointer).unwrap();
-        let cache_path = hydrated_pointer::cache_path_for_worktree_root(root).expect("cache path");
-        HydratedPointerCache::update_on_disk(&cache_path, [(rel.to_owned(), entry)]).unwrap();
-
-        // Modify the file so the stat fingerprint no longer matches.
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        std::fs::write(&full, b"modified content has a different size").unwrap();
-
-        let ctx = AppContext::default();
-        let mut session = CleanSession::new(ctx);
-        session.set_repo_root(root.to_path_buf());
-
-        // Clean must go through the crab path (not return the cached
-        // pointer verbatim). The exact output isn't the point — it's
-        // that it's *not* `fake_pointer`.
-        let bytes = session
-            .clean_file(rel, b"modified content has a different size".to_vec())
-            .unwrap();
-        assert_ne!(bytes, fake_pointer);
-    }
-
-    #[test]
-    fn set_repo_root_uses_linked_worktree_attributes_and_hydrated_cache() {
-        use crate::cache::{HydratedPointerCache, hydrated_pointer};
+    fn set_repo_root_uses_linked_worktree_attributes() {
         use crate::git::filter_attr_cache::FilterKind;
         use std::process::Command;
 
@@ -3916,23 +3584,13 @@ size 45\n";
         )
         .unwrap();
 
-        let rel = "model.bin";
-        let hydrated = b"linked worktree hydrated bytes";
-        let full_path = linked.join(rel);
-        std::fs::write(&full_path, hydrated).unwrap();
-        let pointer = b"version crab/1\nfile-hash abc\nsize 28\n";
-        let entry = hydrated_pointer::entry_for_path(&full_path, pointer).unwrap();
-        let cache_path =
-            hydrated_pointer::cache_path_for_worktree_root(&linked).expect("cache path");
-        HydratedPointerCache::update_on_disk(&cache_path, [(rel.to_owned(), entry)]).unwrap();
-
         let ctx = AppContext::default();
         let mut session = CleanSession::new(ctx);
         session.set_repo_root(linked);
-        session.set_staging_locked(Some(12345));
-
-        assert_eq!(session.resolve_filter_for(rel), Some(FilterKind::Lfs));
-        assert_eq!(session.clean_file(rel, hydrated.to_vec()).unwrap(), pointer);
+        assert_eq!(
+            session.resolve_filter_for("model.bin"),
+            Some(FilterKind::Lfs)
+        );
     }
 
     #[test]

--- a/crab/src/git/filter_process.rs
+++ b/crab/src/git/filter_process.rs
@@ -835,11 +835,6 @@ fn run_filter_loop_with_lfs_source<R: BufRead, W: Write>(
     // starts with a warm fast-path.
     session.save_bloom_to_cache();
 
-    // Flush any hydrated-pointer cache invalidations collected
-    // during this session so the next process doesn't waste a
-    // `matches_stat` call on the same stale entries.
-    session.persist_hydrated_cache_invalidations();
-
     Ok(())
 }
 
@@ -1041,19 +1036,6 @@ fn dispatch_command<R: Read, W: Write>(
             // XET staging lock in a mixed-repository filter session.
             let is_lfs = session.resolve_filter_for(&cmd.pathname)
                 == Some(crate::git::filter_attr_cache::FilterKind::Lfs);
-            // Fast-fast path: if the hydrated-pointer cache already
-            // has a live entry for this pathname, the upcoming clean
-            // will be served from cache without needing staging.
-            // Skip `acquire_writer` entirely so we don't block on the
-            // default flock budget when another crab process
-            // (shell-prompt `git status`, IDE integration, concurrent
-            // `crab add`) holds `.crab/staging`.
-            //
-            // Stat mismatches are caught inside `clean_stream`'s
-            // cache lookup, so a stale entry falls through to the
-            // normal pipeline.
-            let cache_short_circuit = session.has_live_hydrated_entry(&cmd.pathname);
-
             // Lazily acquire a writer handle on the first clean of the
             // session. Subsequent cleans reuse the cached handle
             // without re-flocking. Sessions that only smudge never
@@ -1064,20 +1046,6 @@ fn dispatch_command<R: Read, W: Write>(
                 tracing::debug!(
                     path = %cmd.pathname,
                     "filter clean: LFS route resolved, skipping XET staging"
-                );
-            } else if cache_short_circuit {
-                // Don't mutate the staging-unavailable flag here — if
-                // a prior clean already opened staging successfully,
-                // keep the writer attached so subsequent non-cached
-                // cleans in this session reuse it. If no prior clean
-                // acquired a writer and this one hits the cache, the
-                // session stays in whatever state it was seeded with;
-                // should a later clean on a different pathname miss
-                // the cache, its branch will call `acquire_writer`
-                // and transition the cell then.
-                tracing::debug!(
-                    path = %cmd.pathname,
-                    "filter clean: hydrated-pointer cache hit, skipping staging flock"
                 );
             } else if let Some(h) = handle {
                 match h.block_on(acquire_writer(staging_cell.as_ref())) {

--- a/crab/src/git/worktree.rs
+++ b/crab/src/git/worktree.rs
@@ -271,6 +271,26 @@ fn write_index_stats(root: &Path, updates: &HashMap<Vec<u8>, IndexStatUpdate>) -
     Ok(updated)
 }
 
+/// Keep freshly published filter output outside Git's racy-stat window.
+///
+/// Git re-cleans a file when its mtime can alias the index write time. Aging
+/// the tempfile before publication preserves change detection through ctime
+/// and the remaining stat fields while avoiding a redundant full-file clean.
+pub(crate) fn age_filter_output_mtime(file: &std::fs::File) {
+    let Some(modified) =
+        std::time::SystemTime::now().checked_sub(std::time::Duration::from_secs(2))
+    else {
+        return;
+    };
+    if let Err(error) = filetime::set_file_handle_times(
+        file,
+        None,
+        Some(filetime::FileTime::from_system_time(modified)),
+    ) {
+        tracing::debug!(error = %error, "could not age filter output mtime; Git may re-clean once");
+    }
+}
+
 #[cfg(unix)]
 pub(crate) fn index_path_bytes(path: &Path) -> Vec<u8> {
     use std::os::unix::ffi::OsStrExt;
@@ -374,5 +394,16 @@ mod tests {
             mapped.per_worktree_crab_dir,
             main.join(".crab/worktrees/linked-id")
         );
+    }
+
+    #[test]
+    fn filter_output_mtime_is_older_than_publication() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = std::fs::File::create(directory.path().join("output")).unwrap();
+        let before = std::time::SystemTime::now();
+
+        age_filter_output_mtime(&file);
+
+        assert!(file.metadata().unwrap().modified().unwrap() < before);
     }
 }

--- a/crab/tests/worktree_cache.rs
+++ b/crab/tests/worktree_cache.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 use std::process::{Command, Output};
 
-use crab::cache::{HydratedEntry, HydratedPointerCache, hydrated_pointer};
+use crab::cache::{HydratedPointerCache, hydrated_pointer};
+use crab_types::pointer::Pointer;
 
 fn run_git<I, S>(cwd: &Path, args: I) -> Option<Output>
 where
@@ -53,12 +54,16 @@ fn fixture() -> Option<tempfile::TempDir> {
     Some(tmp)
 }
 
-fn entry(hex: &str) -> HydratedEntry {
-    HydratedEntry {
-        mtime_ns: 1,
-        size: 2,
-        pointer_hex: hex.to_owned(),
+fn entry(path: &Path) -> (crab::cache::HydratedEntry, Vec<u8>) {
+    let content = std::fs::read(path).expect("read hydrated content");
+    let pointer = Pointer {
+        file_hash: *blake3::hash(&content).as_bytes(),
+        size: content.len() as u64,
+        shard_hint: None,
     }
+    .serialize();
+    let entry = hydrated_pointer::entry_for_path(path, &pointer).expect("cacheable entry");
+    (entry, pointer)
 }
 
 #[test]
@@ -79,19 +84,20 @@ fn hydrated_cache_path_is_worktree_scoped_for_main_and_linked_worktrees() {
         repo.join(".crab")
             .join("worktrees")
             .join("main")
-            .join("hydrated-pointers.json")
+            .join("hydrated-pointers-v1.sqlite")
     );
     assert_eq!(
         linked_cache,
         repo.join(".crab")
             .join("worktrees")
             .join("linked")
-            .join("hydrated-pointers.json")
+            .join("hydrated-pointers-v1.sqlite")
     );
     assert_ne!(main_cache, linked_cache);
 }
 
 #[test]
+#[cfg(unix)]
 fn same_relative_path_uses_independent_hydrated_cache_per_worktree() {
     let Some(tmp) = fixture() else {
         eprintln!("SKIP: git unavailable or fixture setup failed");
@@ -117,25 +123,31 @@ fn same_relative_path_uses_independent_hydrated_cache_per_worktree() {
     let linked_cache =
         hydrated_pointer::cache_path_for_worktree_root(&linked).expect("linked cache");
 
-    HydratedPointerCache::update_on_disk(&main_cache, [("model.bin".to_owned(), entry("11"))])
+    let (main_entry, main_pointer) = entry(&repo.join("model.bin"));
+    let (linked_entry, linked_pointer) = entry(&linked.join("model.bin"));
+    HydratedPointerCache::update_on_disk(&main_cache, [("model.bin".to_owned(), main_entry)])
         .expect("write main cache");
-    HydratedPointerCache::update_on_disk(&linked_cache, [("model.bin".to_owned(), entry("22"))])
+    HydratedPointerCache::update_on_disk(&linked_cache, [("model.bin".to_owned(), linked_entry)])
         .expect("write linked cache");
 
     let main = HydratedPointerCache::load_sync(&main_cache);
     let linked = HydratedPointerCache::load_sync(&linked_cache);
 
     assert_eq!(
-        main.get("model.bin").map(|e| e.pointer_hex.as_str()),
-        Some("11")
+        main.get("model.bin")
+            .and_then(hydrated_pointer::decode_pointer),
+        Some(main_pointer)
     );
     assert_eq!(
-        linked.get("model.bin").map(|e| e.pointer_hex.as_str()),
-        Some("22")
+        linked
+            .get("model.bin")
+            .and_then(hydrated_pointer::decode_pointer),
+        Some(linked_pointer)
     );
 }
 
 #[test]
+#[cfg(unix)]
 fn legacy_shared_hydrated_cache_is_ignored_and_not_rewritten() {
     let Some(tmp) = fixture() else {
         eprintln!("SKIP: git unavailable or fixture setup failed");
@@ -149,7 +161,8 @@ fn legacy_shared_hydrated_cache_is_ignored_and_not_rewritten() {
     let canonical = hydrated_pointer::cache_path_for_worktree_root(&repo).expect("main cache");
     assert_ne!(legacy, canonical);
 
-    HydratedPointerCache::update_on_disk(&canonical, [("model.bin".to_owned(), entry("33"))])
+    let (entry, pointer) = entry(&repo.join("model.bin"));
+    HydratedPointerCache::update_on_disk(&canonical, [("model.bin".to_owned(), entry)])
         .expect("write canonical cache");
 
     assert_eq!(
@@ -159,7 +172,7 @@ fn legacy_shared_hydrated_cache_is_ignored_and_not_rewritten() {
     assert_eq!(
         HydratedPointerCache::load_sync(&canonical)
             .get("model.bin")
-            .map(|e| e.pointer_hex.as_str()),
-        Some("33")
+            .and_then(hydrated_pointer::decode_pointer),
+        Some(pointer)
     );
 }

--- a/crab/tests/worktree_cli.rs
+++ b/crab/tests/worktree_cli.rs
@@ -1954,6 +1954,7 @@ fn worktree_mutating_json_reports_payloads_and_changes_git_state() {
 }
 
 #[test]
+#[cfg(unix)]
 fn worktree_list_json_with_crab_state_reports_state_summaries() {
     let Some(tmp) = fixture() else {
         eprintln!("SKIP: git unavailable or fixture setup failed");
@@ -1962,21 +1963,23 @@ fn worktree_list_json_with_crab_state_reports_state_summaries() {
     let repo = tmp.path().join("repo");
     let linked = tmp.path().join("linked");
     let ctx = crab::git::worktree::WorktreeContext::resolve_from(&linked).expect("linked ctx");
-    let mut cache = crab::cache::HydratedPointerCache::new();
-    cache.insert(
-        "large.bin".to_owned(),
-        crab::cache::HydratedEntry {
-            mtime_ns: 1,
-            size: 5,
-            pointer_hex: "706f696e746572".to_owned(),
-        },
-    );
-    cache
-        .save_sync(
-            &ctx.per_worktree_crab_dir
-                .join(crab::cache::hydrated_pointer::HYDRATED_POINTERS_FILENAME),
-        )
-        .expect("save hydrated cache");
+    let content = b"large";
+    let hydrated_path = linked.join("large.bin");
+    std::fs::write(&hydrated_path, content).expect("write hydrated content");
+    let pointer = crab_types::pointer::Pointer {
+        file_hash: *blake3::hash(content).as_bytes(),
+        size: content.len() as u64,
+        shard_hint: None,
+    }
+    .serialize();
+    let entry = crab::cache::hydrated_pointer::entry_for_path(&hydrated_path, &pointer)
+        .expect("cacheable hydrated content");
+    crab::cache::HydratedPointerCache::update_on_disk(
+        &ctx.per_worktree_crab_dir
+            .join(crab::cache::hydrated_pointer::HYDRATED_POINTERS_FILENAME),
+        [("large.bin".to_owned(), entry)],
+    )
+    .expect("save hydrated cache");
     std::fs::write(
         ctx.per_worktree_crab_dir.join("hydration-policy.toml"),
         b"mode = \"full\"\n",

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -43,7 +43,7 @@ pub const READ_BUF_SIZE: usize = 1024 * 1024;
 /// typical data batch closer to 64 MiB before touching the staging index.
 pub const STAGE_BATCH_CHUNKS: usize = 1024;
 pub const STAGE_BATCH_TARGET_BYTES: u64 = 64 * 1024 * 1024;
-const DIRECT_XORB_STAGE_BATCH_TARGET_BYTES: u64 = 8 * 1024 * 1024;
+const DIRECT_XORB_STAGE_BATCH_TARGET_BYTES: u64 = 32 * 1024 * 1024;
 
 /// Optional progress counters updated while streaming a file.
 #[derive(Clone, Default)]
@@ -66,6 +66,7 @@ pub struct StreamStageXorbBuilder {
     build: Arc<dyn Fn() -> XorbBuilder + Send + Sync>,
     admission: Arc<Semaphore>,
     materialization: Arc<Semaphore>,
+    promotion: Arc<Semaphore>,
     serialized_payload_pool: SerializedPayloadPool,
     coordination: Option<Arc<PreparedAuthorityCoordination>>,
 }
@@ -86,6 +87,7 @@ impl StreamStageXorbBuilder {
             build: Arc::new(build),
             admission: Arc::new(Semaphore::new(max_in_flight)),
             materialization: Arc::new(Semaphore::new(1)),
+            promotion: Arc::new(Semaphore::new(1)),
             serialized_payload_pool: SerializedPayloadPool::new(1),
             coordination: None,
         }
@@ -185,6 +187,13 @@ impl StreamStageXorbBuilder {
                 CrabError::Internal("stream xorb materialization admission closed".to_owned())
             }),
         }
+    }
+
+    async fn acquire_promotion(&self) -> Result<OwnedSemaphorePermit> {
+        Arc::clone(&self.promotion)
+            .acquire_owned()
+            .await
+            .map_err(|_| CrabError::Internal("stream xorb promotion admission closed".to_owned()))
     }
 
     #[cfg(test)]
@@ -516,6 +525,7 @@ pub async fn stage_file_streaming_as(
 struct StreamStageHooks {
     after_batch_flush: Option<Arc<dyn Fn() + Send + Sync>>,
     before_prepared_xorb_write: Option<PreparedXorbWriteHook>,
+    before_prepared_xorb_promote: Option<PreparedXorbWriteHook>,
 }
 
 #[cfg(test)]
@@ -708,9 +718,8 @@ async fn stage_file_streaming_inner(
             staging,
             &batch_id,
             &mut stage_stats.prepared_xorbs,
-            xorb_builder
-                .as_ref()
-                .and_then(StreamStageXorbBuilder::preparation_id),
+            xorb_builder.as_ref(),
+            &hooks,
         )
         .await
     {
@@ -1506,12 +1515,26 @@ async fn persist_stream_prepared_authority(
     staging: &StagingArea,
     batch_id: &crate::StagingBatchId,
     prepared_xorbs: &mut [StreamStagePreparedXorb],
-    preparation_id: Option<&crate::AddPreparationId>,
+    xorb_builder: Option<&StreamStageXorbBuilder>,
+    hooks: &StreamStageHooks,
 ) -> Result<()> {
-    let preparation_id = preparation_id.ok_or_else(|| {
+    let xorb_builder = xorb_builder.ok_or_else(|| {
         CrabError::Internal("direct prepared authority has no add preparation".to_owned())
     })?;
+    let preparation_id = xorb_builder.preparation_id().ok_or_else(|| {
+        CrabError::Internal("direct prepared authority has no add preparation".to_owned())
+    })?;
+    let _promotion_permit = if prepared_xorbs.is_empty() {
+        None
+    } else {
+        // Concurrent fsync-backed promotion increases tail latency on the same disk.
+        // Keep chunking parallel, then serialize this operation's authority boundary.
+        Some(xorb_builder.acquire_promotion().await?)
+    };
     for prepared in prepared_xorbs.iter_mut() {
+        if let Some(before_promote) = &hooks.before_prepared_xorb_promote {
+            before_promote(&prepared.payload_path)?;
+        }
         let written =
             move_prepared_xorb(staging.root(), &prepared.hash, &prepared.payload_path).await?;
         if written != prepared.bytes {
@@ -1797,11 +1820,19 @@ mod tests {
     }
 
     #[test]
-    fn direct_xorb_staging_uses_smaller_compression_batches() {
+    fn direct_xorb_staging_uses_bounded_remote_batches() {
         assert_eq!(stage_batch_target_bytes(false), STAGE_BATCH_TARGET_BYTES);
         assert_eq!(
             stage_batch_target_bytes(true),
             DIRECT_XORB_STAGE_BATCH_TARGET_BYTES
+        );
+        let lengths = vec![1024 * 1024; 32];
+        assert_eq!(
+            batch_flush_prefix_from_lengths(
+                lengths.iter().copied(),
+                DIRECT_XORB_STAGE_BATCH_TARGET_BYTES,
+            ),
+            (32, DIRECT_XORB_STAGE_BATCH_TARGET_BYTES)
         );
     }
 
@@ -2818,6 +2849,61 @@ mod tests {
                 .unwrap_or(true)
         );
         assert!(!staging_root.join("push-plans/payloads").exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn prepared_xorb_promotion_is_serialized_per_preparation() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_path = dir.path().join("first.bin");
+        let second_path = dir.path().join("second.bin");
+        write_pattern_file_with_salt(&first_path, 2 * 1024 * 1024, 17);
+        write_pattern_file_with_salt(&second_path, 2 * 1024 * 1024, 41);
+        let staging = StagingArea::open(dir.path().join(".crab/staging"))
+            .await
+            .unwrap();
+        let preparation = staging.create_add_preparation().unwrap();
+        let builders =
+            StreamStageXorbBuilder::new(2, XorbBuilder::new).bind_preparation(preparation.clone());
+        let active = Arc::new(AtomicU64::new(0));
+        let peak = Arc::new(AtomicU64::new(0));
+        let hook_active = Arc::clone(&active);
+        let hook_peak = Arc::clone(&peak);
+        let hooks = StreamStageHooks {
+            before_prepared_xorb_promote: Some(Arc::new(move |_| {
+                let concurrent = hook_active.fetch_add(1, Ordering::SeqCst) + 1;
+                hook_peak.fetch_max(concurrent, Ordering::SeqCst);
+                std::thread::sleep(Duration::from_millis(200));
+                hook_active.fetch_sub(1, Ordering::SeqCst);
+                Ok(())
+            })),
+            ..StreamStageHooks::default()
+        };
+        let progress = StreamStageProgress {
+            xorb_builder: Some(builders),
+            ..StreamStageProgress::default()
+        };
+        let cancel = CancellationToken::new();
+        let first = stage_file_streaming_with_hooks(
+            &first_path,
+            dir.path(),
+            &staging,
+            progress.clone(),
+            &cancel,
+            hooks.clone(),
+        );
+        let second = stage_file_streaming_with_hooks(
+            &second_path,
+            dir.path(),
+            &staging,
+            progress,
+            &cancel,
+            hooks,
+        );
+        let (first, second) = tokio::join!(first, second);
+
+        first.unwrap();
+        second.unwrap();
+        assert_eq!(peak.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- hard-cut the hydrated-pointer cache to `hydrated-pointers-v1.sqlite` with transactional concurrent updates and descriptor-safe validation
- remove the clean-filter worktree shortcut so Git-provided stdin remains authoritative
- avoid immediate post-hydrate/dehydrate racy-stat rescans while retaining ctime/stat and full-hash protection
- increase direct add remote-index classification batches from 8 MiB to 32 MiB
- keep file chunking and classification concurrent, but serialize fsync-backed prepared-payload promotion within one add preparation
- retain canonical v1 contracts only; no compatibility reader or format bump

## Performance evidence

Exact 1 GiB file with a 64 MiB edit, five-run medians:

- add duration: 6.675s -> 6.106s (8.5% faster)
- remote lookup: 1.337s -> 1.053s (21.2% faster)
- peak RSS: 163 MiB -> 215 MiB

Two concurrent 1 GiB files with independent 64 MiB edits, three-run medians:

- 8 MiB baseline: 15.038s
- 32 MiB before promotion admission: 15.613s
- 32 MiB with preparation-scoped promotion admission: 14.494s
- peak RSS: about 306 MiB baseline -> 388 MiB candidate

The larger batch is bounded by the existing two-builder admission, so the memory increase does not scale with repository size or `--jobs 16`.

## Correctness proof

- full `cargo test -p crab --locked`: 3,844 library tests plus all runnable integration targets, add/push E2E, schema drift/validation, and doctests passed
- full `cargo test -p crab-staging --locked`: 195 unit tests and runnable scale proxies passed
- strict `cargo clippy -p crab-staging --all-targets --locked -- -D warnings` passed
- `cargo fmt --all -- --check` passed
- concurrency regression proves two files in one preparation never overlap the payload-promotion boundary
- deterministic remote-batch regression proves the 32 MiB classification bound

## RustFS qualification

A dedicated RustFS bucket completed a two-file, 2 GiB versioned workflow using the exact release build: add, commit, push, fresh lazy clone, hydrate, SHA-256 comparison, dehydrate, second hydrate, second SHA-256 comparison, and `git fsck --full`. Both 1 GiB files reconstructed byte-identically across both hydrate cycles. Exact-source `crab add` took 11.786s at 243 MB peak RSS, and the following Git commit took 0.02s through verified staging.

The earlier hydrated-cache qualification also completed a 512 MiB random-file add/push/lazy-clone/hydrate/dehydrate cycle. Immediate unchanged status fell from 4.03s on the pre-fix racy-stat path to 0.01-0.02s without filter invocation.

## File-index audit follow-up

A minimized two-version RustFS reproduction identified the earlier `crab fsck` finding as a reused-bucket hard-cutover condition: that bucket's pre-v1 `.crab/chunk_index_db` had no canonical-v1 schema receipt, so post-CAS acceleration publication failed closed and hydrate used its committed-shard correctness fallback. A truly new bucket completed the same two-version push and both historical hydrations, then passed `crab fsck --json` with zero errors. Canonical-v1 first-use publication is therefore healthy; pre-hard-cutover bucket metadata remains intentionally unsupported rather than gaining a compatibility path.
