### PR TITLE
release: prepare Crab 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ integration surfaces should be recorded here before release.
 ### Open Source Launch
 
 - Established `crabbuild/crab` as the canonical open-source repository and
-  reset the public release line to 1.0.0. The pre-launch 1.1.0 release remains
-  available as an immutable historical artifact.
+  reset the public release line to 1.0.0. Pre-launch development snapshots are
+  recorded below by date only.
 - Shipped the serverless Git remote helper, direct object-storage large-file
   workflow, partial-clone support, protected publication, and safe repository
   maintenance as the open-source launch baseline.
@@ -19,7 +19,7 @@ integration surfaces should be recorded here before release.
   checksums, build-provenance attestations, public installers, self-update
   support, and the `crabbuild/tap/crab` Homebrew formula.
 
-## 1.1.0 - 2026-08-27
+## 2026-08-27
 
 ### Git And Large Files
 
@@ -58,7 +58,7 @@ integration surfaces should be recorded here before release.
 - Added direct-storage Crab LFS onboarding and expanded large-file, GC,
   optimization, and Continuity architecture guidance.
 
-## 1.0.15 - 2026-08-22
+## 2026-08-22
 
 ### Release Automation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ integration surfaces should be recorded here before release.
 
 ## Unreleased
 
+## 1.0.0 - 2026-08-31
+
+### Open Source Launch
+
+- Established `crabbuild/crab` as the canonical open-source repository and
+  reset the public release line to 1.0.0. The pre-launch 1.1.0 release remains
+  available as an immutable historical artifact.
+- Shipped the serverless Git remote helper, direct object-storage large-file
+  workflow, partial-clone support, protected publication, and safe repository
+  maintenance as the open-source launch baseline.
+- Published native ARM64 and x86_64 archives for macOS, Linux, and Windows with
+  checksums, build-provenance attestations, public installers, self-update
+  support, and the `crabbuild/tap/crab` Homebrew formula.
+
 ## 1.1.0 - 2026-08-27
 
 ### Git And Large Files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "crab"
-version = "1.1.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "crab-auth-server"
-version = "1.1.0"
+version = "1.0.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "crab-cache-server"
-version = "1.1.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "axum 0.8.9",

--- a/crab/Cargo.toml
+++ b/crab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab"
-version = "1.1.0"
+version = "1.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Serverless git remote helper backed by object storage with Xet-style chunk dedup."

--- a/crab/scripts/release/bump-version.sh
+++ b/crab/scripts/release/bump-version.sh
@@ -107,7 +107,7 @@ for manifest in "${PRODUCT_MANIFESTS[@]}"; do
         sed -i "s/^version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" "$manifest"
     fi
 done
-(cd "$WORKSPACE_DIR" && cargo metadata --format-version 1 --no-deps >/dev/null)
+(cd "$WORKSPACE_DIR" && cargo metadata --format-version 1 >/dev/null)
 trap - EXIT
 rm -r "$backup_dir"
 

--- a/crab/scripts/release/check-release-archive-contents.py
+++ b/crab/scripts/release/check-release-archive-contents.py
@@ -425,7 +425,7 @@ def checks(root: Path) -> list[TextCheck]:
                 '"$CRAB_DIR/Cargo.toml"',
                 '"$WORKSPACE_DIR/crates/crab-auth-server/Cargo.toml"',
                 '"$WORKSPACE_DIR/crates/crab-cache-server/Cargo.toml"',
-                "cargo metadata --format-version 1 --no-deps",
+                "cargo metadata --format-version 1",
                 "restore_on_error",
             ),
             excludes=(),

--- a/crates/crab-auth-server/Cargo.toml
+++ b/crates/crab-auth-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-auth-server"
-version = "1.1.0"
+version = "1.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Protected-push and path-scoped view helper binaries for Crab Auth."

--- a/crates/crab-cache-server/Cargo.toml
+++ b/crates/crab-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-cache-server"
-version = "1.1.0"
+version = "1.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Cache server runtime contracts for Crab."


### PR DESCRIPTION
## Summary
- reset the open-source launch version to 1.0.0 across all shipped product manifests and Cargo.lock
- add the dated open-source launch changelog and represent prior development snapshots by date only
- ensure the supported bump command actually refreshes existing workspace package versions in Cargo.lock

All earlier GitHub releases and tags have been removed. v1.0.0 becomes the first public open-source release, GitHub Latest, and the Homebrew release.

## Verification
- make -C crab bump-set VERSION=1.0.0
- make -C crab release-metadata-check
- make -C crab release-archive-contents-check
- cargo metadata --locked --format-version 1 --no-deps
- cargo fmt --all --check
- bash -n crab/scripts/release/bump-version.sh