### PR TITLE
fix(vfs): harden macOS NFS mount lifecycle

### DIFF
--- a/crab/scripts/run-daemon-nfs-macos-smoke.sh
+++ b/crab/scripts/run-daemon-nfs-macos-smoke.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CRAB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-REPO_ROOT="$(cd "$CRAB_DIR/.." && pwd)"
 RUN_ID="${CRAB_DAEMON_NFS_SMOKE_RUN_ID:-daemon-nfs-macos-$(date -u +%Y%m%d-%H%M%S)}"
 RUN_ROOT="${CRAB_DAEMON_NFS_SMOKE_ROOT:-/tmp/crab-daemon-nfs-macos-smoke}/$RUN_ID"
 HOME_DIR="$RUN_ROOT/home"
@@ -13,7 +12,7 @@ MOUNT_ROOT="$RUN_ROOT/mounts"
 SOURCE="$RUN_ROOT/source"
 REMOTE="$RUN_ROOT/remote.git"
 LOG_DIR="$RUN_ROOT/logs"
-CRAB_EXE="$REPO_ROOT/target/debug/crab"
+CRAB_EXE="${CRAB_DAEMON_NFS_SMOKE_CRAB_EXE:-}"
 DAEMON_PID=""
 HOST_HOME="${HOME:-}"
 HOST_CARGO_HOME="${CARGO_HOME:-${HOST_HOME:+$HOST_HOME/.cargo}}"
@@ -84,7 +83,17 @@ cleanup() {
 [ "$(uname -s)" = Darwin ] || die "this smoke test requires macOS"
 command -v cargo >/dev/null 2>&1 || die "cargo is required"
 command -v git >/dev/null 2>&1 || die "git is required"
+command -v python3 >/dev/null 2>&1 || die "python3 is required"
 command -v mount_nfs >/dev/null 2>&1 || die "mount_nfs is required"
+
+if [ -z "$CRAB_EXE" ]; then
+    TARGET_DIR="$(
+        cd "$CRAB_DIR"
+        cargo metadata --format-version=1 --no-deps \
+            | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
+    )"
+    CRAB_EXE="$TARGET_DIR/debug/crab"
+fi
 
 mkdir -p "$HOME_DIR" "$DAEMON_ROOT" "$MOUNT_ROOT" "$SOURCE" "$LOG_DIR"
 RUN_ROOT="$(cd "$RUN_ROOT" && pwd -P)"
@@ -107,7 +116,13 @@ fi
 git config --global user.email daemon-nfs-smoke@crab.local
 git config --global user.name 'Crab Daemon NFS Smoke'
 
-cargo build -p crab --bin crab >"$LOG_DIR/cargo-build.log" 2>&1
+if [ "${CRAB_DAEMON_NFS_SMOKE_SKIP_BUILD:-0}" != 1 ]; then
+    (
+        cd "$CRAB_DIR"
+        cargo build -p crab --bin crab
+    ) >"$LOG_DIR/cargo-build.log" 2>&1
+fi
+[ -x "$CRAB_EXE" ] || die "crab binary is not executable: $CRAB_EXE"
 
 git -C "$SOURCE" init -b main >"$LOG_DIR/git-init.log" 2>&1
 git -C "$SOURCE" config user.email daemon-nfs-smoke@crab.local

--- a/crab/scripts/run-mount-large-macos-rustfs-smoke.sh
+++ b/crab/scripts/run-mount-large-macos-rustfs-smoke.sh
@@ -22,6 +22,8 @@ NEW_MIB="${CRAB_MOUNT_MACOS_NEW_MIB:-40}"
 CONCURRENT_WRITERS="${CRAB_MOUNT_MACOS_CONCURRENT_WRITERS:-4}"
 CONCURRENT_MIB="${CRAB_MOUNT_MACOS_CONCURRENT_MIB:-16}"
 DIRECTORY_ENTRIES="${CRAB_MOUNT_MACOS_DIRECTORY_ENTRIES:-0}"
