### PR TITLE
docs(agent): refresh embedded Crab skills

### DIFF
--- a/crab/skills/crab-cli-core/SKILL.md
+++ b/crab/skills/crab-cli-core/SKILL.md
@@ -10,15 +10,17 @@ stable machine output, and evidence for every externally visible claim.
 
 ## Route by command family
 
-- Repository setup: `init`, `setup`, `clone`, `mirror`, `worktree`, `config`,
-  `track`, `untrack`, `install`, `uninstall`, and `completions`.
+- Repository setup: `configure`, `init`, `setup`, `clone`, `mirror`,
+  `worktree`, `config`, `track`, `untrack`, `install`, `uninstall`, and
+  `completions`.
 - Native large files: `add`, `reset`, `status`, `why`, `hydrate`, `dehydrate`,
   `diff`, `ls-files`, `fetch`, `prune`, `du`, `stat`, `cache`, `staging`,
   `adopt`, `unadopt`, `undo`, `migrate`, and selective `download`.
 - Git synchronization: `push`, `pull`, `ship`, `import`, `export`, locks, and
   the `crab://` remote helper.
 - Workflows: `run`, `repro`, `stage`, `freeze`, `unfreeze`, `exp`, `queue`,
-  `workflow`, `params`, `metrics`, `plots`, and workflow cache operations.
+  `workflow`, `data`, `artifacts`, `params`, `metrics`, `plots`, and workflow
+  cache operations.
 - LFS compatibility: `lfs`, the transfer agent, and `optimize lfs`.
 - Storage operations: `gc`, `fsck`, `compact`, `repack`, `optimize`, `metadb`,
   cache/staging maintenance, and storage-focused `du` or `stat`.
@@ -27,7 +29,7 @@ stable machine output, and evidence for every externally visible claim.
 - Mounts: `mount`, `unmount`, `daemon`, and virtual filesystem coordination.
 - Managed operations: authentication, organizations, repositories, members,
   service accounts, audit, and release manifests.
-- Recovery: `doctor`, `env`, `errors`, `logs`, `version`, `update`, and
+- Recovery: `doctor`, `env`, `errors`, `logs`, `version`, `upgrade`, and
   `recover`.
 - Skill management: `skills list` and `skills install`.
 
@@ -39,9 +41,10 @@ moving policy to the correct command.
 
 1. Parse command arguments before opening repositories, credentials, or remote
    clients.
-2. Resolve output mode once. `--json` is one envelope on stdout; human text
-   belongs on stdout or stderr according to the command contract, and logs do
-   not contaminate machine output.
+2. Resolve output mode once. `--json` is one terminal envelope; `--jsonl`,
+   where supported, is an event stream ending in a result. Machine output owns
+   stdout, progress and logs use stderr, and Git-invoked protocols keep stdout
+   reserved for their wire contract.
 3. Preserve typed errors and their source chain. Use stable error codes when a
    failure is user-visible; never stringify an error and discard its cause.
 4. Keep cancellation safe. Release locks, close metadata databases, flush
@@ -53,6 +56,20 @@ moving policy to the correct command.
 6. Treat config keys, pointer formats, storage layouts, schema names, and
    command flags as cross-component contracts. Search all consumers before
    changing any of them.
+
+## Agent execution contract
+
+- Discover the installed surface with `crab version`, command-specific
+  `--help`, and `crab skills list`; do not infer flags from a different release.
+- Prefer read-only commands and `--json` for decisions. Use `--jsonl` only
+  when progress events are useful, and require its terminal `result` event.
+- Treat stable error code, category, `retryable`, and exit code as the retry
+  contract. Never retry from matching a human log phrase.
+- Before mutation, name the repository, worktree, ref, remote, and intended
+  side effect. Re-read state after mutation instead of trusting optimistic
+  progress.
+- Give concurrent agents separate worktrees and refs by default. Same-ref
+  publication still follows the Git-sync skill's lock and rebase contract.
 
 ## Implementation loop
 
