### PR TITLE
fix(ci): keep NFS smoke private data out of artifacts

### DIFF
--- a/crab/scripts/check-nfs-smoke-scripts.py
+++ b/crab/scripts/check-nfs-smoke-scripts.py
@@ -190,6 +190,16 @@ CONTRACTS: dict[str, ScriptContract] = {
                 ),
             ),
             (
+                "artifact-safe private roots",
+                (
+                    '$PrivateRoot = Join-Path ([System.IO.Path]::GetTempPath()) "crab-nfs-windows-private-$RunId"',
+                    '$TestHome = Join-Path $PrivateRoot "home"',
+                    '$CacheRoot = Join-Path $PrivateRoot "crab-cache"',
+                    '$env:CRAB_CACHE_DIR = $CacheRoot',
+                    'Remove-Item -LiteralPath $PrivateRoot -Recurse -Force',
+                ),
+            ),
+            (
                 "retained report checks",
                 SHARED_REPORT_CHECKS,
             ),

--- a/crab/scripts/docker/run-mount-large-rustfs-smoke.sh
+++ b/crab/scripts/docker/run-mount-large-rustfs-smoke.sh
@@ -21,6 +21,8 @@ CACHE_ROOT="${CRAB_MOUNT_SMOKE_CACHE_ROOT:-$ARTIFACT_ROOT/cache}"
 RUN_ROOT="$ARTIFACT_ROOT/$RUN_ID"
 HOST_TARGET="${CRAB_MOUNT_SMOKE_TARGET_CACHE:-$CACHE_ROOT/target}"
 HOST_CARGO="${CRAB_MOUNT_SMOKE_CARGO_CACHE:-$CACHE_ROOT/cargo}"
+# Keep the private cache outside RUN_ROOT so artifact collection cannot scan it.
+HOST_RUNTIME_CACHE="$CACHE_ROOT/runtime"
 SEED_MIB="${CRAB_MOUNT_SMOKE_SEED_MIB:-32}"
 NEW_MIB="${CRAB_MOUNT_SMOKE_NEW_MIB:-40}"
 RUST_IMAGE="${CRAB_MOUNT_SMOKE_RUST_IMAGE:-rust:1.91-bookworm}"
@@ -53,7 +55,8 @@ command -v "$DOCKER" >/dev/null 2>&1 || die "docker is required"
 command -v "$AWS" >/dev/null 2>&1 || die "aws CLI is required on the host"
 "$DOCKER" info >/dev/null 2>&1 || die "Docker daemon is not running"
 
-mkdir -p "$RUN_ROOT" "$HOST_TARGET" "$HOST_CARGO"
+mkdir -p "$RUN_ROOT" "$HOST_TARGET" "$HOST_CARGO" "$HOST_RUNTIME_CACHE"
+chmod 700 "$HOST_RUNTIME_CACHE"
 
 "$DOCKER" network create "$NET" >/dev/null
 "$DOCKER" run -d \
@@ -95,6 +98,7 @@ printf "rustfs=ready\n"
     -v "$REPO_ROOT:/src" \
     -v "$HOST_TARGET:/src/target" \
     -v "$HOST_CARGO:/cargo" \
+    -v "$HOST_RUNTIME_CACHE:/crab-cache" \
     -v "$RUN_ROOT:/e2e" \
     -e AWS_ACCESS_KEY_ID=crab \
     -e AWS_SECRET_ACCESS_KEY=crab \
@@ -120,7 +124,7 @@ NEW_MIB="$4"
 
 export HOME=/e2e/home
 export PATH="/src/target/debug:$HOME/.cargo/bin:/usr/local/cargo/bin:$PATH"
-export CRAB_CACHE_DIR=/e2e/crab-cache
+export CRAB_CACHE_DIR=/crab-cache
 export GIT_TERMINAL_PROMPT=0
 
 mkdir -p "$HOME" "$CRAB_CACHE_DIR" /e2e/logs /e2e/run

--- a/crab/scripts/run-mount-nfs-windows-smoke.ps1
+++ b/crab/scripts/run-mount-nfs-windows-smoke.ps1
@@ -380,7 +380,11 @@ $CrabDir = (Resolve-Path (Join-Path $ScriptDir "..")).Path
 $WorkspaceRoot = (Resolve-Path (Join-Path $CrabDir "..")).Path
 $RunRoot = Join-Path $ArtifactRoot $RunId
 $LogDir = Join-Path $RunRoot "logs"
-$TestHome = Join-Path $RunRoot "home"
+# Keep the profile and private cache outside RunRoot; artifact collection
+# scans RunRoot recursively.
+$PrivateRoot = Join-Path ([System.IO.Path]::GetTempPath()) "crab-nfs-windows-private-$RunId"
+$TestHome = Join-Path $PrivateRoot "home"
+$CacheRoot = Join-Path $PrivateRoot "crab-cache"
 $Source = Join-Path $RunRoot "source"
 $DebugDir = Join-Path $WorkspaceRoot "target\debug"
 $CrabExe = Join-Path $DebugDir "crab.exe"
@@ -415,10 +419,10 @@ $env:HOME = $TestHome
 $env:USERPROFILE = $TestHome
 $env:CARGO_HOME = $hostCargoHome
 $env:RUSTUP_HOME = $hostRustupHome
-$env:CRAB_CACHE_DIR = Join-Path $RunRoot "crab-cache"
+$env:CRAB_CACHE_DIR = $CacheRoot
 $env:GIT_TERMINAL_PROMPT = "0"
 $env:PATH = "$DebugDir;$env:PATH"
-New-Item -ItemType Directory -Force -Path $env:CRAB_CACHE_DIR | Out-Null
+New-Item -ItemType Directory -Force -Path $LogDir, $TestHome, $Source, $env:CRAB_CACHE_DIR | Out-Null
 
 try {
     Invoke-Native `
@@ -875,5 +879,11 @@ try {
     Write-Host "nfs_smoke_report=$ReportPath"
     Write-Host "windows_nfs_mount_smoke=ok"
 } finally {
-    Cleanup-Mount
+    try {
+        Cleanup-Mount
+    } finally {
+        if (Test-Path -LiteralPath $PrivateRoot) {
+            Remove-Item -LiteralPath $PrivateRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- keep Linux RustFS smoke private cache outside the artifact root
- keep Windows smoke profile and Crab cache outside the artifact root
- assert the Windows artifact-safe layout in the smoke script contract check

## Why

The NFS workflow artifact uploads recursively scanned private/protected directories and either failed with `EACCES`/`EPERM` or timed out. The retained-evidence job then reported the Windows suite as missing.

## Validation

- `make --no-print-directory nfs-smoke-script-check`
- `git diff --check`

Full Docker/NFS and Windows smoke runs require their respective CI environments.