### PR TITLE
perf(metadata): batch previsibility index publication

### DIFF
--- a/crab/scripts/e2e/run_production_scale_rustfs.py
+++ b/crab/scripts/e2e/run_production_scale_rustfs.py
@@ -6,7 +6,8 @@ beneath ``~/Workspace/CrabRepos/ml-model-300gb`` and keeps its source, clone,
 logs, manifests, and report for investigation. The files are sparse with
 deterministic repeated blocks: they exercise 300 GiB of logical content and
 deduplication without consuming several additional terabytes of host storage.
-Every version changes representative files from 100 MiB through 5 GiB.
+Every version changes representative files from 100 MiB through 10 GiB, and
+the clone reconstructs every retained version of those files from a cold cache.
 """
 
 from __future__ import annotations
@@ -92,6 +93,7 @@ class Report:
     commands: list[dict[str, Any]] = field(default_factory=list)
     checks: list[dict[str, Any]] = field(default_factory=list)
     versions: list[dict[str, Any]] = field(default_factory=list)
+    history: list[dict[str, Any]] = field(default_factory=list)
     artifacts: dict[str, str] = field(default_factory=dict)
     started_at: str = ""
     finished_at: str = ""
@@ -124,11 +126,11 @@ def block(label: str, length: int) -> bytes:
 
 def build_workload_plan() -> WorkloadPlan:
     files: list[FileSpec] = []
-    foundation = FileSpec("models/foundation-model-000.safetensors", 5 * GIB, "model", 0x1000)
+    foundation = FileSpec("models/foundation-model-000.safetensors", 10 * GIB, "model", 0x1000)
     files.append(foundation)
     files.extend(
         FileSpec(f"models/checkpoint-{index:03}.safetensors", 5 * GIB, "model", 0x1001 + index)
-        for index in range(9)
+        for index in range(8)
     )
     medium = FileSpec("models/medium-model-000.safetensors", 2 * GIB, "medium-model", 0x2000)
     files.append(medium)
@@ -500,6 +502,7 @@ class ProductionScaleRunner:
         self.stage_paths(self.source, paths, "initial")
         self.commit(self.source, "production-scale initial 300 GiB repository")
         self.push(self.source, "initial")
+        self.record_history_version(manifest, 1, {})
         self.pointer_check(self.source, manifest, "initial-index-pointers")
         after = self.object_stats(".crab/xorbs/", "initial xorb")
         delta = after["bytes"] - before["bytes"]
@@ -514,6 +517,35 @@ class ProductionScaleRunner:
             if item["path"] == path:
                 return item
         raise WorkflowError(f"manifest is missing {path}")
+
+    def record_history_version(
+        self,
+        manifest: dict[str, Any],
+        version: int,
+        offsets: dict[str, int],
+    ) -> None:
+        revision = self.run_git(
+            self.source,
+            ["rev-parse", "HEAD"],
+            f"resolve version {version} revision",
+        )
+        commit = Path(revision.stdout_log).read_text(encoding="utf-8").strip()
+        self.report.history.append(
+            {
+                "version": version,
+                "commit": commit,
+                "offsets": offsets,
+                "files": [
+                    {
+                        "path": target.path,
+                        "size": target.size,
+                        "sha256": self.find_entry(manifest, target.path)["sha256"],
+                    }
+                    for target in self.plan.version_targets
+                ],
+            }
+        )
+        self.write_report()
 
     def write_version_patch(self, target_spec: FileSpec, version: int) -> int:
         target = self.source / target_spec.path
@@ -557,6 +589,7 @@ class ProductionScaleRunner:
             self.stage_paths(self.source, target_paths, f"version {version}")
             self.commit(self.source, f"production-scale size-class files version {version}")
             self.push(self.source, f"version {version}")
+            self.record_history_version(manifest, version, offsets)
             diffs = self.diff_reports()
             after = self.object_stats(".crab/xorbs/", f"version {version} xorb")
             xorb_delta = after["bytes"] - before["bytes"]
@@ -616,6 +649,92 @@ class ProductionScaleRunner:
                 failures.append(item["path"])
         self.check(name, not failures, {"files": len(manifest["files"]), "failures": failures[:10]})
 
+    def reset_cache(self) -> None:
+        if self.cache.exists():
+            shutil.rmtree(self.cache)
+        self.cache.mkdir(parents=True)
+
+    def verify_historical_versions(self) -> None:
+        self.check(
+            "large-file-history-complete",
+            len(self.report.history) == self.plan.version_count + 1,
+            {
+                "versions": len(self.report.history),
+                "mutations_per_file": self.plan.version_count,
+                "files": len(self.plan.version_targets),
+            },
+        )
+        for version in self.report.history:
+            version_number = int(version["version"])
+            self.reset_cache()
+            self.run_git(
+                self.clone,
+                ["checkout", "--detach", str(version["commit"])],
+                f"checkout historical version {version_number}",
+            )
+            failures: list[dict[str, Any]] = []
+            for file in version["files"]:
+                relative = str(file["path"])
+                path = self.clone / relative
+                pointer_before = (
+                    path.is_file()
+                    and path.stat().st_size <= 256
+                    and path.read_bytes().startswith(b"version https://crab.dev/spec/v1\n")
+                )
+                self.run_crab(
+                    self.clone,
+                    ["hydrate", relative, "--jsonl"],
+                    f"hydrate historical version {version_number} {relative}",
+                    timeout=12 * 60 * 60,
+                )
+                actual_size = path.stat().st_size
+                actual_hash = sha256_file(path)
+                self.run_crab(
+                    self.clone,
+                    ["dehydrate", relative, "--jsonl"],
+                    f"dehydrate historical version {version_number} {relative}",
+                    timeout=12 * 60 * 60,
+                )
+                pointer_after = (
+                    path.is_file()
+                    and path.stat().st_size <= 256
+                    and path.read_bytes().startswith(b"version https://crab.dev/spec/v1\n")
+                )
+                if (
+                    not pointer_before
+                    or actual_size != int(file["size"])
+                    or actual_hash != file["sha256"]
+                    or not pointer_after
+                ):
+                    failures.append(
+                        {
+                            "path": relative,
+                            "pointer_before": pointer_before,
+                            "pointer_after": pointer_after,
+                            "size": actual_size,
+                            "sha256": actual_hash,
+                            "expected_sha256": file["sha256"],
+                        }
+                    )
+            status = self.run_git(
+                self.clone,
+                ["status", "--porcelain"],
+                f"historical version {version_number} status",
+            )
+            dirty = Path(status.stdout_log).read_text(encoding="utf-8").strip()
+            self.check(
+                f"historical-version-{version_number}-byte-identity",
+                not failures and not dirty,
+                {
+                    "commit": version["commit"],
+                    "files": len(version["files"]),
+                    "cold_cache": True,
+                    "failures": failures,
+                    "git_status": dirty,
+                },
+            )
+        self.run_git(self.clone, ["checkout", "main"], "restore clone main")
+
     def clone_hydrate_cycle(self, manifest: dict[str, Any]) -> None:
         self.run_cmd("crab clone lazy", ["crab", "clone", self.remote_url, str(self.clone), "--jsonl"], cwd=self.run_root, timeout=12 * 60 * 60)
         self.run_git(self.clone, ["config", "user.email", "clone-developer@crab.local"], "clone git config email")
@@ -634,7 +753,7 @@ class ProductionScaleRunner:
             if sha256_file(self.clone / target) != entry["sha256"]:
                 failures.append(target)
         self.check(
-            "selective-100-mib-through-5-gib-hydrate",
+            "selective-100-mib-through-10-gib-hydrate",
             not failures,
             {"paths": targets, "failures": failures},
         )
@@ -642,6 +761,7 @@ class ProductionScaleRunner:
         self.verify_manifest(self.clone, manifest, "clone-hydrate-byte-identity")
         self.run_crab(self.clone, ["dehydrate", "--all", "--jsonl"], "clone dehydrate all", timeout=12 * 60 * 60)
         self.worktree_pointers(self.clone, manifest, "clone-dehydrate-pointers")
+        self.verify_historical_versions()
         self.run_crab(self.clone, ["hydrate", "--all", "--jsonl"], "clone rehydrate all", timeout=12 * 60 * 60)
         self.verify_manifest(self.clone, manifest, "clone-rehydrate-byte-identity")
 

--- a/crab/scripts/e2e/test_run_production_scale_rustfs.py
+++ b/crab/scripts/e2e/test_run_production_scale_rustfs.py
@@ -23,7 +23,7 @@ class ProductionScaleWorkloadTests(unittest.TestCase):
         plan = QUALIFICATION.build_workload_plan()
 
         self.assertEqual(plan.logical_bytes, 300 * QUALIFICATION.GIB)
-        self.assertEqual(len(plan.files), 897)
+        self.assertEqual(len(plan.files), 896)
         self.assertEqual(
             [target.size for target in plan.version_targets],
             [
@@ -32,9 +32,16 @@ class ProductionScaleWorkloadTests(unittest.TestCase):
                 512 * QUALIFICATION.MIB,
                 QUALIFICATION.GIB,
                 2 * QUALIFICATION.GIB,
-                5 * QUALIFICATION.GIB,
+                10 * QUALIFICATION.GIB,
             ],
         )
+
+    def test_every_large_file_receives_twelve_historical_mutations(self) -> None:
+        plan = QUALIFICATION.build_workload_plan()
+
+        self.assertEqual(plan.version_count, 12)
+        self.assertGreaterEqual(plan.version_count, 10)
+        self.assertLessEqual(plan.version_count, 20)
 
 
 if __name__ == "__main__":

--- a/crab/src/core/config.rs
+++ b/crab/src/core/config.rs
@@ -5265,6 +5265,7 @@ cache_gc_grace = 2
         assert_eq!(meta.file_index.compaction_threshold, 4);
         assert_eq!(meta.file_index.wal_flush_size, 4 * 1024 * 1024);
         assert_eq!(meta.file_index.bloom_bits_per_key, 10);
+        assert_eq!(meta.chunk_index.wal_flush_size, 64 * 1024 * 1024);
         assert_eq!(meta.cache_gc_grace, 3);
         assert_eq!(meta.in_memory_ceiling_bytes, 1024 * 1024 * 1024);
     }

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -282,7 +282,6 @@ const GLOBAL_CHUNK_LOOKUP_REMOTE_BATCH_SIZE: usize = 4_096;
 const GLOBAL_CHUNK_LOOKUP_BUDGET: Duration = Duration::from_secs(120);
 const BASE_SHARD_LOOKUP_LIMIT: usize = 4_096;
 const CANDIDATE_METADATA_BATCH_SIZE: usize = 2_048;
-const CANDIDATE_METADATA_FLUSH_BATCHES: usize = 8;
 const STAGING_VERIFY_CONCURRENCY: usize = 4;
 const REMOTE_XORB_PROOF_MAX_RANGE_BYTES: u64 = 8 * 1024 * 1024;
 const REMOTE_XORB_PROOF_PAYLOAD_CONCURRENCY: usize = 16;
@@ -15468,9 +15467,6 @@ impl PushPipeline {
         aggregate.bytes_written += receipt.bytes_written;
         aggregate.elapsed += receipt.elapsed;
         *batch_count += 1;
-        if (*batch_count).is_multiple_of(CANDIDATE_METADATA_FLUSH_BATCHES) {
-            guard.flush_memtables().await?;
-        }
         Ok(())
     }
 
@@ -15582,8 +15578,9 @@ impl PushPipeline {
             .collect::<Vec<_>>();
 
         // These indexes are pre-visibility, rebuildable acceleration data. Keep each
-        // SlateDB WriteBatch bounded so metadata memory stays independent of
-        // total push size. Partial batch success remains safe and repairable.
+        // transaction bounded; SlateDB freezes memtables at the configured L0 size
+        // and applies backpressure to bound the full publication. The one explicit
+        // flush below is the durability and secondary-reader visibility barrier.
         let mut aggregate = crate::metadata::metadb::PushWriteReceipt::default();
         let mut batch_count = 0usize;
         for batch in receipt_tombstones.chunks(CANDIDATE_METADATA_BATCH_SIZE) {

--- a/crab/src/metadata/metadb/mod.rs
+++ b/crab/src/metadata/metadb/mod.rs
@@ -55,7 +55,7 @@ const DEFAULT_CACHE_GC_GRACE: u64 = 3;
 /// before a compaction is scheduled).
 const DEFAULT_COMPACTION_THRESHOLD: u32 = 4;
 
-/// Default L0 SST target per instance (4 MiB).
+/// Default L0 SST target for the per-repository file index (4 MiB).
 ///
 /// The shipped configuration key is named `wal_flush_size`; SlateDB 0.14
 /// exposes this boundary as `l0_sst_size_bytes`.
@@ -219,7 +219,10 @@ impl Default for MetaDbConfig {
             in_memory_ceiling_bytes: DEFAULT_IN_MEMORY_CEILING_BYTES,
             cache_gc_grace: DEFAULT_CACHE_GC_GRACE,
             file_index: MetaDbEngineConfig::default(),
-            chunk_index: MetaDbEngineConfig::default(),
+            chunk_index: MetaDbEngineConfig {
+                wal_flush_size: crab_metadata::remote_index::DEFAULT_CHUNK_INDEX_L0_SST_SIZE_BYTES,
+                ..MetaDbEngineConfig::default()
+            },
             read_only: false,
         }
     }
@@ -1165,7 +1168,18 @@ mod tests {
         assert_eq!(cfg.file_index.compaction_threshold, 4);
         assert_eq!(cfg.file_index.wal_flush_size, 4 * 1024 * 1024);
         assert_eq!(cfg.file_index.bloom_bits_per_key, 10);
-        assert_eq!(cfg.chunk_index, cfg.file_index);
+        assert_eq!(
+            cfg.chunk_index.wal_flush_size,
+            crab_metadata::remote_index::DEFAULT_CHUNK_INDEX_L0_SST_SIZE_BYTES
+        );
+        assert_eq!(
+            cfg.chunk_index.compaction_threshold,
+            cfg.file_index.compaction_threshold
+        );
+        assert_eq!(
+            cfg.chunk_index.bloom_bits_per_key,
+            cfg.file_index.bloom_bits_per_key
+        );
         assert_eq!(cfg.chunk_index_path, ".crab/chunk_index_db/");
     }
 

--- a/crates/crab-metadata/src/remote_index.rs
+++ b/crates/crab-metadata/src/remote_index.rs
@@ -25,6 +25,14 @@ use crab_xet::xorb::format::{MerkleHash, XorbRef};
 const FILE_INDEX_DB_LABEL: &str = "file_index_db";
 const CHUNK_INDEX_DB_LABEL: &str = "chunk_index_db";
 
+/// Default L0 target for the global chunk index.
+///
+/// One high-entropy 5 GiB file produces roughly 32 MiB of compact placement
+/// rows. Keeping that generation in one memtable avoids object-store and
+/// compaction amplification while SlateDB's backpressure still bounds larger
+/// publications.
+pub const DEFAULT_CHUNK_INDEX_L0_SST_SIZE_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Remote SlateDB paths for Crab's file and chunk indexes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RemoteIndexConfig {
@@ -254,13 +262,19 @@ async fn write_opened_entries(
                 encode_committed_file_record(record).as_slice(),
             );
         }
-        db.write(batch)
-            .await
-            .map(|_| ())
-            .map_err(|source| MetadataError::SlateDbWrite {
-                db: FILE_INDEX_DB_LABEL.to_owned(),
-                source,
-            })?;
+        db.write_with_options(
+            batch,
+            &slatedb::config::WriteOptions {
+                await_durable: false,
+                ..slatedb::config::WriteOptions::default()
+            },
+        )
+        .await
+        .map(|_| ())
+        .map_err(|source| MetadataError::SlateDbWrite {
+            db: FILE_INDEX_DB_LABEL.to_owned(),
+            source,
+        })?;
     }
 
     if let Some(db) = chunk_db
@@ -322,13 +336,19 @@ async fn write_opened_entries(
                 value.as_slice(),
             );
         }
-        db.write(batch)
-            .await
-            .map(|_| ())
-            .map_err(|source| MetadataError::SlateDbWrite {
-                db: CHUNK_INDEX_DB_LABEL.to_owned(),
-                source,
-            })?;
+        db.write_with_options(
+            batch,
+            &slatedb::config::WriteOptions {
+                await_durable: false,
+                ..slatedb::config::WriteOptions::default()
+            },
+        )
+        .await
+        .map(|_| ())
+        .map_err(|source| MetadataError::SlateDbWrite {
+            db: CHUNK_INDEX_DB_LABEL.to_owned(),
+            source,
+        })?;
     }
 
     Ok(())
@@ -415,7 +435,19 @@ async fn open_writer(
     path: &str,
     db: &'static str,
 ) -> Result<slatedb::Db> {
-    slatedb::Db::open(ObjectPath::from(path), store)
+    let l0_sst_size_bytes = usize::try_from(DEFAULT_CHUNK_INDEX_L0_SST_SIZE_BYTES)
+        .map_err(|error| MetadataError::Internal(format!("L0 SST size unsupported: {error}")))?;
+    let settings = slatedb::config::Settings {
+        // Publication owns the final close barrier. Timer flushes turn bounded
+        // replay batches into one remote WAL object each without making the
+        // pre-visibility result any safer.
+        flush_interval: None,
+        l0_sst_size_bytes,
+        ..slatedb::config::Settings::default()
+    };
+    slatedb::Db::builder(ObjectPath::from(path), store)
+        .with_settings(settings)
+        .build()
         .await
         .map_err(|source| MetadataError::SlateDbOpen {
             db: db.to_owned(),
@@ -477,10 +509,45 @@ fn is_manifest_missing(err: &slatedb::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::StreamExt;
     use object_store::memory::InMemory;
 
     fn hash_from_seed(seed: u64) -> MerkleHash {
         MerkleHash::from([seed, seed.wrapping_mul(31), seed.wrapping_mul(97), seed])
+    }
+
+    #[tokio::test]
+    async fn bounded_writer_defers_remote_flush_until_close() {
+        let memory = Arc::new(InMemory::new());
+        let store: Arc<dyn ObjectStore> = memory.clone();
+        let config = RemoteIndexConfig::for_repo("org/buffered");
+        let writer = RemoteIndexWriter::open(store, &config, true, false)
+            .await
+            .expect("open writer");
+        let objects_after_open = memory.list(None).count().await;
+
+        for seed in 1..=8 {
+            writer
+                .write_entries(
+                    &[(
+                        hash_from_seed(seed),
+                        CommittedFileRecord {
+                            recipe_hash: [seed as u8; 32],
+                            shard_hash: hash_from_seed(seed + 100),
+                            committed_generation: 1,
+                            shard_index_hash: hash_from_seed(500),
+                        },
+                    )],
+                    &[],
+                )
+                .await
+                .expect("buffer entry");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        assert_eq!(memory.list(None).count().await, objects_after_open);
+        writer.close().await.expect("close writer");
+        assert!(memory.list(None).count().await > objects_after_open);
     }
 
     #[tokio::test]

--- a/packages/web/content/docs/cli/diagnostics/metadata-database.mdx
+++ b/packages/web/content/docs/cli/diagnostics/metadata-database.mdx
@@ -132,7 +132,7 @@ bloom_bits_per_key = 10
 
 [metadb.chunk_index]
 compaction_threshold = 4
-wal_flush_size = 4194304          # 4 MiB
+wal_flush_size = 67108864         # 64 MiB
 bloom_bits_per_key = 10
 in_memory_ceiling_bytes = 1073741824  # 1 GiB
 cache_gc_grace = 3


### PR DESCRIPTION
## Summary

- buffer pre-visibility file and global chunk-index batches until the required close/flush durability barrier
- raise the global chunk-index L0 target from 4 MiB to 64 MiB while retaining SlateDB backpressure for bounded memory
- apply the same publication contract to CLI pushes and protected receive/view writers
- document the new chunk-index default and cover deferred remote flush behavior
- extend the 300 GiB qualification through 10 GiB files and cold-cache historical hydration

## Why this is the best fix

The measured bottleneck was remote metadata write amplification, not row encoding or chunk generation. A 5 GiB high-entropy update emitted about 83,000 chunks and previously forced several remote flush barriers plus many small L0 objects before refs became visible. SlateDB already provides the needed boundary: non-durable batches remain buffered, the configured L0 size freezes oversized memtables with backpressure, and `Db::close()` durably flushes outstanding data before ref visibility. This removes redundant barriers without introducing a second publication path or weakening reconstruction and visibility invariants.

## Live RustFS result

Local RustFS, S3-compatible credentials, bucket `crab`, 5 GiB high-entropy versioned file with a fresh 256 MiB random replacement:

- end-to-end `crab push`: 19.7 s baseline -> 5.32 s
- candidate metadata publication: 15.49 s -> 1.36 s (91.2% reduction, 11.4x faster)
- 83,248 chunk-index lookups and 79,122 remote-xorb proofs completed
- 268,690,810 bytes uploaded in five xorbs
- metadata publication used 42 bounded batches and two memtable flushes, with no per-batch WAL flushes
- cold clone: 0.65 s; lazy pointer: 124 bytes
- full 5 GiB hydrate: 16.99 s
- source and clone SHA-256 matched: `961f65b7f86f90b67fb87105bd6edada1f496c9a8cec064d9089f691e618e512`
- source and clone passed both Git fsck and Crab fsck

Peak RSS increased from about 371 MiB to 510 MiB. It remains bounded by the 64 MiB L0 target plus the existing push working sets; reducing the independent source-map/cache working sets is a separate follow-up opportunity.

## Multi-file version-history result

An additional high-entropy RustFS run used four files sized 128 MiB, 1 GiB, 5 GiB, and 10 GiB. Every file received twelve distinct 4 MiB mutations, producing thirteen unique hashes per file across thirteen commits.

- 16.125 GiB active working set and 192 MiB of explicit changed bytes
- base push: 121.57 s
- twelve incremental pushes: 10.96–19.58 s, median 16.19 s
- lazy clone: 0.66 s; current cold hydrate: 65.39 s
- all 52 historical file versions checked out, hydrated, SHA-256 verified, and dehydrated from a cleared cache
- 209.625 GiB of historical bytes reconstructed with clean Git status after every version
- 10 GiB historical hydration: 32.55–35.33 s
- 5 GiB historical hydration: 16.46–19.00 s
- all four files had thirteen distinct hashes and twelve distinct mutation offsets
- source and clone passed Git fsck and Crab fsck; RustFS logged no errors, panics, corruption, or timeouts

The run found no historical-version correctness defect. It did expose the next scaling ceiling: `crab add` rescans the complete 16.125 GiB set in 43.75–73.02 s, and incremental candidate publication alternates between roughly 4–12.5 s as metadata compaction occurs. Peak push RSS reached about 2.0 GiB at this larger 250k-plus-chunk working set.

## Verification

- `cargo test -p crab-metadata --features remote-index --locked` — 277 passed, 1 ignored
- `cargo test -p crab-auth-server --lib --locked` — 79 passed
- `cargo test -p crab --lib --locked` — 3,845 passed, 2 ignored
- focused MetaDb config and pre-ref failure tests passed
- strict clippy passed for `crab-metadata` and `crab-auth-server`
- release `make install` passed using an external Cargo target directory
- `npm run build` passed
- `npm run check:links` — 398 pages and 4,292 fragments
- `cargo fmt --all -- --check` and `git diff --check` passed
- production-scale qualification contract suite — 57 tests passed

## Remaining opportunities

- reduce peak push RSS by streaming or partitioning the chunk-source map and separating file/chunk writer lifetimes
- add object-store fault injection around the final close barrier to extend existing pre-ref abort proof
- profile the remaining 1.36 s publication phase before changing its correctness boundary further