@@ -69,6 +86,10 @@ moving policy to the correct command.
    filesystem claim, perform an end-to-end smoke with a disposable fixture.
 
 ## Skill installation contract
+
+`crab install` configures Crab's Git filter/diff drivers, hooks, completions,
+and optional aliases. It does not install agent skills. Use the `skills`
+namespace for the embedded Agent Skills catalog.
 
 List the embedded catalog with:
 
@@ -96,8 +117,8 @@ isolated or project-scoped installs. Existing destination directories require
 Use a volume-backed, checkout-specific Cargo target directory:
 
 ```bash
-CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/<checkout> cargo check --locked
-CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/<checkout> cargo test --locked
+CARGO_TARGET_DIR=$HOME/Workspace/crabbuild-target/<checkout> cargo check --locked
+CARGO_TARGET_DIR=$HOME/Workspace/crabbuild-target/<checkout> cargo test --locked
 ```
 
 Run the command’s real side effect in a disposable repository or local S3

--- a/crab/skills/crab-diagnostics-recovery/SKILL.md
+++ b/crab/skills/crab-diagnostics-recovery/SKILL.md
@@ -21,8 +21,8 @@ state, inventory-only evidence, unavailable bytes, and irrecoverable loss.
 4. Gather recovery inventory from release manifests, pointer roots, workflow or
    import journals, shard/xorb/pack listings, file indexes, replicas, and fsck
    reports. Mark each source and confidence level.
-5. Run `recover plan`, inspect each candidate identity and action, and retain
-   the plan before applying anything.
+5. Run `recover plan --manifest ...`, inspect each candidate identity and
+   action with `recover show`, and retain the plan before applying anything.
 6. Apply only explicitly authorized actions: restore verified files, rebuild an
    index, restore objects, or repair selected refs through the canonical path.
 7. Re-run doctor and integrity checks, inspect the audit event, and prove a
@@ -34,10 +34,16 @@ state, inventory-only evidence, unavailable bytes, and irrecoverable loss.
   diagnostics; they should not mutate repository data.
 - Support bundles must be redacted. Active cache-service probes are opt-in
   write/read/cleanup tests and require a clearly bounded target.
-- `update` changes the installed binary; it is not a recovery workaround.
-- History recovery can discover immutable roots without making their bytes
-  readable. Keep discoverability, metadata integrity, byte availability, and
-  remote repair as separate statuses.
+- `upgrade` verifies the official release manifest, archive size, SHA-256, and
+  staged binary version before replacing the executable; it is not a recovery
+  workaround. Package-manager installations should use their package manager.
+- `recover history list/verify/restore/prune` operates on immutable repository
+  history roots. Listing a root does not prove its bytes are readable; keep
+  discoverability, metadata integrity, byte availability, and remote repair as
+  separate statuses. `prune` and `restore` require reviewed mutation intent.
+- `recover apply` materializes verified files by default. Remote shard, xorb,
+  pack, file-index, and ref repair stay behind their explicit flags and
+  refspecs.
 
 ## Recovery invariants
 

--- a/crab/skills/crab-git-sync/SKILL.md
+++ b/crab/skills/crab-git-sync/SKILL.md
@@ -24,6 +24,10 @@ contracts that serialize remote mutations.
   versioning, collision, journal, and dry-run boundaries.
 - `lock`, `unlock`, and `locks` are advisory file operations. `--force` is an
   explicit ownership override, not a generic retry.
+- Direct object-store remotes and managed logical repositories are distinct
+  publication paths. A managed push prepares a protected session and scoped
+  staging grant, uploads immutable data, then asks the service to verify and
+  finalize. Never fall back to direct bucket credentials when that path fails.
 
 ## Push reasoning
 
@@ -31,12 +35,28 @@ contracts that serialize remote mutations.
    Crab data, and existing locks or journals.
 2. Flush staged chunks and prepared xorbs before publishing remote metadata or
    refs. A ref must never point at an incomplete object set.