+FS_OPERATION_TIMEOUT_SECS="${CRAB_MOUNT_MACOS_FS_OPERATION_TIMEOUT_SECS:-120}"
+CLEANUP_TIMEOUT_SECS="${CRAB_MOUNT_MACOS_CLEANUP_TIMEOUT_SECS:-10}"
 RUSTFS_IMAGE="${CRAB_MOUNT_MACOS_RUSTFS_IMAGE:-rustfs/rustfs:1.0.0-beta.8-glibc}"
 BUCKET="${CRAB_MOUNT_MACOS_BUCKET:-crab}"
 REGION="${AWS_REGION:-us-east-1}"
@@ -58,15 +60,34 @@ with_cache_env() {
         "$@"
 }
 
+run_with_timeout() {
+    local timeout_secs="$1"
+    shift
+    python3 -c '
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(sys.argv[2:], timeout=int(sys.argv[1]))
+except subprocess.TimeoutExpired:
+    print(f"command timed out after {sys.argv[1]}s: {sys.argv[2]}", file=sys.stderr)
+    raise SystemExit(124)
+raise SystemExit(result.returncode)
+' "$timeout_secs" "$@"
+}
+
 cleanup_mount() {
     local mountpoint="$1"
     [[ -d "$mountpoint" ]] || return 0
     if [[ -x "$BIN_DIR/crab" ]]; then
-        with_test_env "$BIN_DIR/crab" unmount --mountpoint "$mountpoint" \
+        with_test_env run_with_timeout "$CLEANUP_TIMEOUT_SECS" \
+            "$BIN_DIR/crab" unmount --mountpoint "$mountpoint" \
             >"$RUN_ROOT/logs/cleanup-$(basename "$mountpoint").log" 2>&1 || true
     fi
-    diskutil unmount force "$mountpoint" >/dev/null 2>&1 || true
-    umount -f "$mountpoint" >/dev/null 2>&1 || true
+    run_with_timeout "$CLEANUP_TIMEOUT_SECS" diskutil unmount force "$mountpoint" \
+        >/dev/null 2>&1 || true
+    run_with_timeout "$CLEANUP_TIMEOUT_SECS" umount -f "$mountpoint" \
+        >/dev/null 2>&1 || true
 }
 
 cleanup() {
@@ -80,7 +101,7 @@ cleanup() {
 trap cleanup EXIT
 
 hash_file() {
-    shasum -a 256 "$1" | awk '{print $1}'
+    run_with_timeout "$FS_OPERATION_TIMEOUT_SECS" shasum -a 256 "$1" | awk '{print $1}'
 }
 
 wait_for_path() {
@@ -90,6 +111,19 @@ wait_for_path() {
         sleep 1
     done
     return 1
+}
+
+capture_nfs_diagnostics() {
+    local label="$1"
+    local mountpoint="$2"
+    [[ "$BACKEND" == "nfs" ]] || return 0
+    mount >"$RUN_ROOT/logs/$label-mounts.txt" 2>&1 || true
+    nfsstat -m >"$RUN_ROOT/logs/$label-nfsstat-mounts.txt" 2>&1 || true
+    nfsstat -c >"$RUN_ROOT/logs/$label-nfsstat-client.txt" 2>&1 || true
+    with_test_env run_with_timeout "$CLEANUP_TIMEOUT_SECS" \
+        "$BIN_DIR/crab" mount status --mountpoint "$mountpoint" --json --verbose \
+        >"$RUN_ROOT/logs/$label-mount-status.json" \
+        2>"$RUN_ROOT/logs/$label-mount-status.err" || true
 }
 
 now_ms() {
@@ -148,6 +182,8 @@ ensure_macfuse_ready() {
 [[ "$CONCURRENT_WRITERS" =~ ^[0-9]+$ ]] || die "CRAB_MOUNT_MACOS_CONCURRENT_WRITERS must be an integer"
 [[ "$CONCURRENT_MIB" =~ ^[0-9]+$ ]] || die "CRAB_MOUNT_MACOS_CONCURRENT_MIB must be an integer"
 [[ "$DIRECTORY_ENTRIES" =~ ^[0-9]+$ ]] || die "CRAB_MOUNT_MACOS_DIRECTORY_ENTRIES must be an integer"
+[[ "$FS_OPERATION_TIMEOUT_SECS" =~ ^[1-9][0-9]*$ ]] || die "CRAB_MOUNT_MACOS_FS_OPERATION_TIMEOUT_SECS must be a positive integer"
+[[ "$CLEANUP_TIMEOUT_SECS" =~ ^[1-9][0-9]*$ ]] || die "CRAB_MOUNT_MACOS_CLEANUP_TIMEOUT_SECS must be a positive integer"
 ((SEED_MIB >= 32)) || die "CRAB_MOUNT_MACOS_SEED_MIB must be at least 32"
 ((NEW_MIB >= 8)) || die "CRAB_MOUNT_MACOS_NEW_MIB must be at least 8"
 ((CONCURRENT_WRITERS >= 2)) || die "CRAB_MOUNT_MACOS_CONCURRENT_WRITERS must be at least 2"
@@ -180,9 +216,7 @@ if [[ "${CRAB_MOUNT_MACOS_SKIP_INSTALL:-0}" != "1" ]]; then
         CARGO_PROFILE_RELEASE_LTO=false \
             CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
             CARGO_PROFILE_RELEASE_DEBUG=0 \
-            PREFIX="$BIN_DIR" \
-            CARGO_BIN="$BIN_DIR" \
-            make install
+            make PREFIX="$BIN_DIR" CARGO_BIN="$BIN_DIR" install
     ) >"$RUN_ROOT/logs/make-install.log" 2>&1
 fi
 
@@ -369,7 +403,12 @@ with_test_env "$BIN_DIR/crab" mount --repo "$REMOTE_URL" --mountpoint "$RO" --re
 wait_for_path "$RO/models/model.bin"
 record_duration_since ro_mount_ready_ms "$phase_start_ms"
 phase_start_ms="$(now_ms)"
-hash_file "$RO/models/model.bin" > "$RUN_ROOT/ro-model.sha256"
+capture_nfs_diagnostics ro-before-read "$RO"
+if ! hash_file "$RO/models/model.bin" > "$RUN_ROOT/ro-model.sha256"; then
+    capture_nfs_diagnostics ro-read-timeout "$RO"
+    die "mounted file hash did not complete within ${FS_OPERATION_TIMEOUT_SECS}s"
+fi
+capture_nfs_diagnostics ro-after-read "$RO"
 cmp "$RUN_ROOT/seed-model.sha256" "$RUN_ROOT/ro-model.sha256"
 
 if ((DIRECTORY_ENTRIES > 0)); then
@@ -386,11 +425,19 @@ if len(names) != expected:
     raise SystemExit(f"expected {expected} directory entries, found {len(names)}")
 if names[0] != "file-00000.txt" or names[-1] != f"file-{expected - 1:05}.txt":
     raise SystemExit(f"directory bounds mismatch: {names[0]} {names[-1]}")
-if (directory / names[0]).read_text() != "entry 0\n":
-    raise SystemExit("first directory entry content mismatch")
-if (directory / names[-1]).read_text() != f"entry {expected - 1}\n":
-    raise SystemExit("last directory entry content mismatch")
-pathlib.Path(sys.argv[3]).write_text(json.dumps({"count": len(names), "first": names[0], "last": names[-1]}, indent=2) + "\n")
+sample_indices = sorted(set(range(min(40, expected))) | {expected // 2, expected - 1})
+for index in sample_indices:
+    path = directory / names[index]
+    if not path.is_file():
+        raise SystemExit(f"directory entry is not a regular file: {names[index]}")
+    if path.read_text() != f"entry {index}\n":
+        raise SystemExit(f"directory entry content mismatch: {names[index]}")
+pathlib.Path(sys.argv[3]).write_text(json.dumps({
+    "count": len(names),
+    "first": names[0],
+    "last": names[-1],
+    "metadata_samples": len(sample_indices),
+}, indent=2) + "\n")
 PY
 fi
 

--- a/crab/src/cmd/mount.rs
+++ b/crab/src/cmd/mount.rs
@@ -2429,29 +2429,10 @@ pub fn run_unmount(path: &Path) -> Result<()> {
     });
 
     if let Some(entry) = entry {
-        let pid = entry.pid;
-
-        if is_pid_alive(pid) {
-            // Process is running — send SIGTERM and wait.
-            info!(pid, mountpoint = %mountpoint.display(), "sending SIGTERM to mount process");
-            terminate_and_force_unmount(pid, &mountpoint)?;
-        } else {
-            // Stale entry — PID is not running. Clean up.
-            info!(pid, mountpoint = %mountpoint.display(), "stale mount entry detected (PID not running)");
-            force_unmount_cli(&mountpoint).ok();
-            println!("Cleaned up stale mount at {}.", mountpoint.display());
-        }
-
-        // Remove the entry from the registry.
-        if let Some(ref rp) = registry_path
-            && let Err(e) = crate::vfs::mounts_registry::remove_entry(rp, &mountpoint_str)
-        {
-            warn!(error = %e, "failed to remove entry from mounts registry");
-        }
-
-        // Also clean up the legacy PID file if present.
-        let crab_dir = find_crab_dir(&mountpoint);
-        clean_pid_file(&crab_dir);
+        let registry_path = registry_path.as_deref().ok_or_else(|| {
+            CrabError::Internal("mount registry path disappeared during unmount".into())
+        })?;
+        unmount_registry_entry(registry_path, &entry)?;
     } else {
         // Not found in registry — fall back to legacy PID file or direct force-unmount.
         let crab_dir = find_crab_dir(&mountpoint);
@@ -2464,6 +2445,7 @@ pub fn run_unmount(path: &Path) -> Result<()> {
         } else {
             warn!(mountpoint = %mountpoint.display(), "no registry entry or PID file found, attempting force-unmount");
             force_unmount_cli(&mountpoint)?;
+            ensure_nfs_unmounted(&mountpoint)?;
         }
     }
 
@@ -2493,9 +2475,8 @@ pub async fn try_mount_control_unmount(path: &Path) -> Result<bool> {
                 };
                 let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
                 while tokio::time::Instant::now() < deadline {
-                    if !is_pid_alive(pid)
-                        || !crate::vfs::nfs_mount::is_mounted(&shutdown.mountpoint)
-                    {
+                    let mounted = crate::vfs::nfs_mount::is_mounted(&shutdown.mountpoint);
+                    if nfs_shutdown_complete(is_pid_alive(pid), mounted, &shutdown.mountpoint)? {
                         crate::vfs::mounts_registry::remove_entry(
                             &registry_path,
                             &shutdown.mountpoint_str,
@@ -2524,6 +2505,20 @@ pub async fn try_mount_control_unmount(path: &Path) -> Result<bool> {
             Ok(true)
         }
     }
+}
+
+#[cfg(feature = "nfs")]
+fn nfs_shutdown_complete(pid_alive: bool, mounted: bool, mountpoint: &Path) -> Result<bool> {
+    if !mounted {
+        return Ok(true);
+    }
+    if !pid_alive {
+        return Err(CrabError::Internal(format!(
+            "NFS helper exited but {} remains mounted",
+            mountpoint.display()
+        )));
+    }
+    Ok(false)
 }
 
 #[cfg(any(feature = "fuse", feature = "nfs"))]
@@ -2625,13 +2620,30 @@ fn unmount_registry_entry(
         terminate_and_force_unmount(pid, mountpoint)?;
     } else {
         info!(pid, mountpoint = %entry.mountpoint, "stale mount entry (PID not running)");
-        force_unmount_cli(mountpoint).ok();
+        unmount_stale_registry_mount(entry, mountpoint)?;
         println!("Cleaned up stale mount at {}.", entry.mountpoint);
     }
 
     clean_pid_file(&find_crab_dir(mountpoint));
     crate::vfs::mounts_registry::remove_entry(registry_path, &entry.mountpoint)?;
     Ok(true)
+}
+
+fn unmount_stale_registry_mount(
+    entry: &crate::vfs::mounts_registry::MountEntry,
+    mountpoint: &Path,
+) -> Result<()> {
+    #[cfg(feature = "nfs")]
+    if entry.backend.as_deref() == Some("nfs") {
+        return force_nfs_unmount_if_mounted(mountpoint);
+    }
+    #[cfg(not(feature = "nfs"))]
+    let _ = entry;
+
+    // FUSE registry entries can outlive a session after its kernel mount is
+    // already gone, so retain their best-effort stale cleanup behavior.
+    force_unmount_cli(mountpoint).ok();
+    Ok(())
 }
 
 #[cfg(any(feature = "fuse", feature = "nfs"))]
@@ -2701,7 +2713,7 @@ fn terminate_and_force_unmount(pid: u32, mountpoint: &Path) -> Result<()> {
         // ESRCH means process doesn't exist — already dead.
         if err.raw_os_error() == Some(libc::ESRCH) {
             info!(pid, "process already exited");
-            return Ok(());
+            return force_nfs_unmount_if_mounted(mountpoint);
         }
         return Err(CrabError::Io(err));
     }
@@ -2712,8 +2724,9 @@ fn terminate_and_force_unmount(pid: u32, mountpoint: &Path) -> Result<()> {
         // SAFETY: kill(pid, 0) checks if process exists without sending a signal.
         let alive = unsafe { libc::kill(pid as i32, 0) };
         if alive != 0 {
-            // Process exited cleanly.
-            return Ok(());
+            // The helper can exit after a failed native unmount. Verify the
+            // kernel mount before removing its registry entry.
+            return force_nfs_unmount_if_mounted(mountpoint);
         }
         std::thread::sleep(Duration::from_millis(100));
     }
@@ -2723,7 +2736,8 @@ fn terminate_and_force_unmount(pid: u32, mountpoint: &Path) -> Result<()> {
         pid,
         "process did not exit within 10s after SIGTERM, force-unmounting"
     );
-    force_unmount_cli(mountpoint)
+    force_unmount_cli(mountpoint)?;
+    ensure_nfs_unmounted(mountpoint)
 }
 
 #[cfg(not(unix))]
@@ -2731,6 +2745,7 @@ fn terminate_and_force_unmount(pid: u32, mountpoint: &Path) -> Result<()> {
     #[cfg(windows)]
     {
         force_unmount_cli(mountpoint)?;
+        ensure_nfs_unmounted(mountpoint)?;
         if wait_for_pid_exit(pid, std::time::Duration::from_secs(10)) {
             return Ok(());
         }
@@ -2823,6 +2838,30 @@ fn force_unmount_cli(mountpoint: &Path) -> Result<()> {
             "force-unmount not supported on this platform".into(),
         ))
     }
+}
+
+fn force_nfs_unmount_if_mounted(mountpoint: &Path) -> Result<()> {
+    #[cfg(feature = "nfs")]
+    if crate::vfs::nfs_mount::is_mounted(mountpoint) {
+        force_unmount_cli(mountpoint)?;
+        ensure_nfs_unmounted(mountpoint)?;
+    }
+    #[cfg(not(feature = "nfs"))]
+    let _ = mountpoint;
+    Ok(())
+}
+
+fn ensure_nfs_unmounted(mountpoint: &Path) -> Result<()> {
+    #[cfg(feature = "nfs")]
+    if crate::vfs::nfs_mount::is_mounted(mountpoint) {
+        return Err(CrabError::Internal(format!(
+            "force-unmount command completed but {} remains mounted",
+            mountpoint.display()
+        )));
+    }
+    #[cfg(not(feature = "nfs"))]
+    let _ = mountpoint;
+    Ok(())
 }
 
 #[cfg(windows)]
@@ -6373,6 +6412,16 @@ mod unmount_tests {
     fn is_pid_alive_returns_true_for_current_process() {
         let my_pid = std::process::id();
         assert!(is_pid_alive(my_pid));
+    }
+
+    #[test]
+    #[cfg(feature = "nfs")]
+    fn nfs_shutdown_requires_kernel_mount_to_disappear() {
+        let mountpoint = Path::new("/mnt/crab");
+
+        assert!(nfs_shutdown_complete(true, false, mountpoint).unwrap());
+        assert!(!nfs_shutdown_complete(true, true, mountpoint).unwrap());
+        assert!(nfs_shutdown_complete(false, true, mountpoint).is_err());
     }
 
     #[test]

--- a/crates/crab-vfs/src/engine.rs
+++ b/crates/crab-vfs/src/engine.rs
@@ -191,7 +191,11 @@ impl OdbReader {
             ))
         };
         let odb = gix_odb::at(&objects_dir).map_err(&open_odb_error)?;
-        let odb = odb.into_arc().map_err(open_odb_error)?;
+        let mut odb = odb.into_arc().map_err(open_odb_error)?;
+        // Partial-clone reads fetch missing blobs into new packs. The gix slot
+        // map is fixed at open, so use the git fallback instead of refreshing
+        // until an unbounded sequence of promisor packs exhausts that map.
+        odb.refresh_never();
 
         std::fs::create_dir_all(blob_cache_dir)?;
 
@@ -3607,10 +3611,14 @@ mod tests {
             .unwrap();
         assert!(output.status.success(), "git init failed");
 
-        // git hash-object -w --stdin
+        let oid_hex = write_git_blob(&git_dir, content);
+        (dir, git_dir, oid_hex)
+    }
+
+    fn write_git_blob(git_dir: &Path, content: &[u8]) -> String {
         let output = std::process::Command::new("git")
             .args(["hash-object", "-w", "--stdin"])
-            .env("GIT_DIR", &git_dir)
+            .env("GIT_DIR", git_dir)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .spawn()
@@ -3621,9 +3629,7 @@ mod tests {
             })
             .unwrap();
         assert!(output.status.success(), "git hash-object failed");
-
-        let oid_hex = String::from_utf8(output.stdout).unwrap().trim().to_owned();
-        (dir, git_dir, oid_hex)
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
     }
 
     #[test]
@@ -3672,6 +3678,46 @@ mod tests {
         let second = reader.read_blob(&oid_hex).unwrap();
         assert_eq!(&second[..], content);
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn odb_reader_promisor_fallback_ignores_new_pack_slot_pressure() {
+        let (_dir, git_dir, initial_oid) = create_git_repo_with_blob(b"initial");
+        let cache_dir = _dir.path().join("blob_cache");
+        let reader = OdbReader::new(&git_dir, &cache_dir).unwrap();
+
+        assert_eq!(&reader.read_blob(&initial_oid).unwrap()[..], b"initial");
+
+        let pack_prefix = git_dir.join("objects/pack/pack");
+        let mut last = None;
+        for index in 0..33 {
+            let content = format!("promisor blob {index}");
+            let oid = write_git_blob(&git_dir, content.as_bytes());
+            let mut child = std::process::Command::new("git")
+                .arg("pack-objects")
+                .arg(&pack_prefix)
+                .env("GIT_DIR", &git_dir)
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::null())
+                .spawn()
+                .unwrap();
+            use std::io::Write;
+            writeln!(child.stdin.take().unwrap(), "{oid}").unwrap();
+            assert!(child.wait().unwrap().success(), "git pack-objects failed");
+            last = Some((oid, content));
+        }
+        assert!(
+            std::process::Command::new("git")
+                .arg("prune-packed")
+                .env("GIT_DIR", &git_dir)
+                .status()
+                .unwrap()
+                .success(),
+            "git prune-packed failed"
+        );
+
+        let (oid, content) = last.unwrap();
+        assert_eq!(&reader.read_blob(&oid).unwrap()[..], content.as_bytes());
     }
 
     #[test]

--- a/crates/crab-vfs/src/nfs.rs
+++ b/crates/crab-vfs/src/nfs.rs
@@ -3145,6 +3145,55 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn nfs_getattr_reports_pointer_size_without_hydration() {
+        let pointer = crab_types::pointer::Pointer {
+            file_hash: [9; 32],
+            size: 32 * 1024 * 1024,
+            shard_hint: Some([4; 32]),
+        };
+        let fixture = nfs_read_fixture(vec![
+            base_dir("models"),
+            BaseNode {
+                path: "models/model.bin".to_owned(),
+                node_type: NodeType::File,
+                mode: 0o100644,
+                object_oid: Some("pointer-blob-oid".to_owned()),
+                pointer: Some(pointer.clone()),
+                size: pointer.size,
+            },
+        ]);
+        let root = FileHandleU64::new(ROOT_ID);
+        let models = <CrabNfsFs as NfsReadFileSystem>::lookup(
+            &fixture.fs,
+            &root,
+            &filename3::from(b"models".as_slice()),
+        )
+        .await
+        .unwrap();
+        let model = <CrabNfsFs as NfsReadFileSystem>::lookup(
+            &fixture.fs,
+            &models,
+            &filename3::from(b"model.bin".as_slice()),
+        )
+        .await
+        .unwrap();
+
+        let attr = <CrabNfsFs as NfsReadFileSystem>::getattr(&fixture.fs, &model)
+            .await
+            .unwrap();
+
+        assert_eq!(attr.size, pointer.size);
+        assert_eq!(
+            fixture
+                .engine
+                .hydration_read_stats_snapshot()
+                .read_range_requests,
+            0
+        );
+        assert_eq!(fixture.fs.protocol_stats.snapshot().read_rpcs, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn nfs_readdirplus_reports_synthetic_gitfile_without_prefetch() {
         let fixture = nfs_read_fixture(Vec::new());
         let root = FileHandleU64::new(ROOT_ID);

--- a/crates/crab-vfs/src/nfs_mount.rs
+++ b/crates/crab-vfs/src/nfs_mount.rs
@@ -315,18 +315,20 @@ pub async fn run_until_cancelled(
     if let Some(handle) = control_handle {
         handle.abort();
     }
-    // Flush overlay state while the server is still available. macOS needs a
-    // forced unmount because its client sends a Mount v1 teardown RPC that
-    // this NFSv3 server does not implement.
+    // Flush overlay state and unmount while the local NFS server can still
+    // answer the kernel client. Forced macOS unmounts require root even when
+    // the user owns the mount, so they are reserved for stale CLI cleanup.
     let write_journal_drain_start = Instant::now();
     let write_journal_drain_result = session.write_journal.sync_all(&session.engine);
     let write_journal_drain_ms = duration_millis(write_journal_drain_start.elapsed());
     let native_unmount_start = Instant::now();
     let mut native_unmount_attempted = false;
-    if is_mounted(&session.mountpoint) {
+    let native_unmount_result = if is_mounted(&session.mountpoint) {
         native_unmount_attempted = true;
-        unmount_native_nfs(&session.mountpoint);
-    }
+        unmount_native_nfs(&session.mountpoint)
+    } else {
+        Ok(())
+    };
     let native_unmount_ms = duration_millis(native_unmount_start.elapsed());
     session.server_handle.abort();
     let stats = session.runtime_snapshot();
@@ -368,18 +370,18 @@ pub async fn run_until_cancelled(
         hydration_read_window_misses = stats.hydration.read_window_cache_misses,
         "draining NFS mount runtime state"
     );
-    let shutdown_ms = duration_millis(shutdown_start.elapsed());
+    write_journal_drain_result?;
+    native_unmount_result?;
+    if let Some(error) = server_error {
+        return Err(error);
+    }
     info!(
-        nfs_shutdown_ms = shutdown_ms,
+        nfs_shutdown_ms = duration_millis(shutdown_start.elapsed()),
         nfs_native_unmount_attempted = native_unmount_attempted,
         nfs_native_unmount_ms = native_unmount_ms,
         nfs_write_journal_drain_ms = write_journal_drain_ms,
         "NFS mount shutdown complete"
     );
-    write_journal_drain_result?;
-    if let Some(error) = server_error {
-        return Err(error);
-    }
     Ok(())
 }
 
@@ -845,45 +847,53 @@ fn running_as_root() -> bool {
     unsafe { libc::getuid() == 0 }
 }
 
-fn unmount_native_nfs(mountpoint: &Path) {
+fn unmount_native_nfs(mountpoint: &Path) -> Result<()> {
     #[cfg(target_os = "linux")]
-    {
-        let status = if running_as_root() {
-            Command::new("umount").arg(mountpoint).status()
+    let output = {
+        if running_as_root() {
+            Command::new("umount").arg(mountpoint).output()
         } else {
             Command::new("sudo")
                 .args(["-n", "umount"])
                 .arg(mountpoint)
-                .status()
-        };
-        if let Err(error) = status {
-            warn!(mountpoint = %mountpoint.display(), error = %error, "NFS unmount command failed");
+                .output()
         }
-    }
+    };
 
     #[cfg(target_os = "macos")]
-    {
-        if let Err(error) = Command::new("umount").arg("-f").arg(mountpoint).status() {
-            warn!(mountpoint = %mountpoint.display(), error = %error, "NFS unmount command failed");
-        }
-    }
+    let output = Command::new("umount").arg(mountpoint).output();
 
     #[cfg(windows)]
+    let output = {
+        let target = windows_mount_target(mountpoint)?;
+        let umount_exe = windows_system_command("umount.exe")?;
+        Command::new(umount_exe).arg(target).output()
+    };
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    return Err(CrabError::Internal(
+        "NFS unmount is not supported on this platform".into(),
+    ));
+
+    #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     {
-        let Ok(target) = windows_mount_target(mountpoint) else {
-            warn!(mountpoint = %mountpoint.display(), "invalid Windows NFS mount target");
-            return;
-        };
-        let umount_exe = match windows_system_command("umount.exe") {
-            Ok(command) => command,
-            Err(error) => {
-                warn!(mountpoint = %target, error = %error, "NFS unmount command unavailable");
-                return;
-            }
-        };
-        if let Err(error) = Command::new(umount_exe).arg(&target).status() {
-            warn!(mountpoint = %target, error = %error, "NFS unmount command failed");
+        let output = output.map_err(CrabError::Io)?;
+        if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(CrabError::Internal(format!(
+                "NFS unmount failed for {} with {}: stdout={stdout} stderr={stderr}",
+                mountpoint.display(),
+                output.status
+            )));
         }
+        if is_mounted(mountpoint) {
+            return Err(CrabError::Internal(format!(
+                "NFS unmount command succeeded but {} remains mounted",
+                mountpoint.display()
+            )));
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

- Make macOS NFS shutdown use the normal unmount path, propagate teardown failures, and retain registry state until the kernel mount is actually gone.
- Keep the gix object database stable while partial-clone fallback fetches add pack indexes, with regression coverage beyond the prior 32-pack slot limit.
- Strengthen the macOS daemon and large-mount smoke harnesses with bounded cleanup, diagnostics, external build artifacts, and broader large-directory sampling.

## Why this fix

The lifecycle policy now lives at the NFS mount and CLI ownership boundaries: NFS shutdown is strict because helper exit can leave a stale kernel mount, while the existing FUSE best-effort contract stays unchanged. The object database follows the documented gix sparse-object contract with `refresh_never`; Git remains responsible for fetching missing promisor blobs, and the disk blob cache serves subsequent reads. This keeps one canonical fetch path instead of adding pack-limit retries or mount-specific workarounds.

## Verification

- `cargo fmt --all -- --check`
- `bash -n` on both changed smoke scripts
- `cargo test -p crab-vfs --no-default-features --features nfs` — 460 passed
- `cargo test -p crab --lib --no-default-features --features nfs unmount_tests` — 14 passed
- Live macOS NFS + RustFS smoke: 10,000-entry repository, 42 metadata/content samples, read-only and read-write flows, 32 MiB Xet restoration, new/sparse/concurrent large-file I/O, range reads, mutations, commit/push/clone, dehydrate, and cold hydrate
- Live multi-workspace smoke: two simultaneous 10,000-entry NFS mounts with concurrent enumeration/hash, Git discovery, overlay isolation/reset, normal unmount, and empty registry afterward
- Live daemon NFS smoke across two repositories, followed by clean helper/daemon teardown