### PR TITLE
docs: update getting started and blog date

### DIFF
--- a/packages/web/content/blog/git-for-large-files-at-any-scale.mdx
+++ b/packages/web/content/blog/git-for-large-files-at-any-scale.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Git for large files at any scale"
 description: "Introducing Crab: one Git history for code, models, datasets, and media, with the heavy bytes stored directly in your own cloud object store."
-date: "2026-08-25"
+date: "2026-09-01"
 author: "Crab Team"
 category: "release"
 tags:

--- a/packages/web/content/docs/cli/getting-started/index.mdx
+++ b/packages/web/content/docs/cli/getting-started/index.mdx
@@ -11,13 +11,6 @@ meta:
 
 Crab extends Git with a separate data path for large files. Git commits small pointer blobs, while Crab stores chunked file content through an object-store adapter.
 
-<Callout type="warning" title="Check provider qualification before deployment">
-  Adapter availability is not a release-support claim. RustFS is currently
-  development-qualified; Amazon S3, Google Cloud Storage, and Azure Blob
-  Storage remain unqualified until the exact release commit has retained
-  real-service evidence. See [Provider Qualification](/docs/cli/storage/provider-qualification).
-</Callout>
-
 <DocsPathDiagram
   id="getting-started-path"
   title="From local file to reproducible checkout"


### PR DESCRIPTION
## Summary

- remove the provider qualification warning from the CLI getting-started page
- move the “Git for large files at any scale” post date to September 1, 2026

## Validation

- `npm run build`
- `npm run check:links` (398 pages, 4,292 fragments)
- `git diff --check`