-3. Acquire the per-ref lock before the CAS decision. Release it on every
-   success, error, cancellation, and early-return path.
+3. Use repository admission to bound expensive direct push work, then acquire
+   canonical per-ref locks before the expected-old decision. Admission is
+   capacity control; ref locks and journal CAS provide correctness.
 4. Verify connectivity from the new ref tip through the local Git object store
-   before committing a remote ref.
-5. Handle non-fast-forward and lock contention through the documented
+   and publish ref-scoped visibility evidence before committing the journal.
+5. Treat the ref-journal active marker as the durable atomic boundary. Release
+   ref locks after it; manifest, locator, commit-graph, frontier, and other
+   derived maintenance belong to the generation owner.
+6. Handle non-fast-forward and lock contention through the documented
    integration/retry path. Never add an ad-hoc force-push fallback.
+
+## Concurrent agents
+
+- Prefer one linked worktree and branch per agent. Different refs can publish
+  concurrently; same-ref writers are serialized and still need Git history
+  integration.
+- `crab push --rebase-on-non-fast-forward` is for one current local branch,
+  without force or delete refspecs. It waits up to the agent integration lock
+  window, fetches and rebases after a competing advance, retries the push, and
+  stops for a local conflict instead of resolving code automatically.
+- Preserve per-ref outcomes for multi-ref pushes. A partial outcome is not a
+  repository-wide success, and retry must target only work that remains valid.
 
 ## Pull and transfer reasoning
 
@@ -47,10 +67,11 @@ disposable location and make resumability explicit.
 
 ## Proof
 
-Verify remote ref state, expected pack/xorb/shard/manifest keys, lock release,
-and any audit event. Then use a fresh clone or hydrate to prove that the
-published content reconstructs byte-identically. For negative tests, use a
-stale lock, missing staged chunk, divergent ref, or malformed Git object and
-assert the stable error plus the absence of a partial ref advance.
+Verify remote ref state, ref-journal transaction and active marker, visibility
+evidence, expected pack/xorb/shard objects, lock release, and any audit event.
+Then use a fresh clone or hydrate to prove that the published content
+reconstructs byte-identically. For negative tests, use a stale lock, missing
+staged chunk, divergent ref, or malformed Git object and assert the stable
+error plus the absence of a partial ref advance.
 
 Never print credentials, signed URLs, or full private object-store endpoints.

--- a/crab/skills/crab-large-files/SKILL.md
+++ b/crab/skills/crab-large-files/SKILL.md
@@ -34,6 +34,13 @@ full file -> verified pointer -> dehydrate -> disk bytes released
 6. Use `fetch` or cache warming when bytes should be available locally without
    replacing pointers. Use selective `download` for files outside a checkout.
 
+Do not confuse native file tracking with source provenance or artifact
+versioning. `crab data import/update` materializes external sources and records
+credential-free descriptors; `crab artifacts version create/get/promote`
+manages immutable workflow outputs and mutable stage labels. A file may later
+be Crab-tracked, but those commands do not replace `crab add` or pointer
+publication.
+
 ## Command map
 
 - `add`, `reset`, `adopt`, `unadopt`, and `undo` change working-tree or index
@@ -45,6 +52,9 @@ full file -> verified pointer -> dehydrate -> disk bytes released
   add-time staging area. `cache` commands operate on reusable local objects.
 - `stat push-plan --verify` checks prepared xorb metadata; it does not replace
   authoritative staged bytes.
+- `data list/status` is read-only source/worktree evidence. Data imports reject
+  existing or unsafe targets, and updates install verified content plus its
+  descriptor transactionally; `--dry-run` must leave both unchanged.
 - `migrate` rewrites history or converts representations. Require a dry run,
   list affected refs, and preserve a recovery point before mutation.
 - `du` distinguishes local staging/cache usage from remote object usage.
@@ -59,6 +69,8 @@ full file -> verified pointer -> dehydrate -> disk bytes released
 - Dehydration never discards uncommitted bytes or silently overwrites a file.
 - GC and cache eviction never remove data still referenced by a live pointer or
   protected by the configured grace period.
