### PR TITLE
fix: harden resumable uploads and bounded push publication

### DIFF
--- a/crab/src/auth/mod.rs
+++ b/crab/src/auth/mod.rs
@@ -318,11 +318,10 @@ pub async fn build_store(
         (storage_scope, credential_provider, built)
     };
 
-    // A crab:// URL puts the bucket in the host component, so host
-    // and container carry the same value today. A later change that
-    // adds an ObjectUrl parser for raw `s3://` / `az://` URLs will
-    // differentiate endpoint host from container.
+    // Multipart recovery has a stricter endpoint-bound identity; retain the
+    // existing bucket identity used for provider selection and safety rails.
     let identity = BucketIdentity::new(built.provider, url.bucket.as_str(), url.bucket.as_str());
+    let multipart_identity = built.multipart_identity.clone();
 
     if let Some(cp) = credential_provider.as_ref() {
         let bucket = url.bucket.clone();
@@ -335,6 +334,8 @@ pub async fn build_store(
             .map(|built| RefreshingStoreParts {
                 inner: built.inner,
                 signer: built.signer,
+                multipart: built.multipart,
+                multipart_identity: built.multipart_identity,
             })
         });
         let refreshing = Arc::new(RefreshingObjectStore::new(
@@ -345,12 +346,19 @@ pub async fn build_store(
             RefreshingStoreParts {
                 inner: built.inner,
                 signer: built.signer,
+                multipart: built.multipart,
+                multipart_identity: built.multipart_identity,
             },
             builder,
         ));
         built.inner = refreshing.clone() as Arc<dyn ObjectStore>;
         built.signer = if refreshing.has_signer().await {
-            Some(refreshing as Arc<dyn object_store::signer::Signer>)
+            Some(refreshing.clone() as Arc<dyn object_store::signer::Signer>)
+        } else {
+            None
+        };
+        built.multipart = if refreshing.has_multipart().await {
+            Some(refreshing as Arc<dyn object_store::multipart::MultipartStore>)
         } else {
             None
         };
@@ -359,6 +367,9 @@ pub async fn build_store(
     let mut store = Store::new(built.inner).with_bucket_identity(identity);
     if let Some(s) = built.signer {
         store = store.with_signer(s);
+    }
+    if let (Some(multipart), Some(identity)) = (built.multipart, multipart_identity) {
+        store = store.with_multipart(multipart, identity);
     }
     if let Some(scope) = storage_scope {
         store = store.with_storage_scope(scope);

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -122,6 +122,26 @@ struct StagedEntry {
     index_stat: Option<crate::cmd::stream_stage::VerifiedIndexStat>,
 }
 
+struct IndexPublicationEntry {
+    batch_id: Option<crab_staging::StagingBatchId>,
+    abs_path: PathBuf,
+    file_hash: [u8; 32],
+    size: u64,
+    index_stat: Option<crate::cmd::stream_stage::VerifiedIndexStat>,
+}
+
+impl From<&StagedEntry> for IndexPublicationEntry {
+    fn from(entry: &StagedEntry) -> Self {
+        Self {
+            batch_id: entry.batch_id.clone(),
+            abs_path: entry.abs_path.clone(),
+            file_hash: entry.file_hash,
+            size: entry.size,
+            index_stat: entry.index_stat,
+        }
+    }
+}
+
 struct AddExecutionPlans {
     duplicate_plan: DuplicateReusePlan,
     stream_xorb_plan: Option<StreamPreparedXorbPlan>,
@@ -1413,95 +1433,127 @@ async fn execute_add(
         // ticks up to `total_files` as each pointer is staged.
         progress.files_done.store(0, Relaxed);
 
-        // Load the persistent shard-hint cache so newly-emitted pointers
-        // carry a hint when one is known. Failure to load is non-fatal
-        // — an empty cache degrades to the file-index path on hydrate.
-        let shard_hints = crate::cache::ShardHintCache::load_sync(
-            &crate::cache::shard_hints::default_path(),
-        )
-        .unwrap_or_else(|err| {
-            debug!(error = %err, "failed to load shard-hint cache; pointers will omit hints");
-            crate::cache::ShardHintCache::new()
-        });
-
         let publication_staging = StagingAreaReadOnly::open(staging_root.clone()).await?;
-        let mut publication_intent = None;
+        let index_entries = staged_entries
+            .iter()
+            .map(IndexPublicationEntry::from)
+            .collect::<Vec<_>>();
+        let index_repo_root = repo_root.clone();
+        let tracking_patterns = generated_tracking_patterns.clone();
         let progress_cb = Arc::clone(&progress);
-        if let Err(e) = write_pointers_and_tracking_to_git_index(
-            &staged_entries,
-            &repo_root,
-            &shard_hints,
-            &generated_tracking_patterns,
-            |index_entries, current_index| {
-                let entries = staged_entries
-                    .iter()
-                    .zip(index_entries)
-                    .map(|(staged, indexed)| {
-                        let batch_id = staged.batch_id.clone().ok_or_else(|| {
-                            CrabError::StagingCorrupt(format!(
-                                "staged path {} has no publication batch",
-                                staged.abs_path.display()
-                            ))
-                        })?;
-                        let path = staged
-                            .abs_path
-                            .strip_prefix(&repo_root)
-                            .unwrap_or(&staged.abs_path)
-                            .to_path_buf();
-                        let index_path = git_index_path_bstring(&path);
-                        Ok(PublicationIntentEntry {
-                            batch_id,
-                            path,
-                            expected_pointer_oid: indexed.sha.clone(),
-                            previous_index_state: git_index_path_state(
-                                current_index,
-                                index_path.as_bstr(),
-                            ),
+        let index_result = tokio::task::spawn_blocking(move || {
+            let shard_hints = crate::cache::ShardHintCache::load_sync(
+                &crate::cache::shard_hints::default_path(),
+            )
+            .unwrap_or_else(|err| {
+                debug!(error = %err, "failed to load shard-hint cache; pointers will omit hints");
+                crate::cache::ShardHintCache::new()
+            });
+            let mut publication_intent = None;
+            let write_result = write_pointers_and_tracking_to_git_index(
+                &index_entries,
+                &index_repo_root,
+                &shard_hints,
+                &tracking_patterns,
+                |git_entries, current_index| {
+                    let entries = index_entries
+                        .iter()
+                        .zip(git_entries)
+                        .map(|(staged, indexed)| {
+                            let batch_id = staged.batch_id.clone().ok_or_else(|| {
+                                CrabError::StagingCorrupt(format!(
+                                    "staged path {} has no publication batch",
+                                    staged.abs_path.display()
+                                ))
+                            })?;
+                            let path = staged
+                                .abs_path
+                                .strip_prefix(&index_repo_root)
+                                .unwrap_or(&staged.abs_path)
+                                .to_path_buf();
+                            let index_path = git_index_path_bstring(&path);
+                            Ok(PublicationIntentEntry {
+                                batch_id,
+                                path,
+                                expected_pointer_oid: indexed.sha.clone(),
+                                previous_index_state: git_index_path_state(
+                                    current_index,
+                                    index_path.as_bstr(),
+                                ),
+                            })
                         })
+                        .collect::<Result<Vec<_>>>()?;
+                    publication_intent =
+                        Some(publication_staging.create_publication_intent(&entries)?);
+                    Ok(())
+                },
+                || {
+                    progress_cb.files_done.fetch_add(1, Relaxed);
+                },
+            );
+            if let Err(error) = write_result {
+                return Err((error, publication_intent));
+            }
+            let Some(publication_intent) = publication_intent else {
+                return Err((
+                    GitIndexWriteError::IndexMutationUncertain(CrabError::Internal(
+                        "Git index publication intent was not recorded".to_owned(),
+                    )),
+                    None,
+                ));
+            };
+            if let Err(error) = publication_staging.publish_publication_intent(&publication_intent)
+            {
+                return Err((
+                    GitIndexWriteError::IndexMutationUncertain(error.into()),
+                    Some(publication_intent),
+                ));
+            }
+
+            let verified_paths = index_entries
+                .iter()
+                .filter_map(|entry| {
+                    entry.index_stat.map(|index_stat| VerifiedPath {
+                        path: entry.abs_path.clone(),
+                        file_hash: entry.file_hash,
+                        size: entry.size,
+                        index_stat,
                     })
-                    .collect::<Result<Vec<_>>>()?;
-                publication_intent = Some(publication_staging.create_publication_intent(&entries)?);
-                Ok(())
-            },
-            || {
-                progress_cb.files_done.fetch_add(1, Relaxed);
-            },
-        ) {
+                })
+                .collect::<Vec<_>>();
+            match crate::cache::add_validation::record_verified_paths(
+                &index_repo_root,
+                &verified_paths,
+            ) {
+                Ok(validations) => debug!(validations, "recorded verified add validations"),
+                Err(error) => debug!(
+                    error = %error,
+                    "failed to persist verified add validations; later add will rehash"
+                ),
+            }
+            Ok(())
+        })
+        .await;
+        let index_error = match index_result {
+            Ok(Ok(())) => None,
+            Ok(Err(error)) => Some(error),
+            Err(error) => Some((
+                GitIndexWriteError::IndexMutationUncertain(CrabError::Io(std::io::Error::other(
+                    error,
+                ))),
+                None,
+            )),
+        };
+        if let Some((error, publication_intent)) = index_error {
             let error = handle_git_index_write_error(
                 &staging_root,
                 &staged_entries,
                 publication_intent.as_ref(),
-                e,
+                error,
             )
             .await;
             stop_progress_ticker(ticker.take(), &ticker_cancel).await;
             return Err(error);
-        }
-        let publication_intent = publication_intent.ok_or_else(|| {
-            CrabError::Internal("Git index publication intent was not recorded".to_owned())
-        })?;
-        publication_staging.publish_publication_intent(&publication_intent)?;
-        let verified_paths = staged_entries
-            .iter()
-            .filter_map(|entry| {
-                entry.index_stat.map(|index_stat| VerifiedPath {
-                    path: entry.abs_path.clone(),
-                    file_hash: entry.file_hash,
-                    size: entry.size,
-                    index_stat,
-                })
-            })
-            .collect::<Vec<_>>();
-        match crate::cache::add_validation::record_verified_paths(&repo_root, &verified_paths) {
-            Ok(validations) => {
-                debug!(validations, "recorded verified add validations");
-            }
-            Err(error) => {
-                debug!(
-                    error = %error,
-                    "failed to persist verified add validations; later add will rehash"
-                );
-            }
         }
         summary.indexing_duration_ms = indexing_start.elapsed().as_millis() as u64;
     }
@@ -3252,8 +3304,12 @@ fn write_pointers_to_git_index(
     shard_hints: &crate::cache::ShardHintCache,
     mut on_file_done: impl FnMut(),
 ) -> std::result::Result<(), GitIndexWriteError> {
+    let entries = entries
+        .iter()
+        .map(IndexPublicationEntry::from)
+        .collect::<Vec<_>>();
     write_pointers_and_tracking_to_git_index(
-        entries,
+        &entries,
         repo_root,
         shard_hints,
         &[],
@@ -3263,7 +3319,7 @@ fn write_pointers_to_git_index(
 }
 
 fn write_pointers_and_tracking_to_git_index(
-    entries: &[StagedEntry],
+    entries: &[IndexPublicationEntry],
     repo_root: &Path,
     shard_hints: &crate::cache::ShardHintCache,
     tracking_patterns: &[String],
@@ -4686,12 +4742,13 @@ mod tests {
         let path = dir.path().join("model.bin");
         let payload = b"model payload";
         std::fs::write(&path, payload).unwrap();
+        let staged = staged_entry(
+            path,
+            *blake3::hash(payload).as_bytes(),
+            payload.len() as u64,
+        );
         write_pointers_and_tracking_to_git_index(
-            &[staged_entry(
-                path,
-                *blake3::hash(payload).as_bytes(),
-                payload.len() as u64,
-            )],
+            &[IndexPublicationEntry::from(&staged)],
             dir.path(),
             &crate::cache::ShardHintCache::new(),
             &["*.bin".to_owned()],

--- a/crab/src/cmd/fsck.rs
+++ b/crab/src/cmd/fsck.rs
@@ -2,7 +2,8 @@
 //!
 //! Checks Crab manifests, pack/index presence, data-chain metadata, and
 //! coordination state. The production object-store checker does not yet run
-//! full Git connectivity or enumerate provider-side multipart uploads.
+//! full Git connectivity or enumerate multipart uploads outside Crab's local
+//! recovery journal.
 
 use std::io::Stdout;
 use std::time::{Duration, SystemTime};
@@ -80,7 +81,12 @@ pub enum IssueKind {
     ExpiredPushLock { key: String, age: Duration },
     /// A multipart upload older than the grace period.
     AbandonedMultipart {
-        upload_id: String,
+        entry_id: String,
+        revision: i64,
+        upload_id: Option<String>,
+        provider: String,
+        host: String,
+        container: String,
         key: String,
         age: Duration,
     },
@@ -216,15 +222,16 @@ impl FsckIssue {
         }
     }
 
-    pub(crate) fn abandoned_multipart(
-        upload_id: impl Into<String>,
-        key: impl Into<String>,
-        age: Duration,
-    ) -> Self {
+    pub(crate) fn abandoned_multipart(upload: &MultipartMeta, age: Duration) -> Self {
         Self {
             kind: IssueKind::AbandonedMultipart {
-                upload_id: upload_id.into(),
-                key: key.into(),
+                entry_id: upload.entry_id.clone(),
+                revision: upload.revision,
+                upload_id: upload.upload_id.clone(),
+                provider: upload.provider.clone(),
+                host: upload.host.clone(),
+                container: upload.container.clone(),
+                key: upload.key.clone(),
                 age,
             },
             severity: IssueSeverity::Error,
@@ -309,12 +316,17 @@ impl std::fmt::Display for FsckIssue {
             }
             IssueKind::AbandonedMultipart {
                 upload_id,
+                provider,
+                host,
+                container,
                 key,
                 age,
+                ..
             } => {
                 write!(
                     f,
-                    "{prefix}: abandoned multipart upload {upload_id} for {key} (age: {}s)",
+                    "{prefix}: abandoned multipart upload {} for {provider} endpoint {host}, container {container}, key {key} (age: {}s)",
+                    upload_id.as_deref().unwrap_or("<not-created>"),
                     age.as_secs()
                 )
             }
@@ -409,12 +421,22 @@ pub struct PushLockMeta {
 /// Metadata for a multipart upload discovered during fsck.
 #[derive(Debug, Clone)]
 pub struct MultipartMeta {
+    /// Stable local journal row ID used for an atomic repair claim.
+    pub entry_id: String,
+    /// Journal revision observed by the checker; repair claims exactly it.
+    pub revision: i64,
     /// Upload ID from the object store.
-    pub upload_id: String,
+    pub upload_id: Option<String>,
+    /// Provider owning the upload.
+    pub provider: String,
+    /// Provider endpoint/host identity.
+    pub host: String,
+    /// Bucket or container owning the upload.
+    pub container: String,
     /// Target key for the upload.
     pub key: String,
-    /// When the upload was initiated.
-    pub initiated: SystemTime,
+    /// Last journal activity used to classify the upload as abandoned.
+    pub last_updated: SystemTime,
 }
 
 /// Trait abstracting the storage queries needed by fsck.
@@ -495,8 +517,7 @@ pub trait FsckRepairer: Send + Sync {
     /// Abort an abandoned multipart upload.
     fn abort_multipart(
         &self,
-        upload_id: &str,
-        key: &str,
+        upload: MultipartMeta,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send + '_>>;
 }
 
@@ -528,8 +549,7 @@ impl FsckRepairer for NullRepairer {
 
     fn abort_multipart(
         &self,
-        _upload_id: &str,
-        _key: &str,
+        _upload: MultipartMeta,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send + '_>> {
         Box::pin(async { Ok(false) })
     }
@@ -603,13 +623,9 @@ pub async fn run_fsck(
         Ok(uploads) => {
             for upload in uploads {
                 let age = now
-                    .duration_since(upload.initiated)
+                    .duration_since(upload.last_updated)
                     .unwrap_or(Duration::ZERO);
-                all_issues.push(FsckIssue::abandoned_multipart(
-                    &upload.upload_id,
-                    &upload.key,
-                    age,
-                ));
+                all_issues.push(FsckIssue::abandoned_multipart(&upload, age));
             }
         }
         Err(e) => warn!(error = %e, "multipart upload check failed"),
@@ -728,17 +744,33 @@ async fn repair_issues(
                 repairer.repair_push_lock(key).await
             }
             IssueKind::AbandonedMultipart {
+                entry_id,
+                revision,
                 upload_id,
+                provider,
+                host,
+                container,
                 key,
                 age,
             } => {
                 info!(
-                    upload_id = %upload_id,
+                    upload_id = upload_id.as_deref().unwrap_or("<not-created>"),
                     key = %key,
                     age_secs = age.as_secs(),
                     "repairing: aborting abandoned multipart upload"
                 );
-                repairer.abort_multipart(upload_id, key).await
+                repairer
+                    .abort_multipart(MultipartMeta {
+                        entry_id: entry_id.clone(),
+                        revision: *revision,
+                        upload_id: upload_id.clone(),
+                        provider: provider.clone(),
+                        host: host.clone(),
+                        container: container.clone(),
+                        key: key.clone(),
+                        last_updated: SystemTime::UNIX_EPOCH,
+                    })
+                    .await
             }
             IssueKind::GitVisibilityBackfill {
                 generation, digest, ..
@@ -858,7 +890,7 @@ mod tests {
     struct MockRepairer {
         repaired_file_indexes: std::sync::Mutex<Vec<String>>,
         repaired_locks: std::sync::Mutex<Vec<String>>,
-        aborted_multiparts: std::sync::Mutex<Vec<(String, String)>>,
+        aborted_multiparts: std::sync::Mutex<Vec<(Option<String>, String)>>,
     }
 
     impl MockRepairer {
@@ -905,14 +937,26 @@ mod tests {
 
         fn abort_multipart(
             &self,
-            upload_id: &str,
-            key: &str,
+            upload: MultipartMeta,
         ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send + '_>>
         {
             if let Ok(mut v) = self.aborted_multiparts.lock() {
-                v.push((upload_id.to_string(), key.to_string()));
+                v.push((upload.upload_id, upload.key));
             }
             Box::pin(async { Ok(true) })
+        }
+    }
+
+    fn multipart_meta(upload_id: &str, key: &str, last_updated: SystemTime) -> MultipartMeta {
+        MultipartMeta {
+            entry_id: format!("entry-{upload_id}"),
+            revision: 0,
+            upload_id: Some(upload_id.to_owned()),
+            provider: "s3".to_owned(),
+            host: "s3.example.test".to_owned(),
+            container: "bucket".to_owned(),
+            key: key.to_owned(),
+            last_updated,
         }
     }
 
@@ -961,11 +1005,11 @@ mod tests {
                 created: now - Duration::from_secs(7200),
                 ttl: Duration::from_secs(3600),
             }],
-            multipart_uploads: vec![MultipartMeta {
-                upload_id: "mp-123".to_string(),
-                key: "xorbs/ab/partial".to_string(),
-                initiated: now - Duration::from_secs(86400),
-            }],
+            multipart_uploads: vec![multipart_meta(
+                "mp-123",
+                "xorbs/ab/partial",
+                now - Duration::from_secs(86400),
+            )],
             shard_divergence_issues: vec![FsckIssue::shard_list_divergence("shards/ef/divergent")],
             orphan_file_index_issues: vec![FsckIssue::orphan_file_index("file-index/gh/orphan1")],
         };
@@ -1057,11 +1101,11 @@ mod tests {
     async fn fsck_repair_aborts_abandoned_multiparts() {
         let now = SystemTime::now();
         let checker = MockChecker {
-            multipart_uploads: vec![MultipartMeta {
-                upload_id: "mp-old".to_string(),
-                key: "xorbs/ab/stale".to_string(),
-                initiated: now - Duration::from_secs(172800),
-            }],
+            multipart_uploads: vec![multipart_meta(
+                "mp-old",
+                "xorbs/ab/stale",
+                now - Duration::from_secs(172800),
+            )],
             ..MockChecker::default()
         };
         let repairer = MockRepairer::new();
@@ -1087,7 +1131,7 @@ mod tests {
         assert_eq!(aborted.len(), 1);
         assert_eq!(
             aborted[0],
-            ("mp-old".to_string(), "xorbs/ab/stale".to_string())
+            (Some("mp-old".to_string()), "xorbs/ab/stale".to_string())
         );
     }
 
@@ -1215,8 +1259,9 @@ mod tests {
             FsckIssue::expired_push_lock("k", Duration::from_secs(1)).severity,
             IssueSeverity::Error
         );
+        let multipart = multipart_meta("u", "k", SystemTime::UNIX_EPOCH);
         assert_eq!(
-            FsckIssue::abandoned_multipart("u", "k", Duration::from_secs(1)).severity,
+            FsckIssue::abandoned_multipart(&multipart, Duration::from_secs(1)).severity,
             IssueSeverity::Error
         );
         assert_eq!(
@@ -1239,7 +1284,8 @@ mod tests {
         assert!(!FsckIssue::orphan_shard("k").repairable);
         assert!(!FsckIssue::pack_list_divergence("k").repairable);
         assert!(FsckIssue::expired_push_lock("k", Duration::from_secs(1)).repairable);
-        assert!(FsckIssue::abandoned_multipart("u", "k", Duration::from_secs(1)).repairable);
+        let multipart = multipart_meta("u", "k", SystemTime::UNIX_EPOCH);
+        assert!(FsckIssue::abandoned_multipart(&multipart, Duration::from_secs(1)).repairable);
         assert!(!FsckIssue::shard_list_divergence("k").repairable);
         assert!(!FsckIssue::orphan_file_index("k").repairable);
     }

--- a/crab/src/cmd/fsck_store.rs
+++ b/crab/src/cmd/fsck_store.rs
@@ -20,7 +20,7 @@ use crate::metadata::manifest::{
     Manifest, read_bulk_pack_list, read_manifest, read_repository_snapshot,
 };
 use crate::storage::StoreLayout;
-use crate::storage::store::Store;
+use crate::storage::store::{MultipartJournal, Store};
 #[cfg(test)]
 use crab_coordination::push_lock_path;
 use crab_coordination::{PushLock, PushLockPayload};
@@ -38,6 +38,7 @@ pub struct StoreChecker {
     store: Store,
     prefix: String,
     router: StoreLayout,
+    multipart_journal: Option<Arc<MultipartJournal>>,
 }
 
 impl StoreChecker {
@@ -47,7 +48,14 @@ impl StoreChecker {
             store,
             prefix,
             router,
+            multipart_journal: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_multipart_journal(mut self, journal: Option<Arc<MultipartJournal>>) -> Self {
+        self.multipart_journal = journal;
+        self
     }
 
     /// Load the current pack list from the compacted manifest and journal.
@@ -533,17 +541,34 @@ impl FsckChecker for StoreChecker {
 
     fn check_multipart_uploads(
         &self,
-        _now: SystemTime,
-        _grace: Duration,
+        now: SystemTime,
+        grace: Duration,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<MultipartMeta>>> + Send + '_>>
     {
         Box::pin(async move {
-            // Multipart uploads are tracked in the local SQLite registry,
-            // not in object storage. The CLI caller should query the
-            // MultipartRegistry directly if available. For the store-only
-            // checker, return an empty list — the local registry check
-            // is handled at the CLI layer when the staging DB is present.
-            Ok(Vec::new())
+            let Some(journal) = &self.multipart_journal else {
+                return Ok(Vec::new());
+            };
+            journal
+                .find_abandoned(now, grace)
+                .await?
+                .into_iter()
+                .map(|upload| {
+                    let updated_seconds = u64::try_from(upload.updated_at).map_err(|_| {
+                        CrabError::Internal("multipart journal has a negative update time".into())
+                    })?;
+                    Ok(MultipartMeta {
+                        entry_id: upload.entry_id,
+                        revision: upload.revision,
+                        upload_id: upload.upload_id,
+                        provider: upload.target.provider,
+                        host: upload.target.host,
+                        container: upload.target.container,
+                        key: upload.target.key,
+                        last_updated: UNIX_EPOCH + Duration::from_secs(updated_seconds),
+                    })
+                })
+                .collect()
         })
     }
 
@@ -591,6 +616,7 @@ pub struct StoreRepairer {
     store: Store,
     prefix: String,
     router: StoreLayout,
+    multipart_journal: Option<Arc<MultipartJournal>>,
 }
 
 impl StoreRepairer {
@@ -603,7 +629,14 @@ impl StoreRepairer {
             store,
             prefix,
             router,
+            multipart_journal: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_multipart_journal(mut self, journal: Option<Arc<MultipartJournal>>) -> Self {
+        self.multipart_journal = journal;
+        self
     }
 
     async fn file_index_target_has_file(&self, file_hash: &MerkleHash) -> Result<bool> {
@@ -711,20 +744,97 @@ impl FsckRepairer for StoreRepairer {
 
     fn abort_multipart(
         &self,
-        _upload_id: &str,
-        _key: &str,
+        upload: MultipartMeta,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send + '_>> {
         Box::pin(async move {
-            // Multipart abort requires the S3 AbortMultipartUpload API,
-            // which is not exposed through the `object_store` crate's
-            // generic interface. The local MultipartRegistry handles
-            // abort_stale for locally-tracked uploads. For remote-only
-            // abandoned uploads, this is a no-op until we add direct S3
-            // API support.
-            debug!("multipart abort not yet supported via generic object store");
-            Ok(false)
+            const REPAIR_LEASE: Duration = Duration::from_secs(60);
+            const REPAIR_HEARTBEAT: Duration = Duration::from_secs(10);
+
+            let Some(journal) = &self.multipart_journal else {
+                return Ok(false);
+            };
+            let now = unix_now();
+            let owner_token = uuid::Uuid::now_v7().simple().to_string();
+            let Some(claim) = journal
+                .claim_abandoned(
+                    &upload.entry_id,
+                    upload.revision,
+                    &owner_token,
+                    now,
+                    REPAIR_LEASE,
+                )
+                .await?
+            else {
+                return Ok(false);
+            };
+            let path = Path::from(claim.target.key.as_str());
+            let Some(target) = self.store.multipart_target(&path) else {
+                let _ = journal.release_repair(&claim.lease, unix_now()).await;
+                return Ok(false);
+            };
+            if target.provider != claim.target.provider
+                || target.host != claim.target.host
+                || target.container != claim.target.container
+                || target.key != claim.target.key
+            {
+                let _ = journal.release_repair(&claim.lease, unix_now()).await;
+                warn!(
+                    entry_id = %upload.entry_id,
+                    provider = %claim.target.provider,
+                    host = %claim.target.host,
+                    container = %claim.target.container,
+                    "multipart repair skipped because the configured destination differs from the journal"
+                );
+                return Ok(false);
+            }
+
+            if let Some(upload_id) = claim.upload_id.as_deref() {
+                let abort = self.store.abort_explicit_multipart(&path, upload_id);
+                tokio::pin!(abort);
+                let start = tokio::time::Instant::now() + REPAIR_HEARTBEAT;
+                let mut heartbeat = tokio::time::interval_at(start, REPAIR_HEARTBEAT);
+                loop {
+                    tokio::select! {
+                        result = &mut abort => {
+                            if let Err(error) = result {
+                                let _ = journal.release_repair(&claim.lease, unix_now()).await;
+                                return Err(error);
+                            }
+                            break;
+                        }
+                        _ = heartbeat.tick() => {
+                            if !journal.renew_repair(
+                                &claim.lease,
+                                unix_now(),
+                                REPAIR_LEASE,
+                            ).await? {
+                                return Err(CrabError::CasConflict {
+                                    path: claim.target.key,
+                                    expected_etag: None,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            if journal.abandon_repair(&claim.lease, unix_now()).await? {
+                Ok(true)
+            } else {
+                Err(CrabError::CasConflict {
+                    path: claim.target.key,
+                    expected_etag: None,
+                })
+            }
         })
     }
+}
+
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok())
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -743,6 +853,7 @@ mod tests {
         XorbChunkSequenceEntry, XorbChunkSequenceHeader,
     };
     use object_store::memory::InMemory;
+    use object_store::multipart::MultipartStore as _;
     use std::sync::Arc;
 
     fn test_store() -> (Store, String) {
@@ -1365,5 +1476,275 @@ mod tests {
         let repairer = StoreRepairer::new(store, prefix);
         let result = repairer.repair_push_lock("nonexistent/lock").await.unwrap();
         assert!(result);
+    }
+
+    #[tokio::test]
+    async fn checker_and_repairer_abort_exact_journal_destination() {
+        let inner = Arc::new(InMemory::new());
+        let object_store: Arc<dyn object_store::ObjectStore> = inner.clone();
+        let multipart: Arc<dyn object_store::multipart::MultipartStore> = inner.clone();
+        let identity = crab_storage::BucketIdentity::new(
+            crab_storage::StorageProviderKind::S3,
+            "s3.example.test",
+            "bucket-a",
+        );
+        let store = Store::new(object_store)
+            .with_bucket_identity(identity.clone())
+            .with_multipart(multipart, identity);
+        let key = "repo/xorbs/ab/payload";
+        let path = Path::from(key);
+        let target = store.multipart_target(&path).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry =
+            crab_staging::MultipartRegistry::open(&dir.path().join("multipart-uploads.sqlite3"))
+                .unwrap();
+        let claim = match registry
+            .claim(
+                &crab_staging::MultipartTarget {
+                    provider: target.provider,
+                    host: target.host,
+                    container: target.container,
+                    key: target.key,
+                },
+                &[1; 32],
+                &[1; 32],
+                8,
+                8,
+                "push-owner",
+                100,
+                Duration::from_secs(60),
+            )
+            .unwrap()
+        {
+            crab_staging::ClaimOutcome::Acquired(claim) => claim,
+            crab_staging::ClaimOutcome::Busy => panic!("new upload must be claimable"),
+        };
+        let upload_id = inner.create_multipart(&path).await.unwrap();
+        assert!(
+            registry
+                .bind_upload(
+                    &claim.lease,
+                    upload_id.as_ref(),
+                    100,
+                    Duration::from_secs(60)
+                )
+                .unwrap()
+        );
+        assert!(registry.release_owned(&claim.lease, 100).unwrap());
+        let journal = Arc::new(MultipartJournal::new(registry));
+        let checker = StoreChecker::new(store.clone(), "repo".to_owned())
+            .with_multipart_journal(Some(Arc::clone(&journal)));
+        let uploads = checker
+            .check_multipart_uploads(SystemTime::now(), Duration::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(uploads.len(), 1);
+
+        let repairer = StoreRepairer::new(store, "repo".to_owned())
+            .with_multipart_journal(Some(Arc::clone(&journal)));
+        assert!(repairer.abort_multipart(uploads[0].clone()).await.unwrap());
+        assert!(
+            checker
+                .check_multipart_uploads(SystemTime::now(), Duration::ZERO)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn multipart_repair_preserves_row_when_configured_endpoint_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry =
+            crab_staging::MultipartRegistry::open(&dir.path().join("multipart-uploads.sqlite3"))
+                .unwrap();
+        let claim = match registry
+            .claim(
+                &crab_staging::MultipartTarget {
+                    provider: "s3".to_owned(),
+                    host: "old-s3.example.test".to_owned(),
+                    container: "shared-bucket".to_owned(),
+                    key: "repo/xorbs/old".to_owned(),
+                },
+                &[2; 32],
+                &[2; 32],
+                8,
+                8,
+                "push-owner",
+                100,
+                Duration::from_secs(60),
+            )
+            .unwrap()
+        {
+            crab_staging::ClaimOutcome::Acquired(claim) => claim,
+            crab_staging::ClaimOutcome::Busy => panic!("new upload must be claimable"),
+        };
+        assert!(registry.release_owned(&claim.lease, 100).unwrap());
+        let journal = Arc::new(MultipartJournal::new(registry));
+        let inner = Arc::new(InMemory::new());
+        let object_store: Arc<dyn object_store::ObjectStore> = inner.clone();
+        let multipart: Arc<dyn object_store::multipart::MultipartStore> = inner;
+        let identity = crab_storage::BucketIdentity::new(
+            crab_storage::StorageProviderKind::S3,
+            "new-s3.example.test",
+            "shared-bucket",
+        );
+        let store = Store::new(object_store)
+            .with_bucket_identity(identity.clone())
+            .with_multipart(multipart, identity);
+        let checker = StoreChecker::new(store.clone(), "repo".to_owned())
+            .with_multipart_journal(Some(Arc::clone(&journal)));
+        let upload = checker
+            .check_multipart_uploads(SystemTime::now(), Duration::ZERO)
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        let repairer = StoreRepairer::new(store, "repo".to_owned())
+            .with_multipart_journal(Some(Arc::clone(&journal)));
+
+        assert!(!repairer.abort_multipart(upload).await.unwrap());
+        assert_eq!(
+            checker
+                .check_multipart_uploads(
+                    SystemTime::now() + Duration::from_secs(1),
+                    Duration::ZERO,
+                )
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn multipart_repair_refuses_row_replaced_after_check() {
+        let inner = Arc::new(InMemory::new());
+        let object_store: Arc<dyn object_store::ObjectStore> = inner.clone();
+        let multipart: Arc<dyn object_store::multipart::MultipartStore> = inner.clone();
+        let identity = crab_storage::BucketIdentity::new(
+            crab_storage::StorageProviderKind::S3,
+            "s3.example.test",
+            "bucket-a",
+        );
+        let store = Store::new(object_store)
+            .with_bucket_identity(identity.clone())
+            .with_multipart(multipart, identity);
+        let key = "repo/xorbs/ab/payload";
+        let path = Path::from(key);
+        let target = store.multipart_target(&path).unwrap();
+        let staging_target = crab_staging::MultipartTarget {
+            provider: target.provider.clone(),
+            host: target.host.clone(),
+            container: target.container.clone(),
+            key: target.key.clone(),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry =
+            crab_staging::MultipartRegistry::open(&dir.path().join("multipart-uploads.sqlite3"))
+                .unwrap();
+        let first = match registry
+            .claim(
+                &staging_target,
+                &[1; 32],
+                &[1; 32],
+                8,
+                8,
+                "push-1",
+                100,
+                Duration::from_secs(60),
+            )
+            .unwrap()
+        {
+            crab_staging::ClaimOutcome::Acquired(claim) => claim,
+            crab_staging::ClaimOutcome::Busy => panic!("new upload must be claimable"),
+        };
+        let old_upload_id = inner.create_multipart(&path).await.unwrap();
+        assert!(
+            registry
+                .bind_upload(
+                    &first.lease,
+                    old_upload_id.as_ref(),
+                    100,
+                    Duration::from_secs(60),
+                )
+                .unwrap()
+        );
+        assert!(registry.release_owned(&first.lease, 100).unwrap());
+        let observed = registry
+            .find_abandoned(UNIX_EPOCH + Duration::from_secs(101), Duration::ZERO)
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        let resumed = match registry
+            .claim(
+                &staging_target,
+                &[2; 32],
+                &[2; 32],
+                8,
+                8,
+                "push-2",
+                101,
+                Duration::from_secs(60),
+            )
+            .unwrap()
+        {
+            crab_staging::ClaimOutcome::Acquired(claim) => claim,
+            crab_staging::ClaimOutcome::Busy => panic!("expired upload must be claimable"),
+        };
+        inner.abort_multipart(&path, &old_upload_id).await.unwrap();
+        assert!(
+            registry
+                .reset_owned(
+                    &resumed.lease,
+                    &[2; 32],
+                    &[2; 32],
+                    8,
+                    8,
+                    101,
+                    Duration::from_secs(60),
+                )
+                .unwrap()
+        );
+        let replacement_id = inner.create_multipart(&path).await.unwrap();
+        assert!(
+            registry
+                .bind_upload(
+                    &resumed.lease,
+                    replacement_id.as_ref(),
+                    101,
+                    Duration::from_secs(60),
+                )
+                .unwrap()
+        );
+        assert!(registry.release_owned(&resumed.lease, 101).unwrap());
+        let journal = Arc::new(MultipartJournal::new(registry));
+        let repairer =
+            StoreRepairer::new(store, "repo".to_owned()).with_multipart_journal(Some(journal));
+        let repaired = repairer
+            .abort_multipart(MultipartMeta {
+                entry_id: observed.entry_id,
+                revision: observed.revision,
+                upload_id: observed.upload_id,
+                provider: observed.target.provider,
+                host: observed.target.host,
+                container: observed.target.container,
+                key: observed.target.key,
+                last_updated: UNIX_EPOCH + Duration::from_secs(100),
+            })
+            .await
+            .unwrap();
+
+        assert!(!repaired);
+        inner
+            .put_part(
+                &path,
+                &replacement_id,
+                0,
+                Bytes::from_static(b"survives").into(),
+            )
+            .await
+            .expect("replacement provider session must remain active");
     }
 }

--- a/crab/src/core/error.rs
+++ b/crab/src/core/error.rs
@@ -1831,6 +1831,12 @@ impl From<crab_storage::error::StorageError> for CrabError {
             crab_storage::error::StorageError::AuthExpired { path } => Self::AuthExpired { path },
             crab_storage::error::StorageError::Io { source } => Self::Io(source),
             crab_storage::error::StorageError::Cancelled => Self::Cancelled,
+            crab_storage::error::StorageError::MultipartJournal { source, .. } => {
+                Self::Storage(object_store::Error::Generic {
+                    store: "multipart journal",
+                    source,
+                })
+            }
             crab_storage::error::StorageError::NotSupported { source }
             | crab_storage::error::StorageError::ObjectStore { source } => Self::Storage(source),
             crab_storage::error::StorageError::Internal(message) => Self::Internal(message),

--- a/crab/src/git/filter_process.rs
+++ b/crab/src/git/filter_process.rs
@@ -20,6 +20,7 @@ use crate::git::worktree::WorktreeContext;
 use crate::speculation::access_db::AsyncAccessDb;
 use crate::speculation::driver::SpeculativeDriver;
 use crate::speculation::predictor::Predictor;
+use crab_git::lfs_pointer::MAX_LFS_POINTER_SIZE;
 use crab_git::pointer_detect::{PointerKind, classify};
 use crab_lfs::LfsObjectStore;
 use crab_staging::StagingArea;
@@ -82,6 +83,12 @@ enum SmudgeOutput {
     Bytes(Bytes),
     File(PathBuf),
     TemporaryFile(tempfile::TempPath),
+}
+
+#[derive(Debug)]
+enum SmudgeInput {
+    PointerCandidate(Vec<u8>),
+    PassthroughFile(tempfile::TempPath),
 }
 
 /// How long the filter process will wait for the next command before
@@ -1091,7 +1098,18 @@ fn dispatch_command<R: Read, W: Write>(
             output.flush().map_err(CrabError::Io)?;
         }
         "smudge" => {
-            let content = read_content_until_flush(input)?;
+            let content = match read_smudge_input_until_flush(input)? {
+                SmudgeInput::PointerCandidate(content) => content,
+                SmudgeInput::PassthroughFile(path) => {
+                    write_status(output, "success")?;
+                    write_flush(output)?;
+                    write_content_file(output, &path)?;
+                    write_flush(output)?;
+                    write_flush(output)?;
+                    output.flush().map_err(CrabError::Io)?;
+                    return Ok(());
+                }
+            };
             let lazy = ctx.config().checkout.lazy;
 
             // Speculative hydration: on smudge of a dehydrated file
@@ -1739,45 +1757,44 @@ fn read_text_line<R: Read>(input: &mut R) -> Result<Option<String>> {
         .map_err(|_| CrabError::Protocol("non-UTF-8 packet-line data".into()))
 }
 
-/// Read content data packets until a flush packet.
+/// Read one complete smudge request without retaining a non-pointer body.
 ///
-/// Pre-allocates a reasonable buffer and reads packet data directly into
-/// the accumulator to avoid per-packet allocations on large files.
-fn read_content_until_flush<R: Read>(input: &mut R) -> Result<Vec<u8>> {
-    // Start with 1 MB; will grow as needed for large files.
-    let mut content = Vec::with_capacity(1024 * 1024);
-    let mut hdr = [0u8; 4];
-    loop {
-        match input.read_exact(&mut hdr) {
-            Ok(()) => {}
-            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
-            Err(e) => return Err(CrabError::Io(e)),
+/// Git requires the request flush before the filter starts its response.
+/// Direct LFS parsing accepts `MAX_LFS_POINTER_SIZE` bytes, so only after that
+/// boundary is exceeded can the body be classified as passthrough and
+/// spooled packet-by-packet to disk with bounded memory.
+fn read_smudge_input_until_flush<R: Read>(input: &mut R) -> Result<SmudgeInput> {
+    let mut reader = PktLineReader::from_read(input);
+    let mut pointer_candidate = Vec::with_capacity(MAX_LFS_POINTER_SIZE);
+    let mut passthrough: Option<tempfile::NamedTempFile> = None;
+    while let Some(packet) = reader.read_packet()? {
+        if let Some(file) = passthrough.as_mut() {
+            file.write_all(packet).map_err(CrabError::Io)?;
+            continue;
+        }
+        let next_len = pointer_candidate
+            .len()
+            .checked_add(packet.len())
+            .ok_or_else(|| CrabError::Protocol("smudge input length overflow".to_owned()))?;
+        if next_len <= MAX_LFS_POINTER_SIZE {
+            pointer_candidate.extend_from_slice(packet);
+            continue;
         }
 
-        if &hdr == b"0000" || &hdr == b"0001" || &hdr == b"0002" {
-            break;
-        }
-
-        let hex = std::str::from_utf8(&hdr)
-            .map_err(|_| CrabError::Protocol("invalid packet-line hex".into()))?;
-        let len: usize = u16::from_str_radix(hex, 16)
-            .map_err(|_| CrabError::Protocol(format!("invalid packet-line length: {hex}")))?
-            .into();
-
-        if len < 4 {
-            return Err(CrabError::Protocol(format!(
-                "packet-line length too small: {len}"
-            )));
-        }
-
-        let data_len = len - 4;
-        let start = content.len();
-        content.resize(start + data_len, 0);
-        input
-            .read_exact(&mut content[start..start + data_len])
-            .map_err(CrabError::Io)?;
+        let mut file = tempfile::NamedTempFile::new().map_err(CrabError::Io)?;
+        file.write_all(&pointer_candidate).map_err(CrabError::Io)?;
+        file.write_all(packet).map_err(CrabError::Io)?;
+        pointer_candidate.clear();
+        passthrough = Some(file);
     }
-    Ok(content)
+
+    match passthrough {
+        Some(mut file) => {
+            file.flush().map_err(CrabError::Io)?;
+            Ok(SmudgeInput::PassthroughFile(file.into_temp_path()))
+        }
+        None => Ok(SmudgeInput::PointerCandidate(pointer_candidate)),
+    }
 }
 
 /// Drain packet-lines from `input` until a flush/delimiter packet is seen
@@ -1979,9 +1996,8 @@ impl<R: Read> PktLineReader<R> {
         self.inner.read_exact(&mut hdr).map_err(CrabError::Io)?;
 
         // Flush and the other delimiter packets all have zero body length.
-        // `read_content_until_flush` treats `0001` and `0002` as flush too,
-        // but the clean-filter content stream only uses `0000`. Accepting
-        // the same set here keeps behavior aligned.
+        // Git's filter content stream uses `0000`; accepting the protocol's
+        // other zero-body delimiters preserves the existing recovery boundary.
         if &hdr == b"0000" || &hdr == b"0001" || &hdr == b"0002" {
             return Ok(None);
         }
@@ -2005,6 +2021,12 @@ impl<R: Read> PktLineReader<R> {
             return Err(CrabError::Io(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("pkt-line length {len} shorter than header"),
+            )));
+        }
+        if len - 4 > PKT_LINE_MAX_BODY {
+            return Err(CrabError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("pkt-line body exceeds {PKT_LINE_MAX_BODY} bytes"),
             )));
         }
 
@@ -2484,14 +2506,74 @@ mod tests {
     }
 
     #[test]
-    fn read_content_collects_data() {
+    fn read_smudge_input_collects_pointer_candidate_across_packets() {
         let mut input = Vec::new();
         input.extend(pkt_data(b"hello "));
         input.extend(pkt_data(b"world"));
         input.extend(pkt_flush());
 
-        let content = read_content_until_flush(&mut &input[..]).unwrap();
-        assert_eq!(content, b"hello world");
+        let content = read_smudge_input_until_flush(&mut &input[..]).unwrap();
+        assert!(matches!(
+            content,
+            SmudgeInput::PointerCandidate(bytes) if bytes == b"hello world"
+        ));
+    }
+
+    #[test]
+    fn read_smudge_input_supports_pointer_split_at_every_byte() {
+        let pointer = crab_types::pointer::Pointer {
+            file_hash: [7; 32],
+            size: 42,
+            shard_hint: Some([8; 32]),
+        }
+        .serialize();
+        let mut input = Vec::new();
+        for byte in &pointer {
+            input.extend(pkt_data(std::slice::from_ref(byte)));
+        }
+        input.extend(pkt_flush());
+
+        let content = read_smudge_input_until_flush(&mut &input[..]).unwrap();
+        assert!(matches!(
+            content,
+            SmudgeInput::PointerCandidate(bytes) if bytes == pointer
+        ));
+    }
+
+    #[test]
+    fn read_smudge_input_spools_large_passthrough_across_many_packets() {
+        let body = (0..(MAX_LFS_POINTER_SIZE * 3 + 17))
+            .map(|idx| (idx % 251) as u8)
+            .collect::<Vec<_>>();
+        let mut input = Vec::new();
+        for chunk in body.chunks(7) {
+            input.extend(pkt_data(chunk));
+        }
+        input.extend(pkt_flush());
+
+        let content = read_smudge_input_until_flush(&mut &input[..]).unwrap();
+        let SmudgeInput::PassthroughFile(path) = content else {
+            panic!("large non-pointer input must be spooled");
+        };
+        assert_eq!(std::fs::read(path).unwrap(), body);
+    }
+
+    #[test]
+    fn read_smudge_input_retains_direct_lfs_parse_size_boundary() {
+        let mut body = b"version https://git-lfs.github.com/spec/v1\noid sha256:0000000000000000000000000000000000000000000000000000000000000000\nsize 1\n".to_vec();
+        body.resize(MAX_LFS_POINTER_SIZE, b'\n');
+        let mut input = Vec::new();
+        for chunk in body.chunks(11) {
+            input.extend(pkt_data(chunk));
+        }
+        input.extend(pkt_flush());
+
+        let content = read_smudge_input_until_flush(&mut &input[..]).unwrap();
+
+        assert!(matches!(
+            content,
+            SmudgeInput::PointerCandidate(bytes) if bytes == body
+        ));
     }
 
     #[test]
@@ -3086,6 +3168,45 @@ size 1048576\n";
             output.windows(content.len()).any(|w| w == content),
             "non-pointer content should pass through unchanged"
         );
+    }
+
+    #[test]
+    fn large_non_pointer_smudge_roundtrips_after_request_flush() {
+        let body = (0..(MAX_LFS_POINTER_SIZE * 3 + 17))
+            .map(|idx| (idx % 251) as u8)
+            .collect::<Vec<_>>();
+        let mut input = build_handshake_input();
+        input.extend(pkt_text("command=smudge"));
+        input.extend(pkt_text("pathname=large.bin"));
+        input.extend(pkt_flush());
+        for chunk in body.chunks(7) {
+            input.extend(pkt_data(chunk));
+        }
+        input.extend(pkt_flush());
+
+        let mut output = Vec::new();
+        run_filter_loop(
+            &mut &input[..],
+            &mut output,
+            AppContext::default(),
+            Arc::new(std::sync::Mutex::new(LazyStaging::Unavailable)),
+            None,
+            None,
+            None,
+            None,
+            Arc::new(std::sync::Mutex::new(None)),
+        )
+        .unwrap();
+
+        let status = output
+            .windows(b"status=success".len())
+            .position(|window| window == b"status=success")
+            .unwrap();
+        let content = output
+            .windows(body.len())
+            .position(|window| window == body)
+            .unwrap();
+        assert!(status < content);
     }
 
     #[test]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -54,7 +54,7 @@ use crate::metadata::manifest::{
 };
 use crate::replication::{ActiveActivePushPlan, ReplicationConfig};
 use crate::storage::StoreLayout;
-use crate::storage::store::{StagedWrite, Store};
+use crate::storage::store::{MultipartJournal, StagedWrite, Store};
 use crab_coordination::write_coordinator::{
     CommitOutcome, CoordinatedRefUpdate, PushTransactionState, WriteCoordinator,
     commit_uploaded_push_refs,
@@ -2880,6 +2880,10 @@ const XORB_UPLOAD_IN_FLIGHT_PAYLOAD_LIMIT: usize = 256 * 1024 * 1024;
 /// bytes, while still allowing one oversized (but valid) chunk to progress.
 const XORB_PACK_READ_PAYLOAD_LIMIT: u64 = 16 * 1024 * 1024;
 
+// Each pack owns an index-pack process and a bounded multipart buffer pool.
+// Bound whole transactions as well as individual provider requests.
+const GIT_PACK_UPLOAD_MAX_CONCURRENCY: usize = 4;
+
 /// Maximum post-success xorb cache warm tasks.
 const XORB_CACHE_WARM_MAX_CONCURRENCY: usize = 8;
 
@@ -2924,7 +2928,7 @@ impl fmt::Debug for ActiveActiveWriteCoordinator {
 /// Configuration for the push pipeline.
 #[derive(Debug, Clone)]
 pub struct PushConfig {
-    /// Maximum number of concurrent xorb uploads (step 7).
+    /// Maximum concurrent uploads; Git pack transactions are additionally capped at four.
     pub upload_concurrency: usize,
     /// Maximum number of concurrent HEAD/LIST requests for the HEAD-check
     /// resume step (step 6). Defaults to 64.
@@ -4088,6 +4092,7 @@ pub struct PushPipeline {
     /// uploaded objects to the cache in the background.
     caching_store: Option<crab_cache_store::CachingStore>,
     staging: Option<Arc<StagingAreaReadOnly>>,
+    multipart_journal: tokio::sync::OnceCell<Arc<MultipartJournal>>,
     /// Object-store key prefix (e.g. `ml` for `crab://crab/ml`).
     prefix: String,
     /// Routes content-addressed paths to `.crab/` and per-repo paths
@@ -4693,12 +4698,9 @@ impl PackedXorb {
         spill_dir: &Path,
         packed_payload_budget: Option<&Arc<tokio::sync::Semaphore>>,
     ) -> Result<Self> {
-        let memory_limit = packed_payload_budget
-            .map(|_| XORB_UPLOAD_IN_FLIGHT_PAYLOAD_LIMIT)
-            .unwrap_or(XORB_MEMORY_PAYLOAD_LIMIT);
         Self::from_result_with_memory_limit(
             result,
-            memory_limit,
+            XORB_MEMORY_PAYLOAD_LIMIT,
             Some(spill_dir),
             packed_payload_budget,
         )
@@ -7365,6 +7367,7 @@ impl PushPipeline {
             store,
             caching_store,
             staging,
+            multipart_journal: tokio::sync::OnceCell::new(),
             prefix,
             router,
             metrics,
@@ -7430,6 +7433,31 @@ impl PushPipeline {
 
     fn git_dir_override(&self) -> Option<&Path> {
         self.config.git_dir.as_deref()
+    }
+
+    async fn multipart_journal(&self) -> Result<Option<Arc<MultipartJournal>>> {
+        let Some(store) = &self.store else {
+            return Ok(None);
+        };
+        let Some(staging) = &self.staging else {
+            return Ok(None);
+        };
+        if !store.has_resumable_multipart() || store.staging_write_prefix().is_some() {
+            return Ok(None);
+        }
+        let path = staging.root().join("multipart-uploads.sqlite3");
+        let journal = self
+            .multipart_journal
+            .get_or_try_init(|| async move {
+                let registry = tokio::task::spawn_blocking(move || {
+                    crab_staging::MultipartRegistry::open(&path)
+                })
+                .await
+                .map_err(|error| CrabError::Io(std::io::Error::other(error)))??;
+                Ok::<_, CrabError>(Arc::new(MultipartJournal::new(registry)))
+            })
+            .await?;
+        Ok(Some(Arc::clone(journal)))
     }
 
     fn discover_git_dir(&self) -> Result<PathBuf> {
@@ -12037,6 +12065,7 @@ impl PushPipeline {
             debug!("step 7: no xorbs to upload");
             return Ok(());
         }
+        let multipart_journal = self.multipart_journal().await?;
 
         let upload_concurrency = Arc::new(UploadConcurrency::from_config(
             self.config.adaptive_concurrency,
@@ -12142,6 +12171,8 @@ impl PushPipeline {
             // Clone the shared progress handle (if any) into the task
             // so the per-part callback can credit bytes in real time.
             let progress_for_task = self.progress.clone();
+            let metrics_for_task = self.metrics.clone();
+            let journal_for_task = multipart_journal.clone();
             #[cfg(test)]
             let test_metrics = Arc::clone(&self.test_metrics);
             // Hand the push cancellation token into the task so the
@@ -12186,17 +12217,38 @@ impl PushPipeline {
                             p.add_upload_bytes(bytes);
                         }
                     });
-                    store_for_task
-                        .put_multipart_file_retry(
+                    let outcome = store_for_task
+                        .put_multipart_file_resumable(
                             &path,
                             file_path,
                             file_len as u64,
                             payload_hash,
+                            &payload_hash,
                             XORB_MULTIPART_PART_SIZE,
                             &cancel_for_task,
                             Some(&*on_part),
+                            journal_for_task.as_deref().map(|journal| {
+                                journal as &dyn crab_storage::multipart::MultipartJournal
+                            }),
                         )
-                        .await
+                        .await;
+                    match outcome {
+                        Ok(outcome) => {
+                            match outcome {
+                                crab_storage::multipart::ResumableUploadOutcome::Resumed => {
+                                    if let Some(metrics) = &metrics_for_task {
+                                        metrics.inc_multipart_resumed_uploads();
+                                    }
+                                }
+                                crab_storage::multipart::ResumableUploadOutcome::AlreadyPresent => {
+                                    on_part(file_len as u64);
+                                }
+                                crab_storage::multipart::ResumableUploadOutcome::Uploaded => {}
+                            }
+                            Ok(())
+                        }
+                        Err(error) => Err(error),
+                    }
                 } else {
                     let data = match payload.read_bytes().await {
                         Ok(data) => data,
@@ -12258,6 +12310,19 @@ impl PushPipeline {
                             store_for_task.put_overwrite(&path, data.clone()).await
                         }
                         other => other,
+                    };
+                    let result = match result {
+                        Ok(()) => {
+                            let payload_hash = *blake3::hash(&data).as_bytes();
+                            store_for_task
+                                .verify_written_size_and_hash(
+                                    &path,
+                                    data.len() as u64,
+                                    &payload_hash,
+                                )
+                                .await
+                        }
+                        Err(error) => Err(error),
                     };
                     drop(data);
                     result
@@ -13352,8 +13417,9 @@ impl PushPipeline {
             return Ok(());
         }
         if all_candidates_proven {
+            let objects = self.git_object_candidates.lock().await.len();
             info!(
-                objects = self.git_object_candidates.lock().await.len(),
+                objects,
                 "step 10: every candidate Git object is committed; no pack upload needed"
             );
             return Ok(());
@@ -13390,17 +13456,24 @@ impl PushPipeline {
         );
 
         if let Some(store) = &self.store {
+            let multipart_journal = self.multipart_journal().await?;
             let ref_tips = refs
                 .iter()
                 .map(|update| update.new_sha.clone())
                 .collect::<Vec<_>>();
             let pack_dir = self.objects_dir()?.join("pack");
             let mut uploaded = Vec::with_capacity(packed_files.len());
-            for packed in packed_files {
+            let ref_tips = &ref_tips;
+            let pack_dir = &pack_dir;
+            let multipart_journal = multipart_journal
+                .as_deref()
+                .map(|journal| journal as &dyn crab_storage::multipart::MultipartJournal);
+            let mut jobs = packed_files.iter().enumerate().map(|(index, packed)| async move {
+                check_cancelled(&self.cancel)?;
                 let pack_sha = packed.pack_blake3_hex.clone();
                 let pack_path = self.router.pack_path(&pack_sha);
                 let installed = pack::install_pack_file_locally_with_timeout(
-                    &pack_dir,
+                    pack_dir,
                     packed.pack_path.as_ref(),
                     &pack_sha,
                     self.config.receive_max_input_size,
@@ -13420,6 +13493,8 @@ impl PushPipeline {
                     packed.pack_size,
                     packed.pack_blake3,
                     &self.cancel,
+                    multipart_journal,
+                    self.metrics.as_deref(),
                 )
                 .await?
                 {
@@ -13525,8 +13600,8 @@ impl PushPipeline {
                     object_count: packed.object_count,
                 };
                 let meta_path = self.router.pack_metadata_path(&pack_sha);
-                // The pack body is verified and durable; its immutable index
-                // evidence, metadata, and origin receipt can now publish in parallel.
+                // Body and index evidence are durable. Publish metadata and
+                // the origin receipt before admitting this pack to the manifest set.
                 let (metadata, _) = tokio::try_join!(
                     upsert_pack_metadata(
                         store,
@@ -13560,13 +13635,46 @@ impl PushPipeline {
                     git_sha1 = %installed.git_sha1,
                     "step 10: bounded pack and immutable locator evidence uploaded"
                 );
-                uploaded.push(UploadedGitPack {
+                Ok::<_, CrabError>((index, UploadedGitPack {
                     entry,
                     idx_path: installed.idx_path,
                     kind_metadata_published: kind_metadata.is_some(),
-                });
+                }))
+            });
+            let concurrency = self
+                .config
+                .upload_concurrency
+                .clamp(1, GIT_PACK_UPLOAD_MAX_CONCURRENCY);
+            let mut running = futures_util::stream::FuturesUnordered::new();
+            for job in jobs.by_ref().take(concurrency) {
+                running.push(job);
             }
-            *self.uploaded_packs.lock().await = uploaded;
+            let mut first_error = None;
+            while let Some(result) = running.next().await {
+                match result {
+                    Ok(pack) => uploaded.push(pack),
+                    Err(error) => {
+                        first_error.get_or_insert(error);
+                    }
+                }
+                // Do not drop active local indexing or provider work on a
+                // sibling failure: its inputs and the push lock must outlive it.
+                if first_error.is_none()
+                    && !self.cancel.is_cancelled()
+                    && let Some(job) = jobs.next()
+                {
+                    running.push(job);
+                }
+            }
+            if let Some(error) = first_error {
+                return Err(error);
+            }
+            check_cancelled(&self.cancel)?;
+            // Completion order is not publication order. Preserve the generated
+            // pack order and expose no partial set to manifest construction.
+            uploaded.sort_unstable_by_key(|(index, _)| *index);
+            *self.uploaded_packs.lock().await =
+                uploaded.into_iter().map(|(_, pack)| pack).collect();
         }
 
         debug!("step 10: pack upload complete");
@@ -18687,19 +18795,34 @@ async fn upload_push_pack_file_body(
     pack_size: u64,
     pack_blake3: [u8; 32],
     cancel: &CancellationToken,
+    journal: Option<&dyn crab_storage::multipart::MultipartJournal>,
+    metrics: Option<&Metrics>,
 ) -> Result<bool> {
     if store.staging_write_prefix().is_some() {
         let pack_bytes = tokio::fs::read(pack_file).await?;
+        verify_pack_body(pack_file, &pack_bytes, pack_size, &pack_blake3)?;
         store.put(pack_path, Bytes::from(pack_bytes)).await?;
+        store
+            .verify_written_size_and_hash(pack_path, pack_size, &pack_blake3)
+            .await?;
         return Ok(true);
     }
 
     match store.head(pack_path).await {
         Ok(_) => {
-            store
+            match store
                 .verify_size_and_hash(pack_path, pack_size, &pack_blake3)
-                .await?;
-            return Ok(false);
+                .await
+            {
+                Ok(()) => return Ok(false),
+                Err(CrabError::CorruptObject { .. }) => {
+                    warn!(
+                        path = %pack_path,
+                        "existing content-addressed pack is corrupt; repairing from verified local body"
+                    );
+                }
+                Err(error) => return Err(error),
+            }
         }
         Err(CrabError::NotFound { .. }) => {}
         Err(e) => return Err(e),
@@ -18708,22 +18831,71 @@ async fn upload_push_pack_file_body(
     if pack_size > PACK_MULTIPART_THRESHOLD_BYTES {
         // Route through `Store` so a transient part-PUT failure retries
         // the whole upload instead of aborting the push.
-        store
-            .put_multipart_file_retry(
+        let outcome = store
+            .put_multipart_file_resumable(
                 pack_path,
                 pack_file,
                 pack_size,
                 pack_blake3,
+                &pack_blake3,
                 PACK_MULTIPART_THRESHOLD_BYTES as usize,
                 cancel,
                 None,
+                journal,
             )
             .await?;
+        if matches!(
+            outcome,
+            crab_storage::multipart::ResumableUploadOutcome::Resumed
+        ) && let Some(metrics) = metrics
+        {
+            metrics.inc_multipart_resumed_uploads();
+        }
     } else {
         let pack_bytes = tokio::fs::read(pack_file).await?;
-        store.put(pack_path, Bytes::from(pack_bytes)).await?;
+        verify_pack_body(pack_file, &pack_bytes, pack_size, &pack_blake3)?;
+        let pack_bytes = Bytes::from(pack_bytes);
+        match store.put(pack_path, pack_bytes.clone()).await {
+            Ok(()) => {}
+            Err(CrabError::CasConflict { .. }) => {
+                store.put_overwrite(pack_path, pack_bytes).await?;
+            }
+            Err(error) => return Err(error),
+        }
+        store
+            .verify_written_size_and_hash(pack_path, pack_size, &pack_blake3)
+            .await?;
     }
     Ok(true)
+}
+
+fn verify_pack_body(
+    pack_file: &Path,
+    body: &[u8],
+    expected_size: u64,
+    expected_hash: &[u8; 32],
+) -> Result<()> {
+    if body.len() as u64 != expected_size {
+        return Err(CrabError::CorruptObject {
+            path: pack_file.display().to_string(),
+            reason: format!(
+                "pack body has {} bytes; expected {expected_size}",
+                body.len()
+            ),
+        });
+    }
+    let actual_hash = *blake3::hash(body).as_bytes();
+    if actual_hash != *expected_hash {
+        return Err(CrabError::CorruptObject {
+            path: pack_file.display().to_string(),
+            reason: format!(
+                "pack body Blake3 {} does not match expected {}",
+                blake3::Hash::from(actual_hash).to_hex(),
+                blake3::Hash::from(*expected_hash).to_hex()
+            ),
+        });
+    }
+    Ok(())
 }
 
 fn hash_file_blake3(path: &Path) -> Result<([u8; 32], u64)> {
@@ -20864,6 +21036,8 @@ mod tests {
         release: Arc<tokio::sync::Semaphore>,
         head_started: Option<Arc<tokio::sync::Semaphore>>,
         head_release: Option<Arc<tokio::sync::Semaphore>>,
+        pack_only: bool,
+        fail_next_put: AtomicBool,
     }
 
     impl std::fmt::Display for GatedPutStore {
@@ -20880,6 +21054,9 @@ mod tests {
             payload: PutPayload,
             opts: PutOptions,
         ) -> object_store::Result<PutResult> {
+            if self.pack_only && !location.as_ref().ends_with(".pack") {
+                return self.inner.put_opts(location, payload, opts).await;
+            }
             self.started.add_permits(1);
             let permit =
                 self.release
@@ -20890,6 +21067,12 @@ mod tests {
                         source: Box::new(error),
                     })?;
             permit.forget();
+            if self.fail_next_put.swap(false, Ordering::SeqCst) {
+                return Err(object_store::Error::NotFound {
+                    path: location.to_string(),
+                    source: "injected pack upload failure".into(),
+                });
+            }
             self.inner.put_opts(location, payload, opts).await
         }
 
@@ -20953,6 +21136,310 @@ mod tests {
         ) -> object_store::Result<()> {
             self.inner.copy_opts(from, to, options).await
         }
+    }
+
+    async fn gated_pack_pipeline(
+        concurrency: usize,
+    ) -> (tempfile::TempDir, Arc<PushPipeline>, Arc<GatedPutStore>) {
+        let source = tempfile::tempdir().unwrap();
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .current_dir(source.path())
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["init", "--initial-branch=main"]);
+        git(&["config", "user.name", "Pack Pipeline Test"]);
+        git(&["config", "user.email", "pack-pipeline@example.test"]);
+        for index in 0..6 {
+            std::fs::write(
+                source.path().join(format!("blob-{index}.bin")),
+                test_deterministic_bytes(index, 700 * 1024),
+            )
+            .unwrap();
+        }
+        git(&["add", "."]);
+        git(&["commit", "-qm", "bounded pack fixture"]);
+        let inner = Arc::new(GatedPutStore {
+            inner: object_store::memory::InMemory::new(),
+            started: Arc::new(tokio::sync::Semaphore::new(0)),
+            release: Arc::new(tokio::sync::Semaphore::new(0)),
+            head_started: None,
+            head_release: None,
+            pack_only: true,
+            fail_next_put: AtomicBool::new(false),
+        });
+        let store = Store::new(inner.clone());
+        let router = StoreLayout::new(store.clone(), "repo-pack-pipeline".to_owned());
+        initialize_test_repository(&store, &router).await;
+        let pipeline = Arc::new(PushPipeline::new(
+            PushConfig {
+                git_dir: Some(source.path().join(".git")),
+                upload_concurrency: concurrency,
+                receive_max_input_size: 1024 * 1024,
+                ..PushConfig::default()
+            },
+            vec![make_spec("refs/heads/main")],
+            Some(store),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router,
+            None,
+            CancellationToken::new(),
+            None,
+        ));
+        (source, pipeline, inner)
+    }
+
+    async fn assert_pack_pipeline_leases_released(
+        pipeline: &PushPipeline,
+        store: &GatedPutStore,
+        objects: &[ObjectMeta],
+    ) {
+        let prefix = pipeline.router.repo_prefix();
+        let ref_lock = crab_coordination::push_lock_path(prefix, "refs/heads/main").unwrap();
+        let slots = format!(
+            "{}/",
+            crab_coordination::push_admission::push_admission_prefix(prefix).unwrap()
+        );
+        let locks = objects
+            .iter()
+            .filter(|object| {
+                object.location.as_ref() == ref_lock || object.location.as_ref().starts_with(&slots)
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            locks.len() >= 2,
+            "fixture must exercise ref and admission leases"
+        );
+        for object in locks {
+            let bytes = store
+                .inner
+                .get(&object.location)
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap();
+            // Coordination releases with holder-checked CAS tombstones; absence
+            // is not its contract and would permit a stale delete to erase a successor.
+            let payload: crab_coordination::push_lock::PushLockPayload =
+                serde_json::from_slice(&bytes).unwrap();
+            assert!(
+                payload.is_released(),
+                "lease still active: {}",
+                object.location
+            );
+        }
+        for domain in [prefix, pipeline.router.global_prefix()] {
+            let sweep = crab_coordination::gc_fence::GcFenceLease::acquire_sweep(
+                pipeline.store.as_ref().unwrap().inner(),
+                domain,
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("no writer GC fence may survive push cleanup");
+            sweep.release().await.unwrap();
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bounded_pack_uploads_overlap_without_publishing_partial_inventory() {
+        let _git_env = CleanGitEnvGuard::new();
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                for (configured, expected) in [(0, 1), (2, 2), (64, 4)] {
+                    let (_source, pipeline, store) = gated_pack_pipeline(configured).await;
+                    let task_pipeline = Arc::clone(&pipeline);
+                    let task =
+                        tokio::task::spawn_local(async move { task_pipeline.execute().await });
+                    tokio::time::timeout(
+                        Duration::from_secs(10),
+                        store.started.acquire_many(expected),
+                    )
+                    .await
+                    .expect("independent packs must enter the upload window")
+                    .unwrap()
+                    .forget();
+                    assert!(
+                        tokio::time::timeout(Duration::from_millis(100), store.started.acquire())
+                            .await
+                            .is_err(),
+                        "the whole-pack concurrency bound must apply while bodies are stalled"
+                    );
+                    assert!(pipeline.uploaded_packs.lock().await.is_empty());
+                    let (manifest, _) =
+                        read_manifest(pipeline.store.as_ref().unwrap(), &pipeline.router)
+                            .await
+                            .unwrap();
+                    assert_eq!(
+                        manifest.generation, 0,
+                        "refs must remain unpublished while packs are incomplete"
+                    );
+                    store.release.add_permits(32);
+                    let result = tokio::time::timeout(Duration::from_secs(20), task)
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    assert!(result.all_ok(), "{result:?}");
+                    let (manifest, _) =
+                        read_manifest(pipeline.store.as_ref().unwrap(), &pipeline.router)
+                            .await
+                            .unwrap();
+                    assert_eq!(manifest.generation, 1);
+                    let packs = read_bulk_pack_list(
+                        pipeline.store.as_ref().unwrap(),
+                        &pipeline.router,
+                        &manifest.pack_index_hash,
+                    )
+                    .await
+                    .unwrap();
+                    assert!(
+                        packs.len() >= 6,
+                        "fixture must exceed every tested upload window"
+                    );
+                    for pack in packs {
+                        let bytes = store
+                            .inner
+                            .get(&pipeline.router.pack_path(&pack.pack_id))
+                            .await
+                            .unwrap()
+                            .bytes()
+                            .await
+                            .unwrap();
+                        assert_eq!(blake3::hash(&bytes).to_hex().as_str(), pack.content_hash);
+                        assert!(bytes.len() <= 1024 * 1024);
+                    }
+                }
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bounded_pack_failure_drains_active_work_without_admitting_more_or_publishing_refs() {
+        let _git_env = CleanGitEnvGuard::new();
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (_source, pipeline, store) = gated_pack_pipeline(2).await;
+                store.fail_next_put.store(true, Ordering::SeqCst);
+                let task_pipeline = Arc::clone(&pipeline);
+                let mut task =
+                    tokio::task::spawn_local(async move { task_pipeline.execute().await });
+                tokio::time::timeout(Duration::from_secs(10), store.started.acquire_many(2))
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .forget();
+                store.release.add_permits(1);
+                tokio::time::timeout(Duration::from_secs(5), async {
+                    while store.fail_next_put.load(Ordering::SeqCst) {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .unwrap();
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(100), &mut task)
+                        .await
+                        .is_err(),
+                    "push must keep ownership until the already-running sibling finishes"
+                );
+                assert_eq!(store.started.available_permits(), 0);
+                store.release.add_permits(1);
+                let result = tokio::time::timeout(Duration::from_secs(20), task)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert!(!result.all_ok());
+                assert_eq!(
+                    store.started.available_permits(),
+                    0,
+                    "failure must stop admitting packs"
+                );
+                assert!(pipeline.uploaded_packs.lock().await.is_empty());
+                let (manifest, _) =
+                    read_manifest(pipeline.store.as_ref().unwrap(), &pipeline.router)
+                        .await
+                        .unwrap();
+                assert_eq!(manifest.generation, 0);
+                let objects = store
+                    .inner
+                    .list(None)
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    objects
+                        .iter()
+                        .filter(|object| object.location.as_ref().ends_with(".pack"))
+                        .count(),
+                    1,
+                    "the admitted sibling must finish before push returns"
+                );
+                assert_eq!(result.failure_stage, Some(PushFailureStage::GitPackUpload));
+                assert_pack_pipeline_leases_released(&pipeline, &store, &objects).await;
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bounded_pack_cancellation_stops_admission_and_leaves_refs_unchanged() {
+        let _git_env = CleanGitEnvGuard::new();
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (_source, pipeline, store) = gated_pack_pipeline(2).await;
+                let task_pipeline = Arc::clone(&pipeline);
+                let mut task =
+                    tokio::task::spawn_local(async move { task_pipeline.execute().await });
+                tokio::time::timeout(Duration::from_secs(10), store.started.acquire_many(2))
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .forget();
+                pipeline.cancel.cancel();
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(100), &mut task)
+                        .await
+                        .is_err(),
+                    "cancellation must drain already-admitted single-PUT transactions"
+                );
+                store.release.add_permits(2);
+                let result = tokio::time::timeout(Duration::from_secs(10), task)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert!(!result.all_ok());
+                assert_eq!(store.started.available_permits(), 0);
+                assert!(pipeline.uploaded_packs.lock().await.is_empty());
+                let (manifest, _) =
+                    read_manifest(pipeline.store.as_ref().unwrap(), &pipeline.router)
+                        .await
+                        .unwrap();
+                assert_eq!(manifest.generation, 0);
+                let objects = store
+                    .inner
+                    .list(None)
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    objects
+                        .iter()
+                        .filter(|object| object.location.as_ref().ends_with(".pack"))
+                        .count(),
+                    2
+                );
+                assert_eq!(result.failure_stage, Some(PushFailureStage::GitPackUpload));
+                assert_pack_pipeline_leases_released(&pipeline, &store, &objects).await;
+            })
+            .await;
     }
 
     #[derive(Debug)]
@@ -21066,6 +21553,8 @@ mod tests {
             body.len() as u64,
             *pack_hash.as_bytes(),
             &CancellationToken::new(),
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -21104,6 +21593,8 @@ mod tests {
             body.len() as u64,
             *pack_hash.as_bytes(),
             &CancellationToken::new(),
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -21114,6 +21605,8 @@ mod tests {
             body.len() as u64,
             *pack_hash.as_bytes(),
             &CancellationToken::new(),
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -21123,6 +21616,74 @@ mod tests {
         let stored = inner.get(&pack_path).await.unwrap().bytes().await.unwrap();
         assert_eq!(stored.len(), body.len());
         assert_eq!(blake3::hash(&stored), pack_hash);
+    }
+
+    #[tokio::test]
+    async fn upload_push_pack_file_body_repairs_corrupt_existing_object() {
+        let inner = Arc::new(object_store::memory::InMemory::new());
+        let store_inner: Arc<dyn object_store::ObjectStore> = inner.clone();
+        let store = crate::storage::store::Store::new(store_inner);
+        let pack_path = ObjectPath::from("repo/packs/content-addressed.pack");
+        inner
+            .put(&pack_path, Bytes::from_static(b"corrupt").into())
+            .await
+            .unwrap();
+        let body = Bytes::from_static(b"verified replacement pack body");
+        let mut pack_file = tempfile::NamedTempFile::new().unwrap();
+        pack_file.write_all(&body).unwrap();
+        pack_file.flush().unwrap();
+        let pack_hash = blake3::hash(&body);
+
+        let uploaded = upload_push_pack_file_body(
+            &store,
+            &pack_path,
+            pack_file.path(),
+            body.len() as u64,
+            *pack_hash.as_bytes(),
+            &CancellationToken::new(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(uploaded);
+        let stored = inner.get(&pack_path).await.unwrap().bytes().await.unwrap();
+        assert_eq!(stored, body);
+    }
+
+    #[tokio::test]
+    async fn upload_push_pack_file_body_rejects_changed_source_before_staging() {
+        let read_inner: Arc<dyn object_store::ObjectStore> = Arc::new(DenyHeadStore::new());
+        let write_inner: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let store = crate::storage::store::Store::new(read_inner)
+            .with_staging_write_store("repo/staging/push-1".to_owned(), write_inner.clone());
+        let pack_path = ObjectPath::from("repo/packs/changed.pack");
+        let staged_path = ObjectPath::from("repo/staging/push-1/objects/repo/packs/changed.pack");
+        let body = Bytes::from_static(b"changed source");
+        let mut pack_file = tempfile::NamedTempFile::new().unwrap();
+        pack_file.write_all(&body).unwrap();
+        pack_file.flush().unwrap();
+
+        let error = upload_push_pack_file_body(
+            &store,
+            &pack_path,
+            pack_file.path(),
+            body.len() as u64,
+            [7; 32],
+            &CancellationToken::new(),
+            None,
+            None,
+        )
+        .await
+        .expect_err("changed pack body must fail before storage mutation");
+
+        assert!(matches!(error, CrabError::CorruptObject { .. }));
+        assert!(matches!(
+            write_inner.head(&staged_path).await,
+            Err(object_store::Error::NotFound { .. })
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -25603,6 +26164,8 @@ mod tests {
             release: Arc::clone(&release),
             head_started: None,
             head_release: None,
+            pack_only: false,
+            fail_next_put: AtomicBool::new(false),
         });
         let mut lock = PushLock::acquire_internal(
             &store,
@@ -31175,6 +31738,8 @@ mod tests {
             release: Arc::clone(&release),
             head_started: None,
             head_release: None,
+            pack_only: false,
+            fail_next_put: AtomicBool::new(false),
         });
         let store = Store::new(inner);
         let router = StoreLayout::new(store.clone(), "repo-backpressure".to_owned());
@@ -31276,6 +31841,8 @@ mod tests {
             release: Arc::clone(&release),
             head_started: Some(Arc::clone(&head_started)),
             head_release: Some(Arc::clone(&head_release)),
+            pack_only: false,
+            fail_next_put: AtomicBool::new(false),
         });
         let store = Store::new(inner);
         let router = StoreLayout::new(store.clone(), "repo-overlap".to_owned());
@@ -31297,10 +31864,12 @@ mod tests {
 
         let (tx, rx) = tokio::sync::mpsc::channel(3);
         for seed in 1..=3u64 {
+            let bytes = Bytes::from(vec![seed as u8; 1024]);
+            let payload_digest = *blake3::hash(&bytes).as_bytes();
             let xorb = PackedXorb::from_result(XorbResult {
-                bytes: Bytes::from(vec![seed as u8; 1024]),
+                bytes,
                 hash: MerkleHash::from([seed, seed, seed, seed]),
-                payload_digest: [9; 32],
+                payload_digest,
                 placements: Vec::new(),
             })
             .await
@@ -31326,9 +31895,16 @@ mod tests {
                     .expect("all uploads must start before any is released")
                     .expect("started semaphore open");
             permits.forget();
+            // Once overlap is proven, allow the canonical read-back HEADs
+            // introduced by post-write integrity verification to finish.
+            head_release.add_permits(3);
             release.add_permits(3);
         };
-        let (uploaded, ()) = tokio::join!(consumer, observe_overlap);
+        let (uploaded, ()) = tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(consumer, observe_overlap)
+        })
+        .await
+        .expect("overlapping uploads and read-back verification must finish");
         let uploaded = uploaded.expect("upload stream");
         assert_eq!(uploaded.planned_xorbs, 3);
         assert_eq!(uploaded.planned_bytes, 3 * 1024);
@@ -31522,6 +32098,32 @@ mod tests {
         assert_eq!(uploaded[0].len(), bytes.len());
         assert!(!uploaded[0].prepared);
         assert!(!uploaded[0].has_payload());
+    }
+
+    #[tokio::test]
+    async fn production_packer_spills_payloads_above_multipart_threshold() {
+        let spill_dir = tempfile::tempdir().expect("spill directory");
+        let budget_units = XORB_UPLOAD_IN_FLIGHT_PAYLOAD_LIMIT
+            .div_ceil(XORB_UPLOAD_PAYLOAD_PERMIT_BYTES)
+            .max(1);
+        let budget = Arc::new(tokio::sync::Semaphore::new(budget_units));
+        let before = budget.available_permits();
+        let bytes = Bytes::from(vec![3; XORB_MULTIPART_THRESHOLD + 1]);
+        let packed = PackedXorb::from_result_in(
+            XorbResult {
+                bytes,
+                hash: MerkleHash::from([3_u64; 4]),
+                payload_digest: [3; 32],
+                placements: Vec::new(),
+            },
+            spill_dir.path(),
+            Some(&budget),
+        )
+        .await
+        .expect("pack large xorb");
+
+        assert!(packed.is_spilled());
+        assert_eq!(budget.available_permits(), before);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -3998,9 +3998,34 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
             let router = crab::storage::StoreLayout::new(store.clone(), prefix.clone());
             crab::core::remote_layout::open(&store, &router).await?;
 
-            let checker = crab::cmd::fsck_store::StoreChecker::new(store.clone(), prefix.clone());
+            let multipart_journal_path =
+                crab::git::discover::resolve_main_worktree_root().map(|root| {
+                    root.join(".crab")
+                        .join("staging")
+                        .join("multipart-uploads.sqlite3")
+                });
+            let multipart_journal = match multipart_journal_path {
+                Some(path) if path.try_exists()? => Some(
+                    tokio::task::spawn_blocking(move || {
+                        crab_staging::MultipartRegistry::open(&path)
+                    })
+                    .await
+                    .map_err(|error| {
+                        crab::core::error::CrabError::Io(std::io::Error::other(error))
+                    })??,
+                ),
+                _ => None,
+            }
+            .map(|registry| {
+                std::sync::Arc::new(crab::storage::store::MultipartJournal::new(registry))
+            });
+            let checker = crab::cmd::fsck_store::StoreChecker::new(store.clone(), prefix.clone())
+                .with_multipart_journal(multipart_journal.clone());
             let repairer: Box<dyn crab::cmd::fsck::FsckRepairer> = if repair {
-                Box::new(crab::cmd::fsck_store::StoreRepairer::new(store, prefix))
+                Box::new(
+                    crab::cmd::fsck_store::StoreRepairer::new(store, prefix)
+                        .with_multipart_journal(multipart_journal),
+                )
             } else {
                 Box::new(crab::cmd::fsck::NullRepairer)
             };

--- a/crab/src/storage/store.rs
+++ b/crab/src/storage/store.rs
@@ -6,6 +6,7 @@
 
 use std::ops::Range;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -17,6 +18,307 @@ use crate::core::error::{CrabError, Result};
 
 pub use crate::git::url::Cloud;
 pub use crab_storage::{BucketIdentity, ETag, StagedWrite};
+
+/// Composition adapter between local staging durability and storage transport.
+pub struct MultipartJournal(Arc<Mutex<crab_staging::MultipartRegistry>>);
+
+impl MultipartJournal {
+    #[must_use]
+    pub fn new(registry: crab_staging::MultipartRegistry) -> Self {
+        Self(Arc::new(Mutex::new(registry)))
+    }
+
+    async fn call<T, F>(&self, f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut crab_staging::MultipartRegistry) -> crab_staging::Result<T> + Send + 'static,
+    {
+        let registry = Arc::clone(&self.0);
+        // SQLite FULL commits and lock waits must not stall the async workers
+        // responsible for provider I/O and lease heartbeats.
+        tokio::task::spawn_blocking(move || {
+            let mut registry = registry.lock().map_err(|_| {
+                crab_staging::StagingError::Internal("multipart journal lock poisoned".into())
+            })?;
+            f(&mut registry)
+        })
+        .await
+        .map_err(|error| CrabError::Io(std::io::Error::other(error)))?
+        .map_err(CrabError::from)
+    }
+
+    pub async fn find_abandoned(
+        &self,
+        now: std::time::SystemTime,
+        grace: Duration,
+    ) -> crate::core::error::Result<Vec<crab_staging::AbandonedUpload>> {
+        self.call(move |registry| registry.find_abandoned(now, grace))
+            .await
+    }
+
+    pub async fn claim_abandoned(
+        &self,
+        entry_id: &str,
+        expected_revision: i64,
+        owner_token: &str,
+        now: i64,
+        lease_duration: Duration,
+    ) -> crate::core::error::Result<Option<crab_staging::AbandonedClaim>> {
+        let entry_id = entry_id.to_owned();
+        let owner_token = owner_token.to_owned();
+        self.call(move |registry| {
+            registry.claim_abandoned(
+                &entry_id,
+                expected_revision,
+                &owner_token,
+                now,
+                lease_duration,
+            )
+        })
+        .await
+    }
+
+    pub async fn renew_repair(
+        &self,
+        lease: &crab_staging::MultipartLease,
+        now: i64,
+        lease_duration: Duration,
+    ) -> crate::core::error::Result<bool> {
+        let lease = lease.clone();
+        self.call(move |registry| registry.renew(&lease, now, lease_duration))
+            .await
+    }
+
+    pub async fn abandon_repair(
+        &self,
+        lease: &crab_staging::MultipartLease,
+        now: i64,
+    ) -> crate::core::error::Result<bool> {
+        let lease = lease.clone();
+        self.call(move |registry| registry.abandon_owned(&lease, now))
+            .await
+    }
+
+    pub async fn release_repair(
+        &self,
+        lease: &crab_staging::MultipartLease,
+        now: i64,
+    ) -> crate::core::error::Result<bool> {
+        let lease = lease.clone();
+        self.call(move |registry| registry.release_owned(&lease, now))
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl crab_storage::multipart::MultipartJournal for MultipartJournal {
+    async fn claim(
+        &self,
+        target: &crab_storage::multipart::MultipartTarget,
+        payload_hash: &[u8],
+        expected_hash: &[u8; 32],
+        size: u64,
+        part_size: usize,
+        owner_token: &str,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> crab_storage::multipart::JournalResult<crab_storage::multipart::JournalClaimOutcome> {
+        let target = crab_staging::MultipartTarget {
+            provider: target.provider.clone(),
+            host: target.host.clone(),
+            container: target.container.clone(),
+            key: target.key.clone(),
+        };
+        let payload_hash = payload_hash.to_vec();
+        let expected_hash = *expected_hash;
+        let owner_token = owner_token.to_owned();
+        let outcome = self
+            .call(move |registry| {
+                registry.claim(
+                    &target,
+                    &payload_hash,
+                    &expected_hash,
+                    size,
+                    part_size,
+                    &owner_token,
+                    now_unix_seconds,
+                    lease_duration,
+                )
+            })
+            .await
+            .map_err(journal_error)?;
+        match outcome {
+            crab_staging::ClaimOutcome::Busy => {
+                Ok(crab_storage::multipart::JournalClaimOutcome::Busy)
+            }
+            crab_staging::ClaimOutcome::Acquired(claim) => {
+                let parts = claim
+                    .completed_parts
+                    .into_iter()
+                    .map(|part| {
+                        Ok(crab_storage::multipart::JournalPart {
+                            part_idx: usize::try_from(part.part_number).map_err(|_| {
+                                Box::new(crab_staging::StagingError::Internal(
+                                    "multipart part index is negative".to_owned(),
+                                ))
+                                    as crab_storage::multipart::JournalError
+                            })?,
+                            content_id: part.etag,
+                            size: u64::try_from(part.size).map_err(|_| {
+                                Box::new(crab_staging::StagingError::Internal(
+                                    "multipart part size is negative".to_owned(),
+                                ))
+                                    as crab_storage::multipart::JournalError
+                            })?,
+                        })
+                    })
+                    .collect::<crab_storage::multipart::JournalResult<Vec<_>>>()?;
+                Ok(crab_storage::multipart::JournalClaimOutcome::Acquired(
+                    crab_storage::multipart::JournalClaim {
+                        lease: crab_storage::multipart::JournalLease {
+                            entry_id: claim.lease.entry_id,
+                            owner_token: claim.lease.owner_token,
+                        },
+                        upload_id: claim.upload_id,
+                        payload_hash: claim.payload_hash,
+                        expected_hash: claim.expected_hash,
+                        size: claim.size,
+                        part_size: claim.part_size,
+                        parts,
+                    },
+                ))
+            }
+        }
+    }
+
+    async fn bind_upload(
+        &self,
+        lease: &crab_storage::multipart::JournalLease,
+        upload_id: &str,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> crab_storage::multipart::JournalResult<bool> {
+        let lease = staging_lease(lease);
+        let upload_id = upload_id.to_owned();
+        self.call(move |registry| {
+            registry.bind_upload(&lease, &upload_id, now_unix_seconds, lease_duration)
+        })
+        .await
+        .map_err(journal_error)
+    }
+
+    async fn renew(
+        &self,
+        lease: &crab_storage::multipart::JournalLease,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> crab_storage::multipart::JournalResult<bool> {
+        let lease = staging_lease(lease);
+        self.call(move |registry| registry.renew(&lease, now_unix_seconds, lease_duration))
+            .await
+            .map_err(journal_error)
+    }
+
+    async fn record_part(
+        &self,
+        lease: &crab_storage::multipart::JournalLease,
+        part: &crab_storage::multipart::JournalPart,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> crab_storage::multipart::JournalResult<bool> {
+        let part = crab_staging::CompletedPart {
+            part_number: i64::try_from(part.part_idx).map_err(|_| {
+                Box::new(crab_staging::StagingError::Internal(
+                    "multipart part index exceeds SQLite range".to_owned(),
+                )) as crab_storage::multipart::JournalError
+            })?,
+            etag: part.content_id.clone(),
+            size: i64::try_from(part.size).map_err(|_| {
+                Box::new(crab_staging::StagingError::Internal(
+                    "multipart part size exceeds SQLite range".to_owned(),
+                )) as crab_storage::multipart::JournalError
+            })?,
+        };
+        let lease = staging_lease(lease);
+        self.call(move |registry| {
+            registry.record_part(&lease, &part, now_unix_seconds, lease_duration)
+        })
+        .await
+        .map_err(journal_error)
+    }
+
+    async fn reset_owned(
+        &self,
+        lease: &crab_storage::multipart::JournalLease,
+        payload_hash: &[u8],
+        expected_hash: &[u8; 32],
+        size: u64,
+        part_size: usize,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> crab_storage::multipart::JournalResult<bool> {
+        let lease = staging_lease(lease);
+        let payload_hash = payload_hash.to_vec();
+        let expected_hash = *expected_hash;
+        self.call(move |registry| {
+            registry.reset_owned(
+                &lease,
+                &payload_hash,
+                &expected_hash,
+                size,
+                part_size,
+                now_unix_seconds,
+                lease_duration,
+            )
+        })
+        .await
+        .map_err(journal_error)
+    }
+
+    async fn complete_owned(
+        &self,
+        lease: &crab_storage::multipart::JournalLease,
+        now_unix_seconds: i64,
+    ) -> crab_storage::multipart::JournalResult<bool> {
+        let lease = staging_lease(lease);
+        self.call(move |registry| registry.complete_owned(&lease, now_unix_seconds))
+            .await
+            .map_err(journal_error)
+    }
+
+    async fn abandon_owned(
+        &self,
+        lease: &crab_storage::multipart::JournalLease,
+        now_unix_seconds: i64,
+    ) -> crab_storage::multipart::JournalResult<bool> {
+        let lease = staging_lease(lease);
+        self.call(move |registry| registry.abandon_owned(&lease, now_unix_seconds))
+            .await
+            .map_err(journal_error)
+    }
+
+    async fn release_owned(
+        &self,
+        lease: &crab_storage::multipart::JournalLease,
+        now_unix_seconds: i64,
+    ) -> crab_storage::multipart::JournalResult<bool> {
+        let lease = staging_lease(lease);
+        self.call(move |registry| registry.release_owned(&lease, now_unix_seconds))
+            .await
+            .map_err(journal_error)
+    }
+}
+
+fn journal_error(error: CrabError) -> crab_storage::multipart::JournalError {
+    Box::new(error)
+}
+
+fn staging_lease(lease: &crab_storage::multipart::JournalLease) -> crab_staging::MultipartLease {
+    crab_staging::MultipartLease {
+        entry_id: lease.entry_id.clone(),
+        owner_token: lease.owner_token.clone(),
+    }
+}
 
 /// CAS-aware facade over an `object_store::ObjectStore`.
 #[derive(Clone)]
@@ -70,6 +372,21 @@ impl Store {
     pub fn with_signer(mut self, signer: Arc<dyn object_store::signer::Signer>) -> Self {
         self.inner = self.inner.with_signer(signer);
         self
+    }
+
+    #[must_use]
+    pub fn with_multipart(
+        mut self,
+        multipart: Arc<dyn object_store::multipart::MultipartStore>,
+        identity: BucketIdentity,
+    ) -> Self {
+        self.inner = self.inner.with_multipart(multipart, identity);
+        self
+    }
+
+    #[must_use]
+    pub fn has_resumable_multipart(&self) -> bool {
+        self.inner.has_resumable_multipart()
     }
 
     #[must_use]
@@ -246,6 +563,18 @@ impl Store {
             .map_err(CrabError::from)
     }
 
+    pub async fn verify_written_size_and_hash(
+        &self,
+        path: &Path,
+        expected_size: u64,
+        expected_hash: &[u8; 32],
+    ) -> Result<()> {
+        self.inner
+            .verify_written_size_and_hash(path, expected_size, expected_hash)
+            .await
+            .map_err(CrabError::from)
+    }
+
     pub async fn head(&self, path: &Path) -> Result<ObjectMeta> {
         self.inner.head(path).await.map_err(CrabError::from)
     }
@@ -373,6 +702,50 @@ impl Store {
                 cancel,
                 on_part_done,
             )
+            .await
+            .map_err(CrabError::from)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn put_multipart_file_resumable(
+        &self,
+        path: &Path,
+        file_path: &std::path::Path,
+        size: u64,
+        expected_hash: [u8; 32],
+        payload_hash: &[u8],
+        part_size: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
+        journal: Option<&dyn crab_storage::multipart::MultipartJournal>,
+    ) -> Result<crab_storage::multipart::ResumableUploadOutcome> {
+        self.inner
+            .put_multipart_file_resumable(
+                path,
+                file_path,
+                size,
+                expected_hash,
+                payload_hash,
+                part_size,
+                cancel,
+                on_part_done,
+                journal,
+            )
+            .await
+            .map_err(CrabError::from)
+    }
+
+    #[must_use]
+    pub fn multipart_target(
+        &self,
+        path: &Path,
+    ) -> Option<crab_storage::multipart::MultipartTarget> {
+        self.inner.multipart_target(path)
+    }
+
+    pub async fn abort_explicit_multipart(&self, path: &Path, upload_id: &str) -> Result<()> {
+        self.inner
+            .abort_explicit_multipart(path, upload_id)
             .await
             .map_err(CrabError::from)
     }

--- a/crab/tests/multipart_resume_live.rs
+++ b/crab/tests/multipart_resume_live.rs
@@ -1,0 +1,213 @@
+//! Opt-in interrupted-upload qualification against real S3 and GCS stores.
+//!
+//! Run an ignored test with its provider flag and scratch bucket set:
+//!
+//! - `CRAB_MULTIPART_LIVE_S3=1`, `CRAB_MULTIPART_LIVE_S3_BUCKET`, and AWS credentials
+//! - `CRAB_MULTIPART_LIVE_GCS=1`, `CRAB_MULTIPART_LIVE_GCS_BUCKET`, and GCS credentials
+//!
+//! The buckets must be disposable test targets. Each run uses and deletes one
+//! unique object beneath `.crab/e2e/multipart-resume/`.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test assertions"
+)]
+
+use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crab::storage::store::{MultipartJournal, Store};
+use crab_storage::multipart::ResumableUploadOutcome;
+use crab_types::storage::StorageProviderKind;
+use futures_util::FutureExt as _;
+use object_store::path::Path as ObjectPath;
+use tokio_util::sync::CancellationToken;
+
+const PART_SIZE: usize = 8 * 1024 * 1024;
+const PAYLOAD_SIZE: usize = PART_SIZE * 5 + 17;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[ignore = "requires a writable live S3 bucket and ambient credentials"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn live_s3_interrupted_multipart_resumes_and_verifies() -> TestResult {
+    run_provider(
+        "CRAB_MULTIPART_LIVE_S3",
+        "CRAB_MULTIPART_LIVE_S3_BUCKET",
+        StorageProviderKind::S3,
+    )
+    .await
+}
+
+#[ignore = "requires a writable live GCS bucket and ambient credentials"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn live_gcs_interrupted_multipart_resumes_and_verifies() -> TestResult {
+    run_provider(
+        "CRAB_MULTIPART_LIVE_GCS",
+        "CRAB_MULTIPART_LIVE_GCS_BUCKET",
+        StorageProviderKind::Gcs,
+    )
+    .await
+}
+
+async fn run_provider(
+    gate_env: &str,
+    bucket_env: &str,
+    provider: StorageProviderKind,
+) -> TestResult {
+    if !enabled(gate_env) {
+        eprintln!("skipping live multipart qualification: {gate_env} is not enabled");
+        return Ok(());
+    }
+    let bucket = env::var(bucket_env)
+        .map_err(|_| std::io::Error::other(format!("{bucket_env} must name a scratch bucket")))?;
+    let storage = crab_storage::build_static_env_store(&bucket, provider)?;
+    let store = Store::from_storage(storage);
+    let temp = tempfile::tempdir()?;
+    let journal_path = temp.path().join("multipart.sqlite3");
+    let file_path = temp.path().join("payload.bin");
+    let payload = vec![0x5a; PAYLOAD_SIZE];
+    tokio::fs::write(&file_path, &payload).await?;
+    let hash = *blake3::hash(&payload).as_bytes();
+    drop(payload);
+    let path = ObjectPath::from(format!(
+        ".crab/e2e/multipart-resume/{}-{}.bin",
+        provider_name(provider),
+        run_id()
+    ));
+
+    let result = std::panic::AssertUnwindSafe(qualify_interruption(
+        provider,
+        &bucket,
+        &journal_path,
+        &path,
+        &file_path,
+        hash,
+    ))
+    .catch_unwind()
+    .await;
+    let journal = MultipartJournal::new(crab_staging::MultipartRegistry::open(&journal_path)?);
+    let cleanup = cleanup(&store, &journal, &path).await;
+    match result {
+        Ok(result) => result?,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+    cleanup
+}
+
+async fn qualify_interruption(
+    provider: StorageProviderKind,
+    bucket: &str,
+    journal_path: &std::path::Path,
+    path: &ObjectPath,
+    file_path: &std::path::Path,
+    hash: [u8; 32],
+) -> TestResult {
+    let store = Store::from_storage(crab_storage::build_static_env_store(bucket, provider)?);
+    let journal = MultipartJournal::new(crab_staging::MultipartRegistry::open(journal_path)?);
+    let cancel = CancellationToken::new();
+    let cancel_after_part = cancel.clone();
+    let uploaded = AtomicU64::new(0);
+    let on_part = |bytes| {
+        uploaded.fetch_add(bytes, Ordering::Relaxed);
+        cancel_after_part.cancel();
+    };
+    let interrupted = store
+        .put_multipart_file_resumable(
+            path,
+            file_path,
+            PAYLOAD_SIZE as u64,
+            hash,
+            &hash,
+            PART_SIZE,
+            &cancel,
+            Some(&on_part),
+            Some(&journal),
+        )
+        .await;
+    assert!(
+        matches!(interrupted, Err(crab::core::error::CrabError::Cancelled)),
+        "first upload must stop at the injected interruption: {interrupted:?}"
+    );
+    assert!(uploaded.load(Ordering::Relaxed) > 0);
+    drop(journal);
+    drop(store);
+
+    let store = Store::from_storage(crab_storage::build_static_env_store(bucket, provider)?);
+    let journal = MultipartJournal::new(crab_staging::MultipartRegistry::open(journal_path)?);
+    let outcome = store
+        .put_multipart_file_resumable(
+            path,
+            file_path,
+            PAYLOAD_SIZE as u64,
+            hash,
+            &hash,
+            PART_SIZE,
+            &CancellationToken::new(),
+            None,
+            Some(&journal),
+        )
+        .await?;
+    assert_eq!(outcome, ResumableUploadOutcome::Resumed);
+    let (persisted, _) = store.get_with_etag(path).await?;
+    assert_eq!(persisted.len(), PAYLOAD_SIZE);
+    assert_eq!(blake3::hash(&persisted).as_bytes(), &hash);
+    assert!(
+        journal
+            .find_abandoned(SystemTime::now() + Duration::from_secs(120), Duration::ZERO,)
+            .await?
+            .is_empty(),
+        "verified completion must remove its journal row"
+    );
+    Ok(())
+}
+
+async fn cleanup(store: &Store, journal: &MultipartJournal, path: &ObjectPath) -> TestResult {
+    let cleanup_now = SystemTime::now() + Duration::from_secs(120);
+    let cleanup_unix = i64::try_from(cleanup_now.duration_since(UNIX_EPOCH)?.as_secs())?;
+    for abandoned in journal.find_abandoned(cleanup_now, Duration::ZERO).await? {
+        let Some(claim) = journal
+            .claim_abandoned(
+                &abandoned.entry_id,
+                abandoned.revision,
+                "live-test-cleanup",
+                cleanup_unix,
+                Duration::from_secs(60),
+            )
+            .await?
+        else {
+            continue;
+        };
+        if let Some(upload_id) = claim.upload_id {
+            store.abort_explicit_multipart(path, &upload_id).await?;
+        }
+        assert!(journal.abandon_repair(&claim.lease, cleanup_unix).await?);
+    }
+    store.delete(path).await?;
+    Ok(())
+}
+
+fn enabled(key: &str) -> bool {
+    env::var(key)
+        .map(|value| !value.is_empty() && value != "0")
+        .unwrap_or(false)
+}
+
+fn provider_name(provider: StorageProviderKind) -> &'static str {
+    match provider {
+        StorageProviderKind::S3 => "s3",
+        StorageProviderKind::Gcs => "gcs",
+        StorageProviderKind::Azure => "azure",
+        StorageProviderKind::Local => "local",
+    }
+}
+
+fn run_id() -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("{}-{timestamp}", std::process::id())
+}

--- a/crates/crab-auth-store/src/lib.rs
+++ b/crates/crab-auth-store/src/lib.rs
@@ -90,9 +90,13 @@ pub fn build_store_from_transfer_grant(
                 direct.endpoint.as_deref().unwrap_or(&direct.container),
                 &direct.container,
             );
+            let multipart_identity = built.multipart_identity;
             let mut store = Store::new(built.inner).with_bucket_identity(identity);
             if let Some(signer) = built.signer {
                 store = store.with_signer(signer);
+            }
+            if let (Some(multipart), Some(identity)) = (built.multipart, multipart_identity) {
+                store = store.with_multipart(multipart, identity);
             }
             store
         }
@@ -194,9 +198,13 @@ pub fn build_object_store_from_credentials(
 pub fn build_store_from_credentials(bucket: &str, credentials: CloudCredentials) -> Result<Store> {
     let built = build_object_store_from_credentials(bucket, credentials)?;
     let identity = crab_storage::BucketIdentity::new(built.provider, bucket, bucket);
+    let multipart_identity = built.multipart_identity;
     let mut store = Store::new(built.inner).with_bucket_identity(identity);
     if let Some(signer) = built.signer {
         store = store.with_signer(signer);
+    }
+    if let (Some(multipart), Some(identity)) = (built.multipart, multipart_identity) {
+        store = store.with_multipart(multipart, identity);
     }
     Ok(store)
 }

--- a/crates/crab-auth-store/src/refreshing_store.rs
+++ b/crates/crab-auth-store/src/refreshing_store.rs
@@ -6,11 +6,12 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures_util::stream::BoxStream;
 use futures_util::{StreamExt, stream};
+use object_store::multipart::{MultipartStore, PartId};
 use object_store::path::Path;
 use object_store::signer::Signer;
 use object_store::{
-    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta,
+    ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
 };
 use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, warn};
@@ -22,6 +23,8 @@ use crate::Result;
 pub struct RefreshingStoreParts {
     pub inner: Arc<dyn ObjectStore>,
     pub signer: Option<Arc<dyn Signer>>,
+    pub multipart: Option<Arc<dyn MultipartStore>>,
+    pub multipart_identity: Option<crab_storage::BucketIdentity>,
 }
 
 impl Clone for RefreshingStoreParts {
@@ -29,6 +32,8 @@ impl Clone for RefreshingStoreParts {
         Self {
             inner: Arc::clone(&self.inner),
             signer: self.signer.as_ref().map(Arc::clone),
+            multipart: self.multipart.as_ref().map(Arc::clone),
+            multipart_identity: self.multipart_identity.clone(),
         }
     }
 }
@@ -92,6 +97,11 @@ where
         self.state.read().await.signer.is_some()
     }
 
+    pub async fn has_multipart(&self) -> bool {
+        let state = self.state.read().await;
+        state.multipart.is_some() && state.multipart_identity.is_some()
+    }
+
     async fn parts_for_operation(&self) -> object_store::Result<RefreshingStoreParts> {
         if self.provider.needs_refresh() {
             self.refresh_parts(false).await
@@ -120,6 +130,17 @@ where
             .await
             .map_err(to_object_store_error)?;
         let parts = (self.build)(resolution).map_err(to_object_store_error)?;
+        let current_identity = self.state.read().await.multipart_identity.clone();
+        if parts.multipart_identity != current_identity {
+            return Err(object_store::Error::Generic {
+                store: "refreshing",
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "refreshed credentials changed the multipart destination",
+                )
+                .into(),
+            });
+        }
         *self.state.write().await = parts.clone();
         Ok(parts)
     }
@@ -303,6 +324,73 @@ where
     }
 }
 
+#[async_trait]
+impl<P> MultipartStore for RefreshingObjectStore<P>
+where
+    P: CredentialProvider + ?Sized + 'static,
+{
+    async fn create_multipart(&self, path: &Path) -> object_store::Result<MultipartId> {
+        self.retryable_multipart_unary(|multipart| {
+            let path = path.clone();
+            async move { multipart.create_multipart(&path).await }
+        })
+        .await
+    }
+
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<MultipartId> {
+        self.retryable_multipart_unary(|multipart| {
+            let path = path.clone();
+            let opts = opts.clone();
+            async move { multipart.create_multipart_opts(&path, opts).await }
+        })
+        .await
+    }
+
+    async fn put_part(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        part_idx: usize,
+        data: PutPayload,
+    ) -> object_store::Result<PartId> {
+        self.retryable_multipart_unary(|multipart| {
+            let path = path.clone();
+            let id = id.clone();
+            let data = data.clone();
+            async move { multipart.put_part(&path, &id, part_idx, data).await }
+        })
+        .await
+    }
+
+    async fn complete_multipart(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        parts: Vec<PartId>,
+    ) -> object_store::Result<PutResult> {
+        self.retryable_multipart_unary(|multipart| {
+            let path = path.clone();
+            let id = id.clone();
+            let parts = parts.clone();
+            async move { multipart.complete_multipart(&path, &id, parts).await }
+        })
+        .await
+    }
+
+    async fn abort_multipart(&self, path: &Path, id: &MultipartId) -> object_store::Result<()> {
+        self.retryable_multipart_unary(|multipart| {
+            let path = path.clone();
+            let id = id.clone();
+            async move { multipart.abort_multipart(&path, &id).await }
+        })
+        .await
+    }
+}
+
 impl<P> RefreshingObjectStore<P>
 where
     P: CredentialProvider + ?Sized,
@@ -324,6 +412,24 @@ where
             Err(err) => Err(err),
         }
     }
+
+    async fn retryable_multipart_unary<T, F, Fut>(&self, op: F) -> object_store::Result<T>
+    where
+        F: Fn(Arc<dyn MultipartStore>) -> Fut,
+        Fut: Future<Output = object_store::Result<T>>,
+    {
+        let parts = self.parts_for_operation().await?;
+        let multipart = parts.multipart.ok_or_else(multipart_not_supported)?;
+        match op(Arc::clone(&multipart)).await {
+            Ok(value) => Ok(value),
+            Err(error) if self.should_retry_auth_error(&error) => {
+                let parts = self.refresh_parts(true).await?;
+                let multipart = parts.multipart.ok_or_else(multipart_not_supported)?;
+                op(Arc::clone(&multipart)).await
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 fn signer_not_supported() -> object_store::Error {
@@ -331,6 +437,16 @@ fn signer_not_supported() -> object_store::Error {
         source: std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "current refreshed backend cannot sign URLs",
+        )
+        .into(),
+    }
+}
+
+fn multipart_not_supported() -> object_store::Error {
+    object_store::Error::NotSupported {
+        source: std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "current refreshed backend has no stable multipart upload IDs",
         )
         .into(),
     }
@@ -417,6 +533,57 @@ mod tests {
         generation: usize,
         unauth_once: bool,
         forbidden: bool,
+    }
+
+    struct MockMultipart {
+        generation: usize,
+        unauthenticated: bool,
+    }
+
+    #[async_trait]
+    impl MultipartStore for MockMultipart {
+        async fn create_multipart(&self, path: &Path) -> object_store::Result<MultipartId> {
+            if self.unauthenticated {
+                return Err(object_store::Error::Unauthenticated {
+                    path: path.to_string(),
+                    source: "expired".into(),
+                });
+            }
+            Ok(format!("gen-{}", self.generation))
+        }
+
+        async fn put_part(
+            &self,
+            _path: &Path,
+            _id: &MultipartId,
+            _part_idx: usize,
+            _data: PutPayload,
+        ) -> object_store::Result<PartId> {
+            Ok(PartId {
+                content_id: format!("gen-{}", self.generation),
+            })
+        }
+
+        async fn complete_multipart(
+            &self,
+            _path: &Path,
+            _id: &MultipartId,
+            _parts: Vec<PartId>,
+        ) -> object_store::Result<PutResult> {
+            Ok(PutResult {
+                e_tag: Some(format!("gen-{}", self.generation)),
+                version: None,
+                extensions: Default::default(),
+            })
+        }
+
+        async fn abort_multipart(
+            &self,
+            _path: &Path,
+            _id: &MultipartId,
+        ) -> object_store::Result<()> {
+            Ok(())
+        }
     }
 
     impl fmt::Display for MockStore {
@@ -534,6 +701,7 @@ mod tests {
         build_count: Arc<AtomicUsize>,
         initial: RefreshingStoreParts,
     ) -> RefreshingObjectStore<MockProvider> {
+        let multipart_identity = initial.multipart_identity.clone();
         let builder = Arc::new(move |_creds| {
             let generation = build_count.fetch_add(1, Ordering::SeqCst) + 1;
             Ok(RefreshingStoreParts {
@@ -543,6 +711,11 @@ mod tests {
                     forbidden: false,
                 }),
                 signer: None,
+                multipart: Some(Arc::new(MockMultipart {
+                    generation,
+                    unauthenticated: false,
+                })),
+                multipart_identity: multipart_identity.clone(),
             })
         });
         RefreshingObjectStore::new(
@@ -570,6 +743,8 @@ mod tests {
                     forbidden: false,
                 }),
                 signer: None,
+                multipart: None,
+                multipart_identity: None,
             },
         );
 
@@ -599,6 +774,8 @@ mod tests {
                     forbidden: false,
                 }),
                 signer: None,
+                multipart: None,
+                multipart_identity: None,
             },
         );
 
@@ -627,6 +804,8 @@ mod tests {
                     forbidden: true,
                 }),
                 signer: None,
+                multipart: None,
+                multipart_identity: None,
             },
         );
 
@@ -654,6 +833,8 @@ mod tests {
                     forbidden: false,
                 }),
                 signer: None,
+                multipart: None,
+                multipart_identity: None,
             },
         );
         let raw: Arc<dyn ObjectStore> = Arc::new(store);
@@ -667,5 +848,99 @@ mod tests {
             .unwrap();
         assert_eq!(got, Bytes::from_static(b"gen-1"));
         assert_eq!(provider.resolve_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn multipart_handle_refreshes_after_unauthenticated_response() {
+        let provider = Arc::new(MockProvider::default());
+        let build_count = Arc::new(AtomicUsize::new(0));
+        let store = wrapper(
+            Arc::clone(&provider),
+            Arc::clone(&build_count),
+            RefreshingStoreParts {
+                inner: Arc::new(MockStore {
+                    generation: 0,
+                    unauth_once: false,
+                    forbidden: false,
+                }),
+                signer: None,
+                multipart: Some(Arc::new(MockMultipart {
+                    generation: 0,
+                    unauthenticated: true,
+                })),
+                multipart_identity: Some(crab_storage::BucketIdentity::new(
+                    crab_storage::StorageProviderKind::S3,
+                    "endpoint-a",
+                    "bucket",
+                )),
+            },
+        );
+
+        let upload_id = store.create_multipart(&Path::from("object")).await.unwrap();
+
+        assert_eq!(upload_id, "gen-1");
+        assert_eq!(provider.resolve_count.load(Ordering::SeqCst), 1);
+        assert_eq!(build_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn multipart_refresh_rejects_changed_destination() {
+        let provider = Arc::new(MockProvider::default());
+        provider.needs_refresh.store(true, Ordering::SeqCst);
+        let initial_identity = crab_storage::BucketIdentity::new(
+            crab_storage::StorageProviderKind::S3,
+            "endpoint-a",
+            "bucket",
+        );
+        let builder = Arc::new(move |_creds| {
+            Ok(RefreshingStoreParts {
+                inner: Arc::new(MockStore {
+                    generation: 1,
+                    unauth_once: false,
+                    forbidden: false,
+                }),
+                signer: None,
+                multipart: Some(Arc::new(MockMultipart {
+                    generation: 1,
+                    unauthenticated: false,
+                })),
+                multipart_identity: Some(crab_storage::BucketIdentity::new(
+                    crab_storage::StorageProviderKind::S3,
+                    "endpoint-b",
+                    "bucket",
+                )),
+            })
+        });
+        let store = RefreshingObjectStore::new(
+            provider,
+            "bucket".into(),
+            "repo".into(),
+            "fetch".into(),
+            RefreshingStoreParts {
+                inner: Arc::new(MockStore {
+                    generation: 0,
+                    unauth_once: false,
+                    forbidden: false,
+                }),
+                signer: None,
+                multipart: Some(Arc::new(MockMultipart {
+                    generation: 0,
+                    unauthenticated: false,
+                })),
+                multipart_identity: Some(initial_identity),
+            },
+            builder,
+        );
+
+        let error = store
+            .create_multipart(&Path::from("object"))
+            .await
+            .expect_err("destination changes must fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("changed the multipart destination")
+        );
     }
 }

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -51,6 +51,11 @@ pub mod shard_replay;
 pub mod stats;
 pub mod stream;
 
+pub use multipart_resume::{
+    AbandonedClaim, AbandonedUpload, ClaimOutcome, CompletedPart, MultipartClaim, MultipartLease,
+    MultipartRegistry, MultipartTarget,
+};
+
 #[cfg(test)]
 #[path = "../tests/unit/prop_compaction_preserves_reads.rs"]
 mod prop_compaction_preserves_reads;
@@ -1496,7 +1501,10 @@ async fn read_prepared_staged_chunks_batch(
                         expected_hash.hex()
                     )));
                 }
-                decoded.push((position, chunk.data));
+                // Parser chunks are slices of the full serialized xorb. The
+                // caller can retain this batch while packing other sources,
+                // so detach each requested chunk before dropping the parser.
+                decoded.push((position, Bytes::copy_from_slice(&chunk.data)));
             }
             Ok::<_, StagingError>((expected_bytes, decoded))
         });
@@ -4982,6 +4990,12 @@ mod tests {
             .expect("read prepared source")
             .expect("one source group");
         assert_eq!(decoded.len(), chunks.len());
+        for (_, _, data) in decoded {
+            assert!(
+                data.try_into_mut().is_ok(),
+                "each decoded chunk must own its allocation instead of retaining the source xorb"
+            );
+        }
         assert!(
             plan.read_next(1, 1)
                 .await

--- a/crates/crab-staging/src/multipart_resume.rs
+++ b/crates/crab-staging/src/multipart_resume.rs
@@ -1,490 +1,955 @@
-//! SQLite-backed registry for multipart upload resume.
+//! SQLite-backed ownership journal for resumable multipart uploads.
 //!
-//! Tracks in-progress multipart uploads so that an interrupted push can
-//! resume from the last completed part rather than re-uploading the
-//! entire xorb. The database lives at `staging/multipart.db` alongside
-//! the staging index.
-//!
-//! The uploader hooks in as follows:
-//! - Before issuing the first part PUT, call [`MultipartRegistry::begin`]
-//!   to persist the upload metadata.
-//! - After each successful part PUT, call [`MultipartRegistry::record_part`].
-//! - On successful `CompleteMultipartUpload`, call [`MultipartRegistry::complete`].
-//! - On abort (cancel, error), call [`MultipartRegistry::abort_stale`].
-//!
-//! The resume path queries [`MultipartRegistry::resumable`] for each
-//! planned xorb before starting a new upload. If a resumable upload
-//! exists, only the missing parts are reissued.
+//! One row owns one exact provider destination. A process must atomically
+//! acquire its expiring lease before it may create, upload, complete, abort,
+//! or delete the corresponding provider session. Part records and lease
+//! renewal commit in the same SQLite transaction.
 
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use rusqlite::{Connection, OptionalExtension, params};
-use tracing::{debug, warn};
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use tracing::debug;
 
 use crate::error::{Result, StagingError};
 
-/// Information needed to resume an interrupted multipart upload.
-#[derive(Debug, Clone)]
-pub struct ResumeInfo {
-    /// The backend-assigned multipart upload ID.
-    pub upload_id: String,
-    /// Bucket where the upload is targeted.
-    pub bucket: String,
-    /// Object key for the upload.
+const SCHEMA_VERSION: i64 = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultipartTarget {
+    pub provider: String,
+    pub host: String,
+    pub container: String,
     pub key: String,
-    /// Parts that have already been successfully uploaded.
-    pub completed_parts: Vec<CompletedPart>,
 }
 
-/// A single completed part within a multipart upload.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompletedPart {
     pub part_number: i64,
     pub etag: String,
     pub size: i64,
 }
 
-/// Metadata for an abandoned multipart upload detected by fsck.
-#[derive(Debug, Clone)]
-pub struct AbandonedUpload {
-    pub upload_id: String,
-    pub xorb_hash: Vec<u8>,
-    pub bucket: String,
-    pub key: String,
-    pub started_at: i64,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultipartLease {
+    pub entry_id: String,
+    pub owner_token: String,
 }
 
-/// SQLite-backed registry tracking in-progress multipart uploads.
-///
-/// Each registry instance owns a single `Connection` to
-/// `staging/multipart.db`. The schema uses WAL mode for safe
-/// concurrent reads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultipartClaim {
+    pub lease: MultipartLease,
+    pub upload_id: Option<String>,
+    pub payload_hash: Vec<u8>,
+    pub expected_hash: [u8; 32],
+    pub size: u64,
+    pub part_size: usize,
+    pub completed_parts: Vec<CompletedPart>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimOutcome {
+    Acquired(MultipartClaim),
+    Busy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbandonedUpload {
+    pub entry_id: String,
+    pub upload_id: Option<String>,
+    pub target: MultipartTarget,
+    pub started_at: i64,
+    pub updated_at: i64,
+    /// Monotonic row revision captured by fsck for compare-and-swap repair.
+    pub revision: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbandonedClaim {
+    pub lease: MultipartLease,
+    pub upload_id: Option<String>,
+    pub target: MultipartTarget,
+}
+
 pub struct MultipartRegistry {
     conn: Connection,
 }
 
 impl MultipartRegistry {
-    /// Open (or create) the multipart registry at `path`.
+    /// Opens the registry and migrates the pre-wiring prototype schema.
     ///
-    /// Enables WAL mode and runs idempotent schema migrations.
+    /// The retired schema was never called by production code and cannot
+    /// express leases or exact provider identity, so migration discards only
+    /// those unusable prototype rows.
     pub fn open(path: &Path) -> Result<Self> {
-        let conn = Connection::open(path).map_err(|e| {
-            StagingError::Internal(format!(
-                "failed to open multipart.db at {}: {e}",
-                path.display()
-            ))
-        })?;
-
-        conn.pragma_update(None, "journal_mode", "WAL")
-            .map_err(|e| StagingError::Internal(format!("failed to set WAL mode: {e}")))?;
-
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to set synchronous = NORMAL: {e}"))
-            })?;
-
-        // Enable foreign-key enforcement. Without this, SQLite silently
-        // ignores the `FOREIGN KEY` clause below and orphaned rows in
-        // `multipart_parts` accumulate when `begin()` replaces an entry
-        // in `multipart_uploads`. See finding CR10-F2.
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| StagingError::Internal(format!("failed to enable foreign_keys: {e}")))?;
+        let conn = Connection::open(path)?;
+        conn.busy_timeout(Duration::from_secs(5))?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "FULL")?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
 
         let mut registry = Self { conn };
         registry.run_migrations()?;
         Ok(registry)
     }
 
-    /// Run schema migrations (idempotent via `IF NOT EXISTS`).
     fn run_migrations(&mut self) -> Result<()> {
-        self.conn
-            .execute_batch(
-                "CREATE TABLE IF NOT EXISTS multipart_uploads (
-                    upload_id   TEXT PRIMARY KEY,
-                    xorb_hash   BLOB NOT NULL,
-                    bucket      TEXT NOT NULL,
-                    key         TEXT NOT NULL,
-                    started_at  INTEGER NOT NULL DEFAULT (unixepoch()),
-                    completed   INTEGER NOT NULL DEFAULT 0
+        // Inspect the schema only after serializing initializers; an earlier
+        // read could retire the canonical journal another process just created.
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(StagingError::from)?;
+        let version = tx
+            .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+            .map_err(StagingError::from)?;
+        if version != 0 && version != SCHEMA_VERSION {
+            return Err(StagingError::Internal(format!(
+                "unsupported multipart journal schema version {version}"
+            )));
+        }
+        if version == SCHEMA_VERSION {
+            tx.commit().map_err(StagingError::from)?;
+            debug!(version = SCHEMA_VERSION, "multipart journal schema ready");
+            return Ok(());
+        }
+
+        let retire_prototype: bool = tx.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM sqlite_master
+                WHERE type = 'table' AND name = 'multipart_uploads'
+            )",
+            [],
+            |row| row.get(0),
+        )?;
+        if retire_prototype {
+            tx.execute_batch(
+                "DROP TABLE IF EXISTS multipart_parts;
+                 DROP TABLE IF EXISTS multipart_uploads;",
+            )?;
+        }
+
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS multipart_uploads (
+                    entry_id          TEXT PRIMARY KEY,
+                    upload_id         TEXT,
+                    payload_hash      BLOB NOT NULL,
+                    expected_hash     BLOB NOT NULL,
+                    provider          TEXT NOT NULL,
+                    host              TEXT NOT NULL,
+                    container         TEXT NOT NULL,
+                    key               TEXT NOT NULL,
+                    size              INTEGER NOT NULL,
+                    part_size         INTEGER NOT NULL,
+                    owner_token       TEXT NOT NULL,
+                    lease_expires_at  INTEGER NOT NULL,
+                    started_at        INTEGER NOT NULL,
+                    updated_at        INTEGER NOT NULL,
+                    revision          INTEGER NOT NULL DEFAULT 0,
+                    UNIQUE(provider, host, container, key)
                 );
 
-                CREATE INDEX IF NOT EXISTS multipart_uploads_by_xorb
-                    ON multipart_uploads(xorb_hash);
-
                 CREATE TABLE IF NOT EXISTS multipart_parts (
-                    upload_id   TEXT NOT NULL,
-                    part_number INTEGER NOT NULL,
-                    etag        TEXT NOT NULL,
-                    size        INTEGER NOT NULL,
-                    PRIMARY KEY (upload_id, part_number),
-                    FOREIGN KEY (upload_id) REFERENCES multipart_uploads(upload_id)
+                    entry_id     TEXT NOT NULL,
+                    part_number  INTEGER NOT NULL,
+                    etag         TEXT NOT NULL,
+                    size         INTEGER NOT NULL,
+                    PRIMARY KEY (entry_id, part_number),
+                    FOREIGN KEY (entry_id) REFERENCES multipart_uploads(entry_id)
                         ON DELETE CASCADE
-                );",
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!("multipart schema migration failed: {e}"))
-            })?;
+                );
 
-        debug!("multipart registry schema ready");
+                CREATE INDEX IF NOT EXISTS multipart_uploads_abandoned
+                    ON multipart_uploads(lease_expires_at, updated_at);",
+        )?;
+        tx.pragma_update(None, "user_version", SCHEMA_VERSION)?;
+        tx.commit().map_err(StagingError::from)?;
+        debug!(version = SCHEMA_VERSION, "multipart journal schema ready");
         Ok(())
     }
 
-    /// Record a new multipart upload before issuing the first part PUT.
-    pub fn begin(&self, xorb_hash: &[u8], bucket: &str, key: &str, upload_id: &str) -> Result<()> {
-        self.conn
-            .execute(
-                "INSERT OR REPLACE INTO multipart_uploads
-                    (upload_id, xorb_hash, bucket, key)
-                 VALUES (?1, ?2, ?3, ?4)",
-                params![upload_id, xorb_hash, bucket, key],
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to insert multipart upload: {e}"))
-            })?;
-
-        debug!(upload_id, "registered multipart upload");
-        Ok(())
-    }
-
-    /// Record a successfully uploaded part.
-    pub fn record_part(
-        &self,
-        upload_id: &str,
-        part_number: i64,
-        etag: &str,
-        size: i64,
-    ) -> Result<()> {
-        self.conn
-            .execute(
-                "INSERT OR REPLACE INTO multipart_parts
-                    (upload_id, part_number, etag, size)
-                 VALUES (?1, ?2, ?3, ?4)",
-                params![upload_id, part_number, etag, size],
-            )
-            .map_err(|e| StagingError::Internal(format!("failed to record multipart part: {e}")))?;
-
-        Ok(())
-    }
-
-    /// Mark an upload as completed and remove its parts.
-    ///
-    /// Called after a successful `CompleteMultipartUpload`.
-    pub fn complete(&self, upload_id: &str) -> Result<()> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn claim(
+        &mut self,
+        target: &MultipartTarget,
+        payload_hash: &[u8],
+        expected_hash: &[u8; 32],
+        size: u64,
+        part_size: usize,
+        owner_token: &str,
+        now: i64,
+        lease_duration: Duration,
+    ) -> Result<ClaimOutcome> {
+        let size = to_sql_u64(size, "multipart size")?;
+        let part_size = to_sql_usize(part_size, "multipart part size")?;
+        let lease_expires_at = lease_deadline(now, lease_duration);
         let tx = self
             .conn
-            .unchecked_transaction()
-            .map_err(|e| StagingError::Internal(format!("failed to begin transaction: {e}")))?;
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(StagingError::from)?;
 
-        tx.execute(
-            "DELETE FROM multipart_parts WHERE upload_id = ?1",
-            params![upload_id],
-        )
-        .map_err(|e| {
-            StagingError::Internal(format!("failed to delete parts for {upload_id}: {e}"))
-        })?;
-
-        tx.execute(
-            "DELETE FROM multipart_uploads WHERE upload_id = ?1",
-            params![upload_id],
-        )
-        .map_err(|e| StagingError::Internal(format!("failed to delete upload {upload_id}: {e}")))?;
-
-        tx.commit().map_err(|e| {
-            StagingError::Internal(format!("failed to commit complete for {upload_id}: {e}"))
-        })?;
-
-        debug!(upload_id, "completed multipart upload");
-        Ok(())
-    }
-
-    /// Abort a stale upload: remove both the upload row and its parts.
-    ///
-    /// Called when the upload is cancelled, errors out, or the backend
-    /// reports `NoSuchUpload`.
-    pub fn abort_stale(&self, upload_id: &str) -> Result<()> {
-        let tx = self
-            .conn
-            .unchecked_transaction()
-            .map_err(|e| StagingError::Internal(format!("failed to begin transaction: {e}")))?;
-
-        tx.execute(
-            "DELETE FROM multipart_parts WHERE upload_id = ?1",
-            params![upload_id],
-        )
-        .map_err(|e| {
-            StagingError::Internal(format!("failed to delete parts for {upload_id}: {e}"))
-        })?;
-
-        tx.execute(
-            "DELETE FROM multipart_uploads WHERE upload_id = ?1",
-            params![upload_id],
-        )
-        .map_err(|e| StagingError::Internal(format!("failed to delete upload {upload_id}: {e}")))?;
-
-        tx.commit().map_err(|e| {
-            StagingError::Internal(format!("failed to commit abort for {upload_id}: {e}"))
-        })?;
-
-        debug!(upload_id, "aborted stale multipart upload");
-        Ok(())
-    }
-
-    /// Look up a resumable upload for the given xorb hash.
-    ///
-    /// Returns `Some(ResumeInfo)` if an incomplete upload exists with at
-    /// least one recorded part. Returns `None` if no resumable upload is
-    /// found.
-    pub fn resumable(&self, xorb_hash: &[u8]) -> Result<Option<ResumeInfo>> {
-        let row: Option<(String, String, String)> = self
-            .conn
+        let existing = tx
             .query_row(
-                "SELECT upload_id, bucket, key
+                "SELECT entry_id, owner_token, lease_expires_at
                  FROM multipart_uploads
-                 WHERE xorb_hash = ?1 AND completed = 0",
-                params![xorb_hash],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                 WHERE provider = ?1 AND host = ?2 AND container = ?3 AND key = ?4",
+                params![target.provider, target.host, target.container, target.key],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
             )
             .optional()
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to query resumable upload: {e}"))
-            })?;
+            .map_err(StagingError::from)?;
 
-        let Some((upload_id, bucket, key)) = row else {
-            return Ok(None);
+        let entry_id = match existing {
+            Some((entry_id, current_owner, expires_at)) => {
+                if current_owner != owner_token && expires_at > now {
+                    tx.commit().map_err(StagingError::from)?;
+                    return Ok(ClaimOutcome::Busy);
+                }
+                let updated = tx
+                    .execute(
+                        "UPDATE multipart_uploads
+                         SET owner_token = ?1, lease_expires_at = ?2, updated_at = ?3,
+                             revision = revision + 1
+                         WHERE entry_id = ?4
+                           AND (owner_token = ?1 OR lease_expires_at <= ?3)",
+                        params![owner_token, lease_expires_at, now, entry_id],
+                    )
+                    .map_err(StagingError::from)?;
+                if updated == 0 {
+                    tx.commit().map_err(StagingError::from)?;
+                    return Ok(ClaimOutcome::Busy);
+                }
+                entry_id
+            }
+            None => {
+                let entry_id = owner_token.to_owned();
+                let inserted = tx
+                    .execute(
+                        "INSERT OR IGNORE INTO multipart_uploads (
+                            entry_id, upload_id, payload_hash, expected_hash,
+                            provider, host, container, key, size, part_size,
+                            owner_token, lease_expires_at, started_at, updated_at
+                         ) VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)",
+                        params![
+                            entry_id,
+                            payload_hash,
+                            expected_hash.as_slice(),
+                            target.provider,
+                            target.host,
+                            target.container,
+                            target.key,
+                            size,
+                            part_size,
+                            owner_token,
+                            lease_expires_at,
+                            now,
+                        ],
+                    )
+                    .map_err(StagingError::from)?;
+                if inserted == 0 {
+                    tx.commit().map_err(StagingError::from)?;
+                    return Ok(ClaimOutcome::Busy);
+                }
+                entry_id
+            }
         };
 
-        let mut stmt = self
+        let claim = load_claim(&tx, &entry_id, owner_token)?;
+        tx.commit().map_err(StagingError::from)?;
+        Ok(ClaimOutcome::Acquired(claim))
+    }
+
+    pub fn bind_upload(
+        &self,
+        lease: &MultipartLease,
+        upload_id: &str,
+        now: i64,
+        lease_duration: Duration,
+    ) -> Result<bool> {
+        self.renewing_update(
+            "UPDATE multipart_uploads
+             SET upload_id = ?1, lease_expires_at = ?2, updated_at = ?3,
+                 revision = revision + 1
+             WHERE entry_id = ?4 AND owner_token = ?5 AND lease_expires_at > ?3",
+            params![
+                upload_id,
+                lease_deadline(now, lease_duration),
+                now,
+                lease.entry_id,
+                lease.owner_token,
+            ],
+        )
+    }
+
+    pub fn renew(
+        &self,
+        lease: &MultipartLease,
+        now: i64,
+        lease_duration: Duration,
+    ) -> Result<bool> {
+        self.renewing_update(
+            "UPDATE multipart_uploads
+             SET lease_expires_at = ?1, updated_at = ?2, revision = revision + 1
+             WHERE entry_id = ?3 AND owner_token = ?4 AND lease_expires_at > ?2",
+            params![
+                lease_deadline(now, lease_duration),
+                now,
+                lease.entry_id,
+                lease.owner_token,
+            ],
+        )
+    }
+
+    pub fn record_part(
+        &mut self,
+        lease: &MultipartLease,
+        part: &CompletedPart,
+        now: i64,
+        lease_duration: Duration,
+    ) -> Result<bool> {
+        let tx = self
             .conn
-            .prepare(
-                "SELECT part_number, etag, size
-                 FROM multipart_parts
-                 WHERE upload_id = ?1
-                 ORDER BY part_number",
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(StagingError::from)?;
+        let renewed = tx
+            .execute(
+                "UPDATE multipart_uploads
+                 SET lease_expires_at = ?1, updated_at = ?2, revision = revision + 1
+                 WHERE entry_id = ?3 AND owner_token = ?4 AND lease_expires_at > ?2",
+                params![
+                    lease_deadline(now, lease_duration),
+                    now,
+                    lease.entry_id,
+                    lease.owner_token,
+                ],
             )
-            .map_err(|e| StagingError::Internal(format!("failed to prepare parts query: {e}")))?;
-
-        let parts: Vec<CompletedPart> = stmt
-            .query_map(params![&upload_id], |row| {
-                Ok(CompletedPart {
-                    part_number: row.get(0)?,
-                    etag: row.get(1)?,
-                    size: row.get(2)?,
-                })
-            })
-            .map_err(|e| StagingError::Internal(format!("failed to query parts: {e}")))?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| StagingError::Internal(format!("failed to collect parts: {e}")))?;
-
-        Ok(Some(ResumeInfo {
-            upload_id,
-            bucket,
-            key,
-            completed_parts: parts,
-        }))
+            .map_err(StagingError::from)?;
+        if renewed == 0 {
+            tx.commit().map_err(StagingError::from)?;
+            return Ok(false);
+        }
+        tx.execute(
+            "INSERT INTO multipart_parts(entry_id, part_number, etag, size)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(entry_id, part_number) DO UPDATE SET
+                etag = excluded.etag, size = excluded.size",
+            params![lease.entry_id, part.part_number, part.etag, part.size],
+        )
+        .map_err(StagingError::from)?;
+        tx.commit().map_err(StagingError::from)?;
+        Ok(true)
     }
 
-    /// Handle a `NoSuchUpload` error from the backend.
-    ///
-    /// Deletes the registry row so the next attempt starts fresh.
-    pub fn handle_no_such_upload(&self, upload_id: &str) -> Result<()> {
-        warn!(
-            upload_id,
-            "backend reported NoSuchUpload, clearing registry"
-        );
-        self.abort_stale(upload_id)
+    #[allow(clippy::too_many_arguments)]
+    pub fn reset_owned(
+        &mut self,
+        lease: &MultipartLease,
+        payload_hash: &[u8],
+        expected_hash: &[u8; 32],
+        size: u64,
+        part_size: usize,
+        now: i64,
+        lease_duration: Duration,
+    ) -> Result<bool> {
+        let size = to_sql_u64(size, "multipart size")?;
+        let part_size = to_sql_usize(part_size, "multipart part size")?;
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(StagingError::from)?;
+        let updated = tx
+            .execute(
+                "UPDATE multipart_uploads
+                 SET upload_id = NULL, payload_hash = ?1, expected_hash = ?2,
+                     size = ?3, part_size = ?4, lease_expires_at = ?5, updated_at = ?6,
+                     revision = revision + 1
+                 WHERE entry_id = ?7 AND owner_token = ?8 AND lease_expires_at > ?6",
+                params![
+                    payload_hash,
+                    expected_hash.as_slice(),
+                    size,
+                    part_size,
+                    lease_deadline(now, lease_duration),
+                    now,
+                    lease.entry_id,
+                    lease.owner_token,
+                ],
+            )
+            .map_err(StagingError::from)?;
+        if updated > 0 {
+            tx.execute(
+                "DELETE FROM multipart_parts WHERE entry_id = ?1",
+                params![lease.entry_id],
+            )
+            .map_err(StagingError::from)?;
+        }
+        tx.commit().map_err(StagingError::from)?;
+        Ok(updated > 0)
     }
 
-    /// Find multipart uploads older than `grace_period` that are not
-    /// marked completed.
-    ///
-    /// Used by fsck to detect and report abandoned uploads.
-    pub fn find_abandoned(&self, grace_period: Duration) -> Result<Vec<AbandonedUpload>> {
-        let cutoff = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64
-            - grace_period.as_secs() as i64;
+    pub fn complete_owned(&self, lease: &MultipartLease, now: i64) -> Result<bool> {
+        self.delete_owned(lease, now)
+    }
 
+    pub fn abandon_owned(&self, lease: &MultipartLease, now: i64) -> Result<bool> {
+        self.delete_owned(lease, now)
+    }
+
+    pub fn release_owned(&self, lease: &MultipartLease, now: i64) -> Result<bool> {
+        self.renewing_update(
+            "UPDATE multipart_uploads
+             SET lease_expires_at = ?1, updated_at = ?1, revision = revision + 1
+             WHERE entry_id = ?2 AND owner_token = ?3",
+            params![now, lease.entry_id, lease.owner_token],
+        )
+    }
+
+    pub fn find_abandoned(
+        &self,
+        now: SystemTime,
+        grace_period: Duration,
+    ) -> Result<Vec<AbandonedUpload>> {
+        let now = unix_seconds(now);
+        let cutoff = now.saturating_sub(duration_seconds(grace_period));
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT upload_id, xorb_hash, bucket, key, started_at
+                "SELECT entry_id, upload_id, provider, host, container, key,
+                        started_at, updated_at, revision
                  FROM multipart_uploads
-                 WHERE completed = 0 AND started_at < ?1",
+                 WHERE lease_expires_at <= ?1 AND updated_at < ?2
+                 ORDER BY started_at, entry_id",
             )
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to prepare abandoned query: {e}"))
-            })?;
-
-        let uploads: Vec<AbandonedUpload> = stmt
-            .query_map(params![cutoff], |row| {
+            .map_err(StagingError::from)?;
+        let rows = stmt
+            .query_map(params![now, cutoff], |row| {
                 Ok(AbandonedUpload {
-                    upload_id: row.get(0)?,
-                    xorb_hash: row.get(1)?,
-                    bucket: row.get(2)?,
-                    key: row.get(3)?,
-                    started_at: row.get(4)?,
+                    entry_id: row.get(0)?,
+                    upload_id: row.get(1)?,
+                    target: MultipartTarget {
+                        provider: row.get(2)?,
+                        host: row.get(3)?,
+                        container: row.get(4)?,
+                        key: row.get(5)?,
+                    },
+                    started_at: row.get(6)?,
+                    updated_at: row.get(7)?,
+                    revision: row.get(8)?,
                 })
             })
-            .map_err(|e| StagingError::Internal(format!("failed to query abandoned uploads: {e}")))?
+            .map_err(StagingError::from)?
             .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to collect abandoned uploads: {e}"))
-            })?;
+            .map_err(StagingError::from)?;
+        Ok(rows)
+    }
 
-        Ok(uploads)
+    /// Claims an expired row for fsck immediately before provider cleanup.
+    pub fn claim_abandoned(
+        &mut self,
+        entry_id: &str,
+        expected_revision: i64,
+        owner_token: &str,
+        now: i64,
+        lease_duration: Duration,
+    ) -> Result<Option<AbandonedClaim>> {
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(StagingError::from)?;
+        let updated = tx
+            .execute(
+                "UPDATE multipart_uploads
+                 SET owner_token = ?1, lease_expires_at = ?2, updated_at = ?3,
+                     revision = revision + 1
+                 WHERE entry_id = ?4 AND revision = ?5 AND lease_expires_at <= ?3",
+                params![
+                    owner_token,
+                    lease_deadline(now, lease_duration),
+                    now,
+                    entry_id,
+                    expected_revision,
+                ],
+            )
+            .map_err(StagingError::from)?;
+        if updated == 0 {
+            tx.commit().map_err(StagingError::from)?;
+            return Ok(None);
+        }
+        let claim = tx
+            .query_row(
+                "SELECT upload_id, provider, host, container, key
+                 FROM multipart_uploads
+                 WHERE entry_id = ?1 AND owner_token = ?2",
+                params![entry_id, owner_token],
+                |row| {
+                    Ok(AbandonedClaim {
+                        lease: MultipartLease {
+                            entry_id: entry_id.to_owned(),
+                            owner_token: owner_token.to_owned(),
+                        },
+                        upload_id: row.get(0)?,
+                        target: MultipartTarget {
+                            provider: row.get(1)?,
+                            host: row.get(2)?,
+                            container: row.get(3)?,
+                            key: row.get(4)?,
+                        },
+                    })
+                },
+            )
+            .map_err(StagingError::from)?;
+        tx.commit().map_err(StagingError::from)?;
+        Ok(Some(claim))
+    }
+
+    fn renewing_update<P>(&self, sql: &str, params: P) -> Result<bool>
+    where
+        P: rusqlite::Params,
+    {
+        self.conn
+            .execute(sql, params)
+            .map(|updated| updated > 0)
+            .map_err(StagingError::from)
+    }
+
+    fn delete_owned(&self, lease: &MultipartLease, now: i64) -> Result<bool> {
+        self.conn
+            .execute(
+                "DELETE FROM multipart_uploads
+                 WHERE entry_id = ?1 AND owner_token = ?2 AND lease_expires_at > ?3",
+                params![lease.entry_id, lease.owner_token, now],
+            )
+            .map(|deleted| deleted > 0)
+            .map_err(StagingError::from)
     }
 }
 
+fn load_claim(conn: &Connection, entry_id: &str, owner_token: &str) -> Result<MultipartClaim> {
+    let row = conn
+        .query_row(
+            "SELECT upload_id, payload_hash, expected_hash, size, part_size
+             FROM multipart_uploads
+             WHERE entry_id = ?1 AND owner_token = ?2",
+            params![entry_id, owner_token],
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .map_err(StagingError::from)?;
+    let expected_hash: [u8; 32] = row.2.try_into().map_err(|hash: Vec<u8>| {
+        StagingError::Internal(format!(
+            "multipart expected hash has {} bytes instead of 32",
+            hash.len()
+        ))
+    })?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT part_number, etag, size FROM multipart_parts
+             WHERE entry_id = ?1 ORDER BY part_number",
+        )
+        .map_err(StagingError::from)?;
+    let completed_parts = stmt
+        .query_map(params![entry_id], |part| {
+            Ok(CompletedPart {
+                part_number: part.get(0)?,
+                etag: part.get(1)?,
+                size: part.get(2)?,
+            })
+        })
+        .map_err(StagingError::from)?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(StagingError::from)?;
+    Ok(MultipartClaim {
+        lease: MultipartLease {
+            entry_id: entry_id.to_owned(),
+            owner_token: owner_token.to_owned(),
+        },
+        upload_id: row.0,
+        payload_hash: row.1,
+        expected_hash,
+        size: from_sql_u64(row.3, "multipart size")?,
+        part_size: from_sql_usize(row.4, "multipart part size")?,
+        completed_parts,
+    })
+}
+
+fn lease_deadline(now: i64, duration: Duration) -> i64 {
+    now.saturating_add(duration_seconds(duration).max(1))
+}
+
+fn duration_seconds(duration: Duration) -> i64 {
+    i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
+}
+
+fn unix_seconds(time: SystemTime) -> i64 {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok())
+        .unwrap_or(i64::MAX)
+}
+
+fn to_sql_u64(value: u64, name: &str) -> Result<i64> {
+    i64::try_from(value)
+        .map_err(|_| StagingError::Internal(format!("{name} exceeds SQLite integer range")))
+}
+
+fn to_sql_usize(value: usize, name: &str) -> Result<i64> {
+    i64::try_from(value)
+        .map_err(|_| StagingError::Internal(format!("{name} exceeds SQLite integer range")))
+}
+
+fn from_sql_u64(value: i64, name: &str) -> Result<u64> {
+    u64::try_from(value)
+        .map_err(|_| StagingError::Internal(format!("{name} is negative in multipart journal")))
+}
+
+fn from_sql_usize(value: i64, name: &str) -> Result<usize> {
+    usize::try_from(value)
+        .map_err(|_| StagingError::Internal(format!("{name} is negative in multipart journal")))
+}
+
 #[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test assertions"
+)]
 mod tests {
     use super::*;
-    use std::time::Duration;
+
+    const LEASE: Duration = Duration::from_secs(60);
+
+    fn target() -> MultipartTarget {
+        MultipartTarget {
+            provider: "s3".into(),
+            host: "endpoint".into(),
+            container: "bucket".into(),
+            key: "repo/xorb".into(),
+        }
+    }
 
     fn open_in_memory() -> MultipartRegistry {
         let conn = Connection::open_in_memory().unwrap();
-        conn.pragma_update(None, "journal_mode", "WAL").unwrap();
-        conn.pragma_update(None, "synchronous", "NORMAL").unwrap();
-        let mut reg = MultipartRegistry { conn };
-        reg.run_migrations().unwrap();
-        reg
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+        let mut registry = MultipartRegistry { conn };
+        registry.run_migrations().unwrap();
+        registry
+    }
+
+    fn acquire(registry: &mut MultipartRegistry, owner: &str, now: i64) -> MultipartClaim {
+        match registry
+            .claim(&target(), b"payload", &[7; 32], 10, 4, owner, now, LEASE)
+            .unwrap()
+        {
+            ClaimOutcome::Acquired(claim) => claim,
+            ClaimOutcome::Busy => panic!("claim unexpectedly busy"),
+        }
     }
 
     #[test]
-    fn schema_migration_is_idempotent() {
-        let mut reg = open_in_memory();
-        reg.run_migrations().unwrap();
-        reg.run_migrations().unwrap();
-    }
-
-    #[test]
-    fn begin_and_resumable_round_trip() {
-        let reg = open_in_memory();
-        let hash = b"deadbeef01234567deadbeef01234567";
-
-        reg.begin(hash, "my-bucket", "xet/xorbs/ab/abcd", "upload-1")
-            .unwrap();
-        reg.record_part("upload-1", 1, "\"etag-1\"", 5_000_000)
-            .unwrap();
-        reg.record_part("upload-1", 2, "\"etag-2\"", 5_000_000)
-            .unwrap();
-
-        let info = reg.resumable(hash).unwrap().expect("should be resumable");
-        assert_eq!(info.upload_id, "upload-1");
-        assert_eq!(info.bucket, "my-bucket");
-        assert_eq!(info.key, "xet/xorbs/ab/abcd");
-        assert_eq!(info.completed_parts.len(), 2);
-        assert_eq!(info.completed_parts[0].part_number, 1);
-        assert_eq!(info.completed_parts[0].etag, "\"etag-1\"");
-        assert_eq!(info.completed_parts[1].part_number, 2);
-    }
-
-    #[test]
-    fn resumable_returns_none_for_unknown_hash() {
-        let reg = open_in_memory();
-        assert!(reg.resumable(b"unknown").unwrap().is_none());
-    }
-
-    #[test]
-    fn complete_removes_upload_and_parts() {
-        let reg = open_in_memory();
-        let hash = b"deadbeef";
-
-        reg.begin(hash, "b", "k", "u1").unwrap();
-        reg.record_part("u1", 1, "e1", 100).unwrap();
-        reg.complete("u1").unwrap();
-
-        assert!(reg.resumable(hash).unwrap().is_none());
-    }
-
-    #[test]
-    fn abort_stale_removes_upload_and_parts() {
-        let reg = open_in_memory();
-        let hash = b"deadbeef";
-
-        reg.begin(hash, "b", "k", "u1").unwrap();
-        reg.record_part("u1", 1, "e1", 100).unwrap();
-        reg.abort_stale("u1").unwrap();
-
-        assert!(reg.resumable(hash).unwrap().is_none());
-    }
-
-    #[test]
-    fn handle_no_such_upload_clears_row() {
-        let reg = open_in_memory();
-        let hash = b"deadbeef";
-
-        reg.begin(hash, "b", "k", "u1").unwrap();
-        reg.record_part("u1", 1, "e1", 100).unwrap();
-        reg.handle_no_such_upload("u1").unwrap();
-
-        assert!(reg.resumable(hash).unwrap().is_none());
-    }
-
-    #[test]
-    fn find_abandoned_returns_old_uploads() {
-        let reg = open_in_memory();
-        let hash = b"deadbeef";
-
-        // Insert with a manually backdated started_at.
-        reg.conn
-            .execute(
-                "INSERT INTO multipart_uploads
-                    (upload_id, xorb_hash, bucket, key, started_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-                params!["old-upload", hash.as_slice(), "b", "k", 1_000_000i64],
+    fn active_lease_excludes_other_owner() {
+        let mut registry = open_in_memory();
+        acquire(&mut registry, "owner-1", 100);
+        let outcome = registry
+            .claim(
+                &target(),
+                b"payload",
+                &[7; 32],
+                10,
+                4,
+                "owner-2",
+                101,
+                LEASE,
             )
             .unwrap();
-
-        // Recent upload should not appear.
-        reg.begin(hash, "b", "k2", "new-upload").unwrap();
-
-        let abandoned = reg.find_abandoned(Duration::from_secs(3600)).unwrap();
-        assert_eq!(abandoned.len(), 1);
-        assert_eq!(abandoned[0].upload_id, "old-upload");
+        assert_eq!(outcome, ClaimOutcome::Busy);
     }
 
     #[test]
-    fn find_abandoned_excludes_completed() {
-        let reg = open_in_memory();
-        let hash = b"deadbeef";
+    fn expired_lease_is_taken_over_with_parts_preserved() {
+        let mut registry = open_in_memory();
+        let first = acquire(&mut registry, "owner-1", 100);
+        assert!(
+            registry
+                .bind_upload(&first.lease, "upload", 100, LEASE)
+                .unwrap()
+        );
+        assert!(
+            registry
+                .record_part(
+                    &first.lease,
+                    &CompletedPart {
+                        part_number: 0,
+                        etag: "etag".into(),
+                        size: 4,
+                    },
+                    100,
+                    LEASE,
+                )
+                .unwrap()
+        );
+        let second = acquire(&mut registry, "owner-2", 161);
+        assert_eq!(second.upload_id.as_deref(), Some("upload"));
+        assert_eq!(second.completed_parts.len(), 1);
+        assert_eq!(second.lease.owner_token, "owner-2");
+    }
 
-        reg.conn
-            .execute(
-                "INSERT INTO multipart_uploads
-                    (upload_id, xorb_hash, bucket, key, started_at, completed)
-                 VALUES (?1, ?2, ?3, ?4, ?5, 1)",
-                params!["done-upload", hash.as_slice(), "b", "k", 1_000_000i64],
+    #[test]
+    fn stale_owner_cannot_record_complete_or_delete() {
+        let mut registry = open_in_memory();
+        let first = acquire(&mut registry, "owner-1", 100);
+        let _second = acquire(&mut registry, "owner-2", 161);
+        assert!(
+            !registry
+                .bind_upload(&first.lease, "stale", 161, LEASE)
+                .unwrap()
+        );
+        assert!(
+            !registry
+                .record_part(
+                    &first.lease,
+                    &CompletedPart {
+                        part_number: 0,
+                        etag: "stale".into(),
+                        size: 4,
+                    },
+                    161,
+                    LEASE,
+                )
+                .unwrap()
+        );
+        assert!(!registry.complete_owned(&first.lease, 161).unwrap());
+    }
+
+    #[test]
+    fn expired_owner_cannot_complete_without_reacquiring_lease() {
+        let mut registry = open_in_memory();
+        let claim = acquire(&mut registry, "owner", 100);
+
+        assert!(!registry.complete_owned(&claim.lease, 161).unwrap());
+        let resumed = acquire(&mut registry, "owner", 161);
+        assert!(registry.complete_owned(&resumed.lease, 161).unwrap());
+    }
+
+    #[test]
+    fn heartbeat_keeps_old_upload_out_of_fsck() {
+        let mut registry = open_in_memory();
+        let claim = acquire(&mut registry, "owner", 100);
+        assert!(registry.renew(&claim.lease, 150, LEASE).unwrap());
+        let abandoned = registry
+            .find_abandoned(
+                UNIX_EPOCH + Duration::from_secs(190),
+                Duration::from_secs(30),
             )
             .unwrap();
-
-        let abandoned = reg.find_abandoned(Duration::from_secs(3600)).unwrap();
         assert!(abandoned.is_empty());
     }
 
     #[test]
-    fn resumable_returns_empty_parts_when_none_recorded() {
-        let reg = open_in_memory();
-        let hash = b"deadbeef";
-
-        reg.begin(hash, "b", "k", "u1").unwrap();
-
-        let info = reg.resumable(hash).unwrap().expect("should be resumable");
-        assert_eq!(info.upload_id, "u1");
-        assert!(info.completed_parts.is_empty());
+    fn fsck_claim_loses_race_to_resumed_owner() {
+        let mut registry = open_in_memory();
+        let first = acquire(&mut registry, "owner-1", 100);
+        assert!(registry.release_owned(&first.lease, 100).unwrap());
+        let observed = registry
+            .find_abandoned(UNIX_EPOCH + Duration::from_secs(101), Duration::ZERO)
+            .unwrap()
+            .pop()
+            .expect("released upload is visible to fsck");
+        let _resumed = acquire(&mut registry, "owner-2", 101);
+        let fsck = registry
+            .claim_abandoned("owner-1", observed.revision, "fsck", 101, LEASE)
+            .unwrap();
+        assert!(fsck.is_none());
     }
 
     #[test]
-    fn begin_replaces_existing_upload_for_same_id() {
-        let reg = open_in_memory();
-        let hash = b"deadbeef";
+    fn fsck_claim_refuses_replacement_after_resume_race() {
+        let mut registry = open_in_memory();
+        let first = acquire(&mut registry, "owner-1", 100);
+        assert!(
+            registry
+                .bind_upload(&first.lease, "old-upload", 100, LEASE)
+                .unwrap()
+        );
+        assert!(registry.release_owned(&first.lease, 100).unwrap());
+        let observed = registry
+            .find_abandoned(UNIX_EPOCH + Duration::from_secs(101), Duration::ZERO)
+            .unwrap()
+            .pop()
+            .expect("released upload is visible to fsck");
 
-        reg.begin(hash, "bucket-1", "key-1", "u1").unwrap();
-        reg.begin(hash, "bucket-2", "key-2", "u1").unwrap();
+        let resumed = acquire(&mut registry, "owner-2", 101);
+        assert!(
+            registry
+                .reset_owned(&resumed.lease, b"payload", &[7; 32], 10, 4, 101, LEASE,)
+                .unwrap()
+        );
+        assert!(
+            registry
+                .bind_upload(&resumed.lease, "new-upload", 101, LEASE)
+                .unwrap()
+        );
+        assert!(registry.release_owned(&resumed.lease, 101).unwrap());
 
-        let info = reg.resumable(hash).unwrap().expect("should be resumable");
-        assert_eq!(info.bucket, "bucket-2");
-        assert_eq!(info.key, "key-2");
+        let claim = registry
+            .claim_abandoned("owner-1", observed.revision, "fsck", 102, LEASE)
+            .unwrap();
+
+        assert!(claim.is_none());
+    }
+
+    #[test]
+    fn exact_destination_distinguishes_provider_and_host() {
+        let mut registry = open_in_memory();
+        acquire(&mut registry, "owner-1", 100);
+        let mut other = target();
+        other.host = "other-endpoint".into();
+        let outcome = registry
+            .claim(&other, b"payload", &[7; 32], 10, 4, "owner-2", 100, LEASE)
+            .unwrap();
+        assert!(matches!(outcome, ClaimOutcome::Acquired(_)));
+    }
+
+    #[test]
+    fn prototype_schema_is_replaced_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multipart.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE multipart_uploads (
+                upload_id TEXT PRIMARY KEY,
+                xorb_hash BLOB NOT NULL,
+                bucket TEXT NOT NULL,
+                key TEXT NOT NULL,
+                started_at INTEGER NOT NULL,
+                completed INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        drop(conn);
+        let mut registry = MultipartRegistry::open(&path).unwrap();
+        acquire(&mut registry, "owner", 100);
+        drop(registry);
+        MultipartRegistry::open(&path).unwrap();
+    }
+
+    #[test]
+    fn concurrent_resumers_on_independent_connections_have_one_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multipart.db");
+        let mut registry = MultipartRegistry::open(&path).unwrap();
+        let original = acquire(&mut registry, "original", 100);
+        assert!(
+            registry
+                .bind_upload(&original.lease, "existing-upload", 100, LEASE)
+                .unwrap()
+        );
+        let part = CompletedPart {
+            part_number: 0,
+            etag: "existing-part".into(),
+            size: 4,
+        };
+        assert!(
+            registry
+                .record_part(&original.lease, &part, 100, LEASE)
+                .unwrap()
+        );
+        drop(registry);
+
+        // Separate SQLite connections share only the on-disk database, not a
+        // process-local mutex. Both contenders resume the same expired session.
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let contenders = ["resumer-a", "resumer-b"].map(|owner| {
+            let path = path.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                let mut registry = MultipartRegistry::open(&path).unwrap();
+                barrier.wait();
+                registry
+                    .claim(&target(), b"payload", &[7; 32], 10, 4, owner, 161, LEASE)
+                    .unwrap()
+            })
+        });
+        let outcomes = contenders.map(|thread| thread.join().unwrap());
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, ClaimOutcome::Busy))
+                .count(),
+            1
+        );
+        let winner = outcomes
+            .into_iter()
+            .find_map(|outcome| match outcome {
+                ClaimOutcome::Acquired(claim) => Some(claim),
+                ClaimOutcome::Busy => None,
+            })
+            .unwrap();
+        assert_eq!(winner.upload_id.as_deref(), Some("existing-upload"));
+        assert_eq!(winner.completed_parts, vec![part]);
+        let registry = MultipartRegistry::open(&path).unwrap();
+        assert!(!registry.complete_owned(&original.lease, 162).unwrap());
+        assert!(registry.complete_owned(&winner.lease, 162).unwrap());
+    }
+
+    #[test]
+    fn concurrent_initializer_rechecks_schema_after_acquiring_write_lock() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        static WAITING_FOR_MIGRATION: AtomicBool = AtomicBool::new(false);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multipart.db");
+        let mut registry = MultipartRegistry::open(&path).unwrap();
+        let claim = acquire(&mut registry, "owner", 100);
+        registry
+            .conn
+            .pragma_update(None, "user_version", 0)
+            .unwrap();
+        let tx = registry
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .unwrap();
+        tx.pragma_update(None, "user_version", SCHEMA_VERSION)
+            .unwrap();
+
+        // The second initializer sees the old committed version until this
+        // transaction commits, exactly as during prototype retirement.
+        let other = std::thread::spawn(move || {
+            let conn = Connection::open(path).unwrap();
+            conn.busy_handler(Some(|_| {
+                WAITING_FOR_MIGRATION.store(true, Ordering::SeqCst);
+                std::thread::sleep(Duration::from_millis(1));
+                true
+            }))
+            .unwrap();
+            let mut other = MultipartRegistry { conn };
+            other.run_migrations().unwrap();
+            other
+        });
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !WAITING_FOR_MIGRATION.load(Ordering::SeqCst) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "initializer did not reach the write lock"
+            );
+            std::thread::yield_now();
+        }
+        tx.commit().unwrap();
+        let other = other.join().unwrap();
+
+        assert!(other.renew(&claim.lease, 101, LEASE).unwrap());
     }
 }

--- a/crates/crab-storage/src/error.rs
+++ b/crates/crab-storage/src/error.rs
@@ -125,6 +125,14 @@ pub enum StorageError {
     #[error("storage operation cancelled")]
     Cancelled,
 
+    /// Local multipart recovery journal failed.
+    #[error("multipart recovery journal failed during {operation}: {source}")]
+    MultipartJournal {
+        operation: &'static str,
+        #[source]
+        source: crate::multipart::JournalError,
+    },
+
     /// Raw object-store error that was not classified more specifically.
     #[error("object store error: {source}")]
     ObjectStore {

--- a/crates/crab-storage/src/lib.rs
+++ b/crates/crab-storage/src/lib.rs
@@ -7,6 +7,7 @@ pub mod external;
 pub mod head_batch;
 pub mod identity;
 pub mod layout;
+pub mod multipart;
 pub mod provider_options;
 pub mod provider_store;
 pub mod retry;

--- a/crates/crab-storage/src/multipart.rs
+++ b/crates/crab-storage/src/multipart.rs
@@ -1,0 +1,222 @@
+//! Durable multipart-upload recovery contracts.
+//!
+//! The storage crate owns provider transport while the staging crate owns the
+//! local SQLite journal. [`MultipartJournal`] is the narrow composition seam
+//! between them: the transport never mutates a recorded upload unless it holds
+//! the current lease token, and the journal never performs provider I/O.
+
+use std::time::Duration;
+
+/// Error returned by a multipart journal implementation.
+pub type JournalError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Result returned by a multipart journal implementation.
+pub type JournalResult<T> = std::result::Result<T, JournalError>;
+
+/// Exact physical destination of one multipart upload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultipartTarget {
+    pub provider: String,
+    pub host: String,
+    pub container: String,
+    pub key: String,
+}
+
+/// One successfully uploaded provider part.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JournalPart {
+    pub part_idx: usize,
+    pub content_id: String,
+    pub size: u64,
+}
+
+/// Opaque proof that one process currently owns a journal row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JournalLease {
+    pub entry_id: String,
+    pub owner_token: String,
+}
+
+/// State returned after atomically acquiring a new or expired lease.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JournalClaim {
+    pub lease: JournalLease,
+    pub upload_id: Option<String>,
+    pub payload_hash: Vec<u8>,
+    pub expected_hash: [u8; 32],
+    pub size: u64,
+    pub part_size: usize,
+    pub parts: Vec<JournalPart>,
+}
+
+/// Result of attempting to acquire an exact-destination upload lease.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JournalClaimOutcome {
+    Acquired(JournalClaim),
+    Busy,
+}
+
+/// Result of a durable multipart upload request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumableUploadOutcome {
+    Uploaded,
+    Resumed,
+    AlreadyPresent,
+}
+
+/// Persistence boundary for in-flight multipart uploads.
+///
+/// Implementations must make `claim` and every ownership-checked mutation
+/// atomic across processes. Returning `false` from a mutation means the lease
+/// was lost; the caller must stop using the provider session immediately.
+#[async_trait::async_trait]
+pub trait MultipartJournal: Send + Sync {
+    #[allow(clippy::too_many_arguments)]
+    async fn claim(
+        &self,
+        target: &MultipartTarget,
+        payload_hash: &[u8],
+        expected_hash: &[u8; 32],
+        size: u64,
+        part_size: usize,
+        owner_token: &str,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> JournalResult<JournalClaimOutcome>;
+
+    async fn bind_upload(
+        &self,
+        lease: &JournalLease,
+        upload_id: &str,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> JournalResult<bool>;
+
+    async fn renew(
+        &self,
+        lease: &JournalLease,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> JournalResult<bool>;
+
+    async fn record_part(
+        &self,
+        lease: &JournalLease,
+        part: &JournalPart,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> JournalResult<bool>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn reset_owned(
+        &self,
+        lease: &JournalLease,
+        payload_hash: &[u8],
+        expected_hash: &[u8; 32],
+        size: u64,
+        part_size: usize,
+        now_unix_seconds: i64,
+        lease_duration: Duration,
+    ) -> JournalResult<bool>;
+
+    async fn complete_owned(
+        &self,
+        lease: &JournalLease,
+        now_unix_seconds: i64,
+    ) -> JournalResult<bool>;
+
+    async fn abandon_owned(
+        &self,
+        lease: &JournalLease,
+        now_unix_seconds: i64,
+    ) -> JournalResult<bool>;
+
+    /// Expire the caller's lease without deleting resumable provider state.
+    async fn release_owned(
+        &self,
+        lease: &JournalLease,
+        now_unix_seconds: i64,
+    ) -> JournalResult<bool>;
+}
+
+/// Places recorded parts into their exact plan slots.
+///
+/// A row is compatible only when every part index and byte length matches the
+/// current fixed-size plan. This rejects boundary drift before provider
+/// completion can assemble a different object.
+#[must_use]
+pub(crate) fn compatible_parts(
+    claim: &JournalClaim,
+    size: u64,
+    part_size: usize,
+) -> Option<Vec<Option<JournalPart>>> {
+    if part_size == 0 || claim.size != size || claim.part_size != part_size {
+        return None;
+    }
+    let total_parts = usize::try_from(size.div_ceil(part_size as u64)).ok()?;
+    let mut slots = vec![None; total_parts];
+    for part in &claim.parts {
+        if part.part_idx >= total_parts || slots[part.part_idx].is_some() {
+            return None;
+        }
+        let offset = u64::try_from(part.part_idx).ok()? * part_size as u64;
+        let expected_size = (size - offset).min(part_size as u64);
+        if part.size != expected_size {
+            return None;
+        }
+        slots[part.part_idx] = Some(part.clone());
+    }
+    Some(slots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn claim(parts: Vec<JournalPart>) -> JournalClaim {
+        JournalClaim {
+            lease: JournalLease {
+                entry_id: "entry".into(),
+                owner_token: "owner".into(),
+            },
+            upload_id: Some("upload".into()),
+            payload_hash: vec![1; 32],
+            expected_hash: [2; 32],
+            size: 10,
+            part_size: 4,
+            parts,
+        }
+    }
+
+    #[test]
+    fn compatible_parts_require_exact_indexes_and_lengths() {
+        let parts = vec![
+            JournalPart {
+                part_idx: 0,
+                content_id: "a".into(),
+                size: 4,
+            },
+            JournalPart {
+                part_idx: 2,
+                content_id: "c".into(),
+                size: 2,
+            },
+        ];
+
+        let slots = compatible_parts(&claim(parts), 10, 4).unwrap();
+        assert!(slots[0].is_some());
+        assert!(slots[1].is_none());
+        assert!(slots[2].is_some());
+    }
+
+    #[test]
+    fn compatible_parts_reject_wrong_final_length() {
+        let parts = vec![JournalPart {
+            part_idx: 2,
+            content_id: "c".into(),
+            size: 4,
+        }];
+
+        assert!(compatible_parts(&claim(parts), 10, 4).is_none());
+    }
+}

--- a/crates/crab-storage/src/provider_options.rs
+++ b/crates/crab-storage/src/provider_options.rs
@@ -22,6 +22,7 @@ pub fn apply_s3_env_overrides(builder: AmazonS3Builder) -> AmazonS3Builder {
 #[must_use]
 pub fn s3_endpoint_from_env() -> Option<String> {
     for key in [
+        "AWS_ENDPOINT_URL_S3",
         "AWS_ENDPOINT_URL",
         "AWS_ENDPOINT",
         "ENDPOINT_URL",
@@ -109,6 +110,7 @@ mod tests {
     #[test]
     fn s3_endpoint_env_accepts_standard_object_store_names() {
         let _lock = ENV_MUTEX.lock().unwrap();
+        let _aws_s3_endpoint = EnvGuard::set("AWS_ENDPOINT_URL_S3", None);
         let _aws_endpoint_url = EnvGuard::set("AWS_ENDPOINT_URL", None);
         let _aws_endpoint = EnvGuard::set("AWS_ENDPOINT", None);
         let _endpoint_url = EnvGuard::set("ENDPOINT_URL", Some(" http://localhost:5000 "));
@@ -117,6 +119,21 @@ mod tests {
         assert_eq!(
             s3_endpoint_from_env(),
             Some("http://localhost:5000".to_owned())
+        );
+    }
+
+    #[test]
+    fn service_specific_s3_endpoint_takes_precedence() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let _aws_s3_endpoint = EnvGuard::set(
+            "AWS_ENDPOINT_URL_S3",
+            Some("https://s3-specific.example.test"),
+        );
+        let _aws_endpoint = EnvGuard::set("AWS_ENDPOINT_URL", Some("https://generic.example.test"));
+
+        assert_eq!(
+            s3_endpoint_from_env(),
+            Some("https://s3-specific.example.test".to_owned())
         );
     }
 

--- a/crates/crab-storage/src/provider_store.rs
+++ b/crates/crab-storage/src/provider_store.rs
@@ -2,16 +2,19 @@
 
 use std::sync::Arc;
 
-use object_store::aws::{AmazonS3, AmazonS3Builder, AwsCredentialProvider, S3CopyIfNotExists};
+use object_store::aws::{
+    AmazonS3, AmazonS3Builder, AmazonS3ConfigKey, AwsCredentialProvider, S3CopyIfNotExists,
+};
 use object_store::azure::MicrosoftAzureBuilder;
-use object_store::gcp::{GcpCredential, GoogleCloudStorageBuilder};
+use object_store::gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey};
 use object_store::path::Path;
 use object_store::{ObjectStore, StaticCredentialProvider};
 
 use crate::error::{Result, StorageError};
 use crate::identity::{BucketIdentity, StorageProviderKind};
 use crate::provider_options::{
-    apply_s3_env_overrides, default_client_options, parse_sas_query_pairs,
+    default_client_options, parse_sas_query_pairs, s3_endpoint_from_env,
+    s3_virtual_hosted_style_from_env,
 };
 use crate::store::Store;
 
@@ -64,7 +67,13 @@ pub enum AzureAuthorization {
 pub struct BuiltObjectStore {
     pub inner: Arc<dyn ObjectStore>,
     pub provider: StorageProviderKind,
+    /// Exact destination used to bind resumable provider sessions.
+    ///
+    /// Custom endpoint and credential-derived endpoint material is stored as
+    /// a non-secret fingerprint, never as credentials or raw endpoint text.
+    pub multipart_identity: Option<BucketIdentity>,
     pub signer: Option<Arc<dyn object_store::signer::Signer>>,
+    pub multipart: Option<Arc<dyn object_store::multipart::MultipartStore>>,
 }
 
 /// Object-store handle parsed from a URL plus the path prefix embedded in that URL.
@@ -297,12 +306,13 @@ pub fn build_s3_object_store_with_provider(
     region: &str,
     credentials: AwsCredentialProvider,
 ) -> Result<BuiltObjectStore> {
+    let endpoint = s3_endpoint_from_env();
     let builder = AmazonS3Builder::from_env()
         .with_bucket_name(bucket)
         .with_region(region)
         .with_credentials(credentials)
         .with_client_options(default_client_options());
-    build_s3_object_store(bucket, builder, None, true)
+    build_s3_object_store(bucket, builder, None, endpoint.as_deref(), true)
 }
 
 /// Builds an object-store backend with an optional grant-pinned endpoint.
@@ -331,20 +341,22 @@ fn build_object_store_inner(
             session_token,
             region,
         } => {
+            let endpoint = endpoint.map(str::to_owned).or_else(|| {
+                allow_environment_overrides
+                    .then(s3_endpoint_from_env)
+                    .flatten()
+            });
             let builder = AmazonS3Builder::new()
                 .with_bucket_name(bucket)
                 .with_access_key_id(&access_key_id)
                 .with_secret_access_key(&secret_access_key)
                 .with_region(&region)
                 .with_client_options(default_client_options());
-            let builder = match endpoint {
-                Some(value) => builder.with_endpoint(value),
-                None => builder,
-            };
             build_s3_object_store(
                 bucket,
                 builder,
                 session_token.as_deref(),
+                endpoint.as_deref(),
                 allow_environment_overrides,
             )
         }
@@ -358,16 +370,21 @@ fn build_object_store_inner(
             let credential_provider = Arc::new(StaticCredentialProvider::new(GcpCredential {
                 bearer: access_token,
             }));
-            let gcs = GoogleCloudStorageBuilder::new()
+            let builder = GoogleCloudStorageBuilder::new()
                 .with_bucket_name(bucket)
                 .with_credentials(credential_provider)
-                .with_client_options(default_client_options())
+                .with_client_options(default_client_options());
+            let (builder, multipart_identity) = gcs_multipart_builder(builder, bucket)?;
+            let gcs = builder
                 .build()
                 .map_err(|source| provider_config_error(provider, bucket, source))?;
+            let gcs = Arc::new(gcs);
             Ok(BuiltObjectStore {
-                inner: Arc::new(gcs),
+                inner: gcs.clone() as Arc<dyn ObjectStore>,
                 provider,
+                multipart_identity: Some(multipart_identity),
                 signer: None,
+                multipart: Some(gcs),
             })
         }
         ObjectStoreCredentials::Azure { account, token } => {
@@ -391,7 +408,9 @@ fn build_object_store_inner(
             Ok(BuiltObjectStore {
                 inner: Arc::new(azure),
                 provider,
+                multipart_identity: None,
                 signer: None,
+                multipart: None,
             })
         }
     }
@@ -404,6 +423,10 @@ pub fn build_static_env_store(bucket: &str, provider: StorageProviderKind) -> Re
     let mut store = Store::new(built.inner).with_bucket_identity(identity);
     if let Some(signer) = built.signer {
         store = store.with_signer(signer);
+    }
+    if let (Some(multipart), Some(multipart_identity)) = (built.multipart, built.multipart_identity)
+    {
+        store = store.with_multipart(multipart, multipart_identity);
     }
     Ok(store)
 }
@@ -462,24 +485,33 @@ fn build_static_env_object_store(
     provider: StorageProviderKind,
 ) -> Result<BuiltObjectStore> {
     match provider {
-        StorageProviderKind::S3 => build_s3_object_store(
-            bucket,
-            AmazonS3Builder::from_env()
-                .with_bucket_name(bucket)
-                .with_client_options(default_client_options()),
-            None,
-            true,
-        ),
+        StorageProviderKind::S3 => {
+            let endpoint = s3_endpoint_from_env();
+            build_s3_object_store(
+                bucket,
+                AmazonS3Builder::from_env()
+                    .with_bucket_name(bucket)
+                    .with_client_options(default_client_options()),
+                None,
+                endpoint.as_deref(),
+                true,
+            )
+        }
         StorageProviderKind::Gcs => {
-            let gcs = GoogleCloudStorageBuilder::from_env()
+            let builder = GoogleCloudStorageBuilder::from_env()
                 .with_bucket_name(bucket)
-                .with_client_options(default_client_options())
+                .with_client_options(default_client_options());
+            let (builder, multipart_identity) = gcs_multipart_builder(builder, bucket)?;
+            let gcs = builder
                 .build()
                 .map_err(|source| provider_config_error(provider, bucket, source))?;
+            let gcs = Arc::new(gcs);
             Ok(BuiltObjectStore {
-                inner: Arc::new(gcs),
+                inner: gcs.clone() as Arc<dyn ObjectStore>,
                 provider,
+                multipart_identity: Some(multipart_identity),
                 signer: None,
+                multipart: Some(gcs),
             })
         }
         StorageProviderKind::Azure => {
@@ -491,7 +523,9 @@ fn build_static_env_object_store(
             Ok(BuiltObjectStore {
                 inner: Arc::new(azure),
                 provider,
+                multipart_identity: None,
                 signer: None,
+                multipart: None,
             })
         }
         StorageProviderKind::Local => Err(StorageError::UnsupportedProvider { provider }),
@@ -502,16 +536,21 @@ fn build_s3_object_store(
     bucket: &str,
     builder: AmazonS3Builder,
     session_token: Option<&str>,
+    endpoint: Option<&str>,
     allow_environment_overrides: bool,
 ) -> Result<BuiltObjectStore> {
-    let mut builder = if allow_environment_overrides {
-        apply_s3_env_overrides(builder)
-    } else {
-        builder
+    let mut builder = match endpoint {
+        Some(endpoint) => builder.with_config(AmazonS3ConfigKey::S3Endpoint, endpoint),
+        None => builder,
     };
+    if allow_environment_overrides && let Some(virtual_hosted) = s3_virtual_hosted_style_from_env()
+    {
+        builder = builder.with_virtual_hosted_style_request(virtual_hosted);
+    }
     if let Some(session_token) = session_token {
         builder = builder.with_token(session_token);
     }
+    let multipart_identity = s3_multipart_identity(&builder, bucket);
     let s3 = builder
         .with_copy_if_not_exists(S3CopyIfNotExists::Multipart)
         .build()
@@ -520,8 +559,76 @@ fn build_s3_object_store(
     Ok(BuiltObjectStore {
         inner: s3.clone() as Arc<dyn ObjectStore>,
         provider: StorageProviderKind::S3,
-        signer: Some(s3 as Arc<dyn object_store::signer::Signer>),
+        multipart_identity: Some(multipart_identity),
+        signer: Some(s3.clone() as Arc<dyn object_store::signer::Signer>),
+        multipart: Some(s3),
     })
+}
+
+fn s3_multipart_identity(builder: &AmazonS3Builder, bucket: &str) -> BucketIdentity {
+    // object_store 0.14 derives the bucket URL from all four routing fields;
+    // custom endpoints with different addressing modes are different targets.
+    let endpoint = builder
+        .get_config_value(&AmazonS3ConfigKey::S3Endpoint)
+        .or_else(|| builder.get_config_value(&AmazonS3ConfigKey::Endpoint));
+    let region = builder.get_config_value(&AmazonS3ConfigKey::Region);
+    let virtual_hosted = builder.get_config_value(&AmazonS3ConfigKey::VirtualHostedStyleRequest);
+    let express = builder.get_config_value(&AmazonS3ConfigKey::S3Express);
+    let routing = format!("{endpoint:?}\0{region:?}\0{virtual_hosted:?}\0{express:?}");
+    multipart_identity(
+        StorageProviderKind::S3,
+        bucket,
+        "s3-routing",
+        routing.as_bytes(),
+    )
+}
+
+fn gcs_multipart_builder(
+    builder: GoogleCloudStorageBuilder,
+    bucket: &str,
+) -> Result<(GoogleCloudStorageBuilder, BucketIdentity)> {
+    let endpoint = if let Some(base_url) = builder.get_config_value(&GoogleConfigKey::BaseUrl) {
+        Some(base_url)
+    } else if let Some(service_account) =
+        builder.get_config_value(&GoogleConfigKey::ServiceAccountKey)
+    {
+        gcs_service_account_base_url(service_account.as_bytes())
+    } else if let Some(path) = builder.get_config_value(&GoogleConfigKey::ServiceAccount) {
+        let service_account = std::fs::read(path)?;
+        gcs_service_account_base_url(&service_account)
+    } else {
+        None
+    };
+    // Pin object_store 0.14's resolved default/custom URL before build rereads
+    // a service-account file, so a concurrent file change cannot retarget it.
+    let endpoint = endpoint.unwrap_or_else(|| "https://storage.googleapis.com".to_owned());
+    let identity = multipart_identity(
+        StorageProviderKind::Gcs,
+        bucket,
+        "gcs-base-url",
+        endpoint.as_bytes(),
+    );
+    Ok((builder.with_base_url(&endpoint), identity))
+}
+
+fn gcs_service_account_base_url(service_account: &[u8]) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(service_account).ok()?;
+    value.get("gcs_base_url")?.as_str().map(str::to_owned)
+}
+
+fn multipart_identity(
+    provider: StorageProviderKind,
+    bucket: &str,
+    kind: &str,
+    material: &[u8],
+) -> BucketIdentity {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"crab multipart destination v1\0");
+    hasher.update(kind.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(material);
+    let host = format!("endpoint:{}", hasher.finalize().to_hex());
+    BucketIdentity::new(provider, host, bucket)
 }
 
 fn provider_config_error(
@@ -614,6 +721,100 @@ mod tests {
 
         assert_eq!(built.provider, StorageProviderKind::S3);
         assert!(built.signer.is_some());
+    }
+
+    #[test]
+    fn explicit_s3_endpoint_is_part_of_destination_identity() {
+        let first = build_object_store_with_endpoint(
+            "shared-bucket",
+            ObjectStoreCredentials::Aws {
+                access_key_id: "access".into(),
+                secret_access_key: "secret".into(),
+                session_token: None,
+                region: "us-east-1".into(),
+            },
+            Some("https://objects.example.test"),
+        )
+        .expect("S3 builder construction does not perform network I/O");
+        let second = build_object_store_with_endpoint(
+            "shared-bucket",
+            ObjectStoreCredentials::Aws {
+                access_key_id: "access".into(),
+                secret_access_key: "secret".into(),
+                session_token: None,
+                region: "us-east-1".into(),
+            },
+            Some("https://other.example.test"),
+        )
+        .expect("S3 builder construction does not perform network I/O");
+
+        assert_ne!(first.multipart_identity, second.multipart_identity);
+        let identity = first.multipart_identity.expect("S3 supports multipart");
+        assert_eq!(identity.container, "shared-bucket");
+        assert!(identity.host.starts_with("endpoint:"));
+        assert!(!identity.host.contains("objects.example.test"));
+    }
+
+    #[test]
+    fn gcs_base_url_and_service_account_config_bind_multipart_identity() {
+        let explicit = GoogleCloudStorageBuilder::new()
+            .with_config(GoogleConfigKey::BaseUrl, "https://gcs-a.example.test");
+        let other_explicit = GoogleCloudStorageBuilder::new()
+            .with_config(GoogleConfigKey::BaseUrl, "https://gcs-b.example.test");
+        let service_account = GoogleCloudStorageBuilder::new().with_config(
+            GoogleConfigKey::ServiceAccountKey,
+            r#"{"gcs_base_url":"https://gcs-a.example.test"}"#,
+        );
+
+        let (_, explicit) = gcs_multipart_builder(explicit, "bucket").expect("identity");
+        let (_, other_explicit) =
+            gcs_multipart_builder(other_explicit, "bucket").expect("identity");
+        let (_, service_account) =
+            gcs_multipart_builder(service_account, "bucket").expect("identity");
+
+        assert_ne!(explicit, other_explicit);
+        assert_eq!(explicit, service_account);
+        assert_eq!(explicit.container, "bucket");
+        assert!(explicit.host.starts_with("endpoint:"));
+    }
+
+    #[test]
+    fn s3_multipart_identity_distinguishes_addressing_mode_and_region() {
+        let path_style = AmazonS3Builder::new()
+            .with_endpoint("https://objects.example.test")
+            .with_region("us-east-1");
+        let virtual_hosted = path_style.clone().with_virtual_hosted_style_request(true);
+        let other_region = path_style.clone().with_region("us-west-2");
+        let identity = s3_multipart_identity(&path_style, "bucket");
+
+        assert_ne!(identity, s3_multipart_identity(&virtual_hosted, "bucket"));
+        assert_ne!(identity, s3_multipart_identity(&other_region, "bucket"));
+    }
+
+    #[test]
+    fn gcs_multipart_pins_endpoint_before_service_account_file_changes() {
+        let dir = tempfile::tempdir().expect("temporary directory");
+        let path = dir.path().join("service-account.json");
+        std::fs::write(&path, r#"{"gcs_base_url":"https://first.example.test"}"#)
+            .expect("write original endpoint");
+        let builder =
+            GoogleCloudStorageBuilder::new().with_service_account_path(path.to_string_lossy());
+        let (builder, identity) = gcs_multipart_builder(builder, "bucket").expect("pin endpoint");
+        std::fs::write(&path, r#"{"gcs_base_url":"https://second.example.test"}"#)
+            .expect("replace credential file");
+
+        assert_eq!(
+            builder
+                .get_config_value(&GoogleConfigKey::BaseUrl)
+                .as_deref(),
+            Some("https://first.example.test"),
+        );
+        assert_eq!(
+            gcs_multipart_builder(builder, "bucket")
+                .expect("recheck pinned endpoint")
+                .1,
+            identity,
+        );
     }
 
     #[test]

--- a/crates/crab-storage/src/retry.rs
+++ b/crates/crab-storage/src/retry.rs
@@ -94,6 +94,7 @@ pub fn retry_class(err: &StorageError) -> RetryClass {
         | StorageError::NoCredentials
         | StorageError::Forbidden { .. }
         | StorageError::Cancelled
+        | StorageError::MultipartJournal { .. }
         | StorageError::Internal(_) => RetryClass::Fatal,
     }
 }

--- a/crates/crab-storage/src/store.rs
+++ b/crates/crab-storage/src/store.rs
@@ -15,6 +15,7 @@
 //!   coordination pointers, and `update` uses `PutMode::Update(etag)`.
 //!   Callers never hand-build `PutOptions`.
 
+use std::collections::HashSet;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -70,6 +71,17 @@ pub struct Store {
     /// `inner` because `ObjectStore` does not expose `as_any`, so we
     /// cannot downcast after the fact.
     signer: Option<Arc<dyn object_store::signer::Signer>>,
+    /// Low-level provider handle with stable explicit upload IDs.
+    ///
+    /// Present for S3 and GCS, including refreshing wrappers. Azure and
+    /// generic `ObjectStore` implementations stay on whole-upload retry.
+    multipart: Option<Arc<dyn object_store::multipart::MultipartStore>>,
+    /// Exact physical destination identity for explicit multipart sessions.
+    ///
+    /// This is deliberately separate from `identity`: bucket identity drives
+    /// cross-scheme equality and provider SDK selection, while resumable
+    /// sessions must also distinguish custom endpoints.
+    multipart_identity: Option<BucketIdentity>,
     storage_scope: Option<StorageScope>,
     read_routes: Option<Arc<Vec<ReadRoute>>>,
     staging_writes: Option<Arc<StagingWriteState>>,
@@ -123,6 +135,8 @@ impl Store {
             retry: RetryPolicy::DEFAULT,
             identity: BucketIdentity::local_unset(),
             signer: None,
+            multipart: None,
+            multipart_identity: None,
             storage_scope: None,
             read_routes: None,
             staging_writes: None,
@@ -143,6 +157,8 @@ impl Store {
             retry,
             identity: BucketIdentity::local_unset(),
             signer: None,
+            multipart: None,
+            multipart_identity: None,
             storage_scope: None,
             read_routes: None,
             staging_writes: None,
@@ -173,6 +189,28 @@ impl Store {
     pub fn with_signer(mut self, signer: Arc<dyn object_store::signer::Signer>) -> Self {
         self.signer = Some(signer);
         self
+    }
+
+    /// Attaches the provider's explicit multipart API.
+    ///
+    /// The handle must address the same physical store as `inner`; otherwise
+    /// journal identity and provider sessions would diverge.
+    #[must_use]
+    pub fn with_multipart(
+        mut self,
+        multipart: Arc<dyn object_store::multipart::MultipartStore>,
+        identity: BucketIdentity,
+    ) -> Self {
+        self.multipart = Some(multipart);
+        self.multipart_identity = Some(identity);
+        self
+    }
+
+    #[must_use]
+    pub fn has_resumable_multipart(&self) -> bool {
+        self.multipart.is_some()
+            && self.multipart_identity.is_some()
+            && self.staging_writes.is_none()
     }
 
     #[must_use]
@@ -1056,24 +1094,64 @@ impl Store {
         expected_size: u64,
         expected_hash: &[u8; 32],
     ) -> Result<()> {
-        let meta = self.head(path).await?;
-        if meta.size != expected_size {
-            return Err(StorageError::CorruptObject {
-                path: path.to_string(),
-                reason: format!("expected {expected_size} bytes, found {}", meta.size),
-            });
-        }
-        if Self::matches_in_streaming(&self.read_inner_for(path), path, expected_hash).await? {
-            Ok(())
-        } else {
-            Err(StorageError::CorruptObject {
-                path: path.to_string(),
-                reason: format!(
-                    "Blake3 content hash did not match {}",
-                    hex_lower(expected_hash)
-                ),
-            })
-        }
+        retry(&self.retry, || async {
+            let meta = self.head(path).await?;
+            if meta.size != expected_size {
+                return Err(StorageError::CorruptObject {
+                    path: path.to_string(),
+                    reason: format!("expected {expected_size} bytes, found {}", meta.size),
+                });
+            }
+            if Self::matches_in_streaming(&self.read_inner_for(path), path, expected_hash).await? {
+                Ok(())
+            } else {
+                Err(StorageError::CorruptObject {
+                    path: path.to_string(),
+                    reason: format!(
+                        "Blake3 content hash did not match {}",
+                        hex_lower(expected_hash)
+                    ),
+                })
+            }
+        })
+        .await
+    }
+
+    /// Streams the physical destination selected for a write and verifies it.
+    ///
+    /// Protected pushes write beneath an unpublished staging prefix, so a
+    /// canonical read cannot prove those bytes before publication.
+    pub async fn verify_written_size_and_hash(
+        &self,
+        path: &Path,
+        expected_size: u64,
+        expected_hash: &[u8; 32],
+    ) -> Result<()> {
+        let (write_path, write_inner, _) = self.exact_write_target(path);
+        retry(&self.retry, || async {
+            let meta = write_inner
+                .head(&write_path)
+                .await
+                .map_err(|error| map_object_store_error(error, write_path.as_ref()))?;
+            if meta.size != expected_size {
+                return Err(StorageError::CorruptObject {
+                    path: write_path.to_string(),
+                    reason: format!("expected {expected_size} bytes, found {}", meta.size),
+                });
+            }
+            if Self::matches_in_streaming(&write_inner, &write_path, expected_hash).await? {
+                Ok(())
+            } else {
+                Err(StorageError::CorruptObject {
+                    path: write_path.to_string(),
+                    reason: format!(
+                        "Blake3 content hash did not match {}",
+                        hex_lower(expected_hash)
+                    ),
+                })
+            }
+        })
+        .await
     }
 
     /// Fetches the metadata for `path` without reading its body.
@@ -1224,20 +1302,22 @@ impl Store {
         expected_hash: &[u8; 32],
         expected_size: u64,
     ) -> Result<bool> {
-        match self.head(canonical).await {
-            Ok(meta) if meta.size == expected_size => {
-                Self::matches_in_streaming(&self.inner, canonical, expected_hash).await
+        retry(&self.retry, || async {
+            match self.head(canonical).await {
+                Ok(meta) if meta.size == expected_size => {
+                    Self::matches_in_streaming(
+                        &self.read_inner_for(canonical),
+                        canonical,
+                        expected_hash,
+                    )
+                    .await
+                }
+                Ok(_) => Ok(false),
+                Err(StorageError::NotFound { .. }) => Ok(false),
+                Err(e) => Err(e),
             }
-            Ok(meta) => Err(StorageError::CorruptObject {
-                path: canonical.to_string(),
-                reason: format!(
-                    "canonical object size {} does not match expected {}",
-                    meta.size, expected_size
-                ),
-            }),
-            Err(StorageError::NotFound { .. }) => Ok(false),
-            Err(e) => Err(e),
-        }
+        })
+        .await
     }
 
     /// Begin a multipart upload for `path`.
@@ -1426,6 +1506,622 @@ impl Store {
             self.record_staged_write(path, &write_path, &expected_hash, size);
         }
         result
+    }
+
+    /// Uploads a content-addressed file with exclusive, durable part resume.
+    ///
+    /// The source is fully size/hash-verified before a provider session is
+    /// claimed. An active owner is waited out rather than bypassed, every part
+    /// mutation renews and checks the lease, and the completed remote body is
+    /// streamed back through Blake3 verification before the journal row is
+    /// removed.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn put_multipart_file_resumable(
+        &self,
+        path: &Path,
+        file_path: &std::path::Path,
+        size: u64,
+        expected_hash: [u8; 32],
+        payload_hash: &[u8],
+        part_size: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
+        journal: Option<&dyn crate::multipart::MultipartJournal>,
+    ) -> Result<crate::multipart::ResumableUploadOutcome> {
+        if part_size == 0 {
+            return Err(StorageError::Internal(
+                "multipart part size must be greater than zero".to_owned(),
+            ));
+        }
+        Self::verify_local_file(file_path, size, &expected_hash, cancel).await?;
+
+        let (Some(multipart), Some(journal), Some(target)) = (
+            self.multipart.as_ref(),
+            journal,
+            self.multipart_target(path),
+        ) else {
+            self.put_multipart_file_retry(
+                path,
+                file_path,
+                size,
+                expected_hash,
+                part_size,
+                cancel,
+                on_part_done,
+            )
+            .await?;
+            self.verify_written_size_and_hash(path, size, &expected_hash)
+                .await?;
+            return Ok(crate::multipart::ResumableUploadOutcome::Uploaded);
+        };
+        if self.canonical_matches(path, &expected_hash, size).await? {
+            return Ok(crate::multipart::ResumableUploadOutcome::AlreadyPresent);
+        }
+
+        let owner_token = random_owner_token();
+        let mut repair_attempt = 0_u8;
+        let mut credited_parts = HashSet::new();
+        loop {
+            if cancel.is_cancelled() {
+                return Err(StorageError::Cancelled);
+            }
+            let claim = loop {
+                match journal_call(
+                    "claim",
+                    journal
+                        .claim(
+                            &target,
+                            payload_hash,
+                            &expected_hash,
+                            size,
+                            part_size,
+                            &owner_token,
+                            unix_now(),
+                            MULTIPART_LEASE_DURATION,
+                        )
+                        .await,
+                )? {
+                    crate::multipart::JournalClaimOutcome::Acquired(claim) => break claim,
+                    crate::multipart::JournalClaimOutcome::Busy => {
+                        tokio::select! {
+                            () = tokio::time::sleep(MULTIPART_CLAIM_POLL) => {}
+                            () = cancel.cancelled() => return Err(StorageError::Cancelled),
+                        }
+                    }
+                }
+            };
+
+            let canonical_matches = await_with_heartbeat(
+                journal,
+                &claim.lease,
+                cancel,
+                self.canonical_matches(path, &expected_hash, size),
+            )
+            .await?;
+            let canonical_matches = match canonical_matches {
+                Ok(matches) => matches,
+                Err(error) => {
+                    release_journal(journal, &claim.lease).await;
+                    return Err(error);
+                }
+            };
+            if canonical_matches {
+                let provider_state_released = match claim.upload_id.as_deref() {
+                    Some(upload_id) => match await_with_heartbeat(
+                        journal,
+                        &claim.lease,
+                        cancel,
+                        self.abort_explicit_multipart(path, upload_id),
+                    )
+                    .await?
+                    {
+                        Ok(()) => true,
+                        Err(error) => {
+                            tracing::warn!(
+                                path = %path,
+                                error = %error,
+                                "canonical object is complete but stale multipart cleanup failed"
+                            );
+                            false
+                        }
+                    },
+                    None => true,
+                };
+                if provider_state_released {
+                    require_journal_owner(
+                        path,
+                        "complete already-present upload",
+                        journal.complete_owned(&claim.lease, unix_now()).await,
+                    )?;
+                } else {
+                    release_journal(journal, &claim.lease).await;
+                }
+                return Ok(crate::multipart::ResumableUploadOutcome::AlreadyPresent);
+            }
+
+            let plan_matches = claim.payload_hash == payload_hash
+                && claim.expected_hash == expected_hash
+                && crate::multipart::compatible_parts(&claim, size, part_size).is_some()
+                && (claim.upload_id.is_some() || claim.parts.is_empty());
+            let mut claim = claim;
+            if !plan_matches {
+                if let Some(upload_id) = claim.upload_id.as_deref()
+                    && let Err(error) = await_with_heartbeat(
+                        journal,
+                        &claim.lease,
+                        cancel,
+                        self.abort_explicit_multipart(path, upload_id),
+                    )
+                    .await?
+                {
+                    release_journal(journal, &claim.lease).await;
+                    return Err(error);
+                }
+                require_journal_owner(
+                    path,
+                    "reset",
+                    journal
+                        .reset_owned(
+                            &claim.lease,
+                            payload_hash,
+                            &expected_hash,
+                            size,
+                            part_size,
+                            unix_now(),
+                            MULTIPART_LEASE_DURATION,
+                        )
+                        .await,
+                )?;
+                claim.upload_id = None;
+                claim.payload_hash = payload_hash.to_vec();
+                claim.expected_hash = expected_hash;
+                claim.size = size;
+                claim.part_size = part_size;
+                claim.parts.clear();
+            }
+
+            let resumed = claim.upload_id.is_some();
+            let upload_id = match claim.upload_id.clone() {
+                Some(upload_id) => upload_id,
+                None => {
+                    let created = await_with_heartbeat(
+                        journal,
+                        &claim.lease,
+                        cancel,
+                        multipart.create_multipart(path),
+                    )
+                    .await?;
+                    let upload_id = match created {
+                        Ok(upload_id) => upload_id,
+                        Err(error) => {
+                            release_journal(journal, &claim.lease).await;
+                            return Err(map_object_store_error(error, path.as_ref()));
+                        }
+                    };
+                    if let Err(error) = require_journal_owner(
+                        path,
+                        "bind upload",
+                        journal
+                            .bind_upload(
+                                &claim.lease,
+                                upload_id.as_ref(),
+                                unix_now(),
+                                MULTIPART_LEASE_DURATION,
+                            )
+                            .await,
+                    ) {
+                        if let Err(abort_error) = self
+                            .abort_explicit_multipart(path, upload_id.as_ref())
+                            .await
+                        {
+                            tracing::warn!(
+                                path = %path,
+                                error = %abort_error,
+                                "failed to abort multipart session after journal bind failure"
+                            );
+                        }
+                        release_journal(journal, &claim.lease).await;
+                        return Err(error);
+                    }
+                    upload_id.to_string()
+                }
+            };
+
+            let slots =
+                crate::multipart::compatible_parts(&claim, size, part_size).ok_or_else(|| {
+                    StorageError::Internal("multipart plan changed after reset".into())
+                })?;
+            let uploaded = await_with_heartbeat(
+                journal,
+                &claim.lease,
+                cancel,
+                self.upload_missing_parts(
+                    multipart,
+                    journal,
+                    &claim.lease,
+                    path,
+                    file_path,
+                    size,
+                    expected_hash,
+                    part_size,
+                    &upload_id,
+                    slots,
+                    &mut credited_parts,
+                    cancel,
+                    on_part_done,
+                ),
+            )
+            .await?;
+            match uploaded {
+                Ok(parts) => {
+                    let provider_parts = parts
+                        .iter()
+                        .map(|part| object_store::multipart::PartId {
+                            content_id: part.content_id.clone(),
+                        })
+                        .collect();
+                    let completed = await_with_heartbeat(
+                        journal,
+                        &claim.lease,
+                        cancel,
+                        multipart.complete_multipart(
+                            path,
+                            &object_store::MultipartId::from(upload_id.as_str()),
+                            provider_parts,
+                        ),
+                    )
+                    .await?;
+                    if let Err(provider_error) = completed {
+                        if await_with_heartbeat(
+                            journal,
+                            &claim.lease,
+                            cancel,
+                            self.verify_size_and_hash(path, size, &expected_hash),
+                        )
+                        .await?
+                        .is_ok()
+                        {
+                            require_journal_owner(
+                                path,
+                                "complete after uncertain provider response",
+                                journal.complete_owned(&claim.lease, unix_now()).await,
+                            )?;
+                            return Ok(if resumed {
+                                crate::multipart::ResumableUploadOutcome::Resumed
+                            } else {
+                                crate::multipart::ResumableUploadOutcome::Uploaded
+                            });
+                        }
+                        if matches!(provider_error, object_store::Error::NotFound { .. }) {
+                            require_journal_owner(
+                                path,
+                                "drop missing provider session",
+                                journal.abandon_owned(&claim.lease, unix_now()).await,
+                            )?;
+                            if repair_attempt == 0 {
+                                repair_attempt += 1;
+                                continue;
+                            }
+                        } else {
+                            release_journal(journal, &claim.lease).await;
+                        }
+                        return Err(map_object_store_error(provider_error, path.as_ref()));
+                    }
+
+                    match await_with_heartbeat(
+                        journal,
+                        &claim.lease,
+                        cancel,
+                        self.verify_size_and_hash(path, size, &expected_hash),
+                    )
+                    .await?
+                    {
+                        Ok(()) => {
+                            require_journal_owner(
+                                path,
+                                "complete",
+                                journal.complete_owned(&claim.lease, unix_now()).await,
+                            )?;
+                            return Ok(if resumed {
+                                crate::multipart::ResumableUploadOutcome::Resumed
+                            } else {
+                                crate::multipart::ResumableUploadOutcome::Uploaded
+                            });
+                        }
+                        Err(error) => {
+                            require_journal_owner(
+                                path,
+                                "drop corrupt completed session",
+                                journal.abandon_owned(&claim.lease, unix_now()).await,
+                            )?;
+                            if repair_attempt == 0 {
+                                repair_attempt += 1;
+                                continue;
+                            }
+                            return Err(error);
+                        }
+                    }
+                }
+                Err(error) => {
+                    if matches!(error, StorageError::NotFound { .. }) {
+                        // Providers return NotFound when a recorded upload ID
+                        // was expired or externally aborted. Drop that exact
+                        // owned row so it cannot trap every future retry.
+                        require_journal_owner(
+                            path,
+                            "drop missing provider session",
+                            journal.abandon_owned(&claim.lease, unix_now()).await,
+                        )?;
+                        if repair_attempt == 0 {
+                            repair_attempt += 1;
+                            continue;
+                        }
+                        return Err(error);
+                    }
+                    if matches!(
+                        error,
+                        StorageError::CorruptObject { .. } | StorageError::Io { .. }
+                    ) {
+                        match await_with_heartbeat(
+                            journal,
+                            &claim.lease,
+                            cancel,
+                            self.abort_explicit_multipart(path, &upload_id),
+                        )
+                        .await?
+                        {
+                            Ok(()) => require_journal_owner(
+                                path,
+                                "abandon changed local source",
+                                journal.abandon_owned(&claim.lease, unix_now()).await,
+                            )?,
+                            Err(abort_error) => {
+                                release_journal(journal, &claim.lease).await;
+                                tracing::warn!(
+                                    path = %path,
+                                    error = %abort_error,
+                                    "failed to abort multipart session after local source changed"
+                                );
+                            }
+                        }
+                        return Err(error);
+                    }
+                    release_journal(journal, &claim.lease).await;
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn upload_missing_parts(
+        &self,
+        multipart: &Arc<dyn object_store::multipart::MultipartStore>,
+        journal: &dyn crate::multipart::MultipartJournal,
+        lease: &crate::multipart::JournalLease,
+        path: &Path,
+        file_path: &std::path::Path,
+        size: u64,
+        expected_hash: [u8; 32],
+        part_size: usize,
+        upload_id: &str,
+        mut slots: Vec<Option<crate::multipart::JournalPart>>,
+        credited_parts: &mut HashSet<usize>,
+        cancel: &tokio_util::sync::CancellationToken,
+        on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
+    ) -> Result<Vec<crate::multipart::JournalPart>> {
+        use futures_util::stream::{FuturesUnordered, StreamExt};
+
+        const IN_FLIGHT_PARTS: usize = 4;
+
+        let mut file = tokio::fs::File::open(file_path).await?;
+        let mut hasher = blake3::Hasher::new();
+        let mut remaining = size;
+        let mut part_idx = 0_usize;
+        let mut pending = FuturesUnordered::new();
+        while remaining > 0 {
+            if cancel.is_cancelled() {
+                return Err(StorageError::Cancelled);
+            }
+            while pending.len() >= IN_FLIGHT_PARTS {
+                let completed = pending.next().await;
+                let (idx, bytes, result) = completed.ok_or_else(|| {
+                    StorageError::Internal("multipart part queue ended while non-empty".into())
+                })?;
+                let provider_part: object_store::multipart::PartId = result?;
+                let part = crate::multipart::JournalPart {
+                    part_idx: idx,
+                    content_id: provider_part.content_id,
+                    size: bytes,
+                };
+                require_journal_owner(
+                    path,
+                    "record part",
+                    journal
+                        .record_part(lease, &part, unix_now(), MULTIPART_LEASE_DURATION)
+                        .await,
+                )?;
+                if let Some(callback) = on_part_done
+                    && credited_parts.insert(idx)
+                {
+                    callback(bytes);
+                }
+                slots[idx] = Some(part);
+            }
+
+            let want = remaining.min(part_size as u64) as usize;
+            let mut buffer = vec![0_u8; want];
+            file.read_exact(&mut buffer).await?;
+            hasher.update(&buffer);
+            if let Some(part) = &slots[part_idx] {
+                if let Some(callback) = on_part_done
+                    && credited_parts.insert(part_idx)
+                {
+                    callback(part.size);
+                }
+            } else {
+                let multipart = Arc::clone(multipart);
+                let retry_policy = self.retry;
+                let path = path.clone();
+                let upload_id = object_store::MultipartId::from(upload_id);
+                let payload: object_store::PutPayload = bytes::Bytes::from(buffer).into();
+                let bytes = want as u64;
+                pending.push(async move {
+                    let result = retry(&retry_policy, || {
+                        let multipart = Arc::clone(&multipart);
+                        let path = path.clone();
+                        let upload_id = upload_id.clone();
+                        let payload = payload.clone();
+                        async move {
+                            multipart
+                                .put_part(&path, &upload_id, part_idx, payload)
+                                .await
+                                .map_err(|error| map_object_store_error(error, path.as_ref()))
+                        }
+                    })
+                    .await;
+                    (part_idx, bytes, result)
+                });
+            }
+            remaining -= want as u64;
+            part_idx += 1;
+        }
+
+        while !pending.is_empty() {
+            let completed = pending.next().await;
+            let (idx, bytes, result) = completed.ok_or_else(|| {
+                StorageError::Internal("multipart part queue ended while non-empty".into())
+            })?;
+            let provider_part: object_store::multipart::PartId = result?;
+            let part = crate::multipart::JournalPart {
+                part_idx: idx,
+                content_id: provider_part.content_id,
+                size: bytes,
+            };
+            require_journal_owner(
+                path,
+                "record part",
+                journal
+                    .record_part(lease, &part, unix_now(), MULTIPART_LEASE_DURATION)
+                    .await,
+            )?;
+            if let Some(callback) = on_part_done
+                && credited_parts.insert(idx)
+            {
+                callback(bytes);
+            }
+            slots[idx] = Some(part);
+        }
+
+        let actual_hash = *hasher.finalize().as_bytes();
+        if actual_hash != expected_hash {
+            return Err(StorageError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: format!(
+                    "local blake3 hash {} does not match expected {}",
+                    hex_lower(&actual_hash),
+                    hex_lower(&expected_hash)
+                ),
+            });
+        }
+        if file.metadata().await?.len() != size {
+            return Err(StorageError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: "local file size changed during multipart upload".to_owned(),
+            });
+        }
+        slots
+            .into_iter()
+            .enumerate()
+            .map(|(idx, part)| {
+                part.ok_or_else(|| {
+                    StorageError::Internal(format!(
+                        "multipart plan is missing completed part {idx}"
+                    ))
+                })
+            })
+            .collect()
+    }
+
+    async fn verify_local_file(
+        file_path: &std::path::Path,
+        size: u64,
+        expected_hash: &[u8; 32],
+        cancel: &tokio_util::sync::CancellationToken,
+    ) -> Result<()> {
+        let mut file = tokio::fs::File::open(file_path).await?;
+        let actual_size = file.metadata().await?.len();
+        if actual_size != size {
+            return Err(StorageError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: format!("local file has {actual_size} bytes; upload expects {size}"),
+            });
+        }
+        let mut remaining = size;
+        let mut buffer = vec![0_u8; 1024 * 1024];
+        let mut hasher = blake3::Hasher::new();
+        while remaining > 0 {
+            if cancel.is_cancelled() {
+                return Err(StorageError::Cancelled);
+            }
+            let want = remaining.min(buffer.len() as u64) as usize;
+            file.read_exact(&mut buffer[..want]).await?;
+            hasher.update(&buffer[..want]);
+            remaining -= want as u64;
+        }
+        let actual_hash = *hasher.finalize().as_bytes();
+        if actual_hash != *expected_hash {
+            return Err(StorageError::CorruptObject {
+                path: file_path.display().to_string(),
+                reason: format!(
+                    "local blake3 hash {} does not match expected {}",
+                    hex_lower(&actual_hash),
+                    hex_lower(expected_hash)
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn multipart_target(&self, path: &Path) -> Option<crate::multipart::MultipartTarget> {
+        if self.multipart.is_none() || self.staging_writes.is_some() {
+            return None;
+        }
+        let identity = self.multipart_identity.as_ref()?;
+        let provider = match identity.cloud {
+            crate::identity::StorageProviderKind::S3 => "s3",
+            crate::identity::StorageProviderKind::Gcs => "gcs",
+            crate::identity::StorageProviderKind::Azure => "azure",
+            crate::identity::StorageProviderKind::Local => "local",
+        };
+        Some(crate::multipart::MultipartTarget {
+            provider: provider.to_owned(),
+            host: identity.host.clone(),
+            container: identity.container.clone(),
+            key: path.to_string(),
+        })
+    }
+
+    pub async fn abort_explicit_multipart(&self, path: &Path, upload_id: &str) -> Result<()> {
+        let multipart = self
+            .multipart
+            .as_ref()
+            .ok_or_else(|| StorageError::NotSupported {
+                source: object_store::Error::NotSupported {
+                    source: "store has no stable multipart upload-id API".into(),
+                },
+            })?;
+        retry(&self.retry, || async {
+            match multipart
+                .abort_multipart(path, &object_store::MultipartId::from(upload_id))
+                .await
+            {
+                Ok(()) | Err(object_store::Error::NotFound { .. }) => Ok(()),
+                Err(error) => Err(map_object_store_error(error, path.as_ref())),
+            }
+        })
+        .await
     }
 
     /// One full multipart-upload attempt: create, write parts with bounded
@@ -1788,6 +2484,120 @@ impl Store {
     }
 }
 
+const MULTIPART_LEASE_DURATION: std::time::Duration = std::time::Duration::from_secs(60);
+const MULTIPART_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+const MULTIPART_CLAIM_POLL: std::time::Duration = std::time::Duration::from_millis(250);
+
+async fn await_with_heartbeat<F, T>(
+    journal: &dyn crate::multipart::MultipartJournal,
+    lease: &crate::multipart::JournalLease,
+    cancel: &tokio_util::sync::CancellationToken,
+    future: F,
+) -> Result<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    if cancel.is_cancelled() {
+        release_journal(journal, lease).await;
+        return Err(StorageError::Cancelled);
+    }
+    // A disk read or a paused process can outlive its lease between phases.
+    // Revalidate before polling a provider future, not only on a later tick.
+    if let Err(error) = require_journal_owner(
+        &Path::from(lease.entry_id.as_str()),
+        "renew lease",
+        journal
+            .renew(lease, unix_now(), MULTIPART_LEASE_DURATION)
+            .await,
+    ) {
+        release_journal(journal, lease).await;
+        return Err(error);
+    }
+    let result = {
+        tokio::pin!(future);
+        let start = tokio::time::Instant::now() + MULTIPART_HEARTBEAT_INTERVAL;
+        let mut heartbeat = tokio::time::interval_at(start, MULTIPART_HEARTBEAT_INTERVAL);
+        loop {
+            tokio::select! {
+                output = &mut future => break Ok(output),
+                () = cancel.cancelled() => break Err(StorageError::Cancelled),
+                _ = heartbeat.tick() => {
+                    if let Err(error) = require_journal_owner(
+                        &Path::from(lease.entry_id.as_str()),
+                        "renew lease",
+                        journal.renew(
+                            lease,
+                            unix_now(),
+                            MULTIPART_LEASE_DURATION,
+                        )
+                        .await,
+                    ) {
+                        break Err(error);
+                    }
+                }
+            }
+        }
+    };
+    if result.is_err() {
+        // Drop the transport future before another process can acquire the
+        // released lease and start using the recorded provider upload ID.
+        release_journal(journal, lease).await;
+    }
+    result
+}
+
+fn journal_call<T>(
+    operation: &'static str,
+    result: crate::multipart::JournalResult<T>,
+) -> Result<T> {
+    result.map_err(|source| StorageError::MultipartJournal { operation, source })
+}
+
+fn require_journal_owner(
+    path: &Path,
+    operation: &'static str,
+    result: crate::multipart::JournalResult<bool>,
+) -> Result<()> {
+    if journal_call(operation, result)? {
+        Ok(())
+    } else {
+        Err(StorageError::StateConflict {
+            path: path.to_string(),
+        })
+    }
+}
+
+async fn release_journal(
+    journal: &dyn crate::multipart::MultipartJournal,
+    lease: &crate::multipart::JournalLease,
+) {
+    match journal.release_owned(lease, unix_now()).await {
+        Ok(true) => {}
+        Ok(false) => tracing::debug!(
+            entry_id = %lease.entry_id,
+            "multipart lease already changed while releasing"
+        ),
+        Err(error) => tracing::warn!(
+            entry_id = %lease.entry_id,
+            error = %error,
+            "failed to release multipart lease"
+        ),
+    }
+}
+
+fn random_owner_token() -> String {
+    use rand::Rng as _;
+    format!("{:032x}", rand::rng().random::<u128>())
+}
+
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok())
+        .unwrap_or(0)
+}
+
 fn ensure_complete_body(path: &Path, expected: u64, actual: u64) -> Result<()> {
     if actual == expected {
         return Ok(());
@@ -1830,9 +2640,426 @@ fn hex_lower(bytes: &[u8; 32]) -> String {
 mod tests {
     use super::*;
     use crate::identity::StorageProviderKind;
-    use futures_util::TryStreamExt as _;
+    use futures_util::{TryStreamExt as _, stream::BoxStream};
     use object_store::memory::InMemory;
+    use object_store::multipart::{MultipartStore, PartId};
+    use object_store::{
+        CopyOptions, GetOptions, GetResult, ListResult, MultipartId, PutMultipartOptions,
+        PutOptions, PutPayload, PutResult,
+    };
+    use std::fmt;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    #[derive(Default)]
+    struct TestJournal {
+        row: std::sync::Mutex<Option<TestJournalRow>>,
+        claims: AtomicU64,
+        renewals: AtomicU64,
+    }
+
+    struct TestJournalRow {
+        target: crate::multipart::MultipartTarget,
+        claim: crate::multipart::JournalClaim,
+        expires_at: i64,
+    }
+
+    impl TestJournal {
+        fn owned_mut<'a>(
+            row: &'a mut Option<TestJournalRow>,
+            lease: &crate::multipart::JournalLease,
+            now: i64,
+        ) -> Option<&'a mut TestJournalRow> {
+            row.as_mut()
+                .filter(|row| row.claim.lease == *lease && row.expires_at > now)
+        }
+
+        fn deadline(now: i64, duration: Duration) -> i64 {
+            now.saturating_add(i64::try_from(duration.as_secs()).unwrap_or(i64::MAX))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::multipart::MultipartJournal for TestJournal {
+        async fn claim(
+            &self,
+            target: &crate::multipart::MultipartTarget,
+            payload_hash: &[u8],
+            expected_hash: &[u8; 32],
+            size: u64,
+            part_size: usize,
+            owner_token: &str,
+            now: i64,
+            lease_duration: Duration,
+        ) -> crate::multipart::JournalResult<crate::multipart::JournalClaimOutcome> {
+            self.claims.fetch_add(1, Ordering::Relaxed);
+            let mut row = self.row.lock().unwrap();
+            if let Some(existing) = row.as_mut() {
+                assert_eq!(&existing.target, target);
+                if existing.expires_at > now && existing.claim.lease.owner_token != owner_token {
+                    return Ok(crate::multipart::JournalClaimOutcome::Busy);
+                }
+                existing.claim.lease.owner_token = owner_token.to_owned();
+                existing.expires_at = Self::deadline(now, lease_duration);
+                return Ok(crate::multipart::JournalClaimOutcome::Acquired(
+                    existing.claim.clone(),
+                ));
+            }
+            let claim = crate::multipart::JournalClaim {
+                lease: crate::multipart::JournalLease {
+                    entry_id: "entry".to_owned(),
+                    owner_token: owner_token.to_owned(),
+                },
+                upload_id: None,
+                payload_hash: payload_hash.to_vec(),
+                expected_hash: *expected_hash,
+                size,
+                part_size,
+                parts: Vec::new(),
+            };
+            *row = Some(TestJournalRow {
+                target: target.clone(),
+                claim: claim.clone(),
+                expires_at: Self::deadline(now, lease_duration),
+            });
+            Ok(crate::multipart::JournalClaimOutcome::Acquired(claim))
+        }
+
+        async fn bind_upload(
+            &self,
+            lease: &crate::multipart::JournalLease,
+            upload_id: &str,
+            now: i64,
+            lease_duration: Duration,
+        ) -> crate::multipart::JournalResult<bool> {
+            let mut row = self.row.lock().unwrap();
+            let Some(row) = Self::owned_mut(&mut row, lease, now) else {
+                return Ok(false);
+            };
+            row.claim.upload_id = Some(upload_id.to_owned());
+            row.expires_at = Self::deadline(now, lease_duration);
+            Ok(true)
+        }
+
+        async fn renew(
+            &self,
+            lease: &crate::multipart::JournalLease,
+            now: i64,
+            lease_duration: Duration,
+        ) -> crate::multipart::JournalResult<bool> {
+            self.renewals.fetch_add(1, Ordering::Relaxed);
+            let mut row = self.row.lock().unwrap();
+            let Some(row) = Self::owned_mut(&mut row, lease, now) else {
+                return Ok(false);
+            };
+            row.expires_at = Self::deadline(now, lease_duration);
+            Ok(true)
+        }
+
+        async fn record_part(
+            &self,
+            lease: &crate::multipart::JournalLease,
+            part: &crate::multipart::JournalPart,
+            now: i64,
+            lease_duration: Duration,
+        ) -> crate::multipart::JournalResult<bool> {
+            let mut row = self.row.lock().unwrap();
+            let Some(row) = Self::owned_mut(&mut row, lease, now) else {
+                return Ok(false);
+            };
+            row.claim
+                .parts
+                .retain(|saved| saved.part_idx != part.part_idx);
+            row.claim.parts.push(part.clone());
+            row.expires_at = Self::deadline(now, lease_duration);
+            Ok(true)
+        }
+
+        async fn reset_owned(
+            &self,
+            lease: &crate::multipart::JournalLease,
+            payload_hash: &[u8],
+            expected_hash: &[u8; 32],
+            size: u64,
+            part_size: usize,
+            now: i64,
+            lease_duration: Duration,
+        ) -> crate::multipart::JournalResult<bool> {
+            let mut row = self.row.lock().unwrap();
+            let Some(row) = Self::owned_mut(&mut row, lease, now) else {
+                return Ok(false);
+            };
+            row.claim.upload_id = None;
+            row.claim.payload_hash = payload_hash.to_vec();
+            row.claim.expected_hash = *expected_hash;
+            row.claim.size = size;
+            row.claim.part_size = part_size;
+            row.claim.parts.clear();
+            row.expires_at = Self::deadline(now, lease_duration);
+            Ok(true)
+        }
+
+        async fn complete_owned(
+            &self,
+            lease: &crate::multipart::JournalLease,
+            now: i64,
+        ) -> crate::multipart::JournalResult<bool> {
+            let mut row = self.row.lock().unwrap();
+            if Self::owned_mut(&mut row, lease, now).is_none() {
+                return Ok(false);
+            }
+            *row = None;
+            Ok(true)
+        }
+
+        async fn abandon_owned(
+            &self,
+            lease: &crate::multipart::JournalLease,
+            now: i64,
+        ) -> crate::multipart::JournalResult<bool> {
+            let mut row = self.row.lock().unwrap();
+            if Self::owned_mut(&mut row, lease, now).is_none() {
+                return Ok(false);
+            }
+            *row = None;
+            Ok(true)
+        }
+
+        async fn release_owned(
+            &self,
+            lease: &crate::multipart::JournalLease,
+            now: i64,
+        ) -> crate::multipart::JournalResult<bool> {
+            let mut row = self.row.lock().unwrap();
+            let Some(row) = row.as_mut().filter(|row| row.claim.lease == *lease) else {
+                return Ok(false);
+            };
+            row.expires_at = now;
+            Ok(true)
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum CompleteBehavior {
+        Normal,
+        ErrorAfterCommit,
+        CorruptAfterCommit,
+    }
+
+    struct TestMultipartStore {
+        inner: Arc<InMemory>,
+        behavior: CompleteBehavior,
+        gate_first_part: bool,
+        part_started: Arc<tokio::sync::Semaphore>,
+        part_release: Arc<tokio::sync::Semaphore>,
+        creates: AtomicU64,
+        parts: AtomicU64,
+        completes: AtomicU64,
+        aborts: AtomicU64,
+        abort_failures: AtomicU64,
+        missing_upload_ids: std::sync::Mutex<HashSet<String>>,
+    }
+
+    #[derive(Debug)]
+    struct FailFirstBodyGetStore {
+        inner: Arc<InMemory>,
+        remaining_failures: AtomicU64,
+    }
+
+    impl fmt::Display for FailFirstBodyGetStore {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("fail-first-body-get")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for FailFirstBodyGetStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            options: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, options).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            options: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            if !options.head
+                && self
+                    .remaining_failures
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok()
+            {
+                return Err(object_store::Error::Generic {
+                    store: "test",
+                    source: "transient body read".into(),
+                });
+            }
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, object_store::Result<Path>>,
+        ) -> BoxStream<'static, object_store::Result<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&Path>,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    impl TestMultipartStore {
+        fn new(inner: Arc<InMemory>, behavior: CompleteBehavior, gate_first_part: bool) -> Self {
+            Self {
+                inner,
+                behavior,
+                gate_first_part,
+                part_started: Arc::new(tokio::sync::Semaphore::new(0)),
+                part_release: Arc::new(tokio::sync::Semaphore::new(0)),
+                creates: AtomicU64::new(0),
+                parts: AtomicU64::new(0),
+                completes: AtomicU64::new(0),
+                aborts: AtomicU64::new(0),
+                abort_failures: AtomicU64::new(0),
+                missing_upload_ids: std::sync::Mutex::new(HashSet::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MultipartStore for TestMultipartStore {
+        async fn create_multipart(&self, path: &Path) -> object_store::Result<MultipartId> {
+            self.creates.fetch_add(1, Ordering::Relaxed);
+            self.inner.create_multipart(path).await
+        }
+
+        async fn put_part(
+            &self,
+            path: &Path,
+            id: &MultipartId,
+            part_idx: usize,
+            data: PutPayload,
+        ) -> object_store::Result<PartId> {
+            if self
+                .missing_upload_ids
+                .lock()
+                .unwrap()
+                .contains(id.as_str())
+            {
+                return Err(object_store::Error::NotFound {
+                    path: path.to_string(),
+                    source: "provider multipart session is absent".into(),
+                });
+            }
+            let call = self.parts.fetch_add(1, Ordering::Relaxed);
+            if self.gate_first_part && call == 0 {
+                self.part_started.add_permits(1);
+                let permit = self.part_release.acquire().await.map_err(|_| {
+                    object_store::Error::Generic {
+                        store: "test",
+                        source: "multipart test gate closed".into(),
+                    }
+                })?;
+                permit.forget();
+            }
+            self.inner.put_part(path, id, part_idx, data).await
+        }
+
+        async fn complete_multipart(
+            &self,
+            path: &Path,
+            id: &MultipartId,
+            parts: Vec<PartId>,
+        ) -> object_store::Result<PutResult> {
+            self.completes.fetch_add(1, Ordering::Relaxed);
+            let result = self.inner.complete_multipart(path, id, parts).await?;
+            match self.behavior {
+                CompleteBehavior::Normal => Ok(result),
+                CompleteBehavior::ErrorAfterCommit => Err(object_store::Error::Generic {
+                    store: "test",
+                    source: "response lost after commit".into(),
+                }),
+                CompleteBehavior::CorruptAfterCommit => {
+                    self.inner
+                        .put(path, Bytes::from_static(b"corrupt").into())
+                        .await?;
+                    Ok(result)
+                }
+            }
+        }
+
+        async fn abort_multipart(&self, path: &Path, id: &MultipartId) -> object_store::Result<()> {
+            self.aborts.fetch_add(1, Ordering::Relaxed);
+            if self
+                .abort_failures
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(object_store::Error::Generic {
+                    store: "test",
+                    source: "transient abort failure".into(),
+                });
+            }
+            self.inner.abort_multipart(path, id).await
+        }
+    }
+
+    fn resumable_store(multipart: Arc<TestMultipartStore>) -> Store {
+        let inner: Arc<dyn ObjectStore> = multipart.inner.clone();
+        let multipart_handle: Arc<dyn MultipartStore> = multipart;
+        let identity = BucketIdentity::new(StorageProviderKind::S3, "s3.example.test", "bucket");
+        memory_store_with_inner(inner)
+            .with_bucket_identity(identity.clone())
+            .with_multipart(multipart_handle, identity)
+    }
+
+    fn memory_store_with_inner(inner: Arc<dyn ObjectStore>) -> Store {
+        Store::with_retry(
+            inner,
+            RetryPolicy {
+                max_attempts: 2,
+                base: Duration::from_millis(1),
+                cap: Duration::from_millis(5),
+            },
+        )
+    }
 
     fn memory_store() -> Store {
         let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -1843,6 +3070,65 @@ mod tests {
             cap: std::time::Duration::from_millis(5),
         };
         Store::with_retry(inner, policy)
+    }
+
+    #[tokio::test]
+    async fn heartbeat_refuses_to_poll_provider_after_ownership_is_lost() {
+        let journal = TestJournal::default();
+        let lease = crate::multipart::JournalLease {
+            entry_id: "retired-entry".into(),
+            owner_token: "former-owner".into(),
+        };
+        let provider_calls = AtomicU64::new(0);
+        let result = await_with_heartbeat(
+            &journal,
+            &lease,
+            &tokio_util::sync::CancellationToken::new(),
+            async { provider_calls.fetch_add(1, Ordering::Relaxed) },
+        )
+        .await;
+
+        assert!(matches!(result, Err(StorageError::StateConflict { .. })));
+        assert_eq!(provider_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn heartbeat_renews_ownership_through_a_slow_phase() {
+        use crate::multipart::MultipartJournal as _;
+
+        let journal = TestJournal::default();
+        let target = crate::multipart::MultipartTarget {
+            provider: "s3".into(),
+            host: "endpoint".into(),
+            container: "bucket".into(),
+            key: "key".into(),
+        };
+        let crate::multipart::JournalClaimOutcome::Acquired(claim) = journal
+            .claim(
+                &target,
+                &[0; 32],
+                &[0; 32],
+                0,
+                8,
+                "owner",
+                unix_now(),
+                MULTIPART_LEASE_DURATION,
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("fresh journal must be acquirable");
+        };
+        await_with_heartbeat(
+            &journal,
+            &claim.lease,
+            &tokio_util::sync::CancellationToken::new(),
+            tokio::time::sleep(MULTIPART_HEARTBEAT_INTERVAL * 2 + Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(journal.renewals.load(Ordering::Relaxed), 3);
     }
 
     #[tokio::test]
@@ -2302,6 +3588,576 @@ mod tests {
             store.head(&path).await,
             Err(StorageError::NotFound { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn resumable_upload_rejects_hash_before_claim_or_provider_creation() {
+        let inner = Arc::new(InMemory::new());
+        let multipart = Arc::new(TestMultipartStore::new(
+            inner,
+            CompleteBehavior::Normal,
+            false,
+        ));
+        let store = resumable_store(Arc::clone(&multipart));
+        let journal = TestJournal::default();
+        let body = b"verified before provider state";
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, body).await.unwrap();
+
+        let error = store
+            .put_multipart_file_resumable(
+                &Path::from("blobs/preverified"),
+                &source,
+                body.len() as u64,
+                [9; 32],
+                b"payload",
+                5,
+                &tokio_util::sync::CancellationToken::new(),
+                None,
+                Some(&journal),
+            )
+            .await
+            .expect_err("wrong expected hash must fail before provider state exists");
+
+        assert!(matches!(error, StorageError::CorruptObject { .. }));
+        assert_eq!(journal.claims.load(Ordering::Relaxed), 0);
+        assert_eq!(multipart.creates.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn resumable_existing_object_retries_transient_body_read() {
+        let inner = Arc::new(InMemory::new());
+        let body = Bytes::from_static(b"already durable");
+        let path = Path::from("blobs/existing-after-transient-read");
+        inner.put(&path, body.clone().into()).await.unwrap();
+        let read_store: Arc<dyn ObjectStore> = Arc::new(FailFirstBodyGetStore {
+            inner: Arc::clone(&inner),
+            remaining_failures: AtomicU64::new(1),
+        });
+        let multipart: Arc<dyn MultipartStore> = inner;
+        let identity = BucketIdentity::new(StorageProviderKind::S3, "s3.example.test", "bucket");
+        let store = memory_store_with_inner(read_store)
+            .with_bucket_identity(identity.clone())
+            .with_multipart(multipart, identity);
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, &body).await.unwrap();
+        let journal = TestJournal::default();
+        let hash = *blake3::hash(&body).as_bytes();
+
+        let outcome = store
+            .put_multipart_file_resumable(
+                &path,
+                &source,
+                body.len() as u64,
+                hash,
+                &hash,
+                8,
+                &tokio_util::sync::CancellationToken::new(),
+                None,
+                Some(&journal),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            crate::multipart::ResumableUploadOutcome::AlreadyPresent
+        );
+        assert_eq!(journal.claims.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn explicit_multipart_abort_retries_transient_failure() {
+        let inner = Arc::new(InMemory::new());
+        let multipart = Arc::new(TestMultipartStore::new(
+            inner,
+            CompleteBehavior::Normal,
+            false,
+        ));
+        let store = resumable_store(Arc::clone(&multipart));
+        let path = Path::from("blobs/abort-retry");
+        let upload_id = multipart.create_multipart(&path).await.unwrap();
+        multipart.abort_failures.store(1, Ordering::Relaxed);
+
+        store
+            .abort_explicit_multipart(&path, upload_id.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(multipart.aborts.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn resumable_upload_reuses_recorded_provider_parts() {
+        use crate::multipart::MultipartJournal as _;
+
+        let inner = Arc::new(InMemory::new());
+        let multipart = Arc::new(TestMultipartStore::new(
+            inner,
+            CompleteBehavior::Normal,
+            false,
+        ));
+        let store = resumable_store(Arc::clone(&multipart));
+        let journal = TestJournal::default();
+        let path = Path::from("blobs/resume");
+        let body = b"resume exact provider parts";
+        let hash = *blake3::hash(body).as_bytes();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, body).await.unwrap();
+        let target = store.multipart_target(&path).unwrap();
+        let now = unix_now();
+        let claim = match journal
+            .claim(
+                &target,
+                &hash,
+                &hash,
+                body.len() as u64,
+                8,
+                "first-owner",
+                now,
+                MULTIPART_LEASE_DURATION,
+            )
+            .await
+            .unwrap()
+        {
+            crate::multipart::JournalClaimOutcome::Acquired(claim) => claim,
+            crate::multipart::JournalClaimOutcome::Busy => panic!("new journal must be acquirable"),
+        };
+        let upload_id = multipart.create_multipart(&path).await.unwrap();
+        assert!(
+            journal
+                .bind_upload(
+                    &claim.lease,
+                    upload_id.as_ref(),
+                    now,
+                    MULTIPART_LEASE_DURATION,
+                )
+                .await
+                .unwrap()
+        );
+        let provider_part = multipart
+            .put_part(
+                &path,
+                &upload_id,
+                0,
+                Bytes::copy_from_slice(&body[..8]).into(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            journal
+                .record_part(
+                    &claim.lease,
+                    &crate::multipart::JournalPart {
+                        part_idx: 0,
+                        content_id: provider_part.content_id,
+                        size: 8,
+                    },
+                    now,
+                    MULTIPART_LEASE_DURATION,
+                )
+                .await
+                .unwrap()
+        );
+        assert!(journal.release_owned(&claim.lease, now).await.unwrap());
+
+        let outcome = store
+            .put_multipart_file_resumable(
+                &path,
+                &source,
+                body.len() as u64,
+                hash,
+                &hash,
+                8,
+                &tokio_util::sync::CancellationToken::new(),
+                None,
+                Some(&journal),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, crate::multipart::ResumableUploadOutcome::Resumed);
+        assert_eq!(multipart.creates.load(Ordering::Relaxed), 1);
+        assert_eq!(multipart.parts.load(Ordering::Relaxed), 4);
+        assert_eq!(
+            store.get_with_etag(&path).await.unwrap().0,
+            Bytes::copy_from_slice(body)
+        );
+    }
+
+    #[tokio::test]
+    async fn resumable_upload_replaces_missing_provider_session() {
+        use crate::multipart::MultipartJournal as _;
+
+        let inner = Arc::new(InMemory::new());
+        let multipart = Arc::new(TestMultipartStore::new(
+            inner,
+            CompleteBehavior::Normal,
+            false,
+        ));
+        let store = resumable_store(Arc::clone(&multipart));
+        let journal = TestJournal::default();
+        let path = Path::from("blobs/provider-session-lost");
+        let body = b"provider session vanishes after one durable part";
+        let hash = *blake3::hash(body).as_bytes();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, body).await.unwrap();
+        let target = store.multipart_target(&path).unwrap();
+        let now = unix_now();
+        let claim = match journal
+            .claim(
+                &target,
+                &hash,
+                &hash,
+                body.len() as u64,
+                8,
+                "first-owner",
+                now,
+                MULTIPART_LEASE_DURATION,
+            )
+            .await
+            .unwrap()
+        {
+            crate::multipart::JournalClaimOutcome::Acquired(claim) => claim,
+            crate::multipart::JournalClaimOutcome::Busy => panic!("new journal must be acquirable"),
+        };
+        let lost_upload_id = multipart.create_multipart(&path).await.unwrap();
+        assert!(
+            journal
+                .bind_upload(
+                    &claim.lease,
+                    lost_upload_id.as_ref(),
+                    now,
+                    MULTIPART_LEASE_DURATION,
+                )
+                .await
+                .unwrap()
+        );
+        let provider_part = multipart
+            .put_part(
+                &path,
+                &lost_upload_id,
+                0,
+                Bytes::copy_from_slice(&body[..8]).into(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            journal
+                .record_part(
+                    &claim.lease,
+                    &crate::multipart::JournalPart {
+                        part_idx: 0,
+                        content_id: provider_part.content_id,
+                        size: 8,
+                    },
+                    now,
+                    MULTIPART_LEASE_DURATION,
+                )
+                .await
+                .unwrap()
+        );
+        assert!(journal.release_owned(&claim.lease, now).await.unwrap());
+        multipart
+            .abort_multipart(&path, &lost_upload_id)
+            .await
+            .unwrap();
+        multipart
+            .missing_upload_ids
+            .lock()
+            .unwrap()
+            .insert(lost_upload_id.to_string());
+        let credited = AtomicU64::new(0);
+        let on_part = |bytes| {
+            credited.fetch_add(bytes, Ordering::Relaxed);
+        };
+
+        let outcome = store
+            .put_multipart_file_resumable(
+                &path,
+                &source,
+                body.len() as u64,
+                hash,
+                &hash,
+                8,
+                &tokio_util::sync::CancellationToken::new(),
+                Some(&on_part),
+                Some(&journal),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, crate::multipart::ResumableUploadOutcome::Uploaded);
+        assert_eq!(multipart.creates.load(Ordering::Relaxed), 2);
+        assert_eq!(credited.load(Ordering::Relaxed), body.len() as u64);
+        assert_eq!(
+            store.get_with_etag(&path).await.unwrap().0,
+            Bytes::copy_from_slice(body)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_resumable_uploads_have_one_provider_owner() {
+        use crate::multipart::MultipartJournal as _;
+
+        for resume_existing in [false, true] {
+            let inner = Arc::new(InMemory::new());
+            let multipart = Arc::new(TestMultipartStore::new(
+                inner,
+                CompleteBehavior::Normal,
+                true,
+            ));
+            let store = resumable_store(Arc::clone(&multipart));
+            let journal = Arc::new(TestJournal::default());
+            let body = b"one owner completes this upload";
+            let hash = *blake3::hash(body).as_bytes();
+            let dir = tempfile::tempdir().unwrap();
+            let source = dir.path().join("payload");
+            tokio::fs::write(&source, body).await.unwrap();
+            let path = Path::from("blobs/concurrent");
+
+            if resume_existing {
+                let target = store.multipart_target(&path).unwrap();
+                let now = unix_now();
+                let crate::multipart::JournalClaimOutcome::Acquired(claim) = journal
+                    .claim(
+                        &target,
+                        &hash,
+                        &hash,
+                        body.len() as u64,
+                        64,
+                        "original",
+                        now,
+                        MULTIPART_LEASE_DURATION,
+                    )
+                    .await
+                    .unwrap()
+                else {
+                    panic!("new journal must be acquirable")
+                };
+                let upload_id = multipart.create_multipart(&path).await.unwrap();
+                assert!(
+                    journal
+                        .bind_upload(&claim.lease, &upload_id, now, MULTIPART_LEASE_DURATION)
+                        .await
+                        .unwrap()
+                );
+                assert!(journal.release_owned(&claim.lease, now).await.unwrap());
+            }
+
+            let first = {
+                let store = store.clone();
+                let journal = Arc::clone(&journal);
+                let source = source.clone();
+                let path = path.clone();
+                tokio::spawn(async move {
+                    store
+                        .put_multipart_file_resumable(
+                            &path,
+                            &source,
+                            body.len() as u64,
+                            hash,
+                            &hash,
+                            64,
+                            &tokio_util::sync::CancellationToken::new(),
+                            None,
+                            Some(journal.as_ref()),
+                        )
+                        .await
+                })
+            };
+            let started = multipart.part_started.acquire().await.unwrap();
+            started.forget();
+            let claims_before_second = journal.claims.load(Ordering::Relaxed);
+            let second = {
+                let store = store.clone();
+                let journal = Arc::clone(&journal);
+                let source = source.clone();
+                let path = path.clone();
+                tokio::spawn(async move {
+                    store
+                        .put_multipart_file_resumable(
+                            &path,
+                            &source,
+                            body.len() as u64,
+                            hash,
+                            &hash,
+                            64,
+                            &tokio_util::sync::CancellationToken::new(),
+                            None,
+                            Some(journal.as_ref()),
+                        )
+                        .await
+                })
+            };
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while journal.claims.load(Ordering::Relaxed) == claims_before_second {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .unwrap();
+            multipart.part_release.add_permits(1);
+            let first = first.await.unwrap().unwrap();
+            let second = second.await.unwrap().unwrap();
+
+            let expected = if resume_existing {
+                crate::multipart::ResumableUploadOutcome::Resumed
+            } else {
+                crate::multipart::ResumableUploadOutcome::Uploaded
+            };
+            assert_eq!(first, expected);
+            assert_eq!(
+                second,
+                crate::multipart::ResumableUploadOutcome::AlreadyPresent
+            );
+            assert_eq!(multipart.creates.load(Ordering::Relaxed), 1);
+            assert_eq!(multipart.completes.load(Ordering::Relaxed), 1);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelled_upload_releases_lease_and_resumes_same_provider_session() {
+        let inner = Arc::new(InMemory::new());
+        let multipart = Arc::new(TestMultipartStore::new(
+            inner,
+            CompleteBehavior::Normal,
+            true,
+        ));
+        let store = resumable_store(Arc::clone(&multipart));
+        let journal = Arc::new(TestJournal::default());
+        let body = b"interrupted upload resumes its provider session";
+        let hash = *blake3::hash(body).as_bytes();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, body).await.unwrap();
+        let path = Path::from("blobs/interrupted");
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let interrupted = {
+            let store = store.clone();
+            let journal = Arc::clone(&journal);
+            let source = source.clone();
+            let path = path.clone();
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                store
+                    .put_multipart_file_resumable(
+                        &path,
+                        &source,
+                        body.len() as u64,
+                        hash,
+                        &hash,
+                        64,
+                        &cancel,
+                        None,
+                        Some(journal.as_ref()),
+                    )
+                    .await
+            })
+        };
+        let started = multipart.part_started.acquire().await.unwrap();
+        started.forget();
+        cancel.cancel();
+        assert!(matches!(
+            interrupted.await.unwrap(),
+            Err(StorageError::Cancelled)
+        ));
+        assert!(journal.row.lock().unwrap().is_some());
+
+        let outcome = store
+            .put_multipart_file_resumable(
+                &path,
+                &source,
+                body.len() as u64,
+                hash,
+                &hash,
+                64,
+                &tokio_util::sync::CancellationToken::new(),
+                None,
+                Some(journal.as_ref()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, crate::multipart::ResumableUploadOutcome::Resumed);
+        assert_eq!(multipart.creates.load(Ordering::Relaxed), 1);
+        assert_eq!(multipart.completes.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn uncertain_completion_is_accepted_only_after_canonical_readback() {
+        let inner = Arc::new(InMemory::new());
+        let multipart = Arc::new(TestMultipartStore::new(
+            inner,
+            CompleteBehavior::ErrorAfterCommit,
+            false,
+        ));
+        let store = resumable_store(multipart);
+        let journal = TestJournal::default();
+        let body = b"provider committed before response was lost";
+        let hash = *blake3::hash(body).as_bytes();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, body).await.unwrap();
+
+        let outcome = store
+            .put_multipart_file_resumable(
+                &Path::from("blobs/uncertain"),
+                &source,
+                body.len() as u64,
+                hash,
+                &hash,
+                9,
+                &tokio_util::sync::CancellationToken::new(),
+                None,
+                Some(&journal),
+            )
+            .await
+            .unwrap();
+        assert_eq!(outcome, crate::multipart::ResumableUploadOutcome::Uploaded);
+        assert!(journal.row.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn corrupt_provider_completion_is_repaired_once_then_rejected() {
+        let inner = Arc::new(InMemory::new());
+        let multipart = Arc::new(TestMultipartStore::new(
+            inner,
+            CompleteBehavior::CorruptAfterCommit,
+            false,
+        ));
+        let store = resumable_store(Arc::clone(&multipart));
+        let journal = TestJournal::default();
+        let body = b"provider returns the wrong canonical bytes";
+        let hash = *blake3::hash(body).as_bytes();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("payload");
+        tokio::fs::write(&source, body).await.unwrap();
+
+        let error = store
+            .put_multipart_file_resumable(
+                &Path::from("blobs/corrupt-complete"),
+                &source,
+                body.len() as u64,
+                hash,
+                &hash,
+                11,
+                &tokio_util::sync::CancellationToken::new(),
+                None,
+                Some(&journal),
+            )
+            .await
+            .expect_err("two corrupt completions must not be accepted");
+
+        assert!(matches!(error, StorageError::CorruptObject { .. }));
+        assert_eq!(multipart.creates.load(Ordering::Relaxed), 2);
+        assert_eq!(multipart.completes.load(Ordering::Relaxed), 2);
+        assert!(journal.row.lock().unwrap().is_none());
     }
 
     #[tokio::test]

--- a/packages/web/content/docs/cli/daily-workflow/pushing-changes.mdx
+++ b/packages/web/content/docs/cli/daily-workflow/pushing-changes.mdx
@@ -42,6 +42,12 @@ failure signal.
 3. Missing chunks are packed into xorbs and uploaded.
 4. The remote ref is updated only after required data is available.
 
+When a push produces multiple Git packs, Crab uploads up to four pack
+transactions concurrently, bounded further by the configured upload concurrency.
+Each transaction installs and verifies its pack before publishing its index and
+metadata. A failure stops new transactions, waits for active transactions to
+finish, and leaves the remote refs unchanged.
+
 ## Verify publication
 
 Check the ref and repository closure after a successful push:
@@ -65,7 +71,9 @@ another job will hydrate the result.
 ## Failure Recovery
 
 - If upload fails, fix the cause and run `crab push` again. Already uploaded
-  chunks are skipped.
+  chunks are skipped. Eligible file-backed S3 and GCS uploads also reuse
+  journaled provider parts; completion is accepted only after the canonical
+  object passes size and Blake3 read-back verification.
 - If a teammate cannot hydrate a file, run `crab fsck` locally and confirm the
   producing machine completed `crab push`.
 - Use `crab logs` for detailed diagnostics when a push fails in CI.

--- a/packages/web/content/docs/cli/diagnostics/integrity-check.mdx
+++ b/packages/web/content/docs/cli/diagnostics/integrity-check.mdx
@@ -51,6 +51,7 @@ crab fsck
 | Issue | Description | Auto-repairable |
 |-------|-------------|:---:|
 | Expired push lock | Lock from a crashed process | ✓ |
+| Abandoned Crab multipart upload | Expired journal lease for an incomplete S3 or GCS upload | ✓ |
 | Orphan shard | Shard not referenced by any file index | ✗ |
 | Shard list divergence | Shard list doesn't match actual shards | ✗ |
 
@@ -62,12 +63,15 @@ crab fsck --repair
 
 Repair is conservative:
 - Expired locks are deleted
+- Journaled multipart sessions are aborted only when the current provider
+  endpoint, container, and key exactly match the recorded destination and the
+  journal row still has the revision observed by the check
 - Derivable historical Git visibility proofs can be rebuilt
 
 Repair is limited to issues explicitly marked repairable. Missing content
-requires history, replica, cache, or backup recovery. Provider-side incomplete
-multipart uploads require a provider lifecycle rule because the generic
-object-store API cannot enumerate them.
+requires history, replica, cache, or backup recovery. Multipart sessions not
+created through Crab's resumable journal still require a provider lifecycle
+rule because the generic object-store API cannot enumerate them.
 
 ## Verify after repair
 

--- a/packages/web/content/docs/cli/diagnostics/store-verification.mdx
+++ b/packages/web/content/docs/cli/diagnostics/store-verification.mdx
@@ -84,18 +84,26 @@ Only specific issue types are auto-repaired:
 | Issue | Repair action |
 |-------|--------------|
 | Expired push lock | Delete the lock |
+| Abandoned Crab multipart upload | Abort the journaled provider session and remove its journal row |
 
 Repairs are conservative. Expired lock objects are deleted only after the
-holder-safe expiry check; committed repository content is not deleted.
+holder-safe expiry check. Multipart repair acquires the expired journal lease
+again and requires the configured provider endpoint, container, and object key
+to match the recorded destination exactly. It also claims the exact journal
+revision observed by the check, so a resumed or replaced session wins a race
+with repair and remains untouched. A changed remote is left untouched and the
+journal row is retained. Committed repository content is not deleted.
 
 ## Current Boundaries
 
 - The current Git-object check does not reconstruct current head and run full
   Git reachability. Monitor an independent clone/fetch; use `crab recover
   history verify <generation>` for strict Git fsck of a historical root.
-- The generic object-store API cannot enumerate provider-side incomplete
-  multipart uploads, so configure the provider lifecycle rule that aborts old
-  incomplete uploads.
+- `fsck` can inspect resumable multipart sessions created by Crab and retained
+  in the shared staging journal. It cannot enumerate sessions created by other
+  clients or by upload paths without stable provider upload IDs. Keep the
+  provider lifecycle rule that aborts old incomplete uploads as the outer
+  cleanup boundary.
 - Locator or visibility acceleration damage requires `crab metadb rebuild`
   followed by another verification run.
 - Same-bucket manifest history is recovery history, not an independent backup.

--- a/packages/web/content/docs/cli/reference/crab-fsck.mdx
+++ b/packages/web/content/docs/cli/reference/crab-fsck.mdx
@@ -21,7 +21,10 @@ crab fsck [OPTIONS]
 
 `crab fsck` performs a deep integrity check of the repository: verifying that
 all pointer blobs reference valid chunks, all chunks are present in the remote
-store, and all hashes match their content.
+store, and all hashes match their content. It also reports expired resumable
+multipart sessions recorded in the shared staging journal. `--repair` aborts
+such a session only after reacquiring its lease and matching its exact provider
+endpoint, container, and object key.
 
 For conceptual background, see [Integrity Check](/docs/cli/diagnostics/integrity-check).
 

--- a/packages/web/content/docs/cli/storage/provider-qualification.mdx
+++ b/packages/web/content/docs/cli/storage/provider-qualification.mdx
@@ -36,7 +36,10 @@ Every provider must independently prove:
 
 - create-only and stale-token conflict behavior;
 - match-token writes and usable ETag or version identity;
-- multipart completion, abort, and file-backed staged upload;
+- multipart completion, abort, file-backed upload, and interruption/resume
+  through the same provider upload ID;
+- exclusion of concurrent resume owners plus post-completion size and Blake3
+  read-back verification;
 - exact range reads and paginated listing without gaps or duplicates;
 - retry/error mapping and cancellation without a visible object;
 - a canonical v1 origin receipt bound to the durable payload identity;
@@ -45,6 +48,27 @@ Every provider must independently prove:
 The retained report records provider/service identity, region or emulator,
 dependency version, Crab commit, workflow identity, commands, request and byte
 metrics, per-row duration, and results. It never records credential values.
+
+Run the opt-in interruption checks only against disposable scratch buckets:
+
+```bash
+CRAB_MULTIPART_LIVE_S3=1 \
+CRAB_MULTIPART_LIVE_S3_BUCKET=crab-scratch-bucket \
+CARGO_TARGET_DIR=$HOME/Workspace/crabbuild-target/crab-qualification \
+cargo test -p crab --test multipart_resume_live \
+  live_s3_interrupted_multipart_resumes_and_verifies -- --ignored
+
+CRAB_MULTIPART_LIVE_GCS=1 \
+CRAB_MULTIPART_LIVE_GCS_BUCKET=crab-scratch-bucket \
+CARGO_TARGET_DIR=$HOME/Workspace/crabbuild-target/crab-qualification \
+cargo test -p crab --test multipart_resume_live \
+  live_gcs_interrupted_multipart_resumes_and_verifies -- --ignored
+```
+
+The provider's normal ambient credential variables must also be configured.
+Each run uses a unique key beneath `.crab/e2e/multipart-resume/` and removes it
+after verification; provider lifecycle cleanup remains required for process or
+host failures that prevent the harness cleanup from running.
 
 ## Canonical v1 boundary
 


### PR DESCRIPTION
## Summary

Reimplements the useful recovery and streaming work from closed #70 against current `main`, rather than merging or rebasing that old PR.

- Add durable multipart owner leases, heartbeat and ownership-checked mutations, exact destination identity, pre-completion size/hash validation, post-write read-back verification, and destination-safe `fsck --repair`.
- Preserve multipart capability through refreshing credentials; wire recovery into xorb and pack uploads.
- Bound smudge memory without a packet-count cutoff, move add/index publication off async workers, and avoid retaining whole xorb allocations for prepared chunk slices.
- Upload up to four complete pack transactions concurrently, preserving per-pack evidence ordering and atomic ref publication. Stop admitting work and drain active transactions on failure/cancellation.
- Add regression coverage and document recovery, publication and opt-in provider qualification.

No dependency or lockfile changes. The production-code growth is primarily the durable lease/recovery boundary and provider transport integration; this is not only a mechanical refactor.

## Verification

Local verification completed during implementation:

| Surface | Result |
| --- | --- |
| Storage / staging unit suites | 151 / 197 passed; 1 staging test ignored |
| Push unit suite | 300 passed; 1 dependency-backed test ignored |
| fsck / add / filter-process unit tests | 32 / 58 / 39 passed |
| Auth-store, managed-service feature | 18 passed |
| Auth-store, no default features | Check passed |
| Add/commit/push, pack-size, push-fsck and fetch-fsck integration suites | 21 checks exercised successfully; 1 malformed-tree fixture internally skipped because Git rejected fixture construction |
| Opt-in multipart test harness | Compiled |
| Local RustFS interrupted multipart check | Passed: persisted part, journal reopen/client reconstruction, resume and independent read-back hash |
| Web | 9 tests passed; typecheck, production build and link checks passed; lint passed with 16 warnings in untouched files |
| Rust formatting / diff whitespace | Passed |
| Repository-configured correctness/suspicious Clippy gate | Passed |

The focused Rust unit total is **795 passed**, with two ignored tests. Regression coverage includes competing independent SQLite connections resuming one existing session, concurrent provider owners, stale repair findings, changed source data, cancellation, and pack publication barriers.

## Qualification limits

- **Real AWS S3/GCS qualification is explicitly deferred at the user's request.** The RustFS result is local S3-compatible evidence, not real-cloud or full CLI cloud E2E proof. The ignored live harness remains available for follow-up.
- Full workspace and cross-platform proof is left to CI; the PR does not claim cloud production readiness.
- A stricter all-warnings/all-test-target Clippy run is not clean. The configured correctness/suspicious gate passes; the stricter output includes existing debt and test-style warnings, including in added tests.

Rebased onto current `main` (`cf52d83`) before publication. On the rebased commit, formatting, the exact configured Clippy gate, `cargo build --package crab --locked`, and all three `bounded_pack` regressions passed. The macOS linker emitted a non-fatal large unwind-table warning. No changes from the superseded LFS/protocol work in #70 are carried forward.
