### PR TITLE
fix(web): announce open-source launch

### DIFF
--- a/packages/web/app/landing-page-client.tsx
+++ b/packages/web/app/landing-page-client.tsx
@@ -124,10 +124,13 @@ export function LandingPageClient() {
           />
           <div className="relative z-1 mx-auto max-w-[920px]">
             <Reveal>
-              <span className="mb-5 inline-flex items-center gap-[7px] rounded-full border border-primary/20 bg-primary-muted px-3.5 py-1 text-xs font-semibold text-primary">
+              <Link
+                href="/blog/git-for-large-files-at-any-scale"
+                className="mb-5 inline-flex items-center gap-[7px] rounded-full border border-primary/20 bg-primary-muted px-3.5 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary-muted/70"
+              >
                 <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary" />
-                Now in Private Beta
-              </span>
+                Now Open Source
+              </Link>
             </Reveal>
             <Reveal>
               <h1 className="mb-4 text-[clamp(32px,5vw,54px)] font-extrabold leading-[1.1] tracking-tight text-foreground">

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -179,7 +179,11 @@ export default function LandingPage() {
     <MarketingLayout>
       {/* ── Hero: Enhanced with floating particles + shimmer headline ── */}
       <HeroSection
-        badge={{ text: "Now in Private Beta", dot: true }}
+        badge={{
+          text: "Now Open Source",
+          href: "/blog/git-for-large-files-at-any-scale",
+          dot: true,
+        }}
         headline="Git for any file at any scale"
         subheadline={
           <>

--- a/packages/web/components/marketing/hero-section.tsx
+++ b/packages/web/components/marketing/hero-section.tsx
@@ -14,7 +14,7 @@ export type HeroAnimatedBackground = "grid" | "gradient-mesh" | "particles" | "n
 export type HeroHeadlineEffect = "gradient" | "typing" | "shimmer" | "none"
 
 export interface HeroSectionProps {
-  badge?: { text: string; dot?: boolean }
+  badge?: { text: string; href?: string; dot?: boolean }
   headline: React.ReactNode
   subheadline: React.ReactNode
   primaryCTA?: { label: string; href: string; icon?: LucideIcon }
@@ -158,7 +158,10 @@ export function HeroSection({
         {badge && (
           <Reveal>
             <div className="mb-6 inline-flex">
-              <Badge variant="secondary">
+              <Badge
+                variant="secondary"
+                render={badge.href ? <Link href={badge.href} /> : undefined}
+              >
                 {badge.dot && (
                   <span
                     aria-hidden="true"


### PR DESCRIPTION
## Summary

- replace the stale private-beta homepage badge with “Now Open Source”
- link the announcement to the Git for Large Files at Any Scale launch article
- add optional link support to the shared hero badge and keep the alternate landing surface consistent

## Verification

- `npm run test`
- `npm run typecheck`
- targeted ESLint checks
- `npm run build`
- `npm run check:links`
- live homepage badge and destination navigation check