+- Native pointers and Git LFS pointers remain different serialized contracts;
+  use the LFS skill for LFS filters, transfers, and history rewrites.
 
 ## Verification
 

--- a/crab/skills/crab-lfs/SKILL.md
+++ b/crab/skills/crab-lfs/SKILL.md
@@ -11,8 +11,9 @@ locks, and verification rules remain distinct.
 
 ## Operating modes
 
-1. Determine whether the checkout uses native LFS, the transfer-agent mode, or
-   a conversion path before changing behavior.
+1. Determine whether the checkout uses Crab-native pointers, Crab's Git LFS
+   filter/storage implementation, the custom transfer agent, or a conversion
+   path before changing behavior.
 2. Inspect `.gitattributes`, Git filters, LFS configuration, pointer format,
    object location, and the hook or protocol entry point.
 3. For fetch, push, pull, and checkout, prove both remote object identity and
@@ -25,19 +26,30 @@ locks, and verification rules remain distinct.
 
 ## Command scope
 
-- `crab lfs` covers status, locks, fetch, push, pull, logs, and transfer-agent
-  operations.
+- `crab lfs install/uninstall/update` owns LFS Git config and hooks. It is
+  separate from top-level `crab install` and from `crab skills install`.
+- `track/untrack`, `pointer`, `clean`, `smudge`, `filter-process`,
+  `merge-driver`, hooks, and `ext` own Git LFS compatibility surfaces.
+- `fetch/pull/push/checkout`, `ls-files`, `status`, `fsck`, `prune`, locks,
+  environment, version, and logs own transfer and local-object lifecycle.
+- `crab lfs clone` is a deprecated compatibility wrapper; new automation
+  should use normal clone plus explicit fetch/pull behavior.
 - `crab lfs-transfer-agent` is a Git-invoked machine protocol, not a human
   command.
-- `crab optimize lfs dedup` removes verified duplicate storage.
-- `crab optimize lfs convert` changes representation with a reversible plan.
-- `crab optimize lfs prune` removes unreachable local objects under explicit
-  verification, age, confirmation, and failure-mode flags.
+- `crab lfs convert` changes the current representation with dry-run and
+  rollback boundaries. `crab lfs migrate import/export/info` is the explicit
+  history-analysis and rewrite surface.
+- `crab lfs dedup` and `crab optimize lfs dedup` remove only verified duplicate
+  storage. `crab optimize lfs prune` and `crab lfs prune` require explicit
+  reachability, recent-object, remote-verification, and confirmation policy.
 
 ## Protocol discipline
 
 - Keep transfer-agent stdin/stdout strictly machine-readable; send diagnostics
   to the correct log channel.
+- A pre-push hook must upload required LFS objects before the Git ref becomes
+  visible. Clean/smudge/filter-process transform bytes locally and do not by
+  themselves prove remote publication.
 - Preserve lock ownership, force semantics, retry boundaries, and request IDs.
 - Never place credentials, signed URLs, or raw authorization headers in logs.
 - Distinguish an LFS pointer parse, an object download, and a verified checkout

--- a/crab/skills/crab-managed-operations/SKILL.md
+++ b/crab/skills/crab-managed-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crab-managed-operations
-description: Manage Crab authentication, managed-service organizations and repositories, memberships, service accounts, audit events, and signed release manifests.
+description: Manage Crab authentication, managed-service organizations and repositories, protected transfer grants and pushes, memberships, service accounts, audit events, and signed release manifests.
 ---
 
 # Crab managed operations
@@ -24,19 +24,37 @@ selected service and the resulting state.
 
 - Before create/update/delete, confirm service, organization, repository,
   member, actor, and requested ownership change.
-- Read current state, use idempotent operations where supported, and do not
-  silently rename or transfer ownership.
+- Read current state, use idempotency keys for creates/jobs and the returned
+  revision for `If-Match` mutations. Do not silently rename, archive, restore,
+  delete, or transfer ownership.
 - Treat service-account keys and one-time secrets as write-only material. Show
   only identifiers and redacted status after creation.
 - Keep pagination, retry, rate limits, and authorization failures distinct in
   errors so automation can decide whether to retry.
 
