### PR TITLE
release: prepare Crab 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ integration surfaces should be recorded here before release.
 
 ## Unreleased
 
+## 1.0.1 - 2026-08-31
+
+### Push And Large Files
+
+- Published large-file indexes before refs so newly pushed file versions are
+  visible to readers only after their index data is available.
+- Bounded metadata shard replay and isolated reconstruction cancellation to
+  prevent large repositories or one failed file from exhausting a push or
+  hydrate operation.
+
 ## 1.0.0 - 2026-08-31
 
 ### Open Source Launch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "crab"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "crab-auth-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "crab-cache-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "axum 0.8.9",

--- a/crab/Cargo.toml
+++ b/crab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Serverless git remote helper backed by object storage with Xet-style chunk dedup."

--- a/crates/crab-auth-server/Cargo.toml
+++ b/crates/crab-auth-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-auth-server"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Protected-push and path-scoped view helper binaries for Crab Auth."

--- a/crates/crab-cache-server/Cargo.toml
+++ b/crates/crab-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-cache-server"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Cache server runtime contracts for Crab."


### PR DESCRIPTION
## Summary

- bump the Crab CLI, auth-server, and cache-server release metadata to 1.0.1
- record the 1.0.1 release notes for the latest large-file publication and bounded replay fixes
- keep the existing pre-1.0.0 changelog entries date-only

## Validation

- `make release-metadata-check`
- `python3 scripts/release/generate-release-manifest.py --self-test`
- `git diff --check`
