### PR TITLE
docs: remove launch and qualification callouts

### DIFF
--- a/packages/web/content/blog/git-for-large-files-at-any-scale.mdx
+++ b/packages/web/content/blog/git-for-large-files-at-any-scale.mdx
@@ -38,11 +38,6 @@ Crab stores compact pointers in Git. Content-defined chunks, immutable packed ob
 
 No Crab data server sits between your team and the bucket.
 
-<TakeawayBox title="The launch in one sentence">
-  Crab keeps Git in charge of history while your object store carries the
-  large-file data plane.
-</TakeawayBox>
-
 <CrabIntroductionWorkbench />
 
 ## The file became infrastructure

--- a/packages/web/content/docs/cli/authentication/static-credentials.mdx
+++ b/packages/web/content/docs/cli/authentication/static-credentials.mdx
@@ -9,13 +9,6 @@ meta:
 
 ## Static Credential Mode
 
-<Callout type="warning" title="Credentials do not qualify a provider">
-  Successful credential discovery only proves access. Amazon S3, GCS, and
-  Azure are currently unqualified for release use; RustFS is
-  development-qualified. Check [Provider Qualification](/docs/cli/storage/provider-qualification)
-  for the retained contract status.
-</Callout>
-
 `static` is Crab's default auth provider. In this mode, Crab does not run
 `crab login` and does not store long-lived cloud access keys in Crab config.
 It builds an object-store client from the credential sources supported by the

--- a/packages/web/content/docs/cli/getting-started/first-repository.mdx
+++ b/packages/web/content/docs/cli/getting-started/first-repository.mdx
@@ -11,13 +11,6 @@ meta:
 
 A Crab repository is a standard git repository with a cloud storage backend for large files. Crab handles the wiring between git and your bucket in a short setup flow.
 
-<Callout type="warning" title="Use a qualified provider for release deployments">
-  The S3, GCS, and Azure adapters can be configured below, but Amazon S3, GCS,
-  and Azure are currently unqualified for release use. RustFS is
-  development-qualified. Check the retained evidence status in [Provider
-  Qualification](/docs/cli/storage/provider-qualification).
-</Callout>
-
 ## Create the repository
 
 ```bash

--- a/packages/web/content/docs/cli/reference/crab-configure.mdx
+++ b/packages/web/content/docs/cli/reference/crab-configure.mdx
@@ -11,13 +11,6 @@ meta:
 
 Set up a new Crab repository in one guided flow.
 
-<Callout type="warning" title="Configuration support is broader than release qualification">
-  Amazon S3, GCS, and Azure adapters are available but currently unqualified
-  for release use. RustFS is development-qualified. See [Provider
-  Qualification](/docs/cli/storage/provider-qualification) before selecting a
-  production backend.
-</Callout>
-
 ```bash
 crab configure [REMOTE] [OPTIONS]
 ```


### PR DESCRIPTION
## Summary

- remove the “The launch in one sentence” callout from the launch blog post
- remove duplicated provider qualification warning banners from `crab-configure`, `first-repository`, and `static-credentials`
- keep the canonical Provider Qualification reference page intact

## Validation

- `npm run build`
- `npm run check:links` (398 pages, 4,292 fragments)
- `git diff --check`