+## Managed transfer boundary
+
+- Resolve a logical repository through the managed service. The client must
+  not learn or persist its physical prefix or canonical provider credential.
+- Clone, fetch, and hydrate request short-lived, repository- and
+  operation-scoped read grants. A protected push first prepares a session and
+  `push_upload` staging grant, uploads immutable objects, then finalizes the
+  exact request digest through the service.
+- Finalize is the publication authority. An upload or successful HTTP response
+  before finalize does not advance refs. Abort uncommitted sessions when safe;
+  retry a timed-out request with its idempotency identity rather than creating
+  an unrelated push.
+- Managed and direct-storage modes have different authorities. Never fall back
+  from a denied or unavailable managed request to ambient bucket credentials.
+
 ## Audit and releases
 
-- Audit log, verify, and export operate on an append-only event chain. Check
-  schema, sequence, digest, timestamp, redaction, and operation filters.
-- A release manifest binds a Git revision to pointer inventory, workflow
-  metadata, parameters, metrics, and optional signatures.
+- Local `audit log/verify/export` operates on `.crab/audit/events.jsonl` and
+  its digest-protected events. Managed audit query/export is a tenant service
+  API. Do not claim the local file is the managed tenant ledger.
+- `release create/verify/export/list` binds a Git revision to pointer inventory,
+  workflow metadata, parameters, metrics, and optional detached signatures;
+  `--publish` stores a named manifest in the repository release namespace.
 - Release creation should reject unintended dirty state. A forced override is
   an explicit policy decision and must appear in evidence.
 - Deep verification reconstructs pointer-backed files and checks identity; JSON

--- a/crab/skills/crab-mount/SKILL.md
+++ b/crab/skills/crab-mount/SKILL.md
@@ -24,6 +24,11 @@ daemon ownership explicit.
 - Foreground: keep the process attached for supervision. Background mode must
   persist enough state for `unmount`, daemon status, and cleanup.
 
+`crab mount` is the interactive mountpoint-oriented workflow. `crab daemon`
+is a separate persistent named-repository service with a registry, shared
+cache, reconciliation loop, and explicit repository control subcommands. Do
+not mix their state or assume one command manages the other mode.
+
 ## Lifecycle
 
 1. Validate source URL/path, revision, backend, mountpoint, permissions, and
@@ -36,12 +41,28 @@ daemon ownership explicit.
 5. On every failure, release locks, stop workers, close databases, remove
    temporary state, and leave the mountpoint in a known state.
 
+## Overlay publication
+
+- Review `mount status --live-only --verbose` and `mount diff`; ordinary
+  status may fall back to persisted metadata and is not live-health proof.
+- Pause writers before `mount export`, `commit`, or `reset`. Independent paths
+  may mutate concurrently, but intersecting paths serialize and publication
+  takes an exclusive overlay snapshot.
+- `mount commit` checks that the base ref did not move, creates a Git commit,
+  refreshes the snapshot, then clears the overlay. With `--push`, a failed push
+  retains both overlay and transaction identity for a matching retry.
+- `mount reset --overlay --yes`, daemon `remount --clean-overlay`, and
+  `mount clean --all` are explicit destructive boundaries.
+
 ## Backend discipline
 
 Keep FUSE and NFS behavior behind the same source and overlay contracts while
 respecting platform-specific error and permission semantics. Do not make a
 backend look healthy by swallowing mount, refresh, or hydration errors. Never
 run an unsafe nested mount without an explicit allow flag.
+
+`--backend=auto` prefers a ready NFS backend and otherwise uses FUSE when
+available. NFS is a local loopback export, not a shared network filesystem.
 
 ## Verification
 

--- a/crab/skills/crab-repository-lifecycle/SKILL.md
+++ b/crab/skills/crab-repository-lifecycle/SKILL.md
@@ -11,14 +11,17 @@ scope explicit.
 
 ## Command scope
 
