### PR TITLE
perf(add): enlarge direct classification batches

### DIFF
--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -162,7 +162,7 @@ parallel files and later adds cannot assign the same chunk to different local
 xorbs. Only the claim winner feeds its builder. Other recipe occurrences wait
 for and then lease the winner's placement. The coordination is disk-backed and
 batch-bounded; it does not require a repository-sized in-memory hash map.
-Direct preparation classifies up to 32 MiB per remote-index query. Files still
+Direct preparation classifies up to 64 MiB per remote-index query. Files still
 chunk and classify concurrently, while prepared-payload promotion is serialized
 within the add preparation to avoid competing durability flushes on one disk.
 

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -43,7 +43,7 @@ pub const READ_BUF_SIZE: usize = 1024 * 1024;
 /// typical data batch closer to 64 MiB before touching the staging index.
 pub const STAGE_BATCH_CHUNKS: usize = 1024;
 pub const STAGE_BATCH_TARGET_BYTES: u64 = 64 * 1024 * 1024;
-const DIRECT_XORB_STAGE_BATCH_TARGET_BYTES: u64 = 32 * 1024 * 1024;
+const DIRECT_XORB_STAGE_BATCH_TARGET_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Optional progress counters updated while streaming a file.
 #[derive(Clone, Default)]
@@ -1826,13 +1826,13 @@ mod tests {
             stage_batch_target_bytes(true),
             DIRECT_XORB_STAGE_BATCH_TARGET_BYTES
         );
-        let lengths = vec![1024 * 1024; 32];
+        let lengths = vec![1024 * 1024; 64];
         assert_eq!(
             batch_flush_prefix_from_lengths(
                 lengths.iter().copied(),
                 DIRECT_XORB_STAGE_BATCH_TARGET_BYTES,
             ),
-            (32, DIRECT_XORB_STAGE_BATCH_TARGET_BYTES)
+            (64, DIRECT_XORB_STAGE_BATCH_TARGET_BYTES)
         );
     }
 


### PR DESCRIPTION
## Summary
- raise direct xorb classification batches from 32 MiB to 64 MiB
- keep the byte-bounded remote lookup and promotion path intact
- document the v1 hard-cutover batch target

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p crab-staging --locked` (197 passed, 1 ignored)
- `cargo check -p crab --locked`
- RustFS end-to-end evidence from the preceding qualification: 2.0625 GiB in-place edit add 12.55s, push 14.75s; fresh-bucket fsck passed with zero errors and isolated-cache clone/hydrate was byte-identical.