-`init`, `setup`, `clone`, `mirror`, `worktree`, `config`, `track`, `untrack`,
-`install`, `uninstall`, and `completions`.
+`configure`, `init`, `setup`, `clone`, `mirror`, `worktree`, `config`, `track`,
+`untrack`, `install`, `uninstall`, and `completions`.
 
 ## Onboarding sequence
 
 1. Inspect Git remotes, branch and worktree state, Crab configuration,
    `.gitattributes`, existing tracking patterns, and any uncommitted changes.
 2. Choose one entry path:
+   - `crab configure` is the guided default: it selects the provider, discovers
+     credentials, initializes the Git/remote state, installs integration, and
+     proposes or applies tracking. Use `--dry-run` for a non-mutating plan.
    - `crab init` creates or adopts a Crab remote configuration.
    - `crab setup` installs local large-file integration after initialization.
    - `crab clone` creates a new checkout; choose lazy, eager, include, exclude,
@@ -30,7 +33,9 @@ scope explicit.
    config scope. Do not silently switch between local, global, and system
    installation.
 5. For worktrees, inspect shared Git metadata and Crab worktree state before
-   creating, switching, hydrating, pruning, or removing a worktree.
+   creating, switching, hydrating, pruning, or removing a worktree. Give each
+   concurrent agent its own linked worktree and branch unless they must
+   serialize on one ref.
 6. Prove one real path: add/commit/push for an existing checkout, or
    clone/hydrate for a new one. Check both Git state and reconstructed bytes.
 
@@ -38,16 +43,24 @@ scope explicit.
 
 - Use `init` for remote and project configuration; do not use `setup` as a
   substitute for remote initialization.
+- Use `configure` when both are wanted. With no remote it may reuse discovered
+  `crab.toml`; in non-interactive automation supply the remote explicitly.
 - Use `clone` when Git history and a new working tree are required. Use
   `download` when selected files are needed without a checkout.
 - Use mirror mode only when a named Git remote should be synchronized into a
   Crab remote; make the direction and ref policy visible.
 - Use `install` or `uninstall` at the requested Git config scope. Global and
   system changes affect other repositories and require explicit authorization.
+- Top-level `install` owns Git filter/diff drivers, repository hooks,
+  completions, and optional aliases. Agent skills are installed only through
+  `crab skills install`.
 - Use `config get` to inspect value origin before changing a key. Preserve
   arrays, unknown sections, comments where supported, and unrelated values.
-- Use `worktree` operations with the same cleanup and lock discipline as the
-  main checkout; never assume a second worktree has independent metadata.
+- Linked worktrees share Git common state and Crab staging, but each has its
+  own hydrated-pointer database and hydration policy under the shared `.crab`
+  tree. A sibling's state is never authoritative. Hydration may use a verified
+  content-addressed filesystem CoW clone, then falls back to normal remote
+  reconstruction.
 
 ## Safety
 

--- a/crab/skills/crab-storage-ops/SKILL.md
+++ b/crab/skills/crab-storage-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crab-storage-ops
-description: Inspect, compact, verify, repair, and optimize Crab storage, metadata indexes, staging, caches, shards, packs, xorbs, and garbage collection.
+description: Inspect, compact, verify, repair, and optimize Crab storage, ref-journal and metadata indexes, artifact reachability, staging, caches, shards, packs, xorbs, and garbage collection.
 ---
 
 # Crab storage operations
@@ -11,14 +11,16 @@ and mutation must be visibly different.
 
 ## Command scope
 
-- `gc` enumerates reachable refs, manifests, packs, xorbs, shards, indexes, and
-  grace-period candidates; it deletes only the requested repository scope.
+- `gc` enumerates reachable refs, active ref-journal transactions, workflow
+  artifact versions, manifests, packs, xorbs, shards, indexes, and grace-period
+  candidates; it deletes only the reviewed scope.
 - `fsck` verifies Git objects, pointers, file indexes, chunk coverage, shard
   terms, packs, checksums, and metadata consistency. Repair is opt-in.
 - `compact` merges small metadata shards while preserving every live row.
 - `repack` consolidates Git packs without changing reachable history.
-- `optimize plan/apply` coordinates cache, index, xorb, pack, shard, tier, and
-  replica actions. Plan is read-only; apply consumes the reviewed plan.
+- `optimize plan/apply` coordinates xorb, pack, shard, tier, cache, index, LFS,
+  workflow-cache, replica, or whole-repository actions. Plan is read-only;
+  apply consumes the reviewed plan.
 - `metadb diagnose/rebuild/compact/cache-*` operates on metadata databases and
   their local chunk-index cache.
 - `staging stats/verify/clean`, `cache stats/verify/clean/prune`, `du`, and
@@ -35,16 +37,25 @@ and mutation must be visibly different.
 5. Compaction and repacking preserve content identity and ref reachability.
 6. A repair report must identify what was changed, what was skipped, and what
    remains corrupt or unavailable.
+7. The ref-journal active marker is current ref authority until the generation
+   owner folds it into a manifest frontier. Maintenance must include committed
+   journal reachability and must not treat a lagging derived catalog as proof
+   that an object is dead.
 
 ## Operating loop
 
-1. Capture the repository or prefix, backend, ref roots, storage classes,
-   retention policy, locks, and current usage.
+1. Capture the repository or prefix, backend, manifest plus ref-journal roots,
+   generation owner, storage classes, retention policy, locks, and current
+   usage.
 2. Run a dry run or read-only diagnose and save the structured report.
 3. Review candidates against live references and recent activity.
 4. Apply one bounded operation, with cancellation and lock release intact.
 5. Re-run fsck or verification, compare object counts and byte totals, and
    prove a fresh read or hydration for content affected by the operation.
+
+Bucket-wide GC crosses repository ownership. Never select it as an automation
+fallback; require an explicit bucket target, authorization, retained inventory,
+and proof that every repository sharing the bucket is included safely.
 
 ## Verification
 

--- a/crab/skills/crab-tier-replication/SKILL.md
+++ b/crab/skills/crab-tier-replication/SKILL.md
@@ -13,8 +13,10 @@ reachability, and an auditable recovery path.
 
 1. Inventory live manifests, refs, object age, storage class, restore state,
    retention, and pending transitions.
-2. `tier plan` produces candidates and cost/latency consequences. Review the
-   plan before `tier apply` or rollback.
+2. `tier plan` renders provider lifecycle rules. `tier plan --apply` performs
+   the provider mutation, `--dry-run` keeps it read-only, `--merge` preserves
+   non-Crab rules, and `tier rollback <backup>` restores a saved lifecycle
+   configuration.
 3. Archived objects require an explicit restore request, selected tier, and
    restore duration. Hydration must wait for readable state or report the
    provider failure; never substitute fabricated bytes.
@@ -27,16 +29,25 @@ reachability, and an auditable recovery path.
   evidence freshness.
 - `replica doctor` diagnoses credentials, endpoint, control-plane, data-plane,
   permissions, and configuration problems without mutating state.
+- `replica add/export/cost/runbook` plans provider resources and operations;
+  provider changes require the command's explicit apply boundary.
 - Backfill is separate from read enablement. Inventory historical objects,
   copy missing data, verify checksums, then advance the durable watermark.
+- Use `wait`, deep `verify`, and `backfill status` before `enable`. Disable or
+  remove a replica explicitly; `remove --apply` only owns documented
+  Crab-created reversible resources.
 - Enable reads only after manifest-referenced objects and current indexes are
   verified in the target region.
-- Failover is a fenced state transition: plan, stop or fence the old writer,
-  promote the selected region, verify leases and refs, then resume traffic.
+- Active-active mode requires declared writers and a managed coordinator.
+  `writers` and `coordinator` manage those identities; the `failover` status,
+  plan, fence, run, and resume operations form one fenced state machine.
+- Read-replica `promote` and guarded `set-primary` differ from active-active
+  failover. Preview them and require their explicit force/apply contract.
 - Repair must converge regional state from coordinator truth, not from a stale
   replica snapshot.
-- Cost and runbook commands are evidence/reporting paths; they do not imply
-  that a replica is healthy or production-ready.
+- `diagnostics` collects a redacted bundle. `certify` runs stricter readiness
+  gates, and `evidence verify` validates retained certification artifacts.
+  Status, cost, doctor, or a generated runbook alone is not production proof.
 
 ## Invariants
 

--- a/crab/skills/crab-workflow/SKILL.md
+++ b/crab/skills/crab-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crab-workflow
-description: Build, run, inspect, reproduce, and maintain Crab content-addressed workflows and experiments. Use for workflow files, stages, run/repro, caches, lockfiles, journals, DAGs, parameters, metrics, plots, experiments, queues, and cache push.
+description: Build, run, inspect, reproduce, and maintain Crab content-addressed workflows, experiments, external data sources, and immutable artifacts. Use for workflow files, stages, run/repro, caches, lockfiles, journals, DAGs, data, artifacts, parameters, metrics, plots, experiments, queues, and cache push.
 ---
 
 # Crab workflow
@@ -29,13 +29,22 @@ match the requested stage.
 - `run` is the canonical executor; `repro` is its compatible spelling.
 - `stage add/list` edits or inspects declarations.
 - `freeze/unfreeze` controls eligibility, not stage definition.
-- `status --workflow`, `workflow status`, `workflow dag`, and `workflow
-  journal` explain graph state. Use dependency expansion and why-style output
+- `status --workflow`, `workflow status`, `workflow dag`, and workflow journal
+  commands explain graph state. Use dependency expansion and why-style output
   rather than guessing from timestamps.
 - `workflow lockfile resolve/split` manages lockfile structure and merge
   conflicts.
 - `exp` creates and inspects isolated experiment runs; `queue` manages batch
-  workers and cleanup.
+  workers and cleanup. Each run uses a temporary worktree; inspect `show` or
+  `diff` before `apply` or `promote`; save, rename, transfer, removal, cleanup,
+  and GC are separate metadata lifecycles.
+- `data list/status/import/import-url/import-db/update` manages materialized
+  external inputs plus credential-free source descriptors. Imports require a
+  new safe target; update is transactional and has a read-only dry run.
+- `artifacts list/show/get/version create/promote/history` manages declared
+  workflow outputs. Versions and payloads are immutable and content-addressed;
+  promotion is a compare-and-swap stage-label move. Retrieval verifies bytes
+  and never overwrites an existing destination.
 - `params`, `metrics`, and `plots` read or compare recorded workflow data.
 - `migrate from-dvc` converts pipeline declarations. Preview generated output
   and preserve unsupported semantics instead of dropping them.
@@ -50,6 +59,9 @@ match the requested stage.
   worker may still own.
 - Separate workflow output hydration from workflow execution; a pointer output
   is not a materialized output.
+- A remote artifact registry is canonical when a Crab remote exists; local
+  registry state is a cache/recovery mirror. Do not delete old remote artifact
+  versions: automatic remote artifact GC is not yet a supported lifecycle.
 - Keep environment capture deterministic and redact secrets from identity,
   logs, and reports.
 


### PR DESCRIPTION
## Summary

- refresh all 11 embedded agent skills against the current Crab CLI and implementation
- clarify Git integration versus agent-skill installation, guided configuration, and executable upgrades
- document current concurrent push, ref-journal, managed transfer, mount overlay, replica, data, artifact, workflow, and LFS contracts

## Validation

- skill-creator quick_validate.py passed for all 11 skill directories
- CARGO_TARGET_DIR=$HOME/Workspace/crabbuild-target/crab-d7bb-skills cargo test -p crab cmd::skills::tests --lib --locked (7 passed)
- rebuilt the Crab CLI, listed the catalog, installed all 11 skills through crab skills install, and compared each installed SKILL.md byte-for-byte with its source
- git diff --check