### PR TITLE
perf(add): harden cached preparation and paged push dedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,9 +2098,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "windows-sys 0.61.2",
  "xet-client",
  "xet-runtime",
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crab/docs/benchmarks/add-push-hardening-rustfs.md
+++ b/crab/docs/benchmarks/add-push-hardening-rustfs.md
@@ -1,0 +1,98 @@
+# Add/push hardening qualification
+
+Qualification for PR #156. Local RustFS results establish the exercised paths,
+not universal correctness or production cloud performance.
+
+## Audit evidence map
+
+| Changed boundary | Entry/caller → owner → callee | Siblings and proof |
+|---|---|---|
+| Literal selection | `run_add` → `collect_candidates` → component metadata and tracked classifier | Full walker never follows symlinks; file/directory selector regression and real CLI outside-file check |
+| Validation cache | Add clean-index filter and hydrate → `AddValidationCache` → batched SQLite lookup | Tokens bind index pointer, mode, full stat and length; changed-file/index tests; Windows does not use Unix ctime shortcut |
+| Advisory remote cache | Add classifier → `AddRemoteCandidateCache` → SQLite transactions and bounded LRU | Restart/concurrent capacity, expiry/promotion and positive/negative round-trip tests; push still revalidates proof |
+| Committed publication | Push visibility success → `post_success_cleanup` → matching negative invalidation | No-op has no shard membership; no-store path skips invalidation; live immediate cross-repository reuse regression |
+| Paged global lookup | Push candidate resolution → `ChunkIndexStore` → local indexes and remote receipt pages | Ordinary unbounded reader still propagates errors; bounded reader preserves completed pages/local hits; corrupt later page and deadline tests |
+| Prepared authority | Add/clean streaming → staging claims, canonical recipes and push plans → xorb upload and shard terms | Re-stage/history, overlapping files, missing/corrupt state, deferred/concurrent add and reconstructed-byte checks |
+| Concurrent proof validation | Parallel add workers → per-call receipt snapshot/result → common origin/manifest validation | Serial versus four-worker live comparison; push keeps its sequential receipt accounting |
+
+Is this the best fix, rather than merely plausible? The bounded changes belong
+at cache lifetime, publication and lookup ownership boundaries. Disabling remote
+dedup for large batches would preserve the performance cliff; promoting cache
+entries into authority would weaken correctness. Neither is necessary.
+
+Compared with the original PR, regression tests reproduced literal ancestor
+symlink traversal and cache growth across repeated process opens. A first live
+run additionally exposed cached misses surviving a successful local push; the
+repeated lifecycle run passed after targeted post-publication invalidation.
+Current main did not contain these add-time cache optimizations. The PR retains
+v1 formats and introduces no dependency override or compatibility reader.
+
+Dependency contracts checked in the resolved source: rusqlite 0.34 maps
+`Immediate` to `BEGIN IMMEDIATE` and rolls transactions back on drop; SQLite
+insert/delete triggers maintain counts inside that transaction; Tokio 1.52.1
+timeouts may accept an immediately-ready future after its deadline, so paging
+explicitly checks the deadline before polling. The Crab database batch wrapper
+preserves input ordering; receipt lookup validates referenced proof records
+before admitting a completed page.
+
+## Completed local gates before receipt isolation
+
+| Gate | Result |
+|---|---|
+| Default-feature Crab library | 4,145 passed; 3 ignored |
+| Staging library | 215 passed; 1 ignored |
+| Nine integration/property/schema binaries | 96 passed |
+| Crab CI clippy gate | Passed |
+| Staging all-target strict clippy | Passed |
+| Formatting and diff whitespace | Passed |
+| Fresh-bucket RustFS lifecycle | 132 checks passed |
+
+Integration binaries: `schema_drift`, `schema_validate`, `add_ship_contract`,
+`add_dry_run`, `e2e_add_commit_push`, `e2e_push_fsck`, `prop_push_batch`,
+`prop_push_reconstruction_coverage`, and `pre_push_input`.
+
+The lifecycle run covers ordinary Git and Crab add/push, committed re-staging
+before first push, partial overlap, immediate cross-repository reuse, concurrent
+pushes, ref deletion/force/shallow behavior, atomic rejection, corrupt/missing
+remote objects, clone, hydrate, dehydrate and rehydrate.
+
+An exploratory non-default gix-only library run was not green: provider/tier
+feature-dependent tests failed, and its stack limit needed increasing. It is
+not counted as successful proof. The normal default-feature suite above passed.
+
+## Pre-isolation runtime identity
+
+- macOS arm64; 12 logical CPUs, 32 GiB memory; APFS workspace volume.
+- RustFS S3 endpoint: loopback port 9000; isolated new buckets.
+- RustFS image ID: `sha256:67f06d4b3479fd9d323d8a99c86aac411e665ac0981d06b52a2b790c66db359e`.
+- Release binary source: `23788258ae0` (pre-rebase identifier).
+- Binary SHA-256: `41c5a08c04851ad2035a0dc32b5614e7d360307263bd5e390ce0c4ffda5bbffa`.
+- Subsequent rebase onto `ebd0e40d14c` removed an unrelated HTTP example and its
+  dev dependencies; that rebase did not change exercised runtime source.
+
+## Scale qualification
+
+The checked-in `crab/scripts/e2e/run_add_push_scale_rustfs.py` defaults to 50
+2-GiB non-zero files in ten shared-content families, 500 code files and three
+versions. Initial unique entropy is 20 GiB, logical size 100 GiB. Copy-on-write
+fixtures are edited independently. This is not a 100-GiB unique-entropy claim.
+
+The harness records command timings and structured add/push telemetry, checks
+a cold cross-repository consumer with more than 4,096 chunks, verifies every
+large/code file by SHA-256 after cold hydration and rehydration, checks pointer
+conversion and Git fsck, and removes only its newly-created data/bucket when
+`--cleanup` is supplied. Reports and logs remain available.
+
+The first run completed initial add (612.749 s) and push (618.033 s). It was
+intentionally interrupted during the edited-version add after a separate
+64-MiB live probe exposed concurrent proof-state interference: one worker
+retained 1,057 remote chunks and prepared four boundary chunks; four workers
+retained 777 and prepared 284. The add workers shared mutable per-push receipt
+state across awaits. This caused unnecessary preparation, not evidence of
+incorrect reconstructed bytes.
+
+The receipt-isolation fix is committed as `6e23f81ee16c`. Its full tests and
+fresh scale run are pending. The interrupted run is not counted as a passed
+100-GiB qualification. Completed canary data/buckets were removed; reports
+and logs were retained. Final scale and cleanup results must be recorded
+before this qualification is considered complete.

--- a/crab/docs/benchmarks/add-push-hardening-rustfs.md
+++ b/crab/docs/benchmarks/add-push-hardening-rustfs.md
@@ -62,7 +62,8 @@ not counted as successful proof. The normal default-feature suite above passed.
 
 ## Pre-isolation runtime identity
 
-- macOS arm64; 12 logical CPUs, 32 GiB memory; APFS workspace volume.
+- macOS arm64; 12 logical CPUs, 32 GiB memory; APFS USB SSD workspace volume.
+  The same volume holds source fixtures, build artifacts and RustFS data.
 - RustFS S3 endpoint: loopback port 9000; isolated new buckets.
 - RustFS image ID: `sha256:67f06d4b3479fd9d323d8a99c86aac411e665ac0981d06b52a2b790c66db359e`.
 - Release binary source: `23788258ae0` (pre-rebase identifier).
@@ -91,8 +92,26 @@ retained 777 and prepared 284. The add workers shared mutable per-push receipt
 state across awaits. This caused unnecessary preparation, not evidence of
 incorrect reconstructed bytes.
 
-The receipt-isolation fix is committed as `6e23f81ee16c`. Its full tests and
-fresh scale run are pending. The interrupted run is not counted as a passed
-100-GiB qualification. Completed canary data/buckets were removed; reports
-and logs were retained. Final scale and cleanup results must be recorded
-before this qualification is considered complete.
+The receipt-isolation fix is committed as `6e23f81ee16c`. Its release binary
+SHA-256 is `e2ad0e0212c150168c8aa9b2a4ff4087148d4cfdc2dfe8b37c8984d7b2cd63a2`.
+The repeated live probe retained 1,057 remote chunks and prepared four boundary
+chunks with both worker counts. The fresh lifecycle rerun passed all 132 checks.
+The full default-feature library suite passed 4,145 tests with three ignored
+using `--test-threads=1`; the Crab clippy gate also passed. A preceding parallel
+run had ten Git/LFS fixture/lock failures, none in receipt validation. Serial
+success is evidence of test-process interference, not a fix to those tests.
+
+CI for implementation revision `69f12689af2` completed with 29 successful and
+eight policy-skipped checks. The unchanged repository-browser release tooltip
+contrast test failed on its first attempt and passed on retry; it also passed
+on current main. No browser code, dependency, test assertion or baseline was
+changed to obtain that result. The intermittent failure remains a separate
+test-reliability concern.
+
+Final corrected 100-GiB results, command timings, byte-check counts and cleanup
+status are recorded in [PR #156](https://github.com/crabbuild/crab/pull/156).
+The interrupted run is not counted as passed qualification. Pre-isolation
+scale/probe data and completed canary data/buckets were removed; reports and
+logs were retained. Qualification covers the exercised local RustFS lifecycle,
+not 100 GiB of unique entropy, all historical large-file versions, all CLI
+commands, or production S3/GCS/Azure behavior.

--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -38,6 +38,7 @@ The important ownership boundaries are:
 | --- | --- |
 | `crab/src/cmd/add.rs` | CLI orchestration, candidate discovery, progress, rollback, pointer publication |
 | `crab/src/cache/add_validation.rs` | Per-worktree v1 proof cache for already-verified indexed content |
+| `crab/src/cache/add_remote_candidates.rs` | Bucket/global-prefix scoped advisory cache for proof-backed remote chunk candidates |
 | `crates/crab-staging/src/stream.rs` | Bounded file streaming, Blake3 hashing, CDC chunking, preparation-wide claims, provisional staging adoption |
 | `crates/crab-staging/src/lib.rs` | Segment writes, SQLite rows, flush/promotion, staged-file adoption and retirement |
 | `crates/crab-staging/src/add_push_plan.rs` | Add-time push-plan construction from staged chunk rows |
@@ -73,7 +74,14 @@ sequenceDiagram
 
 `run_add` resolves the current worktree through
 `crab/src/git/worktree.rs`, opens a `TrackedClassifier`, builds the user's
-path filter, then walks the worktree.
+path filter, then discovers candidates. Path-qualified literal files (for
+example `models/weights.bin`) use a direct metadata/classifier/ignore check;
+this avoids an O(repository-files) walk for the common single-file edit. A
+literal basename remains on the full walk because Git pathspec semantics allow
+it to match that name at any depth. Path-qualified literal directories walk
+only the selected subtree (with the same nested ignore handling), while globs,
+magic pathspecs, and missing paths use the full walker so matching and
+diagnostics stay unchanged.
 
 The classifier has two modes:
 
@@ -190,6 +198,15 @@ publishes a guess: add continues using local authority. The bucket-global
 SlateDB contains only committed, origin-bound receipts and is updated after a
 successful push CAS; it never stores add claims, local paths, or pending
 uploads.
+
+Successful proof-backed candidates and confirmed remote misses are retained in
+a bounded SQLite cache under the user's Crab cache. Persisting misses avoids
+repeating remote-index reads for newly-seen chunks across `crab add`
+invocations. A negative can become stale after another client pushes the
+chunk, so it expires after five minutes and otherwise only causes local
+repacking; push still revalidates every positive placement and origin proof.
+Cache failures, stale entries, and evictions are advisory misses; they cannot
+change the bytes selected for a push.
 
 Prepared bodies use one local content-addressed path:
 

--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -203,10 +203,20 @@ Successful proof-backed candidates and confirmed remote misses are retained in
 a bounded SQLite cache under the user's Crab cache. Persisting misses avoids
 repeating remote-index reads for newly-seen chunks across `crab add`
 invocations. A negative can become stale after another client pushes the
-chunk, so it expires after five minutes and otherwise only causes local
+chunk, so it expires after five minutes in both SQLite and memory; promotion
+preserves the original observation time. Transactional row accounting and
+eviction enforce the combined two-million-entry limit across process restarts
+and concurrent writers, without full-table counts on the add hot path.
+An expired or stale miss otherwise only causes local
 repacking; push still revalidates every positive placement and origin proof.
 Cache failures, stale entries, and evictions are advisory misses; they cannot
 change the bytes selected for a push.
+
+Push reads remote candidates in bounded pages under a shared deadline. It
+retains completed pages and local cache hits if the deadline expires or a later
+remote page fails; every retained placement still crosses normal proof
+validation. A large miss set never disables cross-repository lookup solely
+because it exceeds one page.
 
 Prepared bodies use one local content-addressed path:
 

--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -203,6 +203,11 @@ SlateDB contains only committed, origin-bound receipts and is updated after a
 successful push CAS; it never stores add claims, local paths, or pending
 uploads.
 
+Concurrent add lookups own their receipt snapshot and validation result across
+remote awaits. They share keyed advisory caches, not the push pipeline's
+mutable per-push proof accumulator; otherwise one file can erase another's
+valid proof and cause unnecessary local payload preparation.
+
 Successful proof-backed candidates and confirmed remote misses are retained in
 a bounded SQLite cache under the user's Crab cache. Persisting misses avoids
 repeating remote-index reads for newly-seen chunks across `crab add`

--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -207,6 +207,9 @@ chunk, so it expires after five minutes in both SQLite and memory; promotion
 preserves the original observation time. Transactional row accounting and
 eviction enforce the combined two-million-entry limit across process restarts
 and concurrent writers, without full-table counts on the add hot path.
+After a successful local push, published shard membership invalidates matching
+negative entries, so the next add can reuse newly committed remote chunks
+without waiting for the TTL. Invalidation never publishes pre-CAS authority.
 An expired or stale miss otherwise only causes local
 repacking; push still revalidates every positive placement and origin proof.
 Cache failures, stale entries, and evictions are advisory misses; they cannot

--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -83,6 +83,10 @@ only the selected subtree (with the same nested ignore handling), while globs,
 magic pathspecs, and missing paths use the full walker so matching and
 diagnostics stay unchanged.
 
+Literal selection checks every path component for symlinks, matching the full
+walker's no-follow boundary. A symlinked ancestor must not cause an external
+file to enter staging merely because its final component is a regular file.
+
 The classifier has two modes:
 
 - With `gix-pathmatch`, it delegates path matching to

--- a/crab/docs/design/add.md
+++ b/crab/docs/design/add.md
@@ -239,6 +239,12 @@ There is no persisted per-file JSON plan or per-file payload copy. Runtime
 `FilePushPlan` values are derived from normalized recipe, remote, prepared, and
 segment rows for the push attempt.
 
+Multi-file push-plan preparation validates every file first, then persists all
+normalized authority rows in one SQLite transaction. This keeps the per-file
+coverage and identity checks while eliminating one transaction commit and
+global prepared-payload retirement sweep per file; a failed file still rolls
+back the entire batch.
+
 ## Progress and JSONL
 
 The text progress bar has four command phases:

--- a/crab/scripts/e2e/run_add_push_scale_rustfs.py
+++ b/crab/scripts/e2e/run_add_push_scale_rustfs.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import re
 import shutil
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from run_add_commit_push_rustfs_smoke import AddCommitPushSmoke, sha256_file
@@ -74,6 +75,17 @@ def verify(args: argparse.Namespace, runner: AddCommitPushSmoke) -> None:
             for index in range(args.code_files):
                 with (code / f"module_{index:04}.rs").open("a") as stream:
                     stream.write(f"pub const VERSION_{version}: u64 = {version};\n")
+        if version == 1:
+            selected = str(paths[0].relative_to(repo))
+            runner.run_crab(repo, ["add", "--skip-git-add", selected], name="deferred preparation")
+            runner.run_git(repo, ["add", selected], name="deferred Git publication")
+        if version == 2 and len(paths) > 1:
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                pending = [pool.submit(runner.run_crab, repo,
+                           ["add", str(path.relative_to(repo))], name=f"concurrent add {path.name}")
+                           for path in paths[:2]]
+                for result in pending:
+                    result.result()
         runner.run_crab(repo, ["add", "models/"], name=f"v{version} add")
         runner.run_git(repo, ["add", "src"])
         runner.run_git(repo, ["commit", "-m", f"version {version}"])

--- a/crab/scripts/e2e/run_add_push_scale_rustfs.py
+++ b/crab/scripts/e2e/run_add_push_scale_rustfs.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Qualify add/push with sparse 100-GiB content and cold cross-repo chunk reuse.
+
+Uses a fresh bucket and disposable run directory. Logical size is deliberately
+reported separately from physical size: this is not 100 GiB of unique entropy.
+Reuse the ordinary smoke runner's command logs, credentials, and S3 contracts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+from pathlib import Path
+
+from run_add_commit_push_rustfs_smoke import AddCommitPushSmoke, sha256_file
+
+MIB = 1024 * 1024
+
+
+def run(args: argparse.Namespace) -> None:
+    runner = AddCommitPushSmoke(args)
+    if runner.run_root.exists():
+        raise RuntimeError("use a fresh run directory")
+    try:
+        verify(args, runner)
+    except Exception as error:
+        runner.report.status = "failed"
+        runner.report.artifacts["failure"] = str(error)
+        runner.write_report()
+        raise
+
+
+def verify(args: argparse.Namespace, runner: AddCommitPushSmoke) -> None:
+    status, _, _ = runner.signed_s3_request("HEAD", "")
+    runner.check("fresh-bucket", status == 404, {"head_status": status})
+    runner.preflight()
+    required = args.files * args.file_mib * MIB * 2 + 20 * 1024**3
+    runner.check("disk-capacity", shutil.disk_usage(args.root).free >= required,
+                 {"required_bytes": required})
+    repo, remote, _ = runner.prepare_repo("scale")
+    size = args.file_mib * MIB
+    models = repo / "models"
+    models.mkdir()
+    paths = [models / f"model-{index:03}.bin" for index in range(args.files)]
+    for index, path in enumerate(paths):
+        with path.open("wb") as stream:
+            stream.truncate(size)
+            for offset in (0, size // 2, size - MIB):
+                stream.seek(offset)
+                stream.write(hashlib.shake_256(f"{index}:{offset}".encode()).digest(MIB))
+    # One incompressible region exceeds one remote-candidate page. Zero-heavy
+    # scale data alone would never detect the large cold-cache lookup cliff.
+    with paths[0].open("r+b") as stream:
+        for index in range(512):
+            stream.write(hashlib.shake_256(f"entropy:{index}".encode()).digest(MIB))
+    code = repo / "src"
+    code.mkdir()
+    for index in range(args.code_files):
+        (code / f"module_{index:04}.rs").write_text(f"pub const VALUE: u64 = {index};\n")
+    runner.check("workload-shape", True, {
+        "large_files": len(paths), "logical_bytes": sum(p.stat().st_size for p in paths),
+        "physical_bytes": sum(p.stat().st_blocks * 512 for p in paths),
+        "small_code_files": args.code_files, "versions": args.versions,
+    })
+    for version in range(args.versions):
+        if version:
+            for index, path in enumerate(paths):
+                with path.open("r+b") as stream:
+                    stream.seek(size // 2 + version * MIB)
+                    stream.write(hashlib.shake_256(f"edit:{version}:{index}".encode()).digest(MIB))
+            for index in range(args.code_files):
+                with (code / f"module_{index:04}.rs").open("a") as stream:
+                    stream.write(f"pub const VERSION_{version}: u64 = {version};\n")
+        runner.run_crab(repo, ["add", "models/"], name=f"v{version} add")
+        runner.run_git(repo, ["add", "src"])
+        runner.run_git(repo, ["commit", "-m", f"version {version}"])
+        runner.run_crab(repo, ["push", "origin", "HEAD:refs/heads/main"],
+                        name=f"v{version} push", timeout=args.push_timeout)
+
+    expected = {str(path.relative_to(repo)): sha256_file(path)
+                for path in [*paths, *sorted(code.iterdir())]}
+    (runner.artifacts / "expected-sha256.json").write_text(json.dumps(expected, indent=2))
+
+    # No source cache or prepared proof can mask the consumer's remote lookup.
+    runner.env["CRAB_CACHE_DIR"] = str(runner.run_root / "consumer-cache")
+    consumer, consumer_remote, _ = runner.prepare_repo("cold-consumer")
+    consumer_file = consumer / "model.bin"
+    with paths[0].open("rb") as source, consumer_file.open("wb") as output:
+        for _ in range(512):
+            output.write(source.read(MIB))
+        output.write(hashlib.shake_256(b"consumer-only-tail").digest(MIB))
+    consumer_digest = sha256_file(consumer_file)
+    runner.run_git(consumer, ["add", "model.bin"])
+    inventory = runner.staging_payload_inventory(consumer)
+    runner.check("cold-consumer-exceeds-one-candidate-page", inventory["chunk_payloads"] > 4096, inventory)
+    runner.run_git(consumer, ["commit", "-m", "reuse chunks with a distinct file hash"])
+    before = runner.list_keys(".crab/xorbs/")
+    runner.run_crab(consumer, ["push", "--log-level", "debug", "origin", "HEAD:refs/heads/main"],
+                    name="cold cross-repository push", timeout=args.push_timeout)
+    added = runner.list_keys(".crab/xorbs/") - before
+    runner.check("cold-consumer-reuses-shared-chunks", len(added) <= 1, {"new_xorbs": len(added)})
+    runner.env["CRAB_CACHE_DIR"] = str(runner.run_root / "consumer-clone-cache")
+    consumer_clone = runner.run_root / "consumer-clone"
+    runner.run_cmd("consumer clone", [runner.crab_bin, "clone", consumer_remote, str(consumer_clone)], runner.run_root)
+    runner.run_crab(consumer_clone, ["hydrate", "--all"])
+    runner.check("consumer-byte-identity", sha256_file(consumer_clone / "model.bin") == consumer_digest)
+
+    runner.env["CRAB_CACHE_DIR"] = str(runner.run_root / "cold-clone-cache")
+    clone = runner.run_root / "clone"
+    runner.run_cmd("scale clone", [runner.crab_bin, "clone", remote, str(clone)], runner.run_root)
+    for cycle in ("cold", "rehydrated"):
+        runner.run_crab(clone, ["hydrate", "--all"], name=f"{cycle} hydrate")
+        for relative, digest in expected.items():
+            runner.check(f"{cycle}-bytes-{relative}", sha256_file(clone / relative) == digest)
+        runner.run_crab(clone, ["dehydrate", "--all"], name=f"{cycle} dehydrate")
+        for path in paths:
+            pointer = clone / path.relative_to(repo)
+            runner.check(f"{cycle}-pointer-{path.name}",
+                         pointer.stat().st_size < 1024 and pointer.read_text().startswith("version https://crab.build/spec/v1"))
+    runner.run_git(clone, ["fsck", "--full", "--strict"])
+    runner.check_credential_disclosure()
+    runner.report.status = "passed"
+    runner.write_report()
+    if args.cleanup:
+        # All targets were created by this invocation; retain reports and logs.
+        for path in (repo.parent, consumer.parent, clone, consumer_clone,
+                     runner.cache_dir, runner.run_root / "consumer-cache",
+                     runner.run_root / "consumer-clone-cache", runner.run_root / "cold-clone-cache"):
+            if path.exists():
+                shutil.rmtree(path)
+        runner.run_cmd("clean isolated bucket", ["aws", "--endpoint-url", args.endpoint_url,
+                       "s3", "rb", f"s3://{args.bucket}", "--force"], runner.run_root)
+        runner.check("isolated-data-cleaned", True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--crab-bin", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--endpoint-url", default="http://127.0.0.1:9000")
+    parser.add_argument("--files", type=int, default=50)
+    parser.add_argument("--file-mib", type=int, default=2048)
+    parser.add_argument("--code-files", type=int, default=500)
+    parser.add_argument("--versions", type=int, default=3)
+    parser.add_argument("--cleanup", action="store_true")
+    args = parser.parse_args()
+    if args.files < 1 or args.file_mib < 1024 or not 1 <= args.versions <= 10 or args.code_files < 1:
+        parser.error("require positive file counts, >=1024 MiB/file, and 1–10 versions")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", args.run_id):
+        parser.error("run-id must be a single safe directory name")
+    args.access_key = "crab"
+    args.secret_key = "crab"
+    args.session_token = ""
+    args.region = "us-east-1"
+    args.timeout = 3600
+    args.push_timeout = 3600
+    args.source = None
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/crab/scripts/e2e/run_add_push_scale_rustfs.py
+++ b/crab/scripts/e2e/run_add_push_scale_rustfs.py
@@ -23,6 +23,24 @@ from run_add_commit_push_rustfs_smoke import AddCommitPushSmoke, sha256_file
 MIB = 1024 * 1024
 
 
+def verify_parallel_proofs(runner: AddCommitPushSmoke, paths: list[Path]) -> None:
+    source_cache = runner.env["CRAB_CACHE_DIR"]
+    inventories = []
+    for jobs in (1, 4):
+        runner.env["CRAB_CACHE_DIR"] = str(runner.run_root / f"proof-cache-{jobs}")
+        repo, _, _ = runner.prepare_repo(f"proof-workers-{jobs}")
+        for index, path in enumerate(paths[:4]):
+            with path.open("rb") as source:
+                (repo / f"probe-{index}.bin").write_bytes(source.read(16 * MIB))
+        runner.run_crab(repo, ["add", "--jobs", str(jobs), "--jsonl", "*.bin"],
+                        name=f"proof classification with {jobs} workers")
+        inventories.append(runner.staging_payload_inventory(repo))
+    runner.env["CRAB_CACHE_DIR"] = source_cache
+    runner.check("parallel-proof-classification-preserves-serial-coverage",
+                 inventories[0]["recipe_remote_chunks"] > 0 and inventories[0] == inventories[1],
+                 {"serial": inventories[0], "parallel": inventories[1]})
+
+
 def run(args: argparse.Namespace) -> None:
     runner = AddCommitPushSmoke(args)
     if runner.run_root.exists():
@@ -103,6 +121,8 @@ def verify(args: argparse.Namespace, runner: AddCommitPushSmoke) -> None:
         runner.run_git(repo, ["commit", "-m", f"version {version}"])
         runner.run_crab(repo, ["push", "--jsonl", "origin", "HEAD:refs/heads/main"],
                         name=f"v{version} push", timeout=args.push_timeout)
+        if version == 0:
+            verify_parallel_proofs(runner, paths)
 
     expected = {str(path.relative_to(repo)): sha256_file(path)
                 for path in [*paths, *sorted(code.iterdir())]}
@@ -152,7 +172,9 @@ def verify(args: argparse.Namespace, runner: AddCommitPushSmoke) -> None:
         # All targets were created by this invocation; retain reports and logs.
         for path in (repo.parent, consumer.parent, clone, consumer_clone,
                      runner.cache_dir, runner.run_root / "consumer-cache",
-                     runner.run_root / "consumer-clone-cache", runner.run_root / "cold-clone-cache", outside):
+                     runner.run_root / "consumer-clone-cache", runner.run_root / "cold-clone-cache", outside,
+                     runner.run_root / "proof-cache-1", runner.run_root / "proof-cache-4",
+                     runner.run_root / "proof-workers-1", runner.run_root / "proof-workers-4"):
             if path.exists():
                 shutil.rmtree(path)
         runner.run_cmd("clean isolated bucket", ["aws", "--endpoint-url", args.endpoint_url,

--- a/crab/scripts/e2e/run_add_push_scale_rustfs.py
+++ b/crab/scripts/e2e/run_add_push_scale_rustfs.py
@@ -85,19 +85,19 @@ def verify(args: argparse.Namespace, runner: AddCommitPushSmoke) -> None:
                     stream.write(f"pub const VERSION_{version}: u64 = {version};\n")
         if version == 1:
             selected = str(paths[0].relative_to(repo))
-            runner.run_crab(repo, ["add", "--skip-git-add", selected], name="deferred preparation")
+            runner.run_crab(repo, ["add", "--jsonl", "--skip-git-add", selected], name="deferred preparation")
             runner.run_git(repo, ["add", selected], name="deferred Git publication")
         if version == 2 and len(paths) > 1:
             with ThreadPoolExecutor(max_workers=2) as pool:
                 pending = [pool.submit(runner.run_crab, repo,
-                           ["add", str(path.relative_to(repo))], name=f"concurrent add {path.name}")
+                           ["add", "--jsonl", str(path.relative_to(repo))], name=f"concurrent add {path.name}")
                            for path in paths[:2]]
                 for result in pending:
                     result.result()
-        runner.run_crab(repo, ["add", "models/"], name=f"v{version} add")
+        runner.run_crab(repo, ["add", "--jsonl", "models/"], name=f"v{version} add")
         runner.run_git(repo, ["add", "src"])
         runner.run_git(repo, ["commit", "-m", f"version {version}"])
-        runner.run_crab(repo, ["push", "origin", "HEAD:refs/heads/main"],
+        runner.run_crab(repo, ["push", "--jsonl", "origin", "HEAD:refs/heads/main"],
                         name=f"v{version} push", timeout=args.push_timeout)
 
     expected = {str(path.relative_to(repo)): sha256_file(path)

--- a/crab/scripts/e2e/run_add_push_scale_rustfs.py
+++ b/crab/scripts/e2e/run_add_push_scale_rustfs.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Qualify add/push with sparse 100-GiB content and cold cross-repo chunk reuse.
+"""Qualify add/push with 100-GiB content and cold cross-repo chunk reuse.
 
-Uses a fresh bucket and disposable run directory. Logical size is deliberately
-reported separately from physical size: this is not 100 GiB of unique entropy.
+Uses a fresh bucket and disposable run directory. Ten distinct non-zero bases
+are copied with filesystem copy-on-write, then edited independently. The default
+workload is 100 GiB logical with 20 GiB of unique initial entropy, not sparse zeros.
 Reuse the ordinary smoke runner's command logs, credentials, and S3 contracts.
 """
 
@@ -13,6 +14,7 @@ import hashlib
 import json
 import re
 import shutil
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -54,24 +56,26 @@ def verify(args: argparse.Namespace, runner: AddCommitPushSmoke) -> None:
     models = repo / "models"
     models.mkdir()
     paths = [models / f"model-{index:03}.bin" for index in range(args.files)]
+    families = min(10, len(paths))
+    available_before = shutil.disk_usage(args.root).free
     for index, path in enumerate(paths):
-        with path.open("wb") as stream:
-            stream.truncate(size)
-            for offset in (0, size // 2, size - MIB):
-                stream.seek(offset)
-                stream.write(hashlib.shake_256(f"{index}:{offset}".encode()).digest(MIB))
-    # One incompressible region exceeds one remote-candidate page. Zero-heavy
-    # scale data alone would never detect the large cold-cache lookup cliff.
-    with paths[0].open("r+b") as stream:
-        for index in range(512):
-            stream.write(hashlib.shake_256(f"entropy:{index}".encode()).digest(MIB))
+        if index < families:
+            with path.open("wb") as stream:
+                for block in range(args.file_mib):
+                    stream.write(hashlib.shake_256(f"family:{index}:{block}".encode()).digest(MIB))
+        else:
+            clone_flag = "-c" if sys.platform == "darwin" else "--reflink=always"
+            runner.run_cmd(f"copy-on-write fixture {index}",
+                           ["cp", clone_flag, str(paths[index % families]), str(path)], repo)
     code = repo / "src"
     code.mkdir()
     for index in range(args.code_files):
         (code / f"module_{index:04}.rs").write_text(f"pub const VALUE: u64 = {index};\n")
     runner.check("workload-shape", True, {
         "large_files": len(paths), "logical_bytes": sum(p.stat().st_size for p in paths),
-        "physical_bytes": sum(p.stat().st_blocks * 512 for p in paths),
+        "distinct_basis_bytes": families * size,
+        "allocated_file_bytes_including_shared_extents": sum(p.stat().st_blocks * 512 for p in paths),
+        "observed_free_space_delta": available_before - shutil.disk_usage(args.root).free,
         "small_code_files": args.code_files, "versions": args.versions,
     })
     for version in range(args.versions):

--- a/crab/scripts/e2e/run_add_push_scale_rustfs.py
+++ b/crab/scripts/e2e/run_add_push_scale_rustfs.py
@@ -42,6 +42,14 @@ def verify(args: argparse.Namespace, runner: AddCommitPushSmoke) -> None:
     runner.check("disk-capacity", shutil.disk_usage(args.root).free >= required,
                  {"required_bytes": required})
     repo, remote, _ = runner.prepare_repo("scale")
+    outside = runner.run_root / "symlink-target"
+    outside.mkdir()
+    (outside / "model.bin").write_bytes(b"external bytes must not enter staging")
+    (repo / "linked").symlink_to(outside, target_is_directory=True)
+    runner.run_crab(repo, ["add", "linked/model.bin"], name="symlink ancestor add", check=False)
+    index = repo / ".crab" / "staging" / "index.db"
+    inventory = runner.staging_payload_inventory(repo) if index.exists() else {}
+    runner.check("symlink-ancestor-created-no-payload", not any(inventory.values()), inventory)
     size = args.file_mib * MIB
     models = repo / "models"
     models.mkdir()
@@ -140,7 +148,7 @@ def verify(args: argparse.Namespace, runner: AddCommitPushSmoke) -> None:
         # All targets were created by this invocation; retain reports and logs.
         for path in (repo.parent, consumer.parent, clone, consumer_clone,
                      runner.cache_dir, runner.run_root / "consumer-cache",
-                     runner.run_root / "consumer-clone-cache", runner.run_root / "cold-clone-cache"):
+                     runner.run_root / "consumer-clone-cache", runner.run_root / "cold-clone-cache", outside):
             if path.exists():
                 shutil.rmtree(path)
         runner.run_cmd("clean isolated bucket", ["aws", "--endpoint-url", args.endpoint_url,

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -161,7 +161,7 @@ impl AddRemoteCandidateCache {
             );
             let values = batch
                 .iter()
-                .map(|hash| <[u8; 32]>::from(*hash).to_vec())
+                .map(|hash| <[u8; 32]>::from(*hash))
                 .collect::<Vec<_>>();
             let mut statement = connection
                 .prepare_cached(&query)

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -263,6 +263,7 @@ impl AddRemoteCandidateCache {
         Ok(out)
     }
 
+    #[cfg(test)]
     pub(crate) fn persist_results(
         &self,
         entries: &[(MerkleHash, Option<ExistingChunkCandidate>)],

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -97,17 +97,6 @@ impl AddRemoteCandidateCache {
         })
     }
 
-    pub(crate) fn memory_get(
-        &self,
-        hash: &MerkleHash,
-    ) -> Result<Option<Option<ExistingChunkCandidate>>> {
-        let mut memory = self
-            .memory
-            .lock()
-            .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
-        Ok(memory.get(hash).copied())
-    }
-
     pub(crate) fn memory_get_batch(
         &self,
         hashes: &[MerkleHash],
@@ -126,19 +115,6 @@ impl AddRemoteCandidateCache {
             }
         }
         Ok(out)
-    }
-
-    pub(crate) fn memory_insert(
-        &self,
-        hash: MerkleHash,
-        candidate: Option<ExistingChunkCandidate>,
-    ) -> Result<()> {
-        let mut memory = self
-            .memory
-            .lock()
-            .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
-        memory.put(hash, candidate);
-        Ok(())
     }
 
     pub(crate) fn memory_insert_batch(
@@ -559,9 +535,17 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
         let hash = MerkleHash::from([3; 32]);
-        assert_eq!(cache.memory_get(&hash).expect("lookup"), None);
-        cache.memory_insert(hash, None).expect("insert");
-        assert_eq!(cache.memory_get(&hash).expect("lookup"), Some(None));
+        assert!(
+            !cache
+                .memory_get_batch(&[hash])
+                .expect("lookup")
+                .contains_key(&hash)
+        );
+        cache.memory_insert_batch(&[(hash, None)]).expect("insert");
+        assert_eq!(
+            cache.memory_get_batch(&[hash]).expect("lookup").get(&hash),
+            Some(&None)
+        );
     }
 
     #[test]

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -270,16 +270,23 @@ impl AddRemoteCandidateCache {
         let transaction = connection
             .transaction()
             .map_err(|error| database_error("begin update", error))?;
-        let mut positive_hashes = Vec::new();
-        let mut negative_hashes = Vec::new();
+        let mut latest = HashMap::with_capacity(entries.len());
         for (chunk_hash, candidate) in entries {
-            let chunk_hash = <[u8; 32]>::from(*chunk_hash);
-            if candidate.is_some() {
-                positive_hashes.push(chunk_hash);
+            latest.insert(<[u8; 32]>::from(*chunk_hash), *candidate);
+        }
+        let mut positive_entries = Vec::new();
+        let mut negative_hashes = Vec::new();
+        for (chunk_hash, candidate) in latest {
+            if let Some(candidate) = candidate {
+                positive_entries.push((chunk_hash, candidate));
             } else {
                 negative_hashes.push(chunk_hash);
             }
         }
+        let positive_hashes = positive_entries
+            .iter()
+            .map(|(chunk_hash, _)| *chunk_hash)
+            .collect::<Vec<_>>();
         for batch in positive_hashes.chunks(LOOKUP_BATCH_SIZE) {
             let placeholders = std::iter::repeat_n("?", batch.len())
                 .collect::<Vec<_>>()
@@ -306,52 +313,105 @@ impl AddRemoteCandidateCache {
                 )
                 .map_err(|error| database_error("delete stale positive entries", error))?;
         }
-        {
-            let mut positive_statement = transaction
-                .prepare_cached(
-                    "INSERT INTO remote_candidates_v1
-                         (chunk_hash, xorb_hash, chunk_index, uncompressed_size,
-                          placement_id, origin_proof_id)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                     ON CONFLICT(chunk_hash) DO UPDATE SET
-                         xorb_hash = excluded.xorb_hash,
-                         chunk_index = excluded.chunk_index,
-                         uncompressed_size = excluded.uncompressed_size,
-                         placement_id = excluded.placement_id,
-                         origin_proof_id = excluded.origin_proof_id
-                     WHERE remote_candidates_v1.xorb_hash != excluded.xorb_hash
-                        OR remote_candidates_v1.chunk_index != excluded.chunk_index
-                        OR remote_candidates_v1.uncompressed_size != excluded.uncompressed_size
-                        OR remote_candidates_v1.placement_id != excluded.placement_id
-                        OR remote_candidates_v1.origin_proof_id != excluded.origin_proof_id",
-                )
-                .map_err(|error| database_error("prepare update", error))?;
-            let mut negative_statement = transaction
-                .prepare_cached(
-                    "INSERT INTO remote_candidate_misses_v1 (chunk_hash, observed_at) VALUES (?1, ?2)
-                     ON CONFLICT(chunk_hash) DO UPDATE SET observed_at = excluded.observed_at"
-                )
-                .map_err(|error| database_error("prepare negative update", error))?;
-            for (chunk_hash, candidate) in entries {
-                let chunk_hash = <[u8; 32]>::from(*chunk_hash);
-                if let Some(candidate) = candidate {
-                    let xorb_hash = <[u8; 32]>::from(candidate.xorb_ref.xorb_hash);
-                    positive_statement
-                        .execute(params![
-                            chunk_hash.as_slice(),
-                            xorb_hash.as_slice(),
-                            i64::from(candidate.xorb_ref.chunk_index),
-                            i64::from(candidate.xorb_ref.uncompressed_size),
-                            candidate.placement_id.as_slice(),
-                            candidate.origin_proof_id.as_slice(),
-                        ])
-                        .map_err(|error| database_error("write update", error))?;
-                } else {
-                    negative_statement
-                        .execute(params![chunk_hash.as_slice(), observed_at])
-                        .map_err(|error| database_error("write negative update", error))?;
-                }
+        // Six parameters per row keep positive batches below SQLite's default limit.
+        const POSITIVE_WRITE_BATCH: usize = 128;
+        for batch in positive_entries.chunks(POSITIVE_WRITE_BATCH) {
+            let values_sql = std::iter::repeat_n("(?,?,?,?,?,?)", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query = format!(
+                "INSERT INTO remote_candidates_v1
+                     (chunk_hash, xorb_hash, chunk_index, uncompressed_size,
+                      placement_id, origin_proof_id)
+                 VALUES {values_sql}
+                 ON CONFLICT(chunk_hash) DO UPDATE SET
+                     xorb_hash = excluded.xorb_hash,
+                     chunk_index = excluded.chunk_index,
+                     uncompressed_size = excluded.uncompressed_size,
+                     placement_id = excluded.placement_id,
+                     origin_proof_id = excluded.origin_proof_id
+                 WHERE remote_candidates_v1.xorb_hash != excluded.xorb_hash
+                    OR remote_candidates_v1.chunk_index != excluded.chunk_index
+                    OR remote_candidates_v1.uncompressed_size != excluded.uncompressed_size
+                    OR remote_candidates_v1.placement_id != excluded.placement_id
+                    OR remote_candidates_v1.origin_proof_id != excluded.origin_proof_id"
+            );
+            let mut statement = transaction
+                .prepare_cached(&query)
+                .map_err(|error| database_error("prepare update batch", error))?;
+            let chunk_hashes = batch
+                .iter()
+                .map(|(chunk_hash, _)| chunk_hash.as_slice())
+                .collect::<Vec<_>>();
+            let xorb_hashes = batch
+                .iter()
+                .map(|(_, candidate)| <[u8; 32]>::from(candidate.xorb_ref.xorb_hash))
+                .collect::<Vec<_>>();
+            let indices = batch
+                .iter()
+                .map(|(_, candidate)| i64::from(candidate.xorb_ref.chunk_index))
+                .collect::<Vec<_>>();
+            let sizes = batch
+                .iter()
+                .map(|(_, candidate)| i64::from(candidate.xorb_ref.uncompressed_size))
+                .collect::<Vec<_>>();
+            let placement_ids = batch
+                .iter()
+                .map(|(_, candidate)| candidate.placement_id)
+                .collect::<Vec<_>>();
+            let origin_proof_ids = batch
+                .iter()
+                .map(|(_, candidate)| candidate.origin_proof_id)
+                .collect::<Vec<_>>();
+            let xorb_slices = xorb_hashes
+                .iter()
+                .map(|hash| hash.as_slice())
+                .collect::<Vec<_>>();
+            let placement_slices = placement_ids
+                .iter()
+                .map(|hash| hash.as_slice())
+                .collect::<Vec<_>>();
+            let origin_proof_slices = origin_proof_ids
+                .iter()
+                .map(|hash| hash.as_slice())
+                .collect::<Vec<_>>();
+            let mut values: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(batch.len() * 6);
+            for index in 0..batch.len() {
+                values.push(&chunk_hashes[index]);
+                values.push(&xorb_slices[index]);
+                values.push(&indices[index]);
+                values.push(&sizes[index]);
+                values.push(&placement_slices[index]);
+                values.push(&origin_proof_slices[index]);
             }
+            statement
+                .execute(params_from_iter(values))
+                .map_err(|error| database_error("write update batch", error))?;
+        }
+
+        // Two parameters per row keep negative batches below SQLite's default limit.
+        const NEGATIVE_WRITE_BATCH: usize = 256;
+        for batch in negative_hashes.chunks(NEGATIVE_WRITE_BATCH) {
+            let values_sql = std::iter::repeat_n("(?,?)", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query = format!(
+                "INSERT INTO remote_candidate_misses_v1 (chunk_hash, observed_at)
+                 VALUES {values_sql}
+                 ON CONFLICT(chunk_hash) DO UPDATE SET observed_at = excluded.observed_at"
+            );
+            let mut statement = transaction
+                .prepare_cached(&query)
+                .map_err(|error| database_error("prepare negative update batch", error))?;
+            let hash_slices = batch.iter().map(|hash| hash.as_slice()).collect::<Vec<_>>();
+            let mut values: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(batch.len() * 2);
+            for hash in &hash_slices {
+                values.push(hash);
+                values.push(&observed_at);
+            }
+            statement
+                .execute(params_from_iter(values))
+                .map_err(|error| database_error("write negative update batch", error))?;
         }
         transaction
             .commit()

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -164,7 +164,7 @@ impl AddRemoteCandidateCache {
                 .map(|hash| <[u8; 32]>::from(*hash).to_vec())
                 .collect::<Vec<_>>();
             let mut statement = connection
-                .prepare(&query)
+                .prepare_cached(&query)
                 .map_err(|error| database_error("prepare lookup", error))?;
             let rows = statement
                 .query_map(
@@ -217,7 +217,7 @@ impl AddRemoteCandidateCache {
                  WHERE chunk_hash IN ({placeholders})"
             );
             let mut statement = connection
-                .prepare(&negative_query)
+                .prepare_cached(&negative_query)
                 .map_err(|error| database_error("prepare negative lookup", error))?;
             let rows = statement
                 .query_map(

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -22,6 +22,7 @@ const SCHEMA_VERSION: i64 = 1;
 const MEMORY_CAPACITY: usize = 65_536;
 const MAX_PERSISTENT_ENTRIES: i64 = 2_000_000;
 const LOOKUP_BATCH_SIZE: usize = 512;
+const PERSISTENT_UNION_LOOKUP_BATCH: usize = LOOKUP_BATCH_SIZE / 2;
 const PRUNE_EVERY_WRITES: u64 = 64;
 const NEGATIVE_TABLE: &str = "remote_candidate_misses_v1";
 const NEGATIVE_TTL: Duration = Duration::from_secs(5 * 60);
@@ -150,7 +151,9 @@ impl AddRemoteCandidateCache {
             .lock()
             .map_err(|_| CrabError::Internal("add remote candidate database poisoned".into()))?;
         let mut out = HashMap::with_capacity(hashes.len());
-        for batch in hashes.chunks(LOOKUP_BATCH_SIZE) {
+        // The UNION repeats every hash list, so keep total bind variables below
+        // SQLite's default 999-variable limit.
+        for batch in hashes.chunks(PERSISTENT_UNION_LOOKUP_BATCH) {
             let placeholders = std::iter::repeat_n("?", batch.len())
                 .collect::<Vec<_>>()
                 .join(",");

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -110,7 +110,9 @@ impl AddRemoteCandidateCache {
             .memory
             .lock()
             .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
-        let mut out = HashMap::with_capacity(hashes.len().min(MEMORY_CAPACITY));
+        // A cold lookup commonly returns no rows. Keep the all-miss path
+        // allocation-free; the map grows with actual cache hits.
+        let mut out = HashMap::new();
         for hash in hashes {
             if let Some(candidate) = memory.get(hash).copied() {
                 out.insert(*hash, candidate);
@@ -151,7 +153,9 @@ impl AddRemoteCandidateCache {
             .connection
             .lock()
             .map_err(|_| CrabError::Internal("add remote candidate database poisoned".into()))?;
-        let mut out = HashMap::with_capacity(hashes.len().min(MEMORY_CAPACITY));
+        // A cold persistent lookup commonly returns no rows. Keep the
+        // all-miss path allocation-free; the map grows with actual hits.
+        let mut out = HashMap::new();
         // The UNION repeats every hash list, so keep total bind variables below
         // SQLite's default 999-variable limit.
         for batch in hashes.chunks(PERSISTENT_UNION_LOOKUP_BATCH) {

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -108,6 +108,26 @@ impl AddRemoteCandidateCache {
         Ok(memory.get(hash).copied())
     }
 
+    pub(crate) fn memory_get_batch(
+        &self,
+        hashes: &[MerkleHash],
+    ) -> Result<HashMap<MerkleHash, Option<ExistingChunkCandidate>>> {
+        if hashes.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut memory = self
+            .memory
+            .lock()
+            .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
+        let mut out = HashMap::with_capacity(hashes.len());
+        for hash in hashes {
+            if let Some(candidate) = memory.get(hash).copied() {
+                out.insert(*hash, candidate);
+            }
+        }
+        Ok(out)
+    }
+
     pub(crate) fn memory_insert(
         &self,
         hash: MerkleHash,
@@ -118,6 +138,23 @@ impl AddRemoteCandidateCache {
             .lock()
             .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
         memory.put(hash, candidate);
+        Ok(())
+    }
+
+    pub(crate) fn memory_insert_batch(
+        &self,
+        entries: &[(MerkleHash, Option<ExistingChunkCandidate>)],
+    ) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let mut memory = self
+            .memory
+            .lock()
+            .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
+        for (hash, candidate) in entries {
+            memory.put(*hash, *candidate);
+        }
         Ok(())
     }
 
@@ -525,6 +562,25 @@ mod tests {
         assert_eq!(cache.memory_get(&hash).expect("lookup"), None);
         cache.memory_insert(hash, None).expect("insert");
         assert_eq!(cache.memory_get(&hash).expect("lookup"), Some(None));
+    }
+
+    #[test]
+    fn memory_batch_cache_preserves_positive_negative_and_misses() {
+        let dir = tempdir().expect("tempdir");
+        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let positive_hash = MerkleHash::from([8; 32]);
+        let negative_hash = MerkleHash::from([9; 32]);
+        let missing_hash = MerkleHash::from([10; 32]);
+        cache
+            .memory_insert_batch(&[(positive_hash, Some(candidate(8))), (negative_hash, None)])
+            .expect("insert batch");
+
+        let loaded = cache
+            .memory_get_batch(&[positive_hash, negative_hash, missing_hash])
+            .expect("lookup batch");
+        assert_eq!(loaded.get(&positive_hash), Some(&Some(candidate(8))));
+        assert_eq!(loaded.get(&negative_hash), Some(&None));
+        assert!(!loaded.contains_key(&missing_hash));
     }
 
     #[test]

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -337,6 +337,48 @@ impl AddRemoteCandidateCache {
         self.persist_results_inner(entries, true)
     }
 
+    /// Forget negative results for chunks whose publication has completed locally.
+    pub(crate) fn forget_negatives(&self, hashes: &[MerkleHash]) -> Result<()> {
+        let mut connection = self
+            .connection
+            .lock()
+            .map_err(|_| CrabError::Internal("add remote candidate database poisoned".into()))?;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| database_error("begin negative invalidation", error))?;
+        for batch in hashes.chunks(LOOKUP_BATCH_SIZE) {
+            let placeholders = std::iter::repeat_n("?", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let values = batch
+                .iter()
+                .map(|hash| <[u8; 32]>::from(*hash))
+                .collect::<Vec<_>>();
+            transaction
+                .execute(
+                    &format!("DELETE FROM {NEGATIVE_TABLE} WHERE chunk_hash IN ({placeholders})"),
+                    params_from_iter(values.iter().map(|hash| hash.as_slice())),
+                )
+                .map_err(|error| database_error("forget committed negatives", error))?;
+        }
+        transaction
+            .commit()
+            .map_err(|error| database_error("commit negative invalidation", error))?;
+        let mut memory = self
+            .memory
+            .lock()
+            .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
+        for hash in hashes {
+            if memory
+                .peek(hash)
+                .is_some_and(|entry| entry.candidate.is_none())
+            {
+                memory.pop(hash);
+            }
+        }
+        Ok(())
+    }
+
     /// Persist entries whose chunk hashes are unique within the batch.
     ///
     /// The add classifier already deduplicates lookup inputs, so this path can

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -267,6 +267,25 @@ impl AddRemoteCandidateCache {
         &self,
         entries: &[(MerkleHash, Option<ExistingChunkCandidate>)],
     ) -> Result<()> {
+        self.persist_results_inner(entries, true)
+    }
+
+    /// Persist entries whose chunk hashes are unique within the batch.
+    ///
+    /// The add classifier already deduplicates lookup inputs, so this path can
+    /// skip the repository-sized last-result map used by the general helper.
+    pub(crate) fn persist_unique_results(
+        &self,
+        entries: &[(MerkleHash, Option<ExistingChunkCandidate>)],
+    ) -> Result<()> {
+        self.persist_results_inner(entries, false)
+    }
+
+    fn persist_results_inner(
+        &self,
+        entries: &[(MerkleHash, Option<ExistingChunkCandidate>)],
+        deduplicate: bool,
+    ) -> Result<()> {
         if entries.is_empty() {
             return Ok(());
         }
@@ -275,7 +294,7 @@ impl AddRemoteCandidateCache {
             // pages in input order preserves last-result-wins semantics while
             // avoiding a repository-sized deduplication map.
             for batch in entries.chunks(PERSIST_DEDUP_BATCH_SIZE) {
-                self.persist_results(batch)?;
+                self.persist_results_inner(batch, deduplicate)?;
             }
             return Ok(());
         }
@@ -287,17 +306,27 @@ impl AddRemoteCandidateCache {
         let transaction = connection
             .transaction()
             .map_err(|error| database_error("begin update", error))?;
-        let mut latest = HashMap::with_capacity(entries.len());
-        for (chunk_hash, candidate) in entries {
-            latest.insert(<[u8; 32]>::from(*chunk_hash), *candidate);
-        }
         let mut positive_entries = Vec::new();
         let mut negative_hashes = Vec::new();
-        for (chunk_hash, candidate) in latest {
-            if let Some(candidate) = candidate {
-                positive_entries.push((chunk_hash, candidate));
-            } else {
-                negative_hashes.push(chunk_hash);
+        if deduplicate {
+            let mut latest = HashMap::with_capacity(entries.len());
+            for (chunk_hash, candidate) in entries {
+                latest.insert(<[u8; 32]>::from(*chunk_hash), *candidate);
+            }
+            for (chunk_hash, candidate) in latest {
+                if let Some(candidate) = candidate {
+                    positive_entries.push((chunk_hash, candidate));
+                } else {
+                    negative_hashes.push(chunk_hash);
+                }
+            }
+        } else {
+            for (chunk_hash, candidate) in entries {
+                if let Some(candidate) = candidate {
+                    positive_entries.push((<[u8; 32]>::from(*chunk_hash), *candidate));
+                } else {
+                    negative_hashes.push(<[u8; 32]>::from(*chunk_hash));
+                }
             }
         }
         let positive_hashes = positive_entries
@@ -707,7 +736,9 @@ mod tests {
             .into_iter()
             .map(|(hash, candidate)| (hash, Some(candidate)))
             .collect::<Vec<_>>();
-        cache.persist_results(&entries).expect("persist");
+        cache
+            .persist_unique_results(&entries)
+            .expect("persist unique");
         let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
         assert_eq!(cache.load_persistent(&hashes).expect("load").len(), 600);
     }
@@ -723,7 +754,9 @@ mod tests {
                 (MerkleHash::from(bytes), None)
             })
             .collect::<Vec<_>>();
-        cache.persist_results(&entries).expect("persist negatives");
+        cache
+            .persist_unique_results(&entries)
+            .expect("persist unique negatives");
         let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
         let loaded = cache.load_persistent(&hashes).expect("load negatives");
         assert_eq!(loaded.len(), 600);

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -694,4 +694,22 @@ mod tests {
         let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
         assert_eq!(cache.load_persistent(&hashes).expect("load").len(), 600);
     }
+
+    #[test]
+    fn persistent_negative_writes_batch_large_requests() {
+        let dir = tempdir().expect("tempdir");
+        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let entries = (0..600u16)
+            .map(|seed| {
+                let mut bytes = [0; 32];
+                bytes[..2].copy_from_slice(&seed.to_le_bytes());
+                (MerkleHash::from(bytes), None)
+            })
+            .collect::<Vec<_>>();
+        cache.persist_results(&entries).expect("persist negatives");
+        let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
+        let loaded = cache.load_persistent(&hashes).expect("load negatives");
+        assert_eq!(loaded.len(), 600);
+        assert!(loaded.values().all(Option::is_none));
+    }
 }

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -1,0 +1,549 @@
+//! Persistent advisory cache for proof-backed remote chunk candidates.
+//!
+//! Entries are scoped to one bucket and global content prefix. They only
+//! accelerate `crab add`; push revalidates every placement and origin proof
+//! before adopting it.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use lru::LruCache;
+use rusqlite::{Connection, params, params_from_iter};
+
+use crate::core::error::{CrabError, Result};
+use crab_staging::push_plan::ExistingChunkCandidate;
+use crab_xet::hash::MerkleHash;
+use crab_xet::xorb::format::XorbRef;
+
+const SCHEMA_VERSION: i64 = 1;
+const MEMORY_CAPACITY: usize = 65_536;
+const MAX_PERSISTENT_ENTRIES: i64 = 2_000_000;
+const LOOKUP_BATCH_SIZE: usize = 512;
+const PRUNE_EVERY_WRITES: u64 = 64;
+const NEGATIVE_TABLE: &str = "remote_candidate_misses_v1";
+const NEGATIVE_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// A bounded bucket-scoped cache of proof-backed candidates.
+pub(crate) struct AddRemoteCandidateCache {
+    connection: Mutex<Connection>,
+    memory: Mutex<LruCache<MerkleHash, Option<ExistingChunkCandidate>>>,
+    writes_since_prune: std::sync::atomic::AtomicU64,
+}
+
+impl AddRemoteCandidateCache {
+    /// Open or create the cache. Cache failures are handled by the caller as
+    /// an advisory miss; they must never make `crab add` fail.
+    pub(crate) fn open(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            crab_cache::ensure_private_cache_directory(parent).map_err(|error| {
+                CrabError::Internal(format!(
+                    "prepare private add remote candidate cache directory {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+        let connection = Connection::open(path).map_err(|error| database_error("open", error))?;
+        connection
+            .busy_timeout(Duration::from_millis(250))
+            .map_err(|error| database_error("configure timeout", error))?;
+        connection
+            .execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")
+            .map_err(|error| database_error("configure", error))?;
+        let version = connection
+            .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+            .map_err(|error| database_error("read schema version", error))?;
+        if version == 0 {
+            connection
+                .execute_batch(
+                    "BEGIN IMMEDIATE;
+                     CREATE TABLE remote_candidates_v1 (
+                         chunk_hash BLOB PRIMARY KEY NOT NULL CHECK(length(chunk_hash) = 32),
+                         xorb_hash BLOB NOT NULL CHECK(length(xorb_hash) = 32),
+                         chunk_index INTEGER NOT NULL CHECK(chunk_index >= 0),
+                         uncompressed_size INTEGER NOT NULL CHECK(uncompressed_size >= 0),
+                         placement_id BLOB NOT NULL CHECK(length(placement_id) = 32),
+                         origin_proof_id BLOB NOT NULL CHECK(length(origin_proof_id) = 32)
+                     ) WITHOUT ROWID;
+                     CREATE TABLE remote_candidate_misses_v1 (
+                         chunk_hash BLOB PRIMARY KEY NOT NULL CHECK(length(chunk_hash) = 32),
+                         observed_at INTEGER NOT NULL CHECK(observed_at >= 0)
+                     ) WITHOUT ROWID;
+                     PRAGMA user_version = 1;
+                     COMMIT;",
+                )
+                .map_err(|error| database_error("initialize", error))?;
+        } else if version != SCHEMA_VERSION {
+            return Err(CrabError::Internal(format!(
+                "unsupported add remote candidate cache schema {version}; expected v{SCHEMA_VERSION}"
+            )));
+        }
+        connection
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS remote_candidate_misses_v1 (
+                     chunk_hash BLOB PRIMARY KEY NOT NULL CHECK(length(chunk_hash) = 32),
+                     observed_at INTEGER NOT NULL CHECK(observed_at >= 0)
+                 ) WITHOUT ROWID;",
+            )
+            .map_err(|error| database_error("initialize negative entries", error))?;
+        ensure_negative_timestamp_column(&connection)?;
+        let capacity = NonZeroUsize::new(MEMORY_CAPACITY).unwrap_or(NonZeroUsize::MIN);
+        Ok(Self {
+            connection: Mutex::new(connection),
+            memory: Mutex::new(LruCache::new(capacity)),
+            writes_since_prune: std::sync::atomic::AtomicU64::new(0),
+        })
+    }
+
+    pub(crate) fn memory_get(
+        &self,
+        hash: &MerkleHash,
+    ) -> Result<Option<Option<ExistingChunkCandidate>>> {
+        let mut memory = self
+            .memory
+            .lock()
+            .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
+        Ok(memory.get(hash).copied())
+    }
+
+    pub(crate) fn memory_insert(
+        &self,
+        hash: MerkleHash,
+        candidate: Option<ExistingChunkCandidate>,
+    ) -> Result<()> {
+        let mut memory = self
+            .memory
+            .lock()
+            .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
+        memory.put(hash, candidate);
+        Ok(())
+    }
+
+    pub(crate) fn load_persistent(
+        &self,
+        hashes: &[MerkleHash],
+    ) -> Result<HashMap<MerkleHash, Option<ExistingChunkCandidate>>> {
+        if hashes.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let now = current_unix_timestamp()?;
+        let ttl = i64::try_from(NEGATIVE_TTL.as_secs())
+            .map_err(|_| CrabError::Internal("negative cache TTL exceeds sqlite range".into()))?;
+        let cutoff = now.saturating_sub(ttl);
+        let connection = self
+            .connection
+            .lock()
+            .map_err(|_| CrabError::Internal("add remote candidate database poisoned".into()))?;
+        let mut out = HashMap::with_capacity(hashes.len());
+        for batch in hashes.chunks(LOOKUP_BATCH_SIZE) {
+            let placeholders = std::iter::repeat_n("?", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query = format!(
+                "SELECT chunk_hash, xorb_hash, chunk_index, uncompressed_size,
+                        placement_id, origin_proof_id
+                 FROM remote_candidates_v1 WHERE chunk_hash IN ({placeholders})"
+            );
+            let values = batch
+                .iter()
+                .map(|hash| <[u8; 32]>::from(*hash).to_vec())
+                .collect::<Vec<_>>();
+            let mut statement = connection
+                .prepare(&query)
+                .map_err(|error| database_error("prepare lookup", error))?;
+            let rows = statement
+                .query_map(
+                    params_from_iter(values.iter().map(|value| value.as_slice())),
+                    |row| {
+                        let chunk_hash = decode_hash(row.get(0)?)?;
+                        let xorb_hash = decode_hash(row.get(1)?)?;
+                        let chunk_index = row.get::<_, i64>(2)?;
+                        let uncompressed_size = row.get::<_, i64>(3)?;
+                        let placement_id = decode_hash(row.get(4)?)?;
+                        let origin_proof_id = decode_hash(row.get(5)?)?;
+                        let chunk_index = u32::try_from(chunk_index).map_err(|error| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                2,
+                                rusqlite::types::Type::Integer,
+                                Box::new(error),
+                            )
+                        })?;
+                        let uncompressed_size =
+                            u32::try_from(uncompressed_size).map_err(|error| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    3,
+                                    rusqlite::types::Type::Integer,
+                                    Box::new(error),
+                                )
+                            })?;
+                        Ok((
+                            chunk_hash,
+                            ExistingChunkCandidate {
+                                xorb_ref: XorbRef {
+                                    xorb_hash: xorb_hash.into(),
+                                    chunk_index,
+                                    uncompressed_size,
+                                },
+                                placement_id,
+                                origin_proof_id,
+                            },
+                        ))
+                    },
+                )
+                .map_err(|error| database_error("lookup", error))?;
+            for row in rows {
+                let (chunk_hash, candidate) =
+                    row.map_err(|error| database_error("decode lookup", error))?;
+                out.insert(chunk_hash.into(), Some(candidate));
+            }
+
+            let negative_query = format!(
+                "SELECT chunk_hash, observed_at FROM {NEGATIVE_TABLE}
+                 WHERE chunk_hash IN ({placeholders})"
+            );
+            let mut statement = connection
+                .prepare(&negative_query)
+                .map_err(|error| database_error("prepare negative lookup", error))?;
+            let rows = statement
+                .query_map(
+                    params_from_iter(values.iter().map(|value| value.as_slice())),
+                    |row| Ok((decode_hash(row.get(0)?)?, row.get::<_, i64>(1)?)),
+                )
+                .map_err(|error| database_error("negative lookup", error))?;
+            let mut expired = Vec::new();
+            for row in rows {
+                let (chunk_hash, observed_at) =
+                    row.map_err(|error| database_error("decode negative lookup", error))?;
+                if observed_at >= cutoff && observed_at <= now {
+                    out.entry(chunk_hash.into()).or_insert(None);
+                } else {
+                    expired.push(chunk_hash);
+                }
+            }
+            if !expired.is_empty() {
+                let mut statement = connection
+                    .prepare_cached(&format!(
+                        "DELETE FROM {NEGATIVE_TABLE} WHERE chunk_hash = ?1"
+                    ))
+                    .map_err(|error| database_error("prepare expired negative delete", error))?;
+                for chunk_hash in expired {
+                    statement
+                        .execute(params![chunk_hash.as_slice()])
+                        .map_err(|error| database_error("delete expired negative", error))?;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    pub(crate) fn persist_results(
+        &self,
+        entries: &[(MerkleHash, Option<ExistingChunkCandidate>)],
+    ) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let observed_at = current_unix_timestamp()?;
+        let mut connection = self
+            .connection
+            .lock()
+            .map_err(|_| CrabError::Internal("add remote candidate database poisoned".into()))?;
+        let transaction = connection
+            .transaction()
+            .map_err(|error| database_error("begin update", error))?;
+        {
+            let mut positive_statement = transaction
+                .prepare_cached(
+                    "INSERT INTO remote_candidates_v1
+                         (chunk_hash, xorb_hash, chunk_index, uncompressed_size,
+                          placement_id, origin_proof_id)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                     ON CONFLICT(chunk_hash) DO UPDATE SET
+                         xorb_hash = excluded.xorb_hash,
+                         chunk_index = excluded.chunk_index,
+                         uncompressed_size = excluded.uncompressed_size,
+                         placement_id = excluded.placement_id,
+                         origin_proof_id = excluded.origin_proof_id
+                     WHERE remote_candidates_v1.xorb_hash != excluded.xorb_hash
+                        OR remote_candidates_v1.chunk_index != excluded.chunk_index
+                        OR remote_candidates_v1.uncompressed_size != excluded.uncompressed_size
+                        OR remote_candidates_v1.placement_id != excluded.placement_id
+                        OR remote_candidates_v1.origin_proof_id != excluded.origin_proof_id",
+                )
+                .map_err(|error| database_error("prepare update", error))?;
+            let negative_table = NEGATIVE_TABLE;
+            let mut negative_statement = transaction
+                .prepare_cached(&format!(
+                    "INSERT INTO {negative_table} (chunk_hash, observed_at) VALUES (?1, ?2)
+                     ON CONFLICT(chunk_hash) DO UPDATE SET observed_at = excluded.observed_at"
+                ))
+                .map_err(|error| database_error("prepare negative update", error))?;
+            let mut delete_negative_statement = transaction
+                .prepare_cached(&format!(
+                    "DELETE FROM {negative_table} WHERE chunk_hash = ?1"
+                ))
+                .map_err(|error| database_error("prepare negative delete", error))?;
+            let mut delete_positive_statement = transaction
+                .prepare_cached("DELETE FROM remote_candidates_v1 WHERE chunk_hash = ?1")
+                .map_err(|error| database_error("prepare positive delete", error))?;
+            for (chunk_hash, candidate) in entries {
+                let chunk_hash = <[u8; 32]>::from(*chunk_hash);
+                if let Some(candidate) = candidate {
+                    let xorb_hash = <[u8; 32]>::from(candidate.xorb_ref.xorb_hash);
+                    positive_statement
+                        .execute(params![
+                            chunk_hash.as_slice(),
+                            xorb_hash.as_slice(),
+                            i64::from(candidate.xorb_ref.chunk_index),
+                            i64::from(candidate.xorb_ref.uncompressed_size),
+                            candidate.placement_id.as_slice(),
+                            candidate.origin_proof_id.as_slice(),
+                        ])
+                        .map_err(|error| database_error("write update", error))?;
+                    delete_negative_statement
+                        .execute(params![chunk_hash.as_slice()])
+                        .map_err(|error| database_error("delete negative update", error))?;
+                } else {
+                    delete_positive_statement
+                        .execute(params![chunk_hash.as_slice()])
+                        .map_err(|error| database_error("delete positive update", error))?;
+                    negative_statement
+                        .execute(params![chunk_hash.as_slice(), observed_at])
+                        .map_err(|error| database_error("write negative update", error))?;
+                }
+            }
+        }
+        transaction
+            .commit()
+            .map_err(|error| database_error("commit update", error))?;
+        let writes = self
+            .writes_since_prune
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        if !writes.is_multiple_of(PRUNE_EVERY_WRITES) {
+            return Ok(());
+        }
+        let positive_count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM remote_candidates_v1", [], |row| {
+                row.get(0)
+            })
+            .map_err(|error| database_error("count entries", error))?;
+        let negative_count: i64 = connection
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {NEGATIVE_TABLE}"),
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|error| database_error("count negative entries", error))?;
+        let mut overflow = positive_count
+            .saturating_add(negative_count)
+            .saturating_sub(MAX_PERSISTENT_ENTRIES);
+        if overflow > 0 {
+            let negative_eviction = overflow.min(negative_count);
+            if negative_eviction > 0 {
+                connection
+                    .execute(
+                        &format!(
+                            "DELETE FROM {NEGATIVE_TABLE}
+                             WHERE chunk_hash IN (
+                                 SELECT chunk_hash FROM {NEGATIVE_TABLE}
+                                 ORDER BY chunk_hash LIMIT ?1
+                             )"
+                        ),
+                        params![negative_eviction],
+                    )
+                    .map_err(|error| database_error("evict negative entries", error))?;
+                overflow -= negative_eviction;
+            }
+            if overflow > 0 {
+                connection
+                    .execute(
+                        "DELETE FROM remote_candidates_v1
+                         WHERE chunk_hash IN (
+                             SELECT chunk_hash FROM remote_candidates_v1
+                             ORDER BY chunk_hash LIMIT ?1
+                         )",
+                        params![overflow],
+                    )
+                    .map_err(|error| database_error("evict entries", error))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn decode_hash(value: Vec<u8>) -> rusqlite::Result<[u8; 32]> {
+    value.try_into().map_err(|value: Vec<u8>| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("expected 32-byte hash, got {} bytes", value.len()),
+            )),
+        )
+    })
+}
+
+fn database_error(operation: &str, error: rusqlite::Error) -> CrabError {
+    CrabError::Internal(format!("{operation} add remote candidate cache: {error}"))
+}
+
+fn ensure_negative_timestamp_column(connection: &Connection) -> Result<()> {
+    let mut statement = connection
+        .prepare("PRAGMA table_info(remote_candidate_misses_v1)")
+        .map_err(|error| database_error("inspect negative schema", error))?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|error| database_error("inspect negative columns", error))?;
+    let column_names = columns
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| database_error("decode negative schema", error))?;
+    drop(statement);
+    let has_timestamp = column_names.iter().any(|name| name == "observed_at");
+    if has_timestamp {
+        return Ok(());
+    }
+    connection
+        .execute(
+            "ALTER TABLE remote_candidate_misses_v1
+             ADD COLUMN observed_at INTEGER NOT NULL DEFAULT 0",
+            [],
+        )
+        .map_err(|error| database_error("upgrade negative schema", error))?;
+    Ok(())
+}
+
+fn current_unix_timestamp() -> Result<i64> {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| CrabError::Internal(format!("read add cache clock: {error}")))?
+        .as_secs();
+    i64::try_from(seconds)
+        .map_err(|_| CrabError::Internal("add cache clock exceeds sqlite integer range".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn candidate(seed: u8) -> ExistingChunkCandidate {
+        ExistingChunkCandidate {
+            xorb_ref: XorbRef {
+                xorb_hash: MerkleHash::from([seed; 32]),
+                chunk_index: u32::from(seed),
+                uncompressed_size: 4096,
+            },
+            placement_id: [seed.wrapping_add(1); 32],
+            origin_proof_id: [seed.wrapping_add(2); 32],
+        }
+    }
+
+    #[test]
+    fn persistent_candidates_round_trip() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("remote-candidates.sqlite");
+        let cache = AddRemoteCandidateCache::open(&path).expect("open");
+        let hash = MerkleHash::from([7; 32]);
+        cache
+            .persist_results(&[(hash, Some(candidate(7)))])
+            .expect("persist");
+        cache
+            .persist_results(&[(hash, Some(candidate(8)))])
+            .expect("refresh");
+        let loaded = cache.load_persistent(&[hash]).expect("load");
+        assert_eq!(loaded.get(&hash), Some(&Some(candidate(8))));
+    }
+
+    #[test]
+    fn persistent_negative_entries_round_trip_and_refresh() {
+        let dir = tempdir().expect("tempdir");
+        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let hash = MerkleHash::from([4; 32]);
+        cache
+            .persist_results(&[(hash, None)])
+            .expect("persist negative");
+        assert_eq!(
+            cache.load_persistent(&[hash]).expect("load").get(&hash),
+            Some(&None)
+        );
+
+        cache
+            .persist_results(&[(hash, Some(candidate(4)))])
+            .expect("refresh positive");
+        assert_eq!(
+            cache.load_persistent(&[hash]).expect("load").get(&hash),
+            Some(&Some(candidate(4)))
+        );
+    }
+
+    #[test]
+    fn expired_negative_entries_are_not_reused() {
+        let dir = tempdir().expect("tempdir");
+        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let hash = MerkleHash::from([5; 32]);
+        cache
+            .persist_results(&[(hash, None)])
+            .expect("persist negative");
+        cache
+            .connection
+            .lock()
+            .expect("database lock")
+            .execute(
+                "UPDATE remote_candidate_misses_v1 SET observed_at = 0 WHERE chunk_hash = ?1",
+                params![<[u8; 32]>::from(hash).as_slice()],
+            )
+            .expect("age negative");
+
+        assert!(
+            !cache
+                .load_persistent(&[hash])
+                .expect("load")
+                .contains_key(&hash)
+        );
+        let remaining: i64 = cache
+            .connection
+            .lock()
+            .expect("database lock")
+            .query_row(
+                "SELECT COUNT(*) FROM remote_candidate_misses_v1 WHERE chunk_hash = ?1",
+                params![<[u8; 32]>::from(hash).as_slice()],
+                |row| row.get(0),
+            )
+            .expect("count expired");
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn memory_cache_distinguishes_negative_entries() {
+        let dir = tempdir().expect("tempdir");
+        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let hash = MerkleHash::from([3; 32]);
+        assert_eq!(cache.memory_get(&hash).expect("lookup"), None);
+        cache.memory_insert(hash, None).expect("insert");
+        assert_eq!(cache.memory_get(&hash).expect("lookup"), Some(None));
+    }
+
+    #[test]
+    fn persistent_lookup_batches_large_requests() {
+        let dir = tempdir().expect("tempdir");
+        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let entries = (0..600u16)
+            .map(|seed| {
+                let mut bytes = [0; 32];
+                bytes[..2].copy_from_slice(&seed.to_le_bytes());
+                (MerkleHash::from(bytes), candidate((seed % 256) as u8))
+            })
+            .collect::<Vec<_>>();
+        let entries = entries
+            .into_iter()
+            .map(|(hash, candidate)| (hash, Some(candidate)))
+            .collect::<Vec<_>>();
+        cache.persist_results(&entries).expect("persist");
+        let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
+        assert_eq!(cache.load_persistent(&hashes).expect("load").len(), 600);
+    }
+}

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -266,6 +266,42 @@ impl AddRemoteCandidateCache {
         let transaction = connection
             .transaction()
             .map_err(|error| database_error("begin update", error))?;
+        let mut positive_hashes = Vec::new();
+        let mut negative_hashes = Vec::new();
+        for (chunk_hash, candidate) in entries {
+            let chunk_hash = <[u8; 32]>::from(*chunk_hash);
+            if candidate.is_some() {
+                positive_hashes.push(chunk_hash);
+            } else {
+                negative_hashes.push(chunk_hash);
+            }
+        }
+        for batch in positive_hashes.chunks(LOOKUP_BATCH_SIZE) {
+            let placeholders = std::iter::repeat_n("?", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query =
+                format!("DELETE FROM {NEGATIVE_TABLE} WHERE chunk_hash IN ({placeholders})");
+            transaction
+                .execute(
+                    &query,
+                    params_from_iter(batch.iter().map(|hash| hash.as_slice())),
+                )
+                .map_err(|error| database_error("delete stale negative entries", error))?;
+        }
+        for batch in negative_hashes.chunks(LOOKUP_BATCH_SIZE) {
+            let placeholders = std::iter::repeat_n("?", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query =
+                format!("DELETE FROM remote_candidates_v1 WHERE chunk_hash IN ({placeholders})");
+            transaction
+                .execute(
+                    &query,
+                    params_from_iter(batch.iter().map(|hash| hash.as_slice())),
+                )
+                .map_err(|error| database_error("delete stale positive entries", error))?;
+        }
         {
             let mut positive_statement = transaction
                 .prepare_cached(
@@ -286,21 +322,12 @@ impl AddRemoteCandidateCache {
                         OR remote_candidates_v1.origin_proof_id != excluded.origin_proof_id",
                 )
                 .map_err(|error| database_error("prepare update", error))?;
-            let negative_table = NEGATIVE_TABLE;
             let mut negative_statement = transaction
-                .prepare_cached(&format!(
-                    "INSERT INTO {negative_table} (chunk_hash, observed_at) VALUES (?1, ?2)
+                .prepare_cached(
+                    "INSERT INTO remote_candidate_misses_v1 (chunk_hash, observed_at) VALUES (?1, ?2)
                      ON CONFLICT(chunk_hash) DO UPDATE SET observed_at = excluded.observed_at"
-                ))
+                )
                 .map_err(|error| database_error("prepare negative update", error))?;
-            let mut delete_negative_statement = transaction
-                .prepare_cached(&format!(
-                    "DELETE FROM {negative_table} WHERE chunk_hash = ?1"
-                ))
-                .map_err(|error| database_error("prepare negative delete", error))?;
-            let mut delete_positive_statement = transaction
-                .prepare_cached("DELETE FROM remote_candidates_v1 WHERE chunk_hash = ?1")
-                .map_err(|error| database_error("prepare positive delete", error))?;
             for (chunk_hash, candidate) in entries {
                 let chunk_hash = <[u8; 32]>::from(*chunk_hash);
                 if let Some(candidate) = candidate {
@@ -315,13 +342,7 @@ impl AddRemoteCandidateCache {
                             candidate.origin_proof_id.as_slice(),
                         ])
                         .map_err(|error| database_error("write update", error))?;
-                    delete_negative_statement
-                        .execute(params![chunk_hash.as_slice()])
-                        .map_err(|error| database_error("delete negative update", error))?;
                 } else {
-                    delete_positive_statement
-                        .execute(params![chunk_hash.as_slice()])
-                        .map_err(|error| database_error("delete positive update", error))?;
                     negative_statement
                         .execute(params![chunk_hash.as_slice(), observed_at])
                         .map_err(|error| database_error("write negative update", error))?;
@@ -490,6 +511,29 @@ mod tests {
         assert_eq!(
             cache.load_persistent(&[hash]).expect("load").get(&hash),
             Some(&Some(candidate(4)))
+        );
+    }
+
+    #[test]
+    fn persistent_duplicate_results_keep_input_order() {
+        let dir = tempdir().expect("tempdir");
+        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let hash = MerkleHash::from([6; 32]);
+
+        cache
+            .persist_results(&[(hash, Some(candidate(6))), (hash, None)])
+            .expect("persist negative last");
+        assert_eq!(
+            cache.load_persistent(&[hash]).expect("load").get(&hash),
+            Some(&None)
+        );
+
+        cache
+            .persist_results(&[(hash, None), (hash, Some(candidate(6)))])
+            .expect("persist positive last");
+        assert_eq!(
+            cache.load_persistent(&[hash]).expect("load").get(&hash),
+            Some(&Some(candidate(6)))
         );
     }
 

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -23,6 +23,7 @@ const MEMORY_CAPACITY: usize = 65_536;
 const MAX_PERSISTENT_ENTRIES: i64 = 2_000_000;
 const LOOKUP_BATCH_SIZE: usize = 512;
 const PERSISTENT_UNION_LOOKUP_BATCH: usize = LOOKUP_BATCH_SIZE / 2;
+const PERSIST_DEDUP_BATCH_SIZE: usize = MEMORY_CAPACITY;
 const PRUNE_EVERY_WRITES: u64 = 64;
 const NEGATIVE_TABLE: &str = "remote_candidate_misses_v1";
 const NEGATIVE_TTL: Duration = Duration::from_secs(5 * 60);
@@ -263,6 +264,15 @@ impl AddRemoteCandidateCache {
         entries: &[(MerkleHash, Option<ExistingChunkCandidate>)],
     ) -> Result<()> {
         if entries.is_empty() {
+            return Ok(());
+        }
+        if entries.len() > PERSIST_DEDUP_BATCH_SIZE {
+            // The cache is advisory, so page oversized writes. Processing
+            // pages in input order preserves last-result-wins semantics while
+            // avoiding a repository-sized deduplication map.
+            for batch in entries.chunks(PERSIST_DEDUP_BATCH_SIZE) {
+                self.persist_results(batch)?;
+            }
             return Ok(());
         }
         let observed_at = current_unix_timestamp()?;

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -109,7 +109,7 @@ impl AddRemoteCandidateCache {
             .memory
             .lock()
             .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
-        let mut out = HashMap::with_capacity(hashes.len());
+        let mut out = HashMap::with_capacity(hashes.len().min(MEMORY_CAPACITY));
         for hash in hashes {
             if let Some(candidate) = memory.get(hash).copied() {
                 out.insert(*hash, candidate);
@@ -150,7 +150,7 @@ impl AddRemoteCandidateCache {
             .connection
             .lock()
             .map_err(|_| CrabError::Internal("add remote candidate database poisoned".into()))?;
-        let mut out = HashMap::with_capacity(hashes.len());
+        let mut out = HashMap::with_capacity(hashes.len().min(MEMORY_CAPACITY));
         // The UNION repeats every hash list, so keep total bind variables below
         // SQLite's default 999-variable limit.
         for batch in hashes.chunks(PERSISTENT_UNION_LOOKUP_BATCH) {

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -330,11 +330,7 @@ impl AddRemoteCandidateCache {
                 }
             }
         }
-        let positive_hashes = positive_entries
-            .iter()
-            .map(|(chunk_hash, _)| *chunk_hash)
-            .collect::<Vec<_>>();
-        for batch in positive_hashes.chunks(LOOKUP_BATCH_SIZE) {
+        for batch in positive_entries.chunks(LOOKUP_BATCH_SIZE) {
             let placeholders = std::iter::repeat_n("?", batch.len())
                 .collect::<Vec<_>>()
                 .join(",");
@@ -343,7 +339,7 @@ impl AddRemoteCandidateCache {
             transaction
                 .execute(
                     &query,
-                    params_from_iter(batch.iter().map(|hash| hash.as_slice())),
+                    params_from_iter(batch.iter().map(|(hash, _)| hash.as_slice())),
                 )
                 .map_err(|error| database_error("delete stale negative entries", error))?;
         }

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -583,10 +583,16 @@ mod tests {
         }
     }
 
+    fn cache_path(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        let root = dir.path().join("cache");
+        crab_cache::ensure_private_cache_directory(&root).expect("private cache root");
+        root.join("cache.sqlite")
+    }
+
     #[test]
     fn persistent_candidates_round_trip() {
         let dir = tempdir().expect("tempdir");
-        let path = dir.path().join("remote-candidates.sqlite");
+        let path = cache_path(&dir);
         let cache = AddRemoteCandidateCache::open(&path).expect("open");
         let hash = MerkleHash::from([7; 32]);
         cache
@@ -602,7 +608,7 @@ mod tests {
     #[test]
     fn persistent_negative_entries_round_trip_and_refresh() {
         let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
         let hash = MerkleHash::from([4; 32]);
         cache
             .persist_results(&[(hash, None)])
@@ -624,7 +630,7 @@ mod tests {
     #[test]
     fn persistent_duplicate_results_keep_input_order() {
         let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
         let hash = MerkleHash::from([6; 32]);
 
         cache
@@ -647,7 +653,7 @@ mod tests {
     #[test]
     fn expired_negative_entries_are_not_reused() {
         let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
         let hash = MerkleHash::from([5; 32]);
         cache
             .persist_results(&[(hash, None)])
@@ -684,7 +690,7 @@ mod tests {
     #[test]
     fn memory_cache_distinguishes_negative_entries() {
         let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
         let hash = MerkleHash::from([3; 32]);
         assert!(
             !cache
@@ -702,7 +708,7 @@ mod tests {
     #[test]
     fn memory_batch_cache_preserves_positive_negative_and_misses() {
         let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
         let positive_hash = MerkleHash::from([8; 32]);
         let negative_hash = MerkleHash::from([9; 32]);
         let missing_hash = MerkleHash::from([10; 32]);
@@ -721,7 +727,7 @@ mod tests {
     #[test]
     fn persistent_lookup_batches_large_requests() {
         let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
         let entries = (0..600u16)
             .map(|seed| {
                 let mut bytes = [0; 32];
@@ -743,7 +749,7 @@ mod tests {
     #[test]
     fn persistent_negative_writes_batch_large_requests() {
         let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&dir.path().join("cache.sqlite")).expect("open");
+        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
         let entries = (0..600u16)
             .map(|seed| {
                 let mut bytes = [0; 32];

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -11,7 +11,7 @@ use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use lru::LruCache;
-use rusqlite::{Connection, params, params_from_iter};
+use rusqlite::{Connection, TransactionBehavior, params, params_from_iter};
 
 use crate::core::error::{CrabError, Result};
 use crab_staging::push_plan::ExistingChunkCandidate;
@@ -20,19 +20,31 @@ use crab_xet::xorb::format::XorbRef;
 
 const SCHEMA_VERSION: i64 = 1;
 const MEMORY_CAPACITY: usize = 65_536;
-const MAX_PERSISTENT_ENTRIES: i64 = 2_000_000;
+const MAX_PERSISTENT_ENTRIES: i64 = if cfg!(test) { 1_024 } else { 2_000_000 };
 const LOOKUP_BATCH_SIZE: usize = 512;
 const PERSISTENT_UNION_LOOKUP_BATCH: usize = LOOKUP_BATCH_SIZE / 2;
 const PERSIST_DEDUP_BATCH_SIZE: usize = MEMORY_CAPACITY;
-const PRUNE_EVERY_WRITES: u64 = 64;
 const NEGATIVE_TABLE: &str = "remote_candidate_misses_v1";
 const NEGATIVE_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// A bounded bucket-scoped cache of proof-backed candidates.
 pub(crate) struct AddRemoteCandidateCache {
     connection: Mutex<Connection>,
-    memory: Mutex<LruCache<MerkleHash, Option<ExistingChunkCandidate>>>,
-    writes_since_prune: std::sync::atomic::AtomicU64,
+    memory: Mutex<LruCache<MerkleHash, CachedCandidate>>,
+}
+
+#[derive(Clone, Copy)]
+struct CachedCandidate {
+    candidate: Option<ExistingChunkCandidate>,
+    observed_at: i64,
+}
+
+impl CachedCandidate {
+    fn is_current(self, now: i64) -> bool {
+        self.candidate.is_some()
+            || (self.observed_at <= now
+                && now.saturating_sub(self.observed_at) < NEGATIVE_TTL.as_secs() as i64)
+    }
 }
 
 impl AddRemoteCandidateCache {
@@ -47,21 +59,25 @@ impl AddRemoteCandidateCache {
                 ))
             })?;
         }
-        let connection = Connection::open(path).map_err(|error| database_error("open", error))?;
+        let mut connection =
+            Connection::open(path).map_err(|error| database_error("open", error))?;
         connection
             .busy_timeout(Duration::from_millis(250))
             .map_err(|error| database_error("configure timeout", error))?;
         connection
             .execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")
             .map_err(|error| database_error("configure", error))?;
-        let version = connection
+        // Serialize schema creation with other add processes.
+        let schema = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| database_error("begin schema", error))?;
+        let version = schema
             .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
             .map_err(|error| database_error("read schema version", error))?;
         if version == 0 {
-            connection
+            schema
                 .execute_batch(
-                    "BEGIN IMMEDIATE;
-                     CREATE TABLE remote_candidates_v1 (
+                    "CREATE TABLE remote_candidates_v1 (
                          chunk_hash BLOB PRIMARY KEY NOT NULL CHECK(length(chunk_hash) = 32),
                          xorb_hash BLOB NOT NULL CHECK(length(xorb_hash) = 32),
                          chunk_index INTEGER NOT NULL CHECK(chunk_index >= 0),
@@ -73,8 +89,21 @@ impl AddRemoteCandidateCache {
                          chunk_hash BLOB PRIMARY KEY NOT NULL CHECK(length(chunk_hash) = 32),
                          observed_at INTEGER NOT NULL CHECK(observed_at >= 0)
                      ) WITHOUT ROWID;
-                     PRAGMA user_version = 1;
-                     COMMIT;",
+                     CREATE TABLE cache_counts (
+                         singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+                         positives INTEGER NOT NULL CHECK(positives >= 0),
+                         negatives INTEGER NOT NULL CHECK(negatives >= 0)
+                     );
+                     INSERT INTO cache_counts VALUES (1, 0, 0);
+                     CREATE TRIGGER candidate_insert AFTER INSERT ON remote_candidates_v1
+                     BEGIN UPDATE cache_counts SET positives = positives + 1; END;
+                     CREATE TRIGGER candidate_delete AFTER DELETE ON remote_candidates_v1
+                     BEGIN UPDATE cache_counts SET positives = positives - 1; END;
+                     CREATE TRIGGER miss_insert AFTER INSERT ON remote_candidate_misses_v1
+                     BEGIN UPDATE cache_counts SET negatives = negatives + 1; END;
+                     CREATE TRIGGER miss_delete AFTER DELETE ON remote_candidate_misses_v1
+                     BEGIN UPDATE cache_counts SET negatives = negatives - 1; END;
+                     PRAGMA user_version = 1;",
                 )
                 .map_err(|error| database_error("initialize", error))?;
         } else if version != SCHEMA_VERSION {
@@ -82,26 +111,27 @@ impl AddRemoteCandidateCache {
                 "unsupported add remote candidate cache schema {version}; expected v{SCHEMA_VERSION}"
             )));
         }
-        connection
-            .execute_batch(
-                "CREATE TABLE IF NOT EXISTS remote_candidate_misses_v1 (
-                     chunk_hash BLOB PRIMARY KEY NOT NULL CHECK(length(chunk_hash) = 32),
-                     observed_at INTEGER NOT NULL CHECK(observed_at >= 0)
-                 ) WITHOUT ROWID;",
-            )
-            .map_err(|error| database_error("initialize negative entries", error))?;
-        ensure_negative_timestamp_column(&connection)?;
+        schema
+            .commit()
+            .map_err(|error| database_error("commit schema", error))?;
         let capacity = NonZeroUsize::new(MEMORY_CAPACITY).unwrap_or(NonZeroUsize::MIN);
         Ok(Self {
             connection: Mutex::new(connection),
             memory: Mutex::new(LruCache::new(capacity)),
-            writes_since_prune: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
     pub(crate) fn memory_get_batch(
         &self,
         hashes: &[MerkleHash],
+    ) -> Result<HashMap<MerkleHash, Option<ExistingChunkCandidate>>> {
+        self.memory_get_batch_at(hashes, current_unix_timestamp()?)
+    }
+
+    fn memory_get_batch_at(
+        &self,
+        hashes: &[MerkleHash],
+        now: i64,
     ) -> Result<HashMap<MerkleHash, Option<ExistingChunkCandidate>>> {
         if hashes.is_empty() {
             return Ok(HashMap::new());
@@ -115,7 +145,11 @@ impl AddRemoteCandidateCache {
         let mut out = HashMap::new();
         for hash in hashes {
             if let Some(candidate) = memory.get(hash).copied() {
-                out.insert(*hash, candidate);
+                if candidate.is_current(now) {
+                    out.insert(*hash, candidate.candidate);
+                } else {
+                    memory.pop(hash);
+                }
             }
         }
         Ok(out)
@@ -132,8 +166,15 @@ impl AddRemoteCandidateCache {
             .memory
             .lock()
             .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
+        let observed_at = current_unix_timestamp()?;
         for (hash, candidate) in entries {
-            memory.put(*hash, *candidate);
+            memory.put(
+                *hash,
+                CachedCandidate {
+                    candidate: *candidate,
+                    observed_at,
+                },
+            );
         }
         Ok(())
     }
@@ -156,6 +197,7 @@ impl AddRemoteCandidateCache {
         // A cold persistent lookup commonly returns no rows. Keep the
         // all-miss path allocation-free; the map grows with actual hits.
         let mut out = HashMap::new();
+        let mut memory_updates = Vec::new();
         // The UNION repeats every hash list, so keep total bind variables below
         // SQLite's default 999-variable limit.
         for batch in hashes.chunks(PERSISTENT_UNION_LOOKUP_BATCH) {
@@ -231,9 +273,23 @@ impl AddRemoteCandidateCache {
                     row.map_err(|error| database_error("decode lookup", error))?;
                 if let Some(candidate) = candidate {
                     out.insert(chunk_hash.into(), Some(candidate));
+                    memory_updates.push((
+                        chunk_hash.into(),
+                        CachedCandidate {
+                            candidate: Some(candidate),
+                            observed_at: now,
+                        },
+                    ));
                 } else if let Some(observed_at) = observed_at {
-                    if observed_at >= cutoff && observed_at <= now {
+                    if observed_at > cutoff && observed_at <= now {
                         out.entry(chunk_hash.into()).or_insert(None);
+                        memory_updates.push((
+                            chunk_hash.into(),
+                            CachedCandidate {
+                                candidate: None,
+                                observed_at,
+                            },
+                        ));
                     } else {
                         expired.push(chunk_hash);
                     }
@@ -249,7 +305,8 @@ impl AddRemoteCandidateCache {
                         .collect::<Vec<_>>()
                         .join(",");
                     let query = format!(
-                        "DELETE FROM {NEGATIVE_TABLE} WHERE chunk_hash IN ({placeholders})"
+                        "DELETE FROM {NEGATIVE_TABLE} WHERE chunk_hash IN ({placeholders})
+                         AND (observed_at <= {cutoff} OR observed_at > {now})"
                     );
                     connection
                         .execute(
@@ -258,6 +315,15 @@ impl AddRemoteCandidateCache {
                         )
                         .map_err(|error| database_error("delete expired negative", error))?;
                 }
+            }
+            // Bound promotion scratch to one page and preserve observation time:
+            // reading a miss never renews its lease. Lock order is database → memory.
+            let mut memory = self
+                .memory
+                .lock()
+                .map_err(|_| CrabError::Internal("add remote candidate cache poisoned".into()))?;
+            for (hash, candidate) in memory_updates.drain(..) {
+                memory.put(hash, candidate);
             }
         }
         Ok(out)
@@ -305,7 +371,7 @@ impl AddRemoteCandidateCache {
             .lock()
             .map_err(|_| CrabError::Internal("add remote candidate database poisoned".into()))?;
         let transaction = connection
-            .transaction()
+            .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|error| database_error("begin update", error))?;
         let mut positive_entries = Vec::new();
         let mut negative_hashes = Vec::new();
@@ -456,35 +522,22 @@ impl AddRemoteCandidateCache {
                 .execute(params_from_iter(values))
                 .map_err(|error| database_error("write negative update batch", error))?;
         }
-        transaction
-            .commit()
-            .map_err(|error| database_error("commit update", error))?;
-        let writes = self
-            .writes_since_prune
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
-        if !writes.is_multiple_of(PRUNE_EVERY_WRITES) {
-            return Ok(());
-        }
-        let positive_count: i64 = connection
-            .query_row("SELECT COUNT(*) FROM remote_candidates_v1", [], |row| {
-                row.get(0)
-            })
-            .map_err(|error| database_error("count entries", error))?;
-        let negative_count: i64 = connection
+        // Counts and eviction share the write transaction. The limit survives
+        // process restarts without scanning the full cache on every write.
+        let (positive_count, negative_count): (i64, i64) = transaction
             .query_row(
-                &format!("SELECT COUNT(*) FROM {NEGATIVE_TABLE}"),
+                "SELECT positives, negatives FROM cache_counts WHERE singleton = 1",
                 [],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
-            .map_err(|error| database_error("count negative entries", error))?;
+            .map_err(|error| database_error("read entry counts", error))?;
         let mut overflow = positive_count
             .saturating_add(negative_count)
             .saturating_sub(MAX_PERSISTENT_ENTRIES);
         if overflow > 0 {
             let negative_eviction = overflow.min(negative_count);
             if negative_eviction > 0 {
-                connection
+                transaction
                     .execute(
                         &format!(
                             "DELETE FROM {NEGATIVE_TABLE}
@@ -499,7 +552,7 @@ impl AddRemoteCandidateCache {
                 overflow -= negative_eviction;
             }
             if overflow > 0 {
-                connection
+                transaction
                     .execute(
                         "DELETE FROM remote_candidates_v1
                          WHERE chunk_hash IN (
@@ -511,6 +564,9 @@ impl AddRemoteCandidateCache {
                     .map_err(|error| database_error("evict entries", error))?;
             }
         }
+        transaction
+            .commit()
+            .map_err(|error| database_error("commit update", error))?;
         Ok(())
     }
 }
@@ -532,31 +588,6 @@ fn database_error(operation: &str, error: rusqlite::Error) -> CrabError {
     CrabError::Internal(format!("{operation} add remote candidate cache: {error}"))
 }
 
-fn ensure_negative_timestamp_column(connection: &Connection) -> Result<()> {
-    let mut statement = connection
-        .prepare("PRAGMA table_info(remote_candidate_misses_v1)")
-        .map_err(|error| database_error("inspect negative schema", error))?;
-    let columns = statement
-        .query_map([], |row| row.get::<_, String>(1))
-        .map_err(|error| database_error("inspect negative columns", error))?;
-    let column_names = columns
-        .collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(|error| database_error("decode negative schema", error))?;
-    drop(statement);
-    let has_timestamp = column_names.iter().any(|name| name == "observed_at");
-    if has_timestamp {
-        return Ok(());
-    }
-    connection
-        .execute(
-            "ALTER TABLE remote_candidate_misses_v1
-             ADD COLUMN observed_at INTEGER NOT NULL DEFAULT 0",
-            [],
-        )
-        .map_err(|error| database_error("upgrade negative schema", error))?;
-    Ok(())
-}
-
 fn current_unix_timestamp() -> Result<i64> {
     let seconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -567,202 +598,4 @@ fn current_unix_timestamp() -> Result<i64> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    fn candidate(seed: u8) -> ExistingChunkCandidate {
-        ExistingChunkCandidate {
-            xorb_ref: XorbRef {
-                xorb_hash: MerkleHash::from([seed; 32]),
-                chunk_index: u32::from(seed),
-                uncompressed_size: 4096,
-            },
-            placement_id: [seed.wrapping_add(1); 32],
-            origin_proof_id: [seed.wrapping_add(2); 32],
-        }
-    }
-
-    fn cache_path(dir: &tempfile::TempDir) -> std::path::PathBuf {
-        let root = dir.path().join("cache");
-        crab_cache::ensure_private_cache_directory(&root).expect("private cache root");
-        root.join("cache.sqlite")
-    }
-
-    #[test]
-    fn persistent_candidates_round_trip() {
-        let dir = tempdir().expect("tempdir");
-        let path = cache_path(&dir);
-        let cache = AddRemoteCandidateCache::open(&path).expect("open");
-        let hash = MerkleHash::from([7; 32]);
-        cache
-            .persist_results(&[(hash, Some(candidate(7)))])
-            .expect("persist");
-        cache
-            .persist_results(&[(hash, Some(candidate(8)))])
-            .expect("refresh");
-        let loaded = cache.load_persistent(&[hash]).expect("load");
-        assert_eq!(loaded.get(&hash), Some(&Some(candidate(8))));
-    }
-
-    #[test]
-    fn persistent_negative_entries_round_trip_and_refresh() {
-        let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
-        let hash = MerkleHash::from([4; 32]);
-        cache
-            .persist_results(&[(hash, None)])
-            .expect("persist negative");
-        assert_eq!(
-            cache.load_persistent(&[hash]).expect("load").get(&hash),
-            Some(&None)
-        );
-
-        cache
-            .persist_results(&[(hash, Some(candidate(4)))])
-            .expect("refresh positive");
-        assert_eq!(
-            cache.load_persistent(&[hash]).expect("load").get(&hash),
-            Some(&Some(candidate(4)))
-        );
-    }
-
-    #[test]
-    fn persistent_duplicate_results_keep_input_order() {
-        let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
-        let hash = MerkleHash::from([6; 32]);
-
-        cache
-            .persist_results(&[(hash, Some(candidate(6))), (hash, None)])
-            .expect("persist negative last");
-        assert_eq!(
-            cache.load_persistent(&[hash]).expect("load").get(&hash),
-            Some(&None)
-        );
-
-        cache
-            .persist_results(&[(hash, None), (hash, Some(candidate(6)))])
-            .expect("persist positive last");
-        assert_eq!(
-            cache.load_persistent(&[hash]).expect("load").get(&hash),
-            Some(&Some(candidate(6)))
-        );
-    }
-
-    #[test]
-    fn expired_negative_entries_are_not_reused() {
-        let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
-        let hash = MerkleHash::from([5; 32]);
-        cache
-            .persist_results(&[(hash, None)])
-            .expect("persist negative");
-        cache
-            .connection
-            .lock()
-            .expect("database lock")
-            .execute(
-                "UPDATE remote_candidate_misses_v1 SET observed_at = 0 WHERE chunk_hash = ?1",
-                params![<[u8; 32]>::from(hash).as_slice()],
-            )
-            .expect("age negative");
-
-        assert!(
-            !cache
-                .load_persistent(&[hash])
-                .expect("load")
-                .contains_key(&hash)
-        );
-        let remaining: i64 = cache
-            .connection
-            .lock()
-            .expect("database lock")
-            .query_row(
-                "SELECT COUNT(*) FROM remote_candidate_misses_v1 WHERE chunk_hash = ?1",
-                params![<[u8; 32]>::from(hash).as_slice()],
-                |row| row.get(0),
-            )
-            .expect("count expired");
-        assert_eq!(remaining, 0);
-    }
-
-    #[test]
-    fn memory_cache_distinguishes_negative_entries() {
-        let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
-        let hash = MerkleHash::from([3; 32]);
-        assert!(
-            !cache
-                .memory_get_batch(&[hash])
-                .expect("lookup")
-                .contains_key(&hash)
-        );
-        cache.memory_insert_batch(&[(hash, None)]).expect("insert");
-        assert_eq!(
-            cache.memory_get_batch(&[hash]).expect("lookup").get(&hash),
-            Some(&None)
-        );
-    }
-
-    #[test]
-    fn memory_batch_cache_preserves_positive_negative_and_misses() {
-        let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
-        let positive_hash = MerkleHash::from([8; 32]);
-        let negative_hash = MerkleHash::from([9; 32]);
-        let missing_hash = MerkleHash::from([10; 32]);
-        cache
-            .memory_insert_batch(&[(positive_hash, Some(candidate(8))), (negative_hash, None)])
-            .expect("insert batch");
-
-        let loaded = cache
-            .memory_get_batch(&[positive_hash, negative_hash, missing_hash])
-            .expect("lookup batch");
-        assert_eq!(loaded.get(&positive_hash), Some(&Some(candidate(8))));
-        assert_eq!(loaded.get(&negative_hash), Some(&None));
-        assert!(!loaded.contains_key(&missing_hash));
-    }
-
-    #[test]
-    fn persistent_lookup_batches_large_requests() {
-        let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
-        let entries = (0..600u16)
-            .map(|seed| {
-                let mut bytes = [0; 32];
-                bytes[..2].copy_from_slice(&seed.to_le_bytes());
-                (MerkleHash::from(bytes), candidate((seed % 256) as u8))
-            })
-            .collect::<Vec<_>>();
-        let entries = entries
-            .into_iter()
-            .map(|(hash, candidate)| (hash, Some(candidate)))
-            .collect::<Vec<_>>();
-        cache
-            .persist_unique_results(&entries)
-            .expect("persist unique");
-        let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
-        assert_eq!(cache.load_persistent(&hashes).expect("load").len(), 600);
-    }
-
-    #[test]
-    fn persistent_negative_writes_batch_large_requests() {
-        let dir = tempdir().expect("tempdir");
-        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
-        let entries = (0..600u16)
-            .map(|seed| {
-                let mut bytes = [0; 32];
-                bytes[..2].copy_from_slice(&seed.to_le_bytes());
-                (MerkleHash::from(bytes), None)
-            })
-            .collect::<Vec<_>>();
-        cache
-            .persist_unique_results(&entries)
-            .expect("persist unique negatives");
-        let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
-        let loaded = cache.load_persistent(&hashes).expect("load negatives");
-        assert_eq!(loaded.len(), 600);
-        assert!(loaded.values().all(Option::is_none));
-    }
-}
+mod tests;

--- a/crab/src/cache/add_remote_candidates.rs
+++ b/crab/src/cache/add_remote_candidates.rs
@@ -154,46 +154,54 @@ impl AddRemoteCandidateCache {
             let placeholders = std::iter::repeat_n("?", batch.len())
                 .collect::<Vec<_>>()
                 .join(",");
-            let query = format!(
-                "SELECT chunk_hash, xorb_hash, chunk_index, uncompressed_size,
-                        placement_id, origin_proof_id
-                 FROM remote_candidates_v1 WHERE chunk_hash IN ({placeholders})"
-            );
             let values = batch
                 .iter()
                 .map(|hash| <[u8; 32]>::from(*hash))
                 .collect::<Vec<_>>();
+            let query = format!(
+                "SELECT chunk_hash, xorb_hash, chunk_index, uncompressed_size,
+                        placement_id, origin_proof_id, 1 AS is_positive, NULL AS observed_at
+                 FROM remote_candidates_v1 WHERE chunk_hash IN ({placeholders})
+                 UNION ALL
+                 SELECT chunk_hash, NULL, NULL, NULL, NULL, NULL, 0 AS is_positive, observed_at
+                 FROM {NEGATIVE_TABLE} WHERE chunk_hash IN ({placeholders})"
+            );
             let mut statement = connection
                 .prepare_cached(&query)
                 .map_err(|error| database_error("prepare lookup", error))?;
             let rows = statement
                 .query_map(
-                    params_from_iter(values.iter().map(|value| value.as_slice())),
+                    params_from_iter(
+                        values
+                            .iter()
+                            .chain(values.iter())
+                            .map(|value| value.as_slice()),
+                    ),
                     |row| {
                         let chunk_hash = decode_hash(row.get(0)?)?;
-                        let xorb_hash = decode_hash(row.get(1)?)?;
-                        let chunk_index = row.get::<_, i64>(2)?;
-                        let uncompressed_size = row.get::<_, i64>(3)?;
-                        let placement_id = decode_hash(row.get(4)?)?;
-                        let origin_proof_id = decode_hash(row.get(5)?)?;
-                        let chunk_index = u32::try_from(chunk_index).map_err(|error| {
-                            rusqlite::Error::FromSqlConversionFailure(
-                                2,
-                                rusqlite::types::Type::Integer,
-                                Box::new(error),
-                            )
-                        })?;
-                        let uncompressed_size =
-                            u32::try_from(uncompressed_size).map_err(|error| {
+                        let is_positive: bool = row.get(6)?;
+                        let candidate = if is_positive {
+                            let xorb_hash = decode_hash(row.get(1)?)?;
+                            let chunk_index = row.get::<_, i64>(2)?;
+                            let uncompressed_size = row.get::<_, i64>(3)?;
+                            let placement_id = decode_hash(row.get(4)?)?;
+                            let origin_proof_id = decode_hash(row.get(5)?)?;
+                            let chunk_index = u32::try_from(chunk_index).map_err(|error| {
                                 rusqlite::Error::FromSqlConversionFailure(
-                                    3,
+                                    2,
                                     rusqlite::types::Type::Integer,
                                     Box::new(error),
                                 )
                             })?;
-                        Ok((
-                            chunk_hash,
-                            ExistingChunkCandidate {
+                            let uncompressed_size =
+                                u32::try_from(uncompressed_size).map_err(|error| {
+                                    rusqlite::Error::FromSqlConversionFailure(
+                                        3,
+                                        rusqlite::types::Type::Integer,
+                                        Box::new(error),
+                                    )
+                                })?;
+                            Some(ExistingChunkCandidate {
                                 xorb_ref: XorbRef {
                                     xorb_hash: xorb_hash.into(),
                                     chunk_index,
@@ -201,49 +209,45 @@ impl AddRemoteCandidateCache {
                                 },
                                 placement_id,
                                 origin_proof_id,
-                            },
-                        ))
+                            })
+                        } else {
+                            None
+                        };
+                        Ok((chunk_hash, candidate, row.get::<_, Option<i64>>(7)?))
                     },
                 )
                 .map_err(|error| database_error("lookup", error))?;
-            for row in rows {
-                let (chunk_hash, candidate) =
-                    row.map_err(|error| database_error("decode lookup", error))?;
-                out.insert(chunk_hash.into(), Some(candidate));
-            }
-
-            let negative_query = format!(
-                "SELECT chunk_hash, observed_at FROM {NEGATIVE_TABLE}
-                 WHERE chunk_hash IN ({placeholders})"
-            );
-            let mut statement = connection
-                .prepare_cached(&negative_query)
-                .map_err(|error| database_error("prepare negative lookup", error))?;
-            let rows = statement
-                .query_map(
-                    params_from_iter(values.iter().map(|value| value.as_slice())),
-                    |row| Ok((decode_hash(row.get(0)?)?, row.get::<_, i64>(1)?)),
-                )
-                .map_err(|error| database_error("negative lookup", error))?;
             let mut expired = Vec::new();
             for row in rows {
-                let (chunk_hash, observed_at) =
-                    row.map_err(|error| database_error("decode negative lookup", error))?;
-                if observed_at >= cutoff && observed_at <= now {
-                    out.entry(chunk_hash.into()).or_insert(None);
+                let (chunk_hash, candidate, observed_at) =
+                    row.map_err(|error| database_error("decode lookup", error))?;
+                if let Some(candidate) = candidate {
+                    out.insert(chunk_hash.into(), Some(candidate));
+                } else if let Some(observed_at) = observed_at {
+                    if observed_at >= cutoff && observed_at <= now {
+                        out.entry(chunk_hash.into()).or_insert(None);
+                    } else {
+                        expired.push(chunk_hash);
+                    }
                 } else {
-                    expired.push(chunk_hash);
+                    return Err(CrabError::Internal(
+                        "add remote candidate cache returned an invalid row".into(),
+                    ));
                 }
             }
             if !expired.is_empty() {
-                let mut statement = connection
-                    .prepare_cached(&format!(
-                        "DELETE FROM {NEGATIVE_TABLE} WHERE chunk_hash = ?1"
-                    ))
-                    .map_err(|error| database_error("prepare expired negative delete", error))?;
-                for chunk_hash in expired {
-                    statement
-                        .execute(params![chunk_hash.as_slice()])
+                for expired_batch in expired.chunks(LOOKUP_BATCH_SIZE) {
+                    let placeholders = std::iter::repeat_n("?", expired_batch.len())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let query = format!(
+                        "DELETE FROM {NEGATIVE_TABLE} WHERE chunk_hash IN ({placeholders})"
+                    );
+                    connection
+                        .execute(
+                            &query,
+                            params_from_iter(expired_batch.iter().map(|hash| hash.as_slice())),
+                        )
                         .map_err(|error| database_error("delete expired negative", error))?;
                 }
             }

--- a/crab/src/cache/add_remote_candidates/tests.rs
+++ b/crab/src/cache/add_remote_candidates/tests.rs
@@ -1,0 +1,326 @@
+use super::*;
+use tempfile::tempdir;
+
+#[test]
+fn persistent_promotion_preserves_negative_expiry() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let hash = MerkleHash::from([11; 32]);
+    cache
+        .persist_unique_results(&[(hash, None)])
+        .expect("persist");
+    let now = current_unix_timestamp().expect("clock");
+    let observed_at = now - NEGATIVE_TTL.as_secs() as i64 + 10;
+    cache
+        .connection
+        .lock()
+        .expect("lock")
+        .execute(
+            "UPDATE remote_candidate_misses_v1 SET observed_at = ?1",
+            [observed_at],
+        )
+        .expect("age negative");
+    assert_eq!(
+        cache.load_persistent(&[hash]).expect("promote").get(&hash),
+        Some(&None)
+    );
+    assert!(
+        cache
+            .memory_get_batch_at(&[hash], now + 10)
+            .expect("expired lookup")
+            .is_empty()
+    );
+}
+
+#[test]
+fn memory_negatives_expire_but_positive_proofs_remain_candidates() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let negative = MerkleHash::from([12; 32]);
+    let positive = MerkleHash::from([13; 32]);
+    cache
+        .memory_insert_batch(&[(negative, None), (positive, Some(candidate(13)))])
+        .expect("insert");
+    let later = current_unix_timestamp().expect("clock") + NEGATIVE_TTL.as_secs() as i64;
+    assert_eq!(
+        cache
+            .memory_get_batch_at(&[negative, positive], later)
+            .expect("lookup"),
+        HashMap::from([(positive, Some(candidate(13)))])
+    );
+}
+
+#[test]
+fn concurrent_connections_preserve_capacity_and_counts() {
+    let dir = tempdir().expect("tempdir");
+    let path = cache_path(&dir);
+    drop(AddRemoteCandidateCache::open(&path).expect("initialize"));
+    std::thread::scope(|scope| {
+        for writer in 0..4u64 {
+            let path = &path;
+            scope.spawn(move || {
+                let cache = AddRemoteCandidateCache::open(path).expect("open writer");
+                let entries = (0..400u64)
+                    .map(|index| {
+                        let mut hash = [0; 32];
+                        hash[..8].copy_from_slice(&(writer * 400 + index).to_le_bytes());
+                        (MerkleHash::from(hash), Some(candidate(writer as u8)))
+                    })
+                    .collect::<Vec<_>>();
+                cache
+                    .persist_unique_results(&entries)
+                    .expect("positive write");
+                let misses = entries
+                    .iter()
+                    .map(|(hash, _)| (*hash, None))
+                    .collect::<Vec<_>>();
+                cache
+                    .persist_unique_results(&misses)
+                    .expect("negative replacement");
+                cache
+                    .persist_unique_results(&entries)
+                    .expect("positive replacement");
+            });
+        }
+    });
+    let cache = AddRemoteCandidateCache::open(&path).expect("reopen");
+    let counts: (i64, i64) = cache
+        .connection
+        .lock()
+        .expect("lock")
+        .query_row(
+            "SELECT positives + negatives,
+                (SELECT COUNT(*) FROM remote_candidates_v1) +
+                (SELECT COUNT(*) FROM remote_candidate_misses_v1) FROM cache_counts",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("count");
+    assert_eq!(counts, (MAX_PERSISTENT_ENTRIES, MAX_PERSISTENT_ENTRIES));
+}
+
+#[test]
+fn persistent_capacity_survives_repeated_reopens() {
+    let dir = tempdir().expect("tempdir");
+    for page in 0..4u64 {
+        let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+        let entries = (0..400u64)
+            .map(|offset| {
+                let mut hash = [0; 32];
+                hash[..8].copy_from_slice(&(page * 400 + offset).to_le_bytes());
+                (MerkleHash::from(hash), None)
+            })
+            .collect::<Vec<_>>();
+        cache.persist_unique_results(&entries).expect("persist");
+        let count: i64 = cache
+            .connection
+            .lock()
+            .expect("lock")
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM remote_candidates_v1) +
+                    (SELECT COUNT(*) FROM remote_candidate_misses_v1)",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count");
+        assert!(
+            count <= MAX_PERSISTENT_ENTRIES,
+            "cache grew to {count} entries"
+        );
+    }
+}
+
+fn candidate(seed: u8) -> ExistingChunkCandidate {
+    ExistingChunkCandidate {
+        xorb_ref: XorbRef {
+            xorb_hash: MerkleHash::from([seed; 32]),
+            chunk_index: u32::from(seed),
+            uncompressed_size: 4096,
+        },
+        placement_id: [seed.wrapping_add(1); 32],
+        origin_proof_id: [seed.wrapping_add(2); 32],
+    }
+}
+
+fn cache_path(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    let root = dir.path().join("cache");
+    crab_cache::ensure_private_cache_directory(&root).expect("private cache root");
+    root.join("cache.sqlite")
+}
+
+#[test]
+fn persistent_candidates_round_trip() {
+    let dir = tempdir().expect("tempdir");
+    let path = cache_path(&dir);
+    let cache = AddRemoteCandidateCache::open(&path).expect("open");
+    let hash = MerkleHash::from([7; 32]);
+    cache
+        .persist_results(&[(hash, Some(candidate(7)))])
+        .expect("persist");
+    cache
+        .persist_results(&[(hash, Some(candidate(8)))])
+        .expect("refresh");
+    let loaded = cache.load_persistent(&[hash]).expect("load");
+    assert_eq!(loaded.get(&hash), Some(&Some(candidate(8))));
+}
+
+#[test]
+fn persistent_negative_entries_round_trip_and_refresh() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let hash = MerkleHash::from([4; 32]);
+    cache
+        .persist_results(&[(hash, None)])
+        .expect("persist negative");
+    assert_eq!(
+        cache.load_persistent(&[hash]).expect("load").get(&hash),
+        Some(&None)
+    );
+
+    cache
+        .persist_results(&[(hash, Some(candidate(4)))])
+        .expect("refresh positive");
+    assert_eq!(
+        cache.load_persistent(&[hash]).expect("load").get(&hash),
+        Some(&Some(candidate(4)))
+    );
+}
+
+#[test]
+fn persistent_duplicate_results_keep_input_order() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let hash = MerkleHash::from([6; 32]);
+
+    cache
+        .persist_results(&[(hash, Some(candidate(6))), (hash, None)])
+        .expect("persist negative last");
+    assert_eq!(
+        cache.load_persistent(&[hash]).expect("load").get(&hash),
+        Some(&None)
+    );
+
+    cache
+        .persist_results(&[(hash, None), (hash, Some(candidate(6)))])
+        .expect("persist positive last");
+    assert_eq!(
+        cache.load_persistent(&[hash]).expect("load").get(&hash),
+        Some(&Some(candidate(6)))
+    );
+}
+
+#[test]
+fn expired_negative_entries_are_not_reused() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let hash = MerkleHash::from([5; 32]);
+    cache
+        .persist_results(&[(hash, None)])
+        .expect("persist negative");
+    cache
+        .connection
+        .lock()
+        .expect("database lock")
+        .execute(
+            "UPDATE remote_candidate_misses_v1 SET observed_at = 0 WHERE chunk_hash = ?1",
+            params![<[u8; 32]>::from(hash).as_slice()],
+        )
+        .expect("age negative");
+
+    assert!(
+        !cache
+            .load_persistent(&[hash])
+            .expect("load")
+            .contains_key(&hash)
+    );
+    let remaining: i64 = cache
+        .connection
+        .lock()
+        .expect("database lock")
+        .query_row(
+            "SELECT COUNT(*) FROM remote_candidate_misses_v1 WHERE chunk_hash = ?1",
+            params![<[u8; 32]>::from(hash).as_slice()],
+            |row| row.get(0),
+        )
+        .expect("count expired");
+    assert_eq!(remaining, 0);
+}
+
+#[test]
+fn memory_cache_distinguishes_negative_entries() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let hash = MerkleHash::from([3; 32]);
+    assert!(
+        !cache
+            .memory_get_batch(&[hash])
+            .expect("lookup")
+            .contains_key(&hash)
+    );
+    cache.memory_insert_batch(&[(hash, None)]).expect("insert");
+    assert_eq!(
+        cache.memory_get_batch(&[hash]).expect("lookup").get(&hash),
+        Some(&None)
+    );
+}
+
+#[test]
+fn memory_batch_cache_preserves_positive_negative_and_misses() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let positive_hash = MerkleHash::from([8; 32]);
+    let negative_hash = MerkleHash::from([9; 32]);
+    let missing_hash = MerkleHash::from([10; 32]);
+    cache
+        .memory_insert_batch(&[(positive_hash, Some(candidate(8))), (negative_hash, None)])
+        .expect("insert batch");
+
+    let loaded = cache
+        .memory_get_batch(&[positive_hash, negative_hash, missing_hash])
+        .expect("lookup batch");
+    assert_eq!(loaded.get(&positive_hash), Some(&Some(candidate(8))));
+    assert_eq!(loaded.get(&negative_hash), Some(&None));
+    assert!(!loaded.contains_key(&missing_hash));
+}
+
+#[test]
+fn persistent_lookup_batches_large_requests() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let entries = (0..600u16)
+        .map(|seed| {
+            let mut bytes = [0; 32];
+            bytes[..2].copy_from_slice(&seed.to_le_bytes());
+            (MerkleHash::from(bytes), candidate((seed % 256) as u8))
+        })
+        .collect::<Vec<_>>();
+    let entries = entries
+        .into_iter()
+        .map(|(hash, candidate)| (hash, Some(candidate)))
+        .collect::<Vec<_>>();
+    cache
+        .persist_unique_results(&entries)
+        .expect("persist unique");
+    let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
+    assert_eq!(cache.load_persistent(&hashes).expect("load").len(), 600);
+}
+
+#[test]
+fn persistent_negative_writes_batch_large_requests() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let entries = (0..600u16)
+        .map(|seed| {
+            let mut bytes = [0; 32];
+            bytes[..2].copy_from_slice(&seed.to_le_bytes());
+            (MerkleHash::from(bytes), None)
+        })
+        .collect::<Vec<_>>();
+    cache
+        .persist_unique_results(&entries)
+        .expect("persist unique negatives");
+    let hashes = entries.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
+    let loaded = cache.load_persistent(&hashes).expect("load negatives");
+    assert_eq!(loaded.len(), 600);
+    assert!(loaded.values().all(Option::is_none));
+}

--- a/crab/src/cache/add_remote_candidates/tests.rs
+++ b/crab/src/cache/add_remote_candidates/tests.rs
@@ -2,6 +2,49 @@ use super::*;
 use tempfile::tempdir;
 
 #[test]
+fn committed_chunks_forget_only_matching_negatives_in_both_tiers() {
+    let dir = tempdir().expect("tempdir");
+    let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");
+    let committed = MerkleHash::from([21; 32]);
+    let pending = MerkleHash::from([22; 32]);
+    let positive = MerkleHash::from([23; 32]);
+    let entries = [
+        (committed, None),
+        (pending, None),
+        (positive, Some(candidate(23))),
+    ];
+    cache.persist_unique_results(&entries).expect("persist");
+    cache
+        .load_persistent(&[committed, pending, positive])
+        .expect("promote");
+    cache
+        .forget_negatives(&[committed, positive])
+        .expect("commit invalidation");
+    let expected = HashMap::from([(pending, None), (positive, Some(candidate(23)))]);
+    assert_eq!(
+        cache
+            .memory_get_batch(&[committed, pending, positive])
+            .expect("memory"),
+        expected
+    );
+    assert_eq!(
+        cache
+            .load_persistent(&[committed, pending, positive])
+            .expect("disk"),
+        expected
+    );
+    let counts: (i64, i64) = cache
+        .connection
+        .lock()
+        .expect("lock")
+        .query_row("SELECT positives, negatives FROM cache_counts", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .expect("counts");
+    assert_eq!(counts, (1, 1));
+}
+
+#[test]
 fn persistent_promotion_preserves_negative_expiry() {
     let dir = tempdir().expect("tempdir");
     let cache = AddRemoteCandidateCache::open(&cache_path(&dir)).expect("open");

--- a/crab/src/cache/add_validation.rs
+++ b/crab/src/cache/add_validation.rs
@@ -85,10 +85,10 @@ impl AddValidationCache {
         if entries.is_empty() {
             return Ok(HashSet::new());
         }
-        let expected = entries.iter().copied().collect::<HashMap<_, _>>();
         let mut hits = HashSet::new();
         const LOOKUP_BATCH_SIZE: usize = 512;
         for batch in entries.chunks(LOOKUP_BATCH_SIZE) {
+            let expected = batch.iter().copied().collect::<HashMap<_, _>>();
             let placeholders = std::iter::repeat_n("?", batch.len())
                 .collect::<Vec<_>>()
                 .join(",");

--- a/crab/src/cache/add_validation.rs
+++ b/crab/src/cache/add_validation.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use bstr::ByteSlice;
 use crab_types::pointer::Pointer;
-use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
+use rusqlite::{Connection, params_from_iter};
 
 use crate::core::error::{CrabError, Result};
 
@@ -66,16 +66,6 @@ impl AddValidationCache {
         }
 
         Ok(Self { connection })
-    }
-
-    pub(crate) fn contains(&self, path: &[u8], token: &[u8; 32]) -> Result<bool> {
-        self.connection
-            .prepare_cached("SELECT 1 FROM add_validations WHERE path = ?1 AND token = ?2")
-            .map_err(|error| database_error("prepare add validation cache query", error))?
-            .query_row(params![path, token.as_slice()], |_| Ok(()))
-            .optional()
-            .map(|row| row.is_some())
-            .map_err(|error| database_error("query add validation cache", error))
     }
 
     pub(crate) fn contains_batch(
@@ -315,8 +305,12 @@ mod tests {
 
         cache.upsert(&[(literal_path.clone(), token)]).unwrap();
 
-        assert!(cache.contains(&literal_path, &token).unwrap());
-        assert!(!cache.contains(b"model.bin", &token).unwrap());
+        assert_eq!(
+            cache
+                .contains_batch(&[(&literal_path, &token), (b"model.bin", &token)])
+                .unwrap(),
+            HashSet::from([literal_path])
+        );
     }
 
     #[test]

--- a/crab/src/cache/add_validation.rs
+++ b/crab/src/cache/add_validation.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use bstr::ByteSlice;
 use crab_types::pointer::Pointer;
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 
 use crate::core::error::{CrabError, Result};
 
@@ -85,18 +85,29 @@ impl AddValidationCache {
             .connection
             .transaction()
             .map_err(|error| database_error("begin add validation cache update", error))?;
-        {
+        // Two bind variables per row keep batches below SQLite's default
+        // 999-variable limit while avoiding one statement per file.
+        const UPSERT_BATCH_SIZE: usize = 256;
+        for batch in rows.chunks(UPSERT_BATCH_SIZE) {
+            let values_sql = std::iter::repeat_n("(?,?)", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query = format!(
+                "INSERT INTO add_validations(path, token) VALUES {values_sql}
+                 ON CONFLICT(path) DO UPDATE SET token = excluded.token"
+            );
             let mut statement = transaction
-                .prepare_cached(
-                    "INSERT INTO add_validations(path, token) VALUES (?1, ?2)
-                     ON CONFLICT(path) DO UPDATE SET token = excluded.token",
-                )
+                .prepare_cached(&query)
                 .map_err(|error| database_error("prepare add validation cache update", error))?;
-            for (path, token) in rows {
-                statement
-                    .execute(params![path, token.as_slice()])
-                    .map_err(|error| database_error("write add validation cache row", error))?;
+            let mut values: Vec<&dyn rusqlite::ToSql> =
+                Vec::with_capacity(batch.len().saturating_mul(2));
+            for (path, token) in batch {
+                values.push(path.as_slice() as &dyn rusqlite::ToSql);
+                values.push(token.as_slice() as &dyn rusqlite::ToSql);
             }
+            statement
+                .execute(params_from_iter(values))
+                .map_err(|error| database_error("write add validation cache batch", error))?;
         }
         transaction
             .commit()
@@ -254,6 +265,26 @@ mod tests {
 
         assert!(cache.contains(&literal_path, &token).unwrap());
         assert!(!cache.contains(b"model.bin", &token).unwrap());
+    }
+
+    #[test]
+    fn cache_upsert_batches_large_requests() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(ADD_VALIDATIONS_FILENAME);
+        let mut cache = AddValidationCache::open(&path).unwrap();
+        let rows = (0..600_u16)
+            .map(|index| {
+                let mut path = b"file-".to_vec();
+                path.extend_from_slice(&index.to_le_bytes());
+                (path, [index as u8; 32])
+            })
+            .collect::<Vec<_>>();
+
+        cache.upsert(&rows).unwrap();
+
+        for (path, token) in rows {
+            assert!(cache.contains(&path, &token).unwrap());
+        }
     }
 
     #[test]

--- a/crab/src/cache/add_validation.rs
+++ b/crab/src/cache/add_validation.rs
@@ -5,6 +5,7 @@
 //! and every filesystem stat field captured during verification. An exact
 //! token can resolve Git's racy-stat ambiguity; a miss must hash the file.
 
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -75,6 +76,49 @@ impl AddValidationCache {
             .optional()
             .map(|row| row.is_some())
             .map_err(|error| database_error("query add validation cache", error))
+    }
+
+    pub(crate) fn contains_batch(
+        &self,
+        entries: &[(&[u8], &[u8; 32])],
+    ) -> Result<HashSet<Vec<u8>>> {
+        if entries.is_empty() {
+            return Ok(HashSet::new());
+        }
+        let expected = entries.iter().copied().collect::<HashMap<_, _>>();
+        let mut hits = HashSet::new();
+        const LOOKUP_BATCH_SIZE: usize = 512;
+        for batch in entries.chunks(LOOKUP_BATCH_SIZE) {
+            let placeholders = std::iter::repeat_n("?", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query =
+                format!("SELECT path, token FROM add_validations WHERE path IN ({placeholders})");
+            let mut statement = self.connection.prepare_cached(&query).map_err(|error| {
+                database_error("prepare add validation cache lookup batch", error)
+            })?;
+            let paths = batch.iter().map(|(path, _)| *path).collect::<Vec<_>>();
+            let rows = statement
+                .query_map(params_from_iter(paths.iter().copied()), |row| {
+                    let path = row.get::<_, Vec<u8>>(0)?;
+                    let token = row.get::<_, Vec<u8>>(1)?;
+                    Ok((path, token))
+                })
+                .map_err(|error| {
+                    database_error("query add validation cache lookup batch", error)
+                })?;
+            for row in rows {
+                let (path, token) = row
+                    .map_err(|error| database_error("decode add validation cache lookup", error))?;
+                if expected
+                    .get(path.as_slice())
+                    .is_some_and(|expected_token| token.as_slice() == &expected_token[..])
+                {
+                    hits.insert(path);
+                }
+            }
+        }
+        Ok(hits)
     }
 
     pub(crate) fn upsert(&mut self, rows: &[(Vec<u8>, [u8; 32])]) -> Result<()> {
@@ -290,9 +334,27 @@ mod tests {
 
         cache.upsert(&rows).unwrap();
 
-        for (path, token) in rows {
-            assert!(cache.contains(&path, &token).unwrap());
-        }
+        let entries = rows
+            .iter()
+            .map(|(path, token)| (path.as_slice(), token))
+            .collect::<Vec<_>>();
+        let hits = cache.contains_batch(&entries).unwrap();
+        assert_eq!(hits.len(), rows.len());
+        assert!(rows.iter().all(|(path, _)| hits.contains(path)));
+    }
+
+    #[test]
+    fn cache_batch_lookup_requires_exact_token() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(ADD_VALIDATIONS_FILENAME);
+        let mut cache = AddValidationCache::open(&path).unwrap();
+        let literal_path = b"model.bin".to_vec();
+        let token = [7; 32];
+        let wrong_token = [8; 32];
+        cache.upsert(&[(literal_path.clone(), token)]).unwrap();
+
+        let entries = [(literal_path.as_slice(), &wrong_token)];
+        assert!(cache.contains_batch(&entries).unwrap().is_empty());
     }
 
     #[test]

--- a/crab/src/cache/add_validation.rs
+++ b/crab/src/cache/add_validation.rs
@@ -101,9 +101,17 @@ impl AddValidationCache {
                 .map_err(|error| database_error("prepare add validation cache update", error))?;
             let mut values: Vec<&dyn rusqlite::ToSql> =
                 Vec::with_capacity(batch.len().saturating_mul(2));
-            for (path, token) in batch {
-                values.push(path.as_slice() as &dyn rusqlite::ToSql);
-                values.push(token.as_slice() as &dyn rusqlite::ToSql);
+            let paths = batch
+                .iter()
+                .map(|(path, _)| path.as_slice())
+                .collect::<Vec<_>>();
+            let tokens = batch
+                .iter()
+                .map(|(_, token)| token.as_slice())
+                .collect::<Vec<_>>();
+            for index in 0..batch.len() {
+                values.push(&paths[index] as &dyn rusqlite::ToSql);
+                values.push(&tokens[index] as &dyn rusqlite::ToSql);
             }
             statement
                 .execute(params_from_iter(values))

--- a/crab/src/cache/mod.rs
+++ b/crab/src/cache/mod.rs
@@ -25,6 +25,7 @@ use crab_types::storage::StorageProviderKind;
 pub mod chunks {
     pub use crab_vfs::chunk_cache::*;
 }
+pub(crate) mod add_remote_candidates;
 pub(crate) mod add_validation;
 pub mod hydrated_pointer;
 pub mod shard_hints {
@@ -67,6 +68,23 @@ pub(crate) fn chunk_index_cache_path(cache_root: &Path, identity: &BucketIdentit
         .join("chunk-index.sqlite")
 }
 
+/// Return the scoped persistent add-time remote-candidate cache path.
+pub(crate) fn add_remote_candidate_cache_path(
+    cache_root: &Path,
+    identity: &BucketIdentity,
+    global_prefix: &str,
+) -> PathBuf {
+    let chunk_index_path = chunk_index_cache_path(cache_root, identity);
+    let Some(parent) = chunk_index_path.parent() else {
+        return cache_root.join("remote-candidates.sqlite");
+    };
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"crab-add-remote-candidates-v1\0");
+    hasher.update(global_prefix.as_bytes());
+    let hex = hasher.finalize().to_hex();
+    parent.join(format!("remote-candidates-{}.sqlite", &hex[..16]))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,5 +105,17 @@ mod tests {
             chunk_index_cache_path(root, &other)
         );
         assert!(chunk_index_cache_path(root, &first).ends_with("chunk-index.sqlite"));
+    }
+
+    #[test]
+    fn add_remote_candidate_cache_isolated_by_global_prefix() {
+        let root = Path::new("cache");
+        let bucket = BucketIdentity::new(StorageProviderKind::S3, "bucket-a", "bucket-a");
+        let first = add_remote_candidate_cache_path(root, &bucket, "repo-a/.crab");
+        let same = add_remote_candidate_cache_path(root, &bucket, "repo-a/.crab");
+        let other = add_remote_candidate_cache_path(root, &bucket, "repo-b/.crab");
+        assert_eq!(first, same);
+        assert_ne!(first, other);
+        assert!(first.ends_with(".sqlite"));
     }
 }

--- a/crab/src/cache/mod.rs
+++ b/crab/src/cache/mod.rs
@@ -116,6 +116,9 @@ mod tests {
         let other = add_remote_candidate_cache_path(root, &bucket, "repo-b/.crab");
         assert_eq!(first, same);
         assert_ne!(first, other);
-        assert!(first.ends_with(".sqlite"));
+        assert_eq!(
+            first.extension().and_then(|extension| extension.to_str()),
+            Some("sqlite")
+        );
     }
 }

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -982,7 +982,7 @@ async fn execute_add(
     let filter = build_filter(&args.patterns, &[])?;
 
     // Walk the working tree and collect files to process.
-    let candidates = collect_candidates(&repo_root, &classifier, &filter, cancel)?;
+    let candidates = collect_candidates(&repo_root, &classifier, &filter, &args.patterns, cancel)?;
 
     if candidates.is_empty() {
         if args.dry_run {
@@ -2622,8 +2622,15 @@ fn collect_candidates(
     repo_root: &Path,
     classifier: &TrackedClassifier,
     filter: &PatternFilter,
+    patterns: &[String],
     cancel: &CancellationToken,
 ) -> Result<Vec<(PathBuf, u64)>> {
+    if let Some(candidates) =
+        collect_literal_candidates(repo_root, classifier, filter, patterns, cancel)?
+    {
+        return Ok(candidates);
+    }
+
     let mut candidates = Vec::new();
 
     #[cfg(feature = "gix-pathmatch")]
@@ -2651,6 +2658,207 @@ fn collect_candidates(
     )?;
 
     Ok(candidates)
+}
+
+/// Return direct candidates when every selector names a repo-relative file or
+/// directory. A literal basename can match files at any depth, so it
+/// deliberately falls back to the walker; path-qualified selectors are
+/// unambiguous.
+fn collect_literal_candidates(
+    repo_root: &Path,
+    classifier: &TrackedClassifier,
+    filter: &PatternFilter,
+    patterns: &[String],
+    cancel: &CancellationToken,
+) -> Result<Option<Vec<(PathBuf, u64)>>> {
+    if patterns.is_empty() || patterns.iter().any(|pattern| !is_literal_path(pattern)) {
+        return Ok(None);
+    }
+
+    let mut candidates = Vec::with_capacity(patterns.len());
+    let mut seen_files = HashSet::with_capacity(patterns.len());
+    let mut direct_files = Vec::with_capacity(patterns.len());
+    let mut direct_dirs = Vec::with_capacity(patterns.len());
+    for pattern in patterns {
+        error::check_cancelled(cancel)?;
+        let Some(rel_path) = literal_relative_path(pattern) else {
+            return Ok(None);
+        };
+        let abs_path = repo_root.join(&rel_path);
+        let metadata = match std::fs::symlink_metadata(&abs_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        if metadata.file_type().is_file() {
+            if literal_path_has_hidden_parent(&rel_path) || !seen_files.insert(rel_path.clone()) {
+                continue;
+            }
+            direct_files.push((rel_path, abs_path, metadata.len()));
+        } else if metadata.file_type().is_dir() {
+            if rel_path
+                .components()
+                .any(|component| matches!(component, std::path::Component::Normal(name) if name.to_string_lossy().starts_with('.')))
+            {
+                continue;
+            }
+            direct_dirs.push((rel_path, abs_path));
+        } else {
+            return Ok(None);
+        }
+    }
+
+    for (rel_path, abs_path, file_size) in direct_files {
+        error::check_cancelled(cancel)?;
+
+        #[cfg(feature = "gix-pathmatch")]
+        if literal_candidate_is_ignored(repo_root, &rel_path)? {
+            continue;
+        }
+        if !classifier.is_tracked(&rel_path) {
+            continue;
+        }
+        let rel_str = rel_path.to_string_lossy();
+        if !filter.matches(&rel_str)
+            || crate::engine::pointer::is_working_tree_pointer(&abs_path).unwrap_or(false)
+        {
+            continue;
+        }
+        candidates.push((abs_path, file_size));
+    }
+
+    direct_dirs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    direct_dirs.dedup_by(|(left, _), (right, _)| left == right);
+    let mut selected_dirs = Vec::with_capacity(direct_dirs.len());
+    for (rel_path, abs_path) in direct_dirs {
+        if selected_dirs
+            .iter()
+            .any(|(parent, _)| rel_path.starts_with(parent))
+        {
+            continue;
+        }
+        selected_dirs.push((rel_path, abs_path));
+    }
+
+    let mut seen_paths = candidates
+        .iter()
+        .map(|(path, _)| path.clone())
+        .collect::<HashSet<_>>();
+    for (rel_path, abs_path) in selected_dirs {
+        error::check_cancelled(cancel)?;
+        let mut directory_candidates = Vec::new();
+        #[cfg(feature = "gix-pathmatch")]
+        {
+            let ignore = crate::core::attrs::IgnoreReader::open(repo_root)?;
+            if literal_directory_is_ignored(repo_root, &rel_path, &ignore)? {
+                continue;
+            }
+            walk_candidates(
+                repo_root,
+                &abs_path,
+                classifier,
+                filter,
+                Some(&ignore),
+                cancel,
+                &mut directory_candidates,
+            )?;
+        }
+        #[cfg(not(feature = "gix-pathmatch"))]
+        walk_candidates(
+            repo_root,
+            &abs_path,
+            classifier,
+            filter,
+            cancel,
+            &mut directory_candidates,
+        )?;
+        for (path, size) in directory_candidates {
+            if seen_paths.insert(path.clone()) {
+                candidates.push((path, size));
+            }
+        }
+    }
+
+    Ok(Some(candidates))
+}
+
+fn is_literal_path(pattern: &str) -> bool {
+    pattern.contains('/')
+        && !pattern.starts_with(':')
+        && !pattern.contains('*')
+        && !pattern.contains('?')
+        && !pattern.contains('[')
+}
+
+fn literal_relative_path(pattern: &str) -> Option<PathBuf> {
+    let path = Path::new(pattern);
+    if path.is_absolute() {
+        return None;
+    }
+    let mut relative = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(part) => relative.push(part),
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => return None,
+        }
+    }
+    (!relative.as_os_str().is_empty()).then_some(relative)
+}
+
+fn literal_path_has_hidden_parent(path: &Path) -> bool {
+    let components = path.components().collect::<Vec<_>>();
+    components
+        .iter()
+        .take(components.len().saturating_sub(1))
+        .any(|component| {
+            matches!(component, std::path::Component::Normal(name)
+                if name.to_string_lossy().starts_with('.'))
+        })
+}
+
+#[cfg(feature = "gix-pathmatch")]
+fn literal_directory_is_ignored(
+    repo_root: &Path,
+    rel_path: &Path,
+    ignore: &crate::core::attrs::IgnoreReader,
+) -> Result<bool> {
+    let mut current = repo_root.to_path_buf();
+    let mut relative = PathBuf::new();
+    for component in rel_path.components() {
+        let std::path::Component::Normal(name) = component else {
+            continue;
+        };
+        relative.push(name);
+        if ignore.is_ignored(&relative.to_string_lossy(), true) {
+            return Ok(true);
+        }
+        current.push(name);
+        ignore.append_patterns_from_file(&current.join(".gitignore"), Some(repo_root));
+    }
+    Ok(false)
+}
+
+#[cfg(feature = "gix-pathmatch")]
+fn literal_candidate_is_ignored(repo_root: &Path, rel_path: &Path) -> Result<bool> {
+    let ignore = crate::core::attrs::IgnoreReader::open(repo_root)?;
+    let mut current = repo_root.to_path_buf();
+    let mut relative = PathBuf::new();
+    let components = rel_path.components().collect::<Vec<_>>();
+    for component in components.iter().take(components.len().saturating_sub(1)) {
+        let std::path::Component::Normal(name) = component else {
+            continue;
+        };
+        relative.push(name);
+        if ignore.is_ignored(&relative.to_string_lossy(), true) {
+            return Ok(true);
+        }
+        current.push(name);
+        ignore.append_patterns_from_file(&current.join(".gitignore"), Some(repo_root));
+    }
+    Ok(ignore.is_ignored(&rel_path.to_string_lossy(), false))
 }
 
 async fn filter_clean_indexed_candidates(
@@ -2974,8 +3182,7 @@ fn walk_candidates(
         }
 
         // Get file size for reporting.
-        let metadata = std::fs::metadata(&path)?;
-        let file_size = metadata.len();
+        let file_size = entry.metadata()?.len();
 
         // Skip files that are already pointers (e.g. lazy-checkout left
         // the pointer on disk, or `crab dehydrate` was run). These don't
@@ -3048,8 +3255,7 @@ fn walk_candidates(
         }
 
         // Get file size for reporting.
-        let metadata = std::fs::metadata(&path)?;
-        let file_size = metadata.len();
+        let file_size = entry.metadata()?.len();
 
         // Skip files that are already pointers (e.g. lazy-checkout left
         // the pointer on disk, or `crab dehydrate` was run). These don't
@@ -4035,6 +4241,39 @@ mod tests {
 
         assert!(cls.is_tracked(Path::new("qualification/model.bin")));
         assert!(!cls.is_tracked(Path::new("other/model.bin")));
+    }
+
+    #[test]
+    fn literal_path_candidates_avoid_repository_walk() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("models")).unwrap();
+        std::fs::create_dir_all(dir.path().join("other")).unwrap();
+        std::fs::write(dir.path().join(".gitattributes"), "*.bin filter=crab\n").unwrap();
+        std::fs::write(dir.path().join("models/a.bin"), b"model").unwrap();
+        std::fs::write(dir.path().join("other/a.bin"), b"other").unwrap();
+
+        let classifier = TrackedClassifier::open(dir.path()).unwrap();
+        let filter = build_filter(&["models/a.bin".to_owned()], &[]).unwrap();
+        let candidates = collect_candidates(
+            dir.path(),
+            &classifier,
+            &filter,
+            &["models/a.bin".to_owned()],
+            &CancellationToken::new(),
+        )
+        .unwrap();
+
+        assert_eq!(candidates, vec![(dir.path().join("models/a.bin"), 5)]);
+    }
+
+    #[test]
+    fn literal_path_detection_rejects_ambiguous_selectors() {
+        assert!(is_literal_path("models/a.bin"));
+        assert!(!is_literal_path("a.bin"));
+        assert!(!is_literal_path("models/*.bin"));
+        assert!(literal_relative_path("./models/a.bin").is_some());
+        assert!(literal_relative_path("../outside.bin").is_none());
+        assert!(literal_relative_path("/outside.bin").is_none());
     }
 
     #[test]

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -3554,6 +3554,10 @@ fn write_pointers_and_tracking_to_git_index(
             )))
         })?)
     };
+    // Identical files produce identical pointer payloads. Git's object store
+    // is content-addressed, so one blob write per unique payload is enough;
+    // reusing the OID avoids repeated filesystem work for duplicate paths.
+    let mut pointer_oids = HashMap::<Vec<u8>, String>::new();
 
     for entry in entries {
         // The cache may not contain this file on the first push; the
@@ -3565,8 +3569,14 @@ fn write_pointers_and_tracking_to_git_index(
                 "pointer repository was not opened for non-empty publication".to_owned(),
             ))
         })?;
-        let sha = write_pointer_blob_to_repo(pointer_repo, &payload)
-            .map_err(GitIndexWriteError::BeforeIndexMutation)?;
+        let sha = if let Some(sha) = pointer_oids.get(&payload) {
+            sha.clone()
+        } else {
+            let sha = write_pointer_blob_to_repo(pointer_repo, &payload)
+                .map_err(GitIndexWriteError::BeforeIndexMutation)?;
+            pointer_oids.insert(payload, sha.clone());
+            sha
+        };
 
         // The index-info record bypasses git's normal worktree mode detection,
         // so compute the regular-file mode here to match `git add`.

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -2684,6 +2684,25 @@ fn collect_literal_candidates(
         let Some(rel_path) = literal_relative_path(pattern) else {
             return Ok(None);
         };
+        // The full walker never descends through symlinks. A leaf-only stat
+        // would follow linked ancestors and prepare bytes outside the worktree.
+        let mut selected_path = repo_root.to_path_buf();
+        let mut linked = false;
+        for component in rel_path.components() {
+            selected_path.push(component);
+            match std::fs::symlink_metadata(&selected_path) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    linked = true;
+                    break;
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(error) => return Err(error.into()),
+            }
+        }
+        if linked {
+            continue;
+        }
         let abs_path = repo_root.join(&rel_path);
         let metadata = match std::fs::symlink_metadata(&abs_path) {
             Ok(metadata) => metadata,
@@ -3626,6 +3645,7 @@ struct GitIndexEntry {
     index_stat: crate::cmd::stream_stage::VerifiedIndexStat,
 }
 
+#[cfg(test)]
 fn write_pointer_blob(repo_root: &Path, payload: &[u8]) -> Result<String> {
     let repo = gix::open(repo_root).map_err(|e| {
         CrabError::Internal(format!("failed to open git repository for blob write: {e}"))
@@ -4305,6 +4325,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(candidates, vec![(dir.path().join("models/a.bin"), 5)]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn literal_candidates_skip_symlink_ancestors() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(outside.path().join("models")).unwrap();
+        std::fs::write(outside.path().join("models/a.bin"), b"outside").unwrap();
+        std::fs::write(dir.path().join(".gitattributes"), "*.bin filter=crab\n").unwrap();
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("linked")).unwrap();
+        let classifier = TrackedClassifier::open(dir.path()).unwrap();
+        for selector in ["linked/models/a.bin", "linked/models"] {
+            let patterns = vec![selector.to_owned()];
+            let filter = build_filter(&patterns, &[]).unwrap();
+            assert!(
+                collect_candidates(
+                    dir.path(),
+                    &classifier,
+                    &filter,
+                    &patterns,
+                    &CancellationToken::new()
+                )
+                .unwrap()
+                .is_empty(),
+                "{selector} followed a symlink ancestor"
+            );
+        }
     }
 
     #[test]

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -5251,6 +5251,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn clean_index_filter_defers_cache_setup_without_indexed_pointer() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("SKIP: git init failed");
+            return;
+        }
+
+        let path = dir.path().join("new-model.bin");
+        let payload = b"new model payload";
+        std::fs::write(&path, payload).unwrap();
+        let context = crate::git::worktree::WorktreeContext::resolve_from_path(dir.path()).unwrap();
+        let cache_path = crate::cache::add_validation::cache_path_for_context(&context);
+        assert!(!cache_path.exists());
+
+        let (to_process, skipped) = filter_clean_indexed_candidates(
+            dir.path(),
+            vec![(path, payload.len() as u64)],
+            1,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(to_process.len(), 1);
+        assert_eq!(skipped.files, 0);
+        assert!(!cache_path.exists());
+    }
+
+    #[tokio::test]
     #[cfg(unix)]
     async fn clean_index_filter_reuses_verified_add_validation() {
         let dir = tempfile::tempdir().unwrap();

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -2904,37 +2904,40 @@ async fn filter_clean_indexed_candidates(
     };
     let honor_filemode = git_honors_filemode(repo_root);
     let cache_path = crate::cache::add_validation::cache_path_for_context(&ctx);
-    let validation_cache = match crate::cache::add_validation::AddValidationCache::open(&cache_path)
-    {
-        Ok(cache) => Some(cache),
-        Err(error) => {
-            debug!(
-                path = %cache_path.display(),
-                error = %error,
-                "clean-index add validation cache unavailable; hashing candidates"
-            );
-            None
-        }
-    };
     let mut prepared = Vec::with_capacity(candidates.len());
     for (abs_path, size) in candidates {
         let indexed =
             clean_index_pointer(repo_root, &repo, &index, &abs_path, size, honor_filemode);
         prepared.push((abs_path, size, indexed));
     }
+    let lookup_entries = prepared
+        .iter()
+        .filter_map(|(_, _, indexed)| {
+            indexed.as_ref().and_then(|indexed| {
+                indexed
+                    .validation_token
+                    .as_ref()
+                    .map(|token| (indexed.path_bytes.as_slice(), token))
+            })
+        })
+        .collect::<Vec<_>>();
+    let validation_cache = if lookup_entries.is_empty() {
+        None
+    } else {
+        match crate::cache::add_validation::AddValidationCache::open(&cache_path) {
+            Ok(cache) => Some(cache),
+            Err(error) => {
+                debug!(
+                    path = %cache_path.display(),
+                    error = %error,
+                    "clean-index add validation cache unavailable; hashing candidates"
+                );
+                None
+            }
+        }
+    };
     let mut cache_hits = HashSet::new();
     if let Some(cache) = validation_cache.as_ref() {
-        let lookup_entries = prepared
-            .iter()
-            .filter_map(|(_, _, indexed)| {
-                indexed.as_ref().and_then(|indexed| {
-                    indexed
-                        .validation_token
-                        .as_ref()
-                        .map(|token| (indexed.path_bytes.as_slice(), token))
-                })
-            })
-            .collect::<Vec<_>>();
         match cache.contains_batch(&lookup_entries) {
             Ok(hits) => cache_hits = hits,
             Err(error) => {

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -2904,74 +2904,80 @@ async fn filter_clean_indexed_candidates(
     };
     let honor_filemode = git_honors_filemode(repo_root);
     let cache_path = crate::cache::add_validation::cache_path_for_context(&ctx);
-    let mut validation_cache =
-        match crate::cache::add_validation::AddValidationCache::open(&cache_path) {
-            Ok(cache) => Some(cache),
-            Err(error) => {
-                debug!(
-                    path = %cache_path.display(),
-                    error = %error,
-                    "clean-index add validation cache unavailable; hashing candidates"
-                );
-                None
-            }
-        };
+    let validation_cache = match crate::cache::add_validation::AddValidationCache::open(&cache_path)
+    {
+        Ok(cache) => Some(cache),
+        Err(error) => {
+            debug!(
+                path = %cache_path.display(),
+                error = %error,
+                "clean-index add validation cache unavailable; hashing candidates"
+            );
+            None
+        }
+    };
     let mut prepared = Vec::with_capacity(candidates.len());
     for (abs_path, size) in candidates {
         let indexed =
             clean_index_pointer(repo_root, &repo, &index, &abs_path, size, honor_filemode);
-        let cache_hit = match (
-            validation_cache.as_ref(),
-            indexed.as_ref(),
-            indexed
-                .as_ref()
-                .and_then(|indexed| indexed.validation_token.as_ref()),
-        ) {
-            (Some(cache), Some(indexed), Some(token)) => {
-                match cache.contains(&indexed.path_bytes, token) {
-                    Ok(hit) => hit,
-                    Err(error) => {
-                        debug!(
-                            path = %cache_path.display(),
-                            error = %error,
-                            "clean-index add validation cache query failed; hashing candidates"
-                        );
-                        validation_cache = None;
-                        false
-                    }
-                }
+        prepared.push((abs_path, size, indexed));
+    }
+    let mut cache_hits = HashSet::new();
+    if let Some(cache) = validation_cache.as_ref() {
+        let lookup_entries = prepared
+            .iter()
+            .filter_map(|(_, _, indexed)| {
+                indexed.as_ref().and_then(|indexed| {
+                    indexed
+                        .validation_token
+                        .as_ref()
+                        .map(|token| (indexed.path_bytes.as_slice(), token))
+                })
+            })
+            .collect::<Vec<_>>();
+        match cache.contains_batch(&lookup_entries) {
+            Ok(hits) => cache_hits = hits,
+            Err(error) => {
+                debug!(
+                    path = %cache_path.display(),
+                    error = %error,
+                    "clean-index add validation cache batch query failed; hashing candidates"
+                );
             }
-            _ => false,
-        };
-        prepared.push((abs_path, size, indexed, cache_hit));
+        }
     }
     let mut checks = futures_util::stream::iter(prepared)
-        .map(|(abs_path, size, indexed, cache_hit)| async move {
-            let (matches, verified) = if cache_hit {
-                (
-                    crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&abs_path)
-                        == indexed.as_ref().map(|indexed| indexed.verified_stat),
-                    None,
-                )
-            } else {
-                match indexed {
-                    Some(indexed) => {
-                        let verified = worktree_content_matches_pointer(
-                            &abs_path,
-                            size,
-                            indexed.expected_hash,
-                            cancel,
-                        )
-                        .await?;
-                        (
-                            verified.is_some(),
-                            verified.map(|stat| (indexed.expected_hash, stat)),
-                        )
+        .map(|(abs_path, size, indexed)| {
+            let cache_hit = indexed
+                .as_ref()
+                .is_some_and(|indexed| cache_hits.contains(&indexed.path_bytes));
+            async move {
+                let (matches, verified) = if cache_hit {
+                    (
+                        crate::cmd::stream_stage::VerifiedIndexStat::from_path_no_follow(&abs_path)
+                            == indexed.as_ref().map(|indexed| indexed.verified_stat),
+                        None,
+                    )
+                } else {
+                    match indexed {
+                        Some(indexed) => {
+                            let verified = worktree_content_matches_pointer(
+                                &abs_path,
+                                size,
+                                indexed.expected_hash,
+                                cancel,
+                            )
+                            .await?;
+                            (
+                                verified.is_some(),
+                                verified.map(|stat| (indexed.expected_hash, stat)),
+                            )
+                        }
+                        None => (false, None),
                     }
-                    None => (false, None),
-                }
-            };
-            Ok::<_, CrabError>((abs_path, size, matches, cache_hit, verified))
+                };
+                Ok::<_, CrabError>((abs_path, size, matches, cache_hit, verified))
+            }
         })
         .buffered(jobs.max(1));
 

--- a/crab/src/cmd/add.rs
+++ b/crab/src/cmd/add.rs
@@ -3499,6 +3499,10 @@ enum GitIndexWriteError {
 ///   3. Locks and rereads the current index, applies only the selected
 ///      pointer/stat deltas, and commits one atomic replacement.
 ///
+/// The Git repository handle is opened once for the whole batch so hundreds
+/// of small files do not pay repository discovery and object-store setup per
+/// pointer blob.
+///
 /// Why not just `git add`?  `git add` invokes the crab clean filter,
 /// which re-reads and re-hashes the full file just to emit the same
 /// pointer we can assemble from the data we already have. For a 1.6 GiB
@@ -3541,13 +3545,27 @@ fn write_pointers_and_tracking_to_git_index(
 ) -> std::result::Result<(), GitIndexWriteError> {
     let honor_filemode = git_honors_filemode(repo_root);
     let mut index_entries = Vec::with_capacity(entries.len());
+    let pointer_repo = if entries.is_empty() {
+        None
+    } else {
+        Some(gix::open(repo_root).map_err(|error| {
+            GitIndexWriteError::BeforeIndexMutation(CrabError::Internal(format!(
+                "failed to open git repository for pointer publication: {error}"
+            )))
+        })?)
+    };
 
     for entry in entries {
         // The cache may not contain this file on the first push; the
         // smudge path tolerates a missing hint.
         let pointer = shard_hints.pointer_for(entry.file_hash, entry.size);
         let payload = pointer.serialize();
-        let sha = write_pointer_blob(repo_root, &payload)
+        let pointer_repo = pointer_repo.as_ref().ok_or_else(|| {
+            GitIndexWriteError::BeforeIndexMutation(CrabError::Internal(
+                "pointer repository was not opened for non-empty publication".to_owned(),
+            ))
+        })?;
+        let sha = write_pointer_blob_to_repo(pointer_repo, &payload)
             .map_err(GitIndexWriteError::BeforeIndexMutation)?;
 
         // The index-info record bypasses git's normal worktree mode detection,
@@ -3593,6 +3611,10 @@ fn write_pointer_blob(repo_root: &Path, payload: &[u8]) -> Result<String> {
     let repo = gix::open(repo_root).map_err(|e| {
         CrabError::Internal(format!("failed to open git repository for blob write: {e}"))
     })?;
+    write_pointer_blob_to_repo(&repo, payload)
+}
+
+fn write_pointer_blob_to_repo(repo: &gix::Repository, payload: &[u8]) -> Result<String> {
     let oid = repo
         .write_blob(payload)
         .map_err(|e| CrabError::Internal(format!("failed to write pointer blob: {e}")))?;

--- a/crab/src/cmd/hydrate.rs
+++ b/crab/src/cmd/hydrate.rs
@@ -3963,7 +3963,12 @@ mod tests {
         let cache_path = crate::cache::add_validation::cache_path_for_context(&context);
         let cache = crate::cache::add_validation::AddValidationCache::open(&cache_path).unwrap();
 
-        assert!(cache.contains(b"model.bin", &token).unwrap());
+        assert!(
+            cache
+                .contains_batch(&[(b"model.bin", &token)])
+                .unwrap()
+                .contains(b"model.bin".as_slice())
+        );
     }
 
     #[cfg(unix)]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6805,17 +6805,41 @@ impl PushPipeline {
         Ok(())
     }
 
+    fn visit_recipe_chunks_cached(
+        &self,
+        recipe: &FileRecipe,
+        pages: &mut HashMap<([u8; 32], u64), Arc<crab_staging::recipe::RecipePage>>,
+        mut visit: impl FnMut(MerkleHash, u64) -> Result<()>,
+    ) -> Result<()> {
+        let recipe_hash = recipe.hash();
+        let mut next = 0u64;
+        while next < recipe.chunk_count() {
+            let page = match pages.entry((recipe_hash, next)) {
+                std::collections::hash_map::Entry::Occupied(entry) => Arc::clone(entry.get()),
+                std::collections::hash_map::Entry::Vacant(entry) => entry
+                    .insert(Arc::new(self.recipe_page(recipe, next)?))
+                    .clone(),
+            };
+            for chunk in &page.chunks {
+                visit(chunk.chunk_hash, chunk.len)?;
+            }
+            next = page.next_occurrence();
+        }
+        Ok(())
+    }
+
     fn build_file_terms_for_recipe(
         &self,
         file_hash: &MerkleHash,
         recipe: &FileRecipe,
+        pages: &mut HashMap<([u8; 32], u64), Arc<crab_staging::recipe::RecipePage>>,
         placement: &mut ChunkPlacementMap,
         verified_existing: &ChunkPlacementMap,
         fail_fast_on_missing: bool,
     ) -> Result<Vec<FileTerm>> {
         let mut builder = crab_xet::reconstruction::FileTermBuilder::new();
         let mut chunk_index = 0usize;
-        self.visit_recipe_chunks(recipe, |chunk_hash, _| {
+        self.visit_recipe_chunks_cached(recipe, pages, |chunk_hash, _| {
             if fail_fast_on_missing {
                 let resolved = if let Some(existing) = placement.get(&chunk_hash) {
                     Some(existing)
@@ -12203,13 +12227,18 @@ impl PushPipeline {
         // from the current proceeding ref set may enter the rebuilt shard.
         // Content-addressed uploads for removed refs can be reclaimed as
         // ordinary orphans, but must not become generation dependencies.
+        // The push reader snapshot pins these roots, so a page validated in
+        // the reachability pass remains immutable for term construction.
+        // Keep the cache local to bound its lifetime to shard assembly.
+        let mut recipe_pages = HashMap::new();
         let mut required_chunks = HashSet::new();
+        let mut seen_recipe_files = HashSet::new();
         for (file_hash, _) in &pointer_specs {
-            if remote_only.contains(file_hash) {
+            if remote_only.contains(file_hash) || !seen_recipe_files.insert(*file_hash) {
                 continue;
             }
             if let Some(recipe) = Self::recipe_from_snapshot(&recipe_snapshot, file_hash)? {
-                self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
+                self.visit_recipe_chunks_cached(&recipe, &mut recipe_pages, |chunk_hash, _| {
                     required_chunks.insert(chunk_hash);
                     Ok(())
                 })?;
@@ -12324,6 +12353,7 @@ impl PushPipeline {
                     let terms = self.build_file_terms_for_recipe(
                         file_hash,
                         recipe,
+                        &mut recipe_pages,
                         &mut merged_placement,
                         &verified_existing,
                         !verified_existing.is_empty(),

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6796,7 +6796,7 @@ impl PushPipeline {
         let mut builder = crab_xet::reconstruction::FileTermBuilder::new();
         let mut chunk_index = 0usize;
         self.visit_recipe_chunks(recipe, |chunk_hash, _| {
-            if !placement.contains_key(&chunk_hash) {
+            if !placement.contains_key(&chunk_hash) && !verified_existing.is_empty() {
                 match verified_existing.get(&chunk_hash) {
                     Some(existing) => {
                         placement.insert(chunk_hash, existing.clone());

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -15150,6 +15150,8 @@ impl PushPipeline {
         }
     }
 
+    // Post-commit consumers only need reachable chunks; filter while holding the
+    // source lock so orphan placements never get copied into a large snapshot.
     async fn verified_placement_snapshot_for<'a, I>(&self, required: I) -> ChunkPlacementMap
     where
         I: IntoIterator<Item = &'a MerkleHash>,

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -7803,6 +7803,7 @@ impl PushPipeline {
         let mut recipe_hasher = blake3::Hasher::new();
         recipe_hasher.update(b"crab push file recipes v1\0");
         let remote_records = self.remote_file_recipe_hashes.lock().await.clone();
+        let recipe_snapshot = self.cached_recipe_snapshot().await;
         let mut planned_file_dependencies = Vec::with_capacity(recipe_specs.len());
         for (file_hash, size) in recipe_specs {
             recipe_hasher.update(&<[u8; 32]>::from(file_hash));
@@ -7816,7 +7817,14 @@ impl PushPipeline {
                 })?;
                 (*record, true)
             } else {
-                (self.staged_recipe_hash(&file_hash).await?, false)
+                let recipe =
+                    Self::recipe_from_snapshot(&recipe_snapshot, &file_hash)?.ok_or_else(|| {
+                        CrabError::Internal(format!(
+                            "staged recipe root missing for {}",
+                            file_hash.hex()
+                        ))
+                    })?;
+                (recipe.hash(), false)
             };
             recipe_hasher.update(&recipe_hash);
             planned_file_dependencies.push(PlannedFileDependency {
@@ -15226,18 +15234,6 @@ impl PushPipeline {
         .await;
 
         Ok(())
-    }
-
-    async fn staged_recipe_hash(&self, file_hash: &MerkleHash) -> Result<[u8; 32]> {
-        self.cached_recipe_for_file(file_hash)
-            .await?
-            .map(|recipe| recipe.hash())
-            .ok_or_else(|| {
-                CrabError::Internal(format!(
-                    "staged recipe root missing for {}",
-                    file_hash.hex()
-                ))
-            })
     }
 
     /// Warm the local chunk-index cache tiers for every shard this

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6816,7 +6816,7 @@ impl PushPipeline {
         &self,
         recipe: &FileRecipe,
         start_occurrence: u64,
-    ) -> Result<crab_staging::recipe::RecipePage> {
+    ) -> Result<Arc<crab_staging::recipe::RecipePage>> {
         let key = (recipe.hash(), start_occurrence);
         if let Some(page) = self
             .recipe_page_cache
@@ -6826,7 +6826,7 @@ impl PushPipeline {
             .get(&key)
             .cloned()
         {
-            return Ok((*page).clone());
+            return Ok(page);
         }
         let page = self
             .staging
@@ -6836,11 +6836,12 @@ impl PushPipeline {
             })?
             .recipe_page(recipe, start_occurrence)
             .map_err(CrabError::from)?;
+        let page = Arc::new(page);
         let mut cache = self
             .recipe_page_cache
             .lock()
             .map_err(|_| CrabError::Internal("recipe page cache poisoned".to_owned()))?;
-        cache.insert(key, Arc::new(page.clone()));
+        cache.insert(key, Arc::clone(&page));
         Ok(page)
     }
 
@@ -6874,7 +6875,7 @@ impl PushPipeline {
             let page = if let Some(page) = pages.get(&key) {
                 Arc::clone(page)
             } else {
-                let page = Arc::new(self.recipe_page(recipe, next)?);
+                let page = self.recipe_page(recipe, next)?;
                 let estimated_bytes = page
                     .chunks
                     .capacity()

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -5120,9 +5120,24 @@ async fn verify_prepared_xorb_plan(
         len, &footer, &metadata, file_hash, xorb_hash, planned,
     )?;
 
-    // The upload boundary hashes this file immediately before sending it.
-    // Hashing here too would reread every large prepared body without adding
-    // protection against a later mutation.
+    let mut payload_reader = tokio::fs::File::open(path).await?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = vec![0u8; 1024 * 1024];
+    loop {
+        let read = payload_reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    if hasher.finalize() != expected_payload_hash {
+        return Err(CrabError::StagingCorrupt(format!(
+            "prepared xorb {} for file {} payload digest does not match its plan",
+            xorb_hash.hex(),
+            file_hash.hex()
+        )));
+    }
+
     Ok((placements, *expected_payload_hash.as_bytes()))
 }
 
@@ -14698,7 +14713,10 @@ impl PushPipeline {
 
         let result = tokio::time::timeout(
             GLOBAL_CHUNK_LOOKUP_BUDGET,
-            chunk_store.get_batch_with_candidates_bounded(chunk_hashes, chunk_hashes.len()),
+            chunk_store.get_batch_with_candidates_bounded(
+                chunk_hashes,
+                GLOBAL_CHUNK_LOOKUP_REMOTE_BATCH_SIZE,
+            ),
         )
         .await;
         let (refs, remote_candidates, skipped_remote) = match result {
@@ -15122,6 +15140,18 @@ impl PushPipeline {
     ) -> Result<()> {
         let file_store = guard.file_index().await?;
         let chunk_store = guard.chunk_index().await?;
+
+        for (file_hash, shard_index) in file_index_plan {
+            if shard_hashes.get(*shard_index).is_none() {
+                return Err(CrabError::IncompleteShardReconstruction {
+                    file_hash: file_hash.hex(),
+                    path: None,
+                    uncovered_chunks: 0,
+                    example_chunk_hash: String::new(),
+                    example_chunk_index: u32::MAX,
+                });
+            }
+        }
 
         // Snapshot every recipe used by this file-index plan once. The same
         // immutable roots feed file-index records, committed chunk receipts,

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4395,15 +4395,16 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
             && let Some(cache) = &self.candidate_cache
         {
             let mut remote_misses = Vec::with_capacity(misses.len());
+            let lookup_hashes = Arc::new(std::mem::take(&mut misses));
             let persistent_lookup = {
                 let cache = Arc::clone(cache);
-                let hashes = misses.clone();
-                tokio::task::spawn_blocking(move || cache.load_persistent(&hashes)).await
+                let hashes = Arc::clone(&lookup_hashes);
+                tokio::task::spawn_blocking(move || cache.load_persistent(hashes.as_slice())).await
             };
             match persistent_lookup {
                 Ok(Ok(persisted)) => {
                     let mut memory_updates = Vec::new();
-                    for chunk_hash in misses {
+                    for &chunk_hash in lookup_hashes.iter() {
                         match persisted.get(&chunk_hash).copied() {
                             Some(Some(candidate)) => {
                                 self.candidate_cache_hits
@@ -4428,11 +4429,11 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                 }
                 Ok(Err(error)) => {
                     warn!(error = %error, "add remote candidate persistent cache lookup failed");
-                    remote_misses = misses;
+                    remote_misses.extend(lookup_hashes.iter().copied());
                 }
                 Err(error) => {
                     warn!(error = %error, "add remote candidate persistent cache task failed");
-                    remote_misses = misses;
+                    remote_misses.extend(lookup_hashes.iter().copied());
                 }
             }
             misses = remote_misses;

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4424,30 +4424,22 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                         // reserving this repository-sized buffer for warm hits.
                         remote_misses.reserve(lookup_hashes.len());
                     }
-                    // Persisted misses are not inserted into memory; only grow
-                    // this buffer for rows that actually came back from SQLite.
-                    let mut memory_updates = Vec::new();
                     for &chunk_hash in lookup_hashes.iter() {
                         match persisted.get(&chunk_hash).copied() {
                             Some(Some(candidate)) => {
                                 self.candidate_cache_hits
                                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                memory_updates.push((chunk_hash, Some(candidate)));
                                 candidates.insert(chunk_hash, candidate);
                             }
                             Some(None) => {
                                 self.candidate_cache_hits
                                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                memory_updates.push((chunk_hash, None));
                                 // A persisted negative is advisory: it only avoids
                                 // a duplicate lookup, and push still revalidates
                                 // every candidate it does receive.
                             }
                             None => remote_misses.push(chunk_hash),
                         }
-                    }
-                    if let Err(error) = cache.memory_insert_batch(&memory_updates) {
-                        warn!(error = %error, "add remote candidate memory cache update failed");
                     }
                 }
                 Ok(Err(error)) => {
@@ -14711,17 +14703,17 @@ impl PushPipeline {
             return Ok(None);
         };
 
-        let result = tokio::time::timeout(
-            GLOBAL_CHUNK_LOOKUP_BUDGET,
-            chunk_store.get_batch_with_candidates_bounded(
+        let result = tokio::select! {
+            biased;
+            _ = self.cancel.cancelled() => return Err(CrabError::Cancelled),
+            result = chunk_store.get_batch_with_candidates_until(
                 chunk_hashes,
-                GLOBAL_CHUNK_LOOKUP_REMOTE_BATCH_SIZE,
-            ),
-        )
-        .await;
+                tokio::time::Instant::now() + GLOBAL_CHUNK_LOOKUP_BUDGET,
+            ) => result,
+        };
         let (refs, remote_candidates, skipped_remote) = match result {
-            Ok(Ok(result)) => result,
-            Ok(Err(e)) => {
+            Ok(result) => result,
+            Err(e) => {
                 warn!(
                     error = %e,
                     candidates = chunk_hashes.len(),
@@ -14729,27 +14721,7 @@ impl PushPipeline {
                 );
                 return Ok(Some((HashMap::new(), chunk_hashes.len())));
             }
-            Err(_) => {
-                debug!(
-                    candidates = chunk_hashes.len(),
-                    budget_ms = GLOBAL_CHUNK_LOOKUP_BUDGET.as_millis() as u64,
-                    "step 4: global chunk lookup reached its proof budget"
-                );
-                return Ok(Some((HashMap::new(), chunk_hashes.len())));
-            }
         };
-        if skipped_remote > 0 {
-            // Local and persistent tiers are already exact placements. Keep
-            // those hits even when the remote candidate phase is over budget;
-            // each retained ref still crosses the normal origin-proof check.
-            let hits = chunk_hashes
-                .iter()
-                .copied()
-                .zip(refs)
-                .filter_map(|(chunk_hash, xorb_ref)| xorb_ref.map(|value| (chunk_hash, value)))
-                .collect();
-            return Ok(Some((hits, skipped_remote)));
-        }
 
         {
             let mut candidates = self.committed_chunk_receipt_candidates.lock().await;
@@ -14770,7 +14742,7 @@ impl PushPipeline {
             .zip(refs)
             .filter_map(|(chunk_hash, xorb_ref)| xorb_ref.map(|value| (chunk_hash, value)))
             .collect();
-        Ok(Some((hits, 0)))
+        Ok(Some((hits, skipped_remote)))
     }
 
     async fn lookup_proven_remote_chunks_for_add(
@@ -29194,7 +29166,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn verified_global_lookup_keeps_local_hits_when_remote_budget_is_exceeded() {
+    async fn verified_global_lookup_keeps_local_hits_across_remote_pages() {
         let inner: Arc<dyn object_store::ObjectStore> =
             Arc::new(object_store::memory::InMemory::new());
         let store = Store::new(inner);
@@ -29244,11 +29216,8 @@ mod tests {
             .expect("bounded lookup");
 
         assert_eq!(lookup.refs.get(&local_hash), Some(&xorb_ref));
-        assert!(lookup.lookup_unavailable);
-        assert_eq!(
-            lookup.skipped_after_unavailable,
-            chunk_hashes.len().saturating_sub(1)
-        );
+        assert!(!lookup.lookup_unavailable);
+        assert_eq!(lookup.skipped_after_unavailable, 0);
         pipeline.close_metadb().await;
     }
 
@@ -30022,14 +29991,13 @@ mod tests {
             .lookup_verified_global_chunk_refs(&chunk_hashes)
             .await
             .expect("lookup global refs");
-        assert!(lookup.refs.is_empty());
-        assert!(lookup.lookup_unavailable);
-        assert_eq!(
-            lookup.skipped_after_unavailable,
-            chunk_hashes.len(),
-            "a remote proof set larger than the budget must be skipped atomically"
-        );
-        assert_eq!(lookup.stale_hits, 0);
+        assert!(!lookup.lookup_unavailable);
+        assert_eq!(lookup.skipped_after_unavailable, 0);
+        assert_eq!(lookup.stale_hits, missing_chunk_hashes.len());
+        assert_eq!(lookup.refs.len(), present_chunks.len());
+        for (hash, _) in &present_chunks {
+            assert_eq!(lookup.refs.get(hash).unwrap().xorb_hash, present_xorb);
+        }
 
         pipeline.close_metadb().await;
     }

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -12025,31 +12025,33 @@ impl PushPipeline {
                 .collect()
         };
         pointer_specs.sort_unstable();
-        let mut placement_map = self.chunk_placement.lock().await.clone();
-        let mut verified_existing = self.verified_existing_placement.lock().await.clone();
         let verified_existing_xorb_info = self.verified_existing_xorb_info.lock().await.clone();
         let mut packed_xorb_info = self.packed_xorb_info.lock().await.clone();
-        let mut uncaptured_placements = ChunkPlacementMap::new();
-        for (chunk_hash, placement) in &placement_map {
-            if let Some(info) = packed_xorb_info.get(&placement.xorb_hash) {
-                let entry = usize::try_from(placement.chunk_index)
-                    .ok()
-                    .and_then(|index| info.chunks.get(index));
-                if !entry.is_some_and(|entry| {
-                    entry.chunk_hash == *chunk_hash
-                        && entry.unpacked_segment_bytes == placement.uncompressed_size
-                }) {
-                    return Err(CrabError::StagingCorrupt(format!(
-                        "packed xorb metadata {} does not cover current chunk {} at index {}",
-                        placement.xorb_hash.hex(),
-                        chunk_hash.hex(),
-                        placement.chunk_index
-                    )));
+        let uncaptured_placements = {
+            let placement_map = self.chunk_placement.lock().await;
+            let mut uncaptured = ChunkPlacementMap::new();
+            for (chunk_hash, placement) in placement_map.iter() {
+                if let Some(info) = packed_xorb_info.get(&placement.xorb_hash) {
+                    let entry = usize::try_from(placement.chunk_index)
+                        .ok()
+                        .and_then(|index| info.chunks.get(index));
+                    if !entry.is_some_and(|entry| {
+                        entry.chunk_hash == *chunk_hash
+                            && entry.unpacked_segment_bytes == placement.uncompressed_size
+                    }) {
+                        return Err(CrabError::StagingCorrupt(format!(
+                            "packed xorb metadata {} does not cover current chunk {} at index {}",
+                            placement.xorb_hash.hex(),
+                            chunk_hash.hex(),
+                            placement.chunk_index
+                        )));
+                    }
+                } else {
+                    uncaptured.insert(*chunk_hash, placement.clone());
                 }
-            } else {
-                uncaptured_placements.insert(*chunk_hash, placement.clone());
             }
-        }
+            uncaptured
+        };
         packed_xorb_info.extend(
             build_complete_xorb_info_map(&uncaptured_placements)?
                 .into_iter()
@@ -12079,15 +12081,27 @@ impl PushPipeline {
                 })?;
             }
         }
-        placement_map.retain(|chunk_hash, _| required_chunks.contains(chunk_hash));
-        verified_existing.retain(|chunk_hash, _| required_chunks.contains(chunk_hash));
-
         // Build a merged placement map that includes both new chunks and
         // existing chunks whose referenced xorbs were confirmed present in
         // step 4. Advisory local indexes are not read here; a stale entry
         // must repack, not publish metadata pointing at a missing xorb.
-        let placement_new = placement_map.len();
-        let mut merged_placement: ChunkPlacementMap = placement_map;
+        let mut merged_placement = {
+            let placement_map = self.chunk_placement.lock().await;
+            placement_map
+                .iter()
+                .filter(|(chunk_hash, _)| required_chunks.contains(chunk_hash))
+                .map(|(chunk_hash, placement)| (*chunk_hash, placement.clone()))
+                .collect::<ChunkPlacementMap>()
+        };
+        let placement_new = merged_placement.len();
+        let verified_existing = {
+            let verified_existing = self.verified_existing_placement.lock().await;
+            verified_existing
+                .iter()
+                .filter(|(chunk_hash, _)| required_chunks.contains(chunk_hash))
+                .map(|(chunk_hash, placement)| (*chunk_hash, placement.clone()))
+                .collect::<ChunkPlacementMap>()
+        };
         let mut merged_from_index = 0u64;
         if !verified_existing.is_empty() {
             for (file_hash, _) in &pointer_specs {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4144,6 +4144,10 @@ pub struct PushPipeline {
     /// reconstruction terms from an empty staging list would mis-fire
     /// the tertiary `IncompleteShardReconstruction` sentinel.
     remote_only_pointers: tokio::sync::Mutex<std::collections::HashSet<MerkleHash>>,
+    /// Per-shard chunk placements prepared while publishing candidate
+    /// metadata. Post-success cleanup consumes this snapshot instead of
+    /// paging every recipe a second time.
+    precomputed_chunk_index_entries: tokio::sync::Mutex<Option<Arc<ChunkIndexShardEntries>>>,
     /// Verified recipe hashes backing snapshot-pinned remote-only dependencies.
     remote_file_recipe_hashes: tokio::sync::Mutex<HashMap<MerkleHash, [u8; 32]>>,
     /// ChunkIndex populated by this push's verified MetaDb hits.
@@ -4748,6 +4752,11 @@ struct ClassifiedChunkStats {
     size: u64,
     new_occurrences: u64,
 }
+
+type ChunkIndexShardEntries = Vec<(
+    MerkleHash,
+    Vec<(MerkleHash, crab_xet::xorb::format::XorbRef)>,
+)>;
 
 async fn pack_decoded_chunk_group(
     ordered: Vec<(Chunk, RunId)>,
@@ -6663,6 +6672,7 @@ impl PushPipeline {
             file_shard_index: tokio::sync::Mutex::new(HashMap::new()),
             pending_file_index_plan: tokio::sync::Mutex::new(Vec::new()),
             remote_only_pointers: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+            precomputed_chunk_index_entries: tokio::sync::Mutex::new(None),
             remote_file_recipe_hashes: tokio::sync::Mutex::new(HashMap::new()),
             chunk_index: tokio::sync::Mutex::new(ChunkIndex::with_ceiling(chunk_index_ceiling)),
             uploaded_packs: tokio::sync::Mutex::new(Vec::new()),
@@ -14179,6 +14189,7 @@ impl PushPipeline {
         self.shard_results.lock().await.clear();
         self.file_shard_index.lock().await.clear();
         self.pending_file_index_plan.lock().await.clear();
+        *self.precomputed_chunk_index_entries.lock().await = None;
         self.uploaded_shard_hashes.lock().await.clear();
         self.merged_placement.lock().await.clear();
         self.origin_receipts.lock().await.clear();
@@ -15234,8 +15245,15 @@ impl PushPipeline {
                     .collect()
             })
             .collect();
-        for (idx, shard_hash) in shard_hashes.iter().enumerate() {
-            let entries = &per_shard_chunks[idx];
+        let shard_entries = Arc::new(
+            shard_hashes
+                .iter()
+                .copied()
+                .zip(per_shard_chunks)
+                .collect::<Vec<_>>(),
+        );
+        *self.precomputed_chunk_index_entries.lock().await = Some(Arc::clone(&shard_entries));
+        for (shard_hash, entries) in shard_entries.iter() {
             if entries.is_empty() {
                 continue;
             }
@@ -15432,109 +15450,109 @@ impl PushPipeline {
         self.stop_heartbeat_and_release_lock().await;
 
         // Build the per-shard chunk→xorb entries outside the ChunkIndex
-        // lock to minimize lock contention. We snapshot the placement map
-        // and shard results, then release those locks before acquiring
-        // the ChunkIndex lock.
+        // lock to minimize lock contention. The metadata path hands us a
+        // prepared snapshot; only offline/no-MetaDb pushes use the defensive
+        // reconstruction below.
         //
         // Each file's chunks are packed into one shard (see `add_file` in
         // the shard session). We use `file_shard_index` to map each file
         // back to its shard, then group the file's chunk placements under
         // that shard for the session-local ChunkIndex.
-        let shard_entries: Vec<(
-            MerkleHash,
-            Vec<(MerkleHash, crab_xet::xorb::format::XorbRef)>,
-        )> = {
-            let shard_results = self.shard_results.lock().await;
-            let placement_map = self.merged_placement.lock().await;
-            let file_shard_index = self.file_shard_index.lock().await;
-            let pointers = self.pointers.lock().await;
+        let shard_entries = match self.precomputed_chunk_index_entries.lock().await.take() {
+            Some(entries) => entries,
+            None => Arc::new({
+                let shard_results = self.shard_results.lock().await;
+                let placement_map = self.merged_placement.lock().await;
+                let file_shard_index = self.file_shard_index.lock().await;
+                let pointers = self.pointers.lock().await;
 
-            if shard_results.is_empty() || placement_map.is_empty() {
-                Vec::new()
-            } else {
-                // Per-shard entry buckets. A `Vec<Vec<...>>` indexed by
-                // shard index is cheaper than a HashMap for the small
-                // shard counts in practice (usually 1, up to a handful).
-                let mut per_shard: Vec<Vec<(MerkleHash, crab_xet::xorb::format::XorbRef)>> =
-                    vec![Vec::new(); shard_results.len()];
+                if shard_results.is_empty() || placement_map.is_empty() {
+                    Vec::new()
+                } else {
+                    // Per-shard entry buckets. A `Vec<Vec<...>>` indexed by
+                    // shard index is cheaper than a HashMap for the small
+                    // shard counts in practice (usually 1, up to a handful).
+                    let mut per_shard: Vec<Vec<(MerkleHash, crab_xet::xorb::format::XorbRef)>> =
+                        vec![Vec::new(); shard_results.len()];
 
-                // Dedup pointers by file_hash to match `build_shard`'s
-                // added_files guard. Without this, a file appearing at
-                // multiple paths in the tree would produce duplicate
-                // chunk entries across the per-shard buckets.
-                let mut seen_files: HashSet<MerkleHash> = HashSet::new();
+                    // Dedup pointers by file_hash to match `build_shard`'s
+                    // added_files guard. Without this, a file appearing at
+                    // multiple paths in the tree would produce duplicate
+                    // chunk entries across the per-shard buckets.
+                    let mut seen_files: HashSet<MerkleHash> = HashSet::new();
 
-                for ptr in pointers.iter() {
-                    let file_hash = MerkleHash::from(ptr.file_hash);
-                    if !seen_files.insert(file_hash) {
-                        continue;
-                    }
-                    let Some(&shard_idx) = file_shard_index.get(&file_hash) else {
-                        // Remote-only pointers (verified durable by step 2)
-                        // have no shard entry — skip them here; their
-                        // chunks are already durable elsewhere.
-                        continue;
-                    };
-                    if shard_idx >= per_shard.len() {
-                        // Defense in depth: log and skip rather than panic.
-                        warn!(
-                            file_hash = %file_hash.hex(),
-                            shard_idx,
-                            shards = shard_results.len(),
-                            "step 13: file_shard_index points past shard_results, skipping"
-                        );
-                        continue;
-                    }
-
-                    let recipe = {
-                        let cache = self.chunk_cache.lock().await;
-                        cache
-                            .get(&file_hash)
-                            .and_then(|cached| cached.recipe.clone())
-                    };
-                    let Some(recipe) = recipe else {
-                        continue;
-                    };
-
-                    if let Err(error) = self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
-                        let Some(p) = placement_map.get(&chunk_hash) else {
-                            // Invariant: build_shard guarantees every
-                            // chunk has a placement. Log and skip — the
-                            // push already succeeded at this point so we
-                            // are defensive about cleanup warnings.
-                            return Ok(());
+                    for ptr in pointers.iter() {
+                        let file_hash = MerkleHash::from(ptr.file_hash);
+                        if !seen_files.insert(file_hash) {
+                            continue;
+                        }
+                        let Some(&shard_idx) = file_shard_index.get(&file_hash) else {
+                            // Remote-only pointers (verified durable by step 2)
+                            // have no shard entry — skip them here; their
+                            // chunks are already durable elsewhere.
+                            continue;
                         };
-                        per_shard[shard_idx].push((
-                            chunk_hash,
-                            crab_xet::xorb::format::XorbRef {
-                                xorb_hash: p.xorb_hash,
-                                chunk_index: p.chunk_index,
-                                uncompressed_size: p.uncompressed_size,
-                            },
-                        ));
-                        Ok(())
-                    }) {
-                        warn!(
-                            file_hash = %file_hash.hex(),
-                            error = %error,
-                            "step 13: failed to page recipe for local cache update"
-                        );
-                    }
-                }
+                        if shard_idx >= per_shard.len() {
+                            // Defense in depth: log and skip rather than panic.
+                            warn!(
+                                file_hash = %file_hash.hex(),
+                                shard_idx,
+                                shards = shard_results.len(),
+                                "step 13: file_shard_index points past shard_results, skipping"
+                            );
+                            continue;
+                        }
 
-                shard_results
-                    .iter()
-                    .zip(per_shard.into_iter())
-                    .map(|((_, shard_hash), entries)| (*shard_hash, entries))
-                    .collect()
-            }
-            // shard_results / placement_map / file_shard_index / pointers
-            // locks dropped here.
+                        let recipe = {
+                            let cache = self.chunk_cache.lock().await;
+                            cache
+                                .get(&file_hash)
+                                .and_then(|cached| cached.recipe.clone())
+                        };
+                        let Some(recipe) = recipe else {
+                            continue;
+                        };
+
+                        if let Err(error) = self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
+                            let Some(p) = placement_map.get(&chunk_hash) else {
+                                // Invariant: build_shard guarantees every
+                                // chunk has a placement. Log and skip — the
+                                // push already succeeded at this point so we
+                                // are defensive about cleanup warnings.
+                                return Ok(());
+                            };
+                            per_shard[shard_idx].push((
+                                chunk_hash,
+                                crab_xet::xorb::format::XorbRef {
+                                    xorb_hash: p.xorb_hash,
+                                    chunk_index: p.chunk_index,
+                                    uncompressed_size: p.uncompressed_size,
+                                },
+                            ));
+                            Ok(())
+                        }) {
+                            warn!(
+                                file_hash = %file_hash.hex(),
+                                error = %error,
+                                "step 13: failed to page recipe for local cache update"
+                            );
+                        }
+                    }
+
+                    shard_results
+                        .iter()
+                        .zip(per_shard.into_iter())
+                        .map(|((_, shard_hash), entries)| (*shard_hash, entries))
+                        .collect()
+                }
+                // shard_results / placement_map / file_shard_index / pointers
+                // locks dropped here.
+            }),
         };
 
         if !shard_entries.is_empty() {
             let mut chunk_index = self.chunk_index.lock().await;
-            for (shard_hash, entries) in &shard_entries {
+            for (shard_hash, entries) in shard_entries.iter() {
                 let already_installed = chunk_index.has_shard(shard_hash);
                 chunk_index.install_shard(*shard_hash, entries);
                 if !already_installed && let Some(metrics) = self.metrics.as_deref() {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -33355,7 +33355,8 @@ mod tests {
             },
         ));
         let chunk_store = guard.chunk_index().await.expect("chunk index store");
-        let required_chunks = HashSet::from([new_chunk, existing_chunk]);
+        let required_chunk_list = vec![new_chunk, existing_chunk];
+        let required_chunks = required_chunk_list.iter().copied().collect::<HashSet<_>>();
         let placement_snapshot = pipeline
             .verified_placement_snapshot_for(&required_chunks)
             .await;
@@ -33363,7 +33364,7 @@ mod tests {
         pipeline
             .warm_local_chunk_index(
                 chunk_store,
-                vec![required_chunks.to_vec()],
+                vec![required_chunk_list],
                 &placement_snapshot,
                 &[shard_hash],
             )

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4410,7 +4410,7 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
         if !misses.is_empty()
             && let Some(cache) = &self.candidate_cache
         {
-            let mut remote_misses = Vec::with_capacity(misses.len());
+            let mut remote_misses = Vec::new();
             let lookup_hashes = Arc::new(std::mem::take(&mut misses));
             let persistent_lookup = {
                 let cache = Arc::clone(cache);

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -10429,7 +10429,7 @@ impl PushPipeline {
             if recipe.chunk_count() == 0 {
                 continue;
             }
-            let mut file_sizes = HashMap::new();
+            let mut file_chunks = HashSet::new();
             self.visit_recipe_chunks(&recipe, |chunk_hash, size| {
                 total_occurrence_bytes = total_occurrence_bytes.saturating_add(size);
                 total_occurrence_chunks = total_occurrence_chunks.saturating_add(1);
@@ -10442,13 +10442,8 @@ impl PushPipeline {
                     }
                     _ => {}
                 }
-                match file_sizes.insert(chunk_hash, size) {
-                    Some(existing) if existing != size => Err(CrabError::StagingCorrupt(format!(
-                        "chunk {} has conflicting sizes within one recipe",
-                        chunk_hash.hex()
-                    ))),
-                    _ => Ok(()),
-                }
+                file_chunks.insert(chunk_hash);
+                Ok(())
             })?;
 
             let Some(plan) = plans.remove(&file_hash) else {
@@ -10457,7 +10452,7 @@ impl PushPipeline {
                     file_hash = %file_hash.hex(),
                     "step 4: no add-time push plan for staged pointer; classifying only this file normally"
                 );
-                residual_chunks.extend(file_sizes.keys().copied());
+                residual_chunks.extend(file_chunks.iter().copied());
                 continue;
             };
             if !add_push_plan_matches_staging(&plan, &file_hash, pointer_size, &recipe) {
@@ -10472,7 +10467,7 @@ impl PushPipeline {
                     file_hash = %file_hash.hex(),
                     "step 4: add-time push plan no longer matches staging; classifying only this file normally"
                 );
-                residual_chunks.extend(file_sizes.keys().copied());
+                residual_chunks.extend(file_chunks.iter().copied());
                 continue;
             }
 
@@ -10516,7 +10511,7 @@ impl PushPipeline {
                     &recipe,
                     "contains malformed prepared-xorb metadata",
                 )?;
-                residual_chunks.extend(file_sizes.keys().copied());
+                residual_chunks.extend(file_chunks.iter().copied());
                 continue;
             }
 
@@ -10526,14 +10521,21 @@ impl PushPipeline {
                 for (chunk_hash, candidate) in
                     staging.recipe_remote_chunk_page(&recipe, next_occurrence)?
                 {
-                    let size = file_sizes.get(&chunk_hash).ok_or_else(|| {
+                    let size = expected_sizes.get(&chunk_hash).copied().ok_or_else(|| {
                         CrabError::StagingCorrupt(format!(
                             "remote authority for chunk {} escaped file {} recipe coverage",
                             chunk_hash.hex(),
                             file_hash.hex()
                         ))
                     })?;
-                    if u64::from(candidate.xorb_ref.uncompressed_size) != *size {
+                    if !file_chunks.contains(&chunk_hash) {
+                        return Err(CrabError::StagingCorrupt(format!(
+                            "remote authority for chunk {} escaped file {} recipe coverage",
+                            chunk_hash.hex(),
+                            file_hash.hex()
+                        )));
+                    }
+                    if u64::from(candidate.xorb_ref.uncompressed_size) != size {
                         return Err(CrabError::StagingCorrupt(format!(
                             "remote authority for chunk {} in file {} has size {}, expected {size}",
                             chunk_hash.hex(),
@@ -10565,7 +10567,7 @@ impl PushPipeline {
                 file_hash,
                 recipe,
                 plan,
-                file_sizes,
+                file_chunks,
                 prepared,
                 remote_authority_hashes,
             ));
@@ -10700,7 +10702,7 @@ impl PushPipeline {
                         );
                         unusable_prepared_xorbs += 1;
                         for placement in planned_placements {
-                            if !chunks.contains_key(&placement.chunk_hash) {
+                            if !chunks.contains(&placement.chunk_hash) {
                                 continue;
                             }
                             residual_chunks.insert(placement.chunk_hash);
@@ -10742,7 +10744,14 @@ impl PushPipeline {
                 {
                     continue;
                 }
-                let size = chunks.get(chunk_hash).copied().ok_or_else(|| {
+                if !chunks.contains(chunk_hash) {
+                    return Err(CrabError::StagingCorrupt(format!(
+                        "remote authority for chunk {} escaped file {} recipe coverage",
+                        chunk_hash.hex(),
+                        file_hash.hex()
+                    )));
+                }
+                let size = expected_sizes.get(chunk_hash).copied().ok_or_else(|| {
                     CrabError::StagingCorrupt(format!(
                         "remote authority for chunk {} escaped file {} recipe coverage",
                         chunk_hash.hex(),
@@ -10761,7 +10770,7 @@ impl PushPipeline {
                     )));
                 }
             }
-            for chunk_hash in chunks.keys() {
+            for chunk_hash in chunks {
                 if placement_map.contains_key(chunk_hash)
                     || verified_placement.contains_key(chunk_hash)
                 {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6766,6 +6766,29 @@ impl PushPipeline {
             })
     }
 
+    async fn cached_recipe_snapshot(&self) -> HashMap<MerkleHash, Option<FileRecipe>> {
+        let cache = self.chunk_cache.lock().await;
+        cache
+            .iter()
+            .map(|(file_hash, cached)| (*file_hash, cached.recipe.clone()))
+            .collect()
+    }
+
+    fn recipe_from_snapshot<'a>(
+        snapshot: &'a HashMap<MerkleHash, Option<FileRecipe>>,
+        file_hash: &MerkleHash,
+    ) -> Result<Option<&'a FileRecipe>> {
+        snapshot
+            .get(file_hash)
+            .map(Option::as_ref)
+            .ok_or_else(|| {
+                CrabError::Internal(format!(
+                    "push pipeline invariant violated: verified recipe root missing for file {}; lookup_staging must run first",
+                    file_hash.hex()
+                ))
+            })
+    }
+
     fn recipe_page(
         &self,
         recipe: &FileRecipe,
@@ -10470,8 +10493,9 @@ impl PushPipeline {
         let mut residual_chunks = HashSet::new();
         let mut total_occurrence_bytes = 0u64;
         let mut total_occurrence_chunks = 0u64;
+        let recipe_cache = self.cached_recipe_snapshot().await;
         for (file_hash, pointer_size) in pointer_specs {
-            let Some(recipe) = self.cached_recipe_for_file(&file_hash).await? else {
+            let Some(recipe) = Self::recipe_from_snapshot(&recipe_cache, &file_hash)? else {
                 continue;
             };
             if recipe.chunk_count() == 0 {
@@ -10926,9 +10950,10 @@ impl PushPipeline {
             .iter()
             .map(|pointer| MerkleHash::from(pointer.file_hash))
             .collect::<Vec<_>>();
+        let recipe_cache = self.cached_recipe_snapshot().await;
         let mut file_recipes = Vec::with_capacity(file_hashes.len());
         for file_hash in file_hashes {
-            if let Some(recipe) = self.cached_recipe_for_file(&file_hash).await? {
+            if let Some(recipe) = Self::recipe_from_snapshot(&recipe_cache, &file_hash)? {
                 file_recipes.push(recipe);
             }
         }
@@ -11215,13 +11240,7 @@ impl PushPipeline {
         // Recipe roots are immutable after lookup_staging. Snapshot the
         // small per-file map once so the pack read schedule does not await
         // the cache mutex for every pointer in a large repository.
-        let recipe_cache = {
-            let cache = self.chunk_cache.lock().await;
-            cache
-                .iter()
-                .map(|(file_hash, cached)| (*file_hash, cached.recipe.clone()))
-                .collect::<HashMap<_, _>>()
-        };
+        let recipe_cache = self.cached_recipe_snapshot().await;
 
         let residual_add_plan_chunks = self
             .new_chunk_hashes

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4255,6 +4255,9 @@ pub struct PushPipeline {
 /// Shared add-time classifier backed by the push pipeline's full proof path.
 pub(crate) struct AddRemoteChunkClassifier {
     pipeline: PushPipeline,
+    candidate_cache: Option<Arc<crate::cache::add_remote_candidates::AddRemoteCandidateCache>>,
+    candidate_cache_hits: std::sync::atomic::AtomicU64,
+    candidate_cache_misses: std::sync::atomic::AtomicU64,
 }
 
 impl AddRemoteChunkClassifier {
@@ -4291,10 +4294,44 @@ impl AddRemoteChunkClassifier {
             true,
         );
         pipeline.install_metadb(guard);
-        Self { pipeline }
+        let cache_path = crate::cache::add_remote_candidate_cache_path(
+            &crate::cache::default_cache_root(),
+            &store.bucket_identity(),
+            router.global_prefix(),
+        );
+        let candidate_cache =
+            match crate::cache::add_remote_candidates::AddRemoteCandidateCache::open(&cache_path) {
+                Ok(cache) => Some(Arc::new(cache)),
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        path = %cache_path.display(),
+                        "add remote candidate cache unavailable; using remote proof lookup"
+                    );
+                    None
+                }
+            };
+        Self {
+            pipeline,
+            candidate_cache,
+            candidate_cache_hits: std::sync::atomic::AtomicU64::new(0),
+            candidate_cache_misses: std::sync::atomic::AtomicU64::new(0),
+        }
     }
 
     pub(crate) async fn close(&self) {
+        let cache_hits = self
+            .candidate_cache_hits
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let cache_misses = self
+            .candidate_cache_misses
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if cache_hits > 0 || cache_misses > 0 {
+            debug!(
+                cache_hits,
+                cache_misses, "add remote candidate cache summary"
+            );
+        }
         self.pipeline.close_metadb().await;
     }
 
@@ -4313,17 +4350,119 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
         &self,
         chunks: &[(MerkleHash, u64)],
     ) -> crab_staging::Result<Vec<Option<crab_staging::push_plan::ExistingChunkCandidate>>> {
-        let hashes = chunks.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
-        let candidates = self
-            .pipeline
-            .lookup_proven_remote_chunks_for_add(&hashes)
-            .await
-            .map_err(|error| match error {
-                CrabError::Cancelled => crab_staging::StagingError::Cancelled,
-                error => crab_staging::StagingError::Internal(format!(
-                    "remote add classifier failed: {error}"
-                )),
-            })?;
+        let mut candidates = HashMap::new();
+        let mut misses = Vec::new();
+        let mut seen = HashSet::with_capacity(chunks.len());
+        for (chunk_hash, _) in chunks {
+            if !seen.insert(*chunk_hash) {
+                continue;
+            }
+            let Some(cache) = &self.candidate_cache else {
+                misses.push(*chunk_hash);
+                continue;
+            };
+            match cache.memory_get(chunk_hash) {
+                Ok(Some(candidate)) => {
+                    self.candidate_cache_hits
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if let Some(candidate) = candidate {
+                        candidates.insert(*chunk_hash, candidate);
+                    }
+                }
+                Ok(None) => misses.push(*chunk_hash),
+                Err(error) => {
+                    warn!(error = %error, "add remote candidate memory cache lookup failed");
+                    misses.push(*chunk_hash);
+                }
+            }
+        }
+
+        if let Some(cache) = &self.candidate_cache {
+            let mut remote_misses = Vec::with_capacity(misses.len());
+            let persistent_lookup = {
+                let cache = Arc::clone(cache);
+                let hashes = misses.clone();
+                tokio::task::spawn_blocking(move || cache.load_persistent(&hashes)).await
+            };
+            match persistent_lookup {
+                Ok(Ok(persisted)) => {
+                    for chunk_hash in misses {
+                        match persisted.get(&chunk_hash).copied() {
+                            Some(Some(candidate)) => {
+                                self.candidate_cache_hits
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                if let Err(error) = cache.memory_insert(chunk_hash, Some(candidate))
+                                {
+                                    warn!(error = %error, "add remote candidate memory cache update failed");
+                                }
+                                candidates.insert(chunk_hash, candidate);
+                            }
+                            Some(None) => {
+                                self.candidate_cache_hits
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                if let Err(error) = cache.memory_insert(chunk_hash, None) {
+                                    warn!(error = %error, "add remote candidate memory cache update failed");
+                                }
+                                // A persisted negative is advisory: it only avoids
+                                // a duplicate lookup, and push still revalidates
+                                // every candidate it does receive.
+                            }
+                            None => remote_misses.push(chunk_hash),
+                        }
+                    }
+                }
+                Ok(Err(error)) => {
+                    warn!(error = %error, "add remote candidate persistent cache lookup failed");
+                    remote_misses = misses;
+                }
+                Err(error) => {
+                    warn!(error = %error, "add remote candidate persistent cache task failed");
+                    remote_misses = misses;
+                }
+            }
+            misses = remote_misses;
+        }
+
+        self.candidate_cache_misses
+            .fetch_add(misses.len() as u64, std::sync::atomic::Ordering::Relaxed);
+        if !misses.is_empty() {
+            let fetched = self
+                .pipeline
+                .lookup_proven_remote_chunks_for_add(&misses)
+                .await
+                .map_err(|error| match error {
+                    CrabError::Cancelled => crab_staging::StagingError::Cancelled,
+                    error => crab_staging::StagingError::Internal(format!(
+                        "remote add classifier failed: {error}"
+                    )),
+                })?;
+            let mut persistent = Vec::with_capacity(misses.len());
+            for chunk_hash in misses {
+                let candidate = fetched.get(&chunk_hash).copied();
+                if let Some(cache) = &self.candidate_cache {
+                    if let Err(error) = cache.memory_insert(chunk_hash, candidate) {
+                        warn!(error = %error, "add remote candidate memory cache update failed");
+                    }
+                    persistent.push((chunk_hash, candidate));
+                }
+                if let Some(candidate) = candidate {
+                    candidates.insert(chunk_hash, candidate);
+                }
+            }
+            if let Some(cache) = &self.candidate_cache {
+                let cache = Arc::clone(cache);
+                match tokio::task::spawn_blocking(move || cache.persist_results(&persistent)).await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        warn!(error = %error, "add remote candidate persistent cache update failed");
+                    }
+                    Err(error) => {
+                        warn!(error = %error, "add remote candidate persistent cache task failed");
+                    }
+                }
+            }
+        }
         Ok(chunks
             .iter()
             .map(|(chunk_hash, size)| {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -12086,7 +12086,8 @@ impl PushPipeline {
         // existing chunks whose referenced xorbs were confirmed present in
         // step 4. Advisory local indexes are not read here; a stale entry
         // must repack, not publish metadata pointing at a missing xorb.
-        let mut merged_placement: ChunkPlacementMap = placement_map.clone();
+        let placement_new = placement_map.len();
+        let mut merged_placement: ChunkPlacementMap = placement_map;
         let mut merged_from_index = 0u64;
         if !verified_existing.is_empty() {
             for (file_hash, _) in &pointer_specs {
@@ -12129,7 +12130,7 @@ impl PushPipeline {
             }
         }
         info!(
-            placement_new = placement_map.len(),
+            placement_new,
             merged_from_index,
             merged_total = merged_placement.len(),
             verified_existing = verified_existing.len(),

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -9515,11 +9515,21 @@ impl PushPipeline {
             .map(|(file_hash, _)| *file_hash)
             .collect::<Vec<_>>();
         let published_recipes = Arc::new(staging.published_recipes_for_files(&file_hashes)?);
-        let staging = Arc::clone(staging);
+        let recipe_hashes = published_recipes
+            .values()
+            .filter_map(|recipe| recipe.as_ref().map(FileRecipe::hash))
+            .collect::<Vec<_>>();
+        let prepared_xorbs = match staging.prepared_xorbs_for_recipes(&recipe_hashes) {
+            Ok(prepared_xorbs) => Some(Arc::new(prepared_xorbs)),
+            Err(error) => {
+                warn!(error = %error, "failed to batch read prepared xorb authority; continuing without add-time plans");
+                None
+            }
+        };
         let verify_results = futures_util::stream::iter(unique_specs.into_iter().map(
             |(file_hash, pointer_size)| {
-                let staging = Arc::clone(&staging);
                 let published_recipes = Arc::clone(&published_recipes);
+                let prepared_xorbs = prepared_xorbs.clone();
                 async move {
                     let recipe = published_recipes
                         .get(&file_hash)
@@ -9576,35 +9586,27 @@ impl PushPipeline {
                         )));
                     }
 
-                    let add_push_plan = match staging.load_file_push_plan(&file_hash).await
-                    {
-                        Ok(Some(plan))
-                            if add_push_plan_matches_staging(
-                                &plan,
-                                &file_hash,
-                                pointer_size,
-                                &recipe,
-                            ) =>
-                        {
+                    let add_push_plan = prepared_xorbs.as_ref().and_then(|prepared_xorbs| {
+                        let mut plan = FilePushPlan::new_verified_recipe(&recipe);
+                        plan.prepared_xorbs = prepared_xorbs
+                            .get(&recipe.hash())
+                            .cloned()
+                            .unwrap_or_default();
+                        if add_push_plan_matches_staging(
+                            &plan,
+                            &file_hash,
+                            pointer_size,
+                            &recipe,
+                        ) {
                             Some(plan)
-                        }
-                        Ok(Some(_)) => {
+                        } else {
                             debug!(
                                 file_hash = %file_hash.hex(),
-                                "step 2: add-time push plan did not match the verified recipe; ignoring plan"
+                                "batch add-time push plan did not match the verified recipe; ignoring plan"
                             );
                             None
                         }
-                        Ok(None) => None,
-                        Err(e) => {
-                            warn!(
-                                file_hash = %file_hash.hex(),
-                                error = %e,
-                                "step 2: failed to read add-time push plan; continuing from verified recipe"
-                            );
-                            None
-                        }
-                    };
+                    });
 
                     Ok((
                         file_hash,

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -287,6 +287,7 @@ async fn existing_pack_metadata_is_oversized(store: &Store, path: &ObjectPath) -
 
 const GLOBAL_CHUNK_LOOKUP_REMOTE_BATCH_SIZE: usize = 4_096;
 const GLOBAL_CHUNK_LOOKUP_BUDGET: Duration = Duration::from_secs(120);
+const ADD_REMOTE_CLASSIFIER_INITIAL_CAPACITY: usize = 65_536;
 const BASE_SHARD_LOOKUP_LIMIT: usize = 4_096;
 const CANDIDATE_METADATA_BATCH_SIZE: usize = 2_048;
 const STAGING_VERIFY_CONCURRENCY: usize = 4;
@@ -4365,15 +4366,16 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
         if chunks.is_empty() {
             return Ok(Vec::new());
         }
-        let mut candidates = HashMap::with_capacity(chunks.len());
-        let mut unique_chunks = Vec::with_capacity(chunks.len());
-        let mut seen = HashSet::with_capacity(chunks.len());
+        let initial_capacity = chunks.len().min(ADD_REMOTE_CLASSIFIER_INITIAL_CAPACITY);
+        let mut unique_chunks = Vec::with_capacity(initial_capacity);
+        let mut seen = HashSet::with_capacity(initial_capacity);
         for (chunk_hash, _) in chunks {
             if seen.insert(*chunk_hash) {
                 unique_chunks.push(*chunk_hash);
             }
         }
 
+        let mut candidates = HashMap::with_capacity(unique_chunks.len());
         let mut misses = Vec::with_capacity(unique_chunks.len());
         if let Some(cache) = &self.candidate_cache {
             match cache.memory_get_batch(&unique_chunks) {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4452,25 +4452,22 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                         "remote add classifier failed: {error}"
                     )),
                 })?;
-            let mut persistent = Vec::with_capacity(misses.len());
-            let mut memory_updates = Vec::with_capacity(misses.len());
+            let mut updates = Vec::with_capacity(misses.len());
             for chunk_hash in misses {
                 let candidate = fetched.get(&chunk_hash).copied();
-                if let Some(cache) = &self.candidate_cache {
-                    memory_updates.push((chunk_hash, candidate));
-                    persistent.push((chunk_hash, candidate));
+                if self.candidate_cache.is_some() {
+                    updates.push((chunk_hash, candidate));
                 }
                 if let Some(candidate) = candidate {
                     candidates.insert(chunk_hash, candidate);
                 }
             }
             if let Some(cache) = &self.candidate_cache {
-                if let Err(error) = cache.memory_insert_batch(&memory_updates) {
+                if let Err(error) = cache.memory_insert_batch(&updates) {
                     warn!(error = %error, "add remote candidate memory cache update failed");
                 }
                 let cache = Arc::clone(cache);
-                match tokio::task::spawn_blocking(move || cache.persist_results(&persistent)).await
-                {
+                match tokio::task::spawn_blocking(move || cache.persist_results(&updates)).await {
                     Ok(Ok(())) => {}
                     Ok(Err(error)) => {
                         warn!(error = %error, "add remote candidate persistent cache update failed");

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -10855,10 +10855,34 @@ impl PushPipeline {
                 )
             })
             .collect();
-        let mut segment_candidates_by_file: Vec<(MerkleHash, Vec<(MerkleHash, u64)>)> = Vec::new();
-        let mut all_segment_candidates = Vec::new();
+        const SEGMENT_PAYLOAD_CHECK_BATCH: usize = 16_384;
+        let mut segment_candidates = Vec::with_capacity(SEGMENT_PAYLOAD_CHECK_BATCH);
+        let check_segment_candidates = |segment_candidates: &mut Vec<(
+            MerkleHash,
+            MerkleHash,
+            u64,
+        )>|
+         -> Result<()> {
+            if segment_candidates.is_empty() {
+                return Ok(());
+            }
+            let requested = segment_candidates
+                .iter()
+                .map(|(_, chunk_hash, size)| (*chunk_hash, *size))
+                .collect::<Vec<_>>();
+            let present = staging.segment_payloads_exist(&requested)?;
+            for (file_hash, chunk_hash, _) in segment_candidates.drain(..) {
+                if !present.contains(&chunk_hash) {
+                    return Err(CrabError::StagingCorrupt(format!(
+                        "add-time remote proof for chunk {} in file {} is stale and no local payload copy exists; run crab add again",
+                        chunk_hash.hex(),
+                        file_hash.hex()
+                    )));
+                }
+            }
+            Ok(())
+        };
         for (file_hash, _, _, chunks, _, remote_authority_hashes) in &needed_plans {
-            let mut segment_candidates = Vec::new();
             for chunk_hash in remote_authority_hashes {
                 if verified_placement.contains_key(chunk_hash)
                     || placement_map.contains_key(chunk_hash)
@@ -10879,25 +10903,13 @@ impl PushPipeline {
                         file_hash.hex()
                     ))
                 })?;
-                segment_candidates.push((*chunk_hash, size));
-            }
-            if !segment_candidates.is_empty() {
-                all_segment_candidates.extend(segment_candidates.iter().copied());
-                segment_candidates_by_file.push((*file_hash, segment_candidates));
-            }
-        }
-        let segment_payloads = staging.segment_payloads_exist(&all_segment_candidates)?;
-        for (file_hash, segment_candidates) in segment_candidates_by_file {
-            for (chunk_hash, _) in segment_candidates {
-                if !segment_payloads.contains(&chunk_hash) {
-                    return Err(CrabError::StagingCorrupt(format!(
-                        "add-time remote proof for chunk {} in file {} is stale and no local payload copy exists; run crab add again",
-                        chunk_hash.hex(),
-                        file_hash.hex()
-                    )));
+                segment_candidates.push((*file_hash, *chunk_hash, size));
+                if segment_candidates.len() == SEGMENT_PAYLOAD_CHECK_BATCH {
+                    check_segment_candidates(&mut segment_candidates)?;
                 }
             }
         }
+        check_segment_candidates(&mut segment_candidates)?;
         for (_, _, _, chunks, _, _) in &needed_plans {
             for chunk_hash in chunks {
                 if placement_map.contains_key(chunk_hash)

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4351,29 +4351,40 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
         &self,
         chunks: &[(MerkleHash, u64)],
     ) -> crab_staging::Result<Vec<Option<crab_staging::push_plan::ExistingChunkCandidate>>> {
+        if chunks.is_empty() {
+            return Ok(Vec::new());
+        }
         let mut candidates = HashMap::new();
-        let mut misses = Vec::new();
+        let mut unique_chunks = Vec::with_capacity(chunks.len());
         let mut seen = HashSet::with_capacity(chunks.len());
         for (chunk_hash, _) in chunks {
-            if !seen.insert(*chunk_hash) {
-                continue;
+            if seen.insert(*chunk_hash) {
+                unique_chunks.push(*chunk_hash);
             }
-            let Some(cache) = &self.candidate_cache else {
-                misses.push(*chunk_hash);
-                continue;
-            };
-            match cache.memory_get(chunk_hash) {
-                Ok(Some(candidate)) => {
-                    self.candidate_cache_hits
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    if let Some(candidate) = candidate {
-                        candidates.insert(*chunk_hash, candidate);
+        }
+
+        let mut misses = unique_chunks.clone();
+        if let Some(cache) = &self.candidate_cache {
+            match cache.memory_get_batch(&unique_chunks) {
+                Ok(cached) => {
+                    misses.clear();
+                    for chunk_hash in &unique_chunks {
+                        match cached.get(chunk_hash).copied() {
+                            Some(Some(candidate)) => {
+                                self.candidate_cache_hits
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                candidates.insert(*chunk_hash, candidate);
+                            }
+                            Some(None) => {
+                                self.candidate_cache_hits
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            }
+                            None => misses.push(*chunk_hash),
+                        }
                     }
                 }
-                Ok(None) => misses.push(*chunk_hash),
                 Err(error) => {
                     warn!(error = %error, "add remote candidate memory cache lookup failed");
-                    misses.push(*chunk_hash);
                 }
             }
         }
@@ -4387,29 +4398,28 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
             };
             match persistent_lookup {
                 Ok(Ok(persisted)) => {
+                    let mut memory_updates = Vec::new();
                     for chunk_hash in misses {
                         match persisted.get(&chunk_hash).copied() {
                             Some(Some(candidate)) => {
                                 self.candidate_cache_hits
                                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                if let Err(error) = cache.memory_insert(chunk_hash, Some(candidate))
-                                {
-                                    warn!(error = %error, "add remote candidate memory cache update failed");
-                                }
+                                memory_updates.push((chunk_hash, Some(candidate)));
                                 candidates.insert(chunk_hash, candidate);
                             }
                             Some(None) => {
                                 self.candidate_cache_hits
                                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                if let Err(error) = cache.memory_insert(chunk_hash, None) {
-                                    warn!(error = %error, "add remote candidate memory cache update failed");
-                                }
+                                memory_updates.push((chunk_hash, None));
                                 // A persisted negative is advisory: it only avoids
                                 // a duplicate lookup, and push still revalidates
                                 // every candidate it does receive.
                             }
                             None => remote_misses.push(chunk_hash),
                         }
+                    }
+                    if let Err(error) = cache.memory_insert_batch(&memory_updates) {
+                        warn!(error = %error, "add remote candidate memory cache update failed");
                     }
                 }
                 Ok(Err(error)) => {
@@ -4438,12 +4448,11 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                     )),
                 })?;
             let mut persistent = Vec::with_capacity(misses.len());
+            let mut memory_updates = Vec::with_capacity(misses.len());
             for chunk_hash in misses {
                 let candidate = fetched.get(&chunk_hash).copied();
                 if let Some(cache) = &self.candidate_cache {
-                    if let Err(error) = cache.memory_insert(chunk_hash, candidate) {
-                        warn!(error = %error, "add remote candidate memory cache update failed");
-                    }
+                    memory_updates.push((chunk_hash, candidate));
                     persistent.push((chunk_hash, candidate));
                 }
                 if let Some(candidate) = candidate {
@@ -4451,6 +4460,9 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                 }
             }
             if let Some(cache) = &self.candidate_cache {
+                if let Err(error) = cache.memory_insert_batch(&memory_updates) {
+                    warn!(error = %error, "add remote candidate memory cache update failed");
+                }
                 let cache = Arc::clone(cache);
                 match tokio::task::spawn_blocking(move || cache.persist_results(&persistent)).await
                 {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4614,6 +4614,12 @@ struct CommittedChunkCandidates {
     source_anchors: HashMap<[u8; 32], crab_metadata::receipts::SourceAnchor>,
 }
 
+#[derive(Default)]
+struct ValidatedCommittedChunkReceipts {
+    origins: HashMap<XorbHash, crab_metadata::receipts::OriginReceipt>,
+    placements: HashMap<MerkleHash, [u8; 32]>,
+}
+
 #[derive(Debug, Clone)]
 struct PlannedChunkDependency {
     chunk_hash: MerkleHash,
@@ -14019,18 +14025,28 @@ impl PushPipeline {
         &self,
         placements: &HashMap<MerkleHash, XorbRef>,
     ) -> HashMap<XorbHash, crab_metadata::receipts::OriginReceipt> {
-        self.verified_committed_chunk_receipts.lock().await.clear();
-        if placements.is_empty() {
-            return HashMap::new();
+        let candidates = std::mem::take(&mut *self.committed_chunk_receipt_candidates.lock().await);
+        let validated = self
+            .validate_committed_chunk_candidates(placements, candidates)
+            .await;
+        *self.verified_committed_chunk_receipts.lock().await = validated.placements;
+        validated.origins
+    }
+
+    async fn validate_committed_chunk_candidates(
+        &self,
+        placements: &HashMap<MerkleHash, XorbRef>,
+        candidates: CommittedChunkCandidates,
+    ) -> ValidatedCommittedChunkReceipts {
+        // Add calls this concurrently. Own the entire proof snapshot and result
+        // across awaits so another file cannot replace or clear this lookup.
+        if placements.is_empty() || candidates.placements.is_empty() {
+            return ValidatedCommittedChunkReceipts::default();
         }
         let Some(store) = &self.store else {
-            return HashMap::new();
+            return ValidatedCommittedChunkReceipts::default();
         };
         let source_roots = {
-            let candidates = self.committed_chunk_receipt_candidates.lock().await;
-            if candidates.placements.is_empty() {
-                return HashMap::new();
-            }
             let referenced_anchor_ids = placements
                 .keys()
                 .filter_map(|chunk_hash| {
@@ -14134,7 +14150,6 @@ impl PushPipeline {
             }
         }
 
-        let candidates = self.committed_chunk_receipt_candidates.lock().await;
         let candidate_count = candidates.placements.len();
         let mut verified = HashMap::new();
         let mut verified_origins = HashMap::new();
@@ -14197,12 +14212,12 @@ impl PushPipeline {
             verified_chunks = verified.len(),
             "generation-pinned committed chunk receipt validation complete"
         );
-        drop(candidates);
-        *self.committed_chunk_receipt_candidates.lock().await = CommittedChunkCandidates::default();
-        *self.verified_committed_chunk_receipts.lock().await = verified;
         self.tombstone_stale_committed_chunk_receipts(&stale_receipts)
             .await;
-        verified_origins
+        ValidatedCommittedChunkReceipts {
+            origins: verified_origins,
+            placements: verified,
+        }
     }
 
     // A staging miss is acceptable only with a recipe in the captured journal
@@ -14797,21 +14812,22 @@ impl PushPipeline {
                 (placement.placement_id(), placement.origin_proof_id),
             );
         }
-        *self.committed_chunk_receipt_candidates.lock().await = CommittedChunkCandidates {
+        let candidates = CommittedChunkCandidates {
             placements: remote_candidates.placements,
             origin_proofs: remote_candidates.origin_proofs,
             source_anchors: remote_candidates.source_anchors,
         };
-        let committed_receipts = self.validate_committed_chunk_receipts(&refs).await;
-        let validated = self.verified_committed_chunk_receipts.lock().await.clone();
+        let validated = self
+            .validate_committed_chunk_candidates(&refs, candidates)
+            .await;
         let verified = self
-            .verify_xorb_refs_with_committed_receipts(&refs, &committed_receipts)
+            .verify_xorb_refs_with_committed_receipts(&refs, &validated.origins)
             .await?;
         Ok(verified
             .into_iter()
             .filter_map(|(chunk_hash, xorb_ref)| {
                 let (placement_id, origin_proof_id) = proof_ids.get(&chunk_hash).copied()?;
-                (validated.get(&chunk_hash) == Some(&placement_id)).then_some((
+                (validated.placements.get(&chunk_hash) == Some(&placement_id)).then_some((
                     chunk_hash,
                     crab_staging::push_plan::ExistingChunkCandidate {
                         xorb_ref,

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -5075,6 +5075,14 @@ async fn verify_prepared_xorb_plan(
             file_hash.hex()
         )));
     }
+    let expected_payload_hash = blake3::Hash::from_hex(&planned.payload_hash).map_err(|error| {
+        CrabError::StagingCorrupt(format!(
+            "prepared xorb {} for file {} has invalid planned payload hash {}: {error}",
+            xorb_hash.hex(),
+            file_hash.hex(),
+            planned.payload_hash
+        ))
+    })?;
 
     let mut file = tokio::fs::File::open(path).await?;
     let footer_offset = u64::try_from(len - FOOTER_SIZE).map_err(|_| {
@@ -5158,14 +5166,6 @@ async fn verify_prepared_xorb_plan(
         )));
     }
     let payload_hash = *hasher.finalize().as_bytes();
-    let expected_payload_hash = blake3::Hash::from_hex(&planned.payload_hash).map_err(|error| {
-        CrabError::StagingCorrupt(format!(
-            "prepared xorb {} for file {} has invalid planned payload hash {}: {error}",
-            xorb_hash.hex(),
-            file_hash.hex(),
-            planned.payload_hash
-        ))
-    })?;
     if blake3::Hash::from(payload_hash) != expected_payload_hash {
         return Err(CrabError::StagingCorrupt(format!(
             "prepared xorb {} for file {} has payload hash {}, plan says {}",

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -9616,7 +9616,16 @@ impl PushPipeline {
         let mut verified = HashMap::new();
         let mut cached_xorb_hashes = HashSet::new();
         let mut refs_by_xorb: HashMap<XorbHash, Vec<(MerkleHash, XorbRef)>> = HashMap::new();
-        let full_xorb_cache = self.remote_full_xorb_ref_cache.lock().await.clone();
+        // The cache is global and may contain many repositories' xorbs. Only
+        // retain entries referenced by this push; later proof work never needs
+        // to inspect the rest of the cache.
+        let full_xorb_cache = {
+            let cache = self.remote_full_xorb_ref_cache.lock().await;
+            refs.values()
+                .map(|xorb_ref| xorb_ref.xorb_hash)
+                .filter(|xorb_hash| cache.contains(xorb_hash))
+                .collect::<HashSet<_>>()
+        };
         {
             let chunk_ref_cache = self.remote_chunk_ref_cache.lock().await;
             for (chunk_hash, xorb_ref) in refs {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4419,7 +4419,9 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
             };
             match persistent_lookup {
                 Ok(Ok(persisted)) => {
-                    let mut memory_updates = Vec::with_capacity(lookup_hashes.len());
+                    // Persisted misses are not inserted into memory; only grow
+                    // this buffer for rows that actually came back from SQLite.
+                    let mut memory_updates = Vec::new();
                     for &chunk_hash in lookup_hashes.iter() {
                         match persisted.get(&chunk_hash).copied() {
                             Some(Some(candidate)) => {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6752,20 +6752,6 @@ impl PushPipeline {
         Ok(self.common_git_dir()?.join("objects"))
     }
 
-    async fn cached_recipe_for_file(&self, file_hash: &MerkleHash) -> Result<Option<FileRecipe>> {
-        self.chunk_cache
-            .lock()
-            .await
-            .get(file_hash)
-            .map(|cached| cached.recipe.clone())
-            .ok_or_else(|| {
-                CrabError::Internal(format!(
-                    "push pipeline invariant violated: verified recipe root missing for file {}; lookup_staging must run first",
-                    file_hash.hex()
-                ))
-            })
-    }
-
     async fn cached_recipe_snapshot(&self) -> HashMap<MerkleHash, Option<FileRecipe>> {
         let cache = self.chunk_cache.lock().await;
         cache

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4485,7 +4485,9 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                     warn!(error = %error, "add remote candidate memory cache update failed");
                 }
                 let cache = Arc::clone(cache);
-                match tokio::task::spawn_blocking(move || cache.persist_results(&updates)).await {
+                match tokio::task::spawn_blocking(move || cache.persist_unique_results(&updates))
+                    .await
+                {
                     Ok(Ok(())) => {}
                     Ok(Err(error)) => {
                         warn!(error = %error, "add remote candidate persistent cache update failed");

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -30022,15 +30022,14 @@ mod tests {
             .lookup_verified_global_chunk_refs(&chunk_hashes)
             .await
             .expect("lookup global refs");
-        assert_eq!(lookup.stale_hits, missing_chunk_hashes.len());
-        assert_eq!(lookup.refs.len(), 2);
-        for chunk_hash in &chunk_hashes[missing_chunk_hashes.len()..] {
-            let xorb_ref = lookup
-                .refs
-                .get(chunk_hash)
-                .expect("present xorb hit should survive stale earlier batch");
-            assert_eq!(xorb_ref.xorb_hash, present_xorb);
-        }
+        assert!(lookup.refs.is_empty());
+        assert!(lookup.lookup_unavailable);
+        assert_eq!(
+            lookup.skipped_after_unavailable,
+            chunk_hashes.len(),
+            "a remote proof set larger than the budget must be skipped atomically"
+        );
+        assert_eq!(lookup.stale_hits, 0);
 
         pipeline.close_metadb().await;
     }

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -14908,7 +14908,7 @@ impl PushPipeline {
 
         let raw: Vec<[u8; 32]> = chunk_hashes.iter().map(|h| (*h).into()).collect();
         let result = caching_store
-            .dedup_query(self.router.repo_prefix(), &raw)
+            .dedup_query_unique(self.router.repo_prefix(), &raw)
             .await?;
 
         let mut hits = HashMap::new();

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4130,8 +4130,9 @@ pub struct PushPipeline {
     /// through coordinator commit. Protected pushes use the receive service's
     /// equivalent fence and therefore do not populate this slot.
     gc_writer: tokio::sync::Mutex<Option<crate::maintenance::GcWriterLeases>>,
-    /// Shard bytes + hash pairs produced by step 8, consumed by step 9.
-    shard_results: tokio::sync::Mutex<Vec<(Vec<u8>, MerkleHash)>>,
+    /// Shard payloads + hashes produced by step 8, consumed by step 9.
+    /// `Bytes` keeps upload/cache readers zero-copy after shard construction.
+    shard_results: tokio::sync::Mutex<Vec<(Bytes, MerkleHash)>>,
     /// Maps file_hash → index into `shard_results`, so step 9 knows which
     /// shard contains each file's reconstruction info.
     file_shard_index: tokio::sync::Mutex<HashMap<MerkleHash, usize>>,
@@ -12280,7 +12281,13 @@ impl PushPipeline {
             current_shard_file_count += 1;
         }
 
-        let results = shard_session.finalize()?;
+        // Convert the finalized buffers without copying; step 9 and cache
+        // warming retain immutable `Bytes` handles to the same payload.
+        let results: Vec<(Bytes, MerkleHash)> = shard_session
+            .finalize()?
+            .into_iter()
+            .map(|(bytes, hash)| (Bytes::from(bytes), hash))
+            .collect();
         let shard_count = results.len();
         let total_shard_bytes: usize = results.iter().map(|(b, _)| b.len()).sum();
 
@@ -12315,7 +12322,7 @@ impl PushPipeline {
     async fn persist_shard_hints(
         &self,
         file_shard_idx: &HashMap<MerkleHash, usize>,
-        shard_results: &[(Vec<u8>, MerkleHash)],
+        shard_results: &[(Bytes, MerkleHash)],
     ) {
         if file_shard_idx.is_empty() || shard_results.is_empty() {
             return;
@@ -12412,7 +12419,7 @@ impl PushPipeline {
                     (
                         *shard_hash,
                         self.router.shard_path(shard_hash),
-                        Bytes::from(shard_bytes.clone()),
+                        shard_bytes.clone(),
                     )
                 })
                 .collect()
@@ -30747,7 +30754,7 @@ mod tests {
         let shard_results = pipeline.shard_results.lock().await;
         assert_eq!(shard_results.len(), 1);
         let (shard_bytes, shard_hash) = &shard_results[0];
-        let reader = ShardReader::from_bytes(Bytes::from(shard_bytes.clone()), *shard_hash);
+        let reader = ShardReader::from_bytes(shard_bytes.clone(), *shard_hash);
 
         let xorb_info = reader
             .get_xorb_info(&xorb_hash)
@@ -30838,7 +30845,7 @@ mod tests {
         drop(merged);
         let shards = pipeline.shard_results.lock().await;
         let (bytes, hash) = shards.first().expect("one rebuilt shard");
-        let reader = ShardReader::from_bytes(Bytes::from(bytes.clone()), *hash);
+        let reader = ShardReader::from_bytes(bytes.clone(), *hash);
         assert!(
             reader
                 .get_file_info(&kept_file)
@@ -30935,7 +30942,7 @@ mod tests {
 
         let shards = pipeline.shard_results.lock().await;
         let (bytes, hash) = shards.first().expect("one rebuilt shard");
-        let reader = ShardReader::from_bytes(Bytes::from(bytes.clone()), *hash);
+        let reader = ShardReader::from_bytes(bytes.clone(), *hash);
         let xorb_info = reader
             .get_xorb_info(&shared_xorb)
             .expect("read shared xorb")
@@ -32223,7 +32230,8 @@ mod tests {
             false,
         );
         pipeline.install_metadb(guard);
-        *pipeline.shard_results.lock().await = vec![(shard_bytes.to_vec(), shard_hash)];
+        *pipeline.shard_results.lock().await =
+            vec![(Bytes::from(shard_bytes.to_vec()), shard_hash)];
 
         pipeline
             .upload_shard_and_file_index()
@@ -35013,7 +35021,7 @@ mod tests {
         assert_eq!(first_results.len(), 2);
         let mut extracted_files = Vec::new();
         for (bytes, _) in &first_results {
-            let recipes = crab_xet::shard_parse::extract_file_recipes(&Bytes::from(bytes.clone()))
+            let recipes = crab_xet::shard_parse::extract_file_recipes(bytes)
                 .expect("each forced shard must be independently dependency closed");
             assert_eq!(recipes.len(), 1);
             extracted_files.push(recipes[0].file_hash);
@@ -35107,7 +35115,7 @@ mod tests {
         let shard_results = pipeline.shard_results.lock().await;
         assert_eq!(shard_results.len(), 1);
         let (bytes, shard_hash) = &shard_results[0];
-        let reader = ShardReader::from_bytes(Bytes::from(bytes.clone()), *shard_hash);
+        let reader = ShardReader::from_bytes(bytes.clone(), *shard_hash);
         let file_info = reader
             .get_file_info(&file_hash)
             .expect("read shard file info")

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4189,6 +4189,10 @@ pub struct PushPipeline {
     /// Per-file immutable recipe-root cache populated by step 2.
     /// Ordered terms remain indexed in staging and are consumed in fixed pages.
     chunk_cache: tokio::sync::Mutex<HashMap<MerkleHash, CachedFileRecipe>>,
+    /// Bounded cross-phase cache for immutable recipe pages. It is cleared
+    /// whenever step 2 rebuilds the recipe snapshot, so retries cannot reuse
+    /// pages from a prior staging view.
+    recipe_page_cache: std::sync::Mutex<RecipePageCache>,
     /// Add-time push plans that matched an exact published recipe during step 2.
     ///
     /// These are advisory until step 4 re-proves every remote placement
@@ -4748,6 +4752,35 @@ struct CachedFileRecipe {
 impl CachedFileRecipe {
     fn new(recipe: Option<FileRecipe>) -> Self {
         Self { recipe }
+    }
+}
+
+#[derive(Default)]
+struct RecipePageCache {
+    pages: HashMap<([u8; 32], u64), Arc<crab_staging::recipe::RecipePage>>,
+    bytes: usize,
+}
+
+impl RecipePageCache {
+    fn clear(&mut self) {
+        self.pages.clear();
+        self.bytes = 0;
+    }
+
+    fn insert(&mut self, key: ([u8; 32], u64), page: Arc<crab_staging::recipe::RecipePage>) {
+        if self.pages.contains_key(&key) {
+            return;
+        }
+        let page_bytes = page
+            .chunks
+            .capacity()
+            .saturating_mul(std::mem::size_of::<crab_staging::recipe::RecipeChunk>());
+        let entry_bytes = page_bytes.saturating_add(RECIPE_PAGE_CACHE_ENTRY_OVERHEAD);
+        if entry_bytes > RECIPE_PAGE_CACHE_BYTES.saturating_sub(self.bytes) {
+            return;
+        }
+        self.bytes = self.bytes.saturating_add(entry_bytes);
+        self.pages.insert(key, page);
     }
 }
 
@@ -6688,6 +6721,7 @@ impl PushPipeline {
             planned_git_bytes: std::sync::atomic::AtomicU64::new(0),
             uploaded_xorbs: tokio::sync::Mutex::new(Vec::new()),
             chunk_cache: tokio::sync::Mutex::new(HashMap::new()),
+            recipe_page_cache: std::sync::Mutex::new(RecipePageCache::default()),
             add_push_plans: tokio::sync::Mutex::new(HashMap::new()),
             staging_push_id: uuid::Uuid::now_v7().to_string(),
             staging_push_marked: tokio::sync::Mutex::new(false),
@@ -6783,13 +6817,31 @@ impl PushPipeline {
         recipe: &FileRecipe,
         start_occurrence: u64,
     ) -> Result<crab_staging::recipe::RecipePage> {
-        self.staging
+        let key = (recipe.hash(), start_occurrence);
+        if let Some(page) = self
+            .recipe_page_cache
+            .lock()
+            .map_err(|_| CrabError::Internal("recipe page cache poisoned".to_owned()))?
+            .pages
+            .get(&key)
+            .cloned()
+        {
+            return Ok((*page).clone());
+        }
+        let page = self
+            .staging
             .as_ref()
             .ok_or_else(|| {
                 CrabError::Internal("staging disappeared during recipe read".to_owned())
             })?
             .recipe_page(recipe, start_occurrence)
-            .map_err(CrabError::from)
+            .map_err(CrabError::from)?;
+        let mut cache = self
+            .recipe_page_cache
+            .lock()
+            .map_err(|_| CrabError::Internal("recipe page cache poisoned".to_owned()))?;
+        cache.insert(key, Arc::new(page.clone()));
+        Ok(page)
     }
 
     fn visit_recipe_chunks(
@@ -9442,6 +9494,10 @@ impl PushPipeline {
         // recipe-derived set from the surviving refs so a rejected sibling
         // cannot contribute payload, proof, or receipt state to the retry.
         self.chunk_cache.lock().await.clear();
+        self.recipe_page_cache
+            .lock()
+            .map_err(|_| CrabError::Internal("recipe page cache poisoned".to_owned()))?
+            .clear();
         self.add_push_plans.lock().await.clear();
         self.remote_only_pointers.lock().await.clear();
         self.remote_file_recipe_hashes.lock().await.clear();

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -9510,12 +9510,27 @@ impl PushPipeline {
             }
         }
 
+        let file_hashes = unique_specs
+            .iter()
+            .map(|(file_hash, _)| *file_hash)
+            .collect::<Vec<_>>();
+        let published_recipes = Arc::new(staging.published_recipes_for_files(&file_hashes)?);
         let staging = Arc::clone(staging);
         let verify_results = futures_util::stream::iter(unique_specs.into_iter().map(
             |(file_hash, pointer_size)| {
                 let staging = Arc::clone(&staging);
+                let published_recipes = Arc::clone(&published_recipes);
                 async move {
-                    let Some(recipe) = staging.published_recipe_for_file(&file_hash)? else {
+                    let recipe = published_recipes
+                        .get(&file_hash)
+                        .cloned()
+                        .ok_or_else(|| {
+                            CrabError::Internal(format!(
+                                "staging recipe batch lookup omitted file {}",
+                                file_hash.hex()
+                            ))
+                        })?;
+                    let Some(recipe) = recipe else {
                         debug!(
                             file_hash = %file_hash.hex(),
                             "step 2: no published staging recipe for pointer"

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4376,7 +4376,9 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
         }
         drop(seen);
 
-        let mut candidates = HashMap::with_capacity(unique_chunks.len());
+        // Most first pushes are all misses; grow only when a positive candidate
+        // exists instead of reserving buckets for the whole repository.
+        let mut candidates = HashMap::new();
         let mut misses = Vec::with_capacity(unique_chunks.len());
         if let Some(cache) = &self.candidate_cache {
             match cache.memory_get_batch(&unique_chunks) {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -10855,6 +10855,8 @@ impl PushPipeline {
                 )
             })
             .collect();
+        let mut segment_candidates_by_file: Vec<(MerkleHash, Vec<(MerkleHash, u64)>)> = Vec::new();
+        let mut all_segment_candidates = Vec::new();
         for (file_hash, _, _, chunks, _, remote_authority_hashes) in &needed_plans {
             let mut segment_candidates = Vec::new();
             for chunk_hash in remote_authority_hashes {
@@ -10879,7 +10881,13 @@ impl PushPipeline {
                 })?;
                 segment_candidates.push((*chunk_hash, size));
             }
-            let segment_payloads = staging.segment_payloads_exist(&segment_candidates)?;
+            if !segment_candidates.is_empty() {
+                all_segment_candidates.extend(segment_candidates.iter().copied());
+                segment_candidates_by_file.push((*file_hash, segment_candidates));
+            }
+        }
+        let segment_payloads = staging.segment_payloads_exist(&all_segment_candidates)?;
+        for (file_hash, segment_candidates) in segment_candidates_by_file {
             for (chunk_hash, _) in segment_candidates {
                 if !segment_payloads.contains(&chunk_hash) {
                     return Err(CrabError::StagingCorrupt(format!(
@@ -10889,6 +10897,8 @@ impl PushPipeline {
                     )));
                 }
             }
+        }
+        for (_, _, _, chunks, _, _) in &needed_plans {
             for chunk_hash in chunks {
                 if placement_map.contains_key(chunk_hash)
                     || verified_placement.contains_key(chunk_hash)

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -10732,6 +10732,7 @@ impl PushPipeline {
             })
             .collect();
         for (file_hash, _, _, chunks, _, remote_authority_hashes) in &needed_plans {
+            let mut segment_candidates = Vec::new();
             for chunk_hash in remote_authority_hashes {
                 if verified_placement.contains_key(chunk_hash)
                     || placement_map.contains_key(chunk_hash)
@@ -10745,7 +10746,11 @@ impl PushPipeline {
                         file_hash.hex()
                     ))
                 })?;
-                if !staging.has_segment_payload(chunk_hash, size)? {
+                segment_candidates.push((*chunk_hash, size));
+            }
+            let segment_payloads = staging.segment_payloads_exist(&segment_candidates)?;
+            for (chunk_hash, _) in segment_candidates {
+                if !segment_payloads.contains(&chunk_hash) {
                     return Err(CrabError::StagingCorrupt(format!(
                         "add-time remote proof for chunk {} in file {} is stale and no local payload copy exists; run crab add again",
                         chunk_hash.hex(),

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -14925,6 +14925,28 @@ impl PushPipeline {
         let file_store = guard.file_index().await?;
         let chunk_store = guard.chunk_index().await?;
 
+        // Snapshot every recipe used by this file-index plan once. The same
+        // immutable roots feed file-index records, committed chunk receipts,
+        // and local cache warming; reacquiring the cache mutex per file would
+        // add scheduler overhead and repeat the recipe-page reads below.
+        let cached_recipes = {
+            let cache = self.chunk_cache.lock().await;
+            let mut recipes = HashMap::with_capacity(file_index_plan.len());
+            for (file_hash, _) in file_index_plan {
+                let recipe = cache
+                    .get(file_hash)
+                    .and_then(|cached| cached.recipe.clone())
+                    .ok_or_else(|| {
+                        CrabError::Internal(format!(
+                            "staged recipe root missing for {}",
+                            file_hash.hex()
+                        ))
+                    })?;
+                recipes.insert(*file_hash, recipe);
+            }
+            recipes
+        };
+
         let mut file_entries: Vec<(MerkleHash, crab_metadata::value_codec::CommittedFileRecord)> =
             Vec::with_capacity(file_index_plan.len());
         for (file_hash, idx) in file_index_plan {
@@ -14937,10 +14959,16 @@ impl PushPipeline {
                     example_chunk_index: u32::MAX,
                 });
             };
+            let recipe = cached_recipes.get(file_hash).ok_or_else(|| {
+                CrabError::Internal(format!(
+                    "staged recipe root missing for {}",
+                    file_hash.hex()
+                ))
+            })?;
             file_entries.push((
                 *file_hash,
                 crab_metadata::value_codec::CommittedFileRecord {
-                    recipe_hash: self.staged_recipe_hash(file_hash).await?,
+                    recipe_hash: recipe.hash(),
                     shard_hash: *shard_hash,
                     committed_generation: anchor.generation,
                     shard_index_hash: anchor.shard_index_hash,
@@ -14965,6 +14993,7 @@ impl PushPipeline {
             std::mem::take(&mut *verified)
         };
         let mut chunk_sources = HashMap::new();
+        let mut warm_hashes_by_shard: Vec<Vec<MerkleHash>> = vec![Vec::new(); shard_hashes.len()];
         for (file_hash, shard_index) in file_index_plan {
             let shard_hash = shard_hashes.get(*shard_index).ok_or_else(|| {
                 CrabError::IncompleteShardReconstruction {
@@ -14975,10 +15004,25 @@ impl PushPipeline {
                     example_chunk_index: u32::MAX,
                 }
             })?;
-            let Some(recipe) = self.cached_recipe_for_file(file_hash).await? else {
-                continue;
-            };
-            self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
+            let recipe = cached_recipes.get(file_hash).ok_or_else(|| {
+                CrabError::Internal(format!(
+                    "staged recipe root missing for {}",
+                    file_hash.hex()
+                ))
+            })?;
+            let warm_bucket = warm_hashes_by_shard.get_mut(*shard_index).ok_or_else(|| {
+                CrabError::IncompleteShardReconstruction {
+                    file_hash: file_hash.hex(),
+                    path: None,
+                    uncovered_chunks: 0,
+                    example_chunk_hash: String::new(),
+                    example_chunk_index: u32::MAX,
+                }
+            })?;
+            self.visit_recipe_chunks(recipe, |chunk_hash, _| {
+                // Local shard markers must retain every shard membership even
+                // when one chunk hash occurs in multiple files or shards.
+                warm_bucket.push(chunk_hash);
                 // The global index is rebuildable acceleration. Re-publishing an
                 // already generation-pinned receipt only grows immutable history;
                 // if that source root later disappears, validation repacks or repair
@@ -14990,8 +15034,13 @@ impl PushPipeline {
                 Ok(())
             })?;
         }
+        let warm_required_chunks = warm_hashes_by_shard
+            .iter()
+            .flat_map(|hashes| hashes.iter())
+            .copied()
+            .collect::<HashSet<_>>();
         let placement_snapshot = self
-            .verified_placement_snapshot_for(chunk_sources.keys())
+            .verified_placement_snapshot_for(&warm_required_chunks)
             .await;
         for chunk_hash in chunk_sources.keys() {
             let placement = placement_snapshot.get(chunk_hash).ok_or_else(|| {
@@ -15105,7 +15154,6 @@ impl PushPipeline {
             .await?;
         }
         guard.flush_memtables().await?;
-        drop(placement_snapshot);
         drop(origin_receipts);
         self.pending_committed_receipt_tombstones
             .lock()
@@ -15126,8 +15174,13 @@ impl PushPipeline {
         // step 8. Failures are logged and swallowed — the remote
         // state is authoritative and the cache will refill on next
         // read.
-        self.warm_local_chunk_index(chunk_store, file_index_plan, shard_hashes)
-            .await;
+        self.warm_local_chunk_index(
+            chunk_store,
+            warm_hashes_by_shard,
+            &placement_snapshot,
+            shard_hashes,
+        )
+        .await;
 
         Ok(())
     }
@@ -15148,62 +15201,24 @@ impl PushPipeline {
     /// push uploaded.
     ///
     /// Called from [`Self::commit_metadb_and_warm_cache_with_guard`] after the
-    /// remote commit succeeds. Groups verified chunk placements by shard
-    /// index and calls [`ChunkIndexStore::warm_local_shard`] per
-    /// shard so the local cache's `shards_v1` presence marker and
-    /// chunk rows stay consistent with the shard metadata uploaded in
-    /// step 8.
+    /// remote commit succeeds. Converts the precomputed per-shard chunk
+    /// membership into verified placements and calls
+    /// [`ChunkIndexStore::warm_local_shard`] per shard so the local cache's
+    /// `shards_v1` presence marker and chunk rows stay consistent with the
+    /// shard metadata uploaded in step 8.
     ///
     /// Extracted into its own method so the outer `execute` state
     /// machine stays compact.
     async fn warm_local_chunk_index(
         &self,
         chunk_store: crate::metadata::ChunkIndexStore,
-        file_index_plan: &[(MerkleHash, usize)],
+        per_shard_hashes: Vec<Vec<MerkleHash>>,
+        placement_snapshot: &ChunkPlacementMap,
         shard_hashes: &[MerkleHash],
     ) {
-        let mut per_shard_hashes: Vec<Vec<MerkleHash>> = vec![Vec::new(); shard_hashes.len()];
         if self.staging.is_none() {
             return;
         }
-        let mut required_chunks = HashSet::new();
-        for (file_hash, shard_idx) in file_index_plan {
-            let recipe = match self.cached_recipe_for_file(file_hash).await {
-                Ok(Some(recipe)) => recipe,
-                Ok(None) => continue,
-                Err(e) => {
-                    warn!(
-                        file_hash = %file_hash.hex(),
-                        error = %e,
-                        "candidate metadata failed to resolve chunk list for warm grouping; skipping file"
-                    );
-                    continue;
-                }
-            };
-            let Some(bucket) = per_shard_hashes.get_mut(*shard_idx) else {
-                warn!(
-                    file_hash = %file_hash.hex(),
-                    shard_idx,
-                    shards = per_shard_hashes.len(),
-                    "candidate metadata file-index plan points past uploaded shard hashes, skipping local warm"
-                );
-                continue;
-            };
-            if let Err(error) = self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
-                required_chunks.insert(chunk_hash);
-                bucket.push(chunk_hash);
-                Ok(())
-            }) {
-                warn!(
-                    file_hash = %file_hash.hex(),
-                    error = %error,
-                    "candidate metadata failed to page recipe for warm grouping; skipping file"
-                );
-            }
-        }
-        let placement_snapshot = self
-            .verified_placement_snapshot_for(required_chunks.iter())
-            .await;
         let per_shard_chunks: Vec<Vec<(MerkleHash, XorbRef)>> = per_shard_hashes
             .into_iter()
             .map(|hashes| {
@@ -15237,11 +15252,10 @@ impl PushPipeline {
 
     // Post-commit consumers only need reachable chunks; filter while holding the
     // source lock so orphan placements never get copied into a large snapshot.
-    async fn verified_placement_snapshot_for<'a, I>(&self, required: I) -> ChunkPlacementMap
-    where
-        I: IntoIterator<Item = &'a MerkleHash>,
-    {
-        let required = required.into_iter().collect::<HashSet<_>>();
+    async fn verified_placement_snapshot_for(
+        &self,
+        required: &HashSet<MerkleHash>,
+    ) -> ChunkPlacementMap {
         if required.is_empty() {
             return ChunkPlacementMap::new();
         }
@@ -33323,9 +33337,18 @@ mod tests {
             },
         ));
         let chunk_store = guard.chunk_index().await.expect("chunk index store");
+        let required_chunks = HashSet::from([new_chunk, existing_chunk]);
+        let placement_snapshot = pipeline
+            .verified_placement_snapshot_for(&required_chunks)
+            .await;
 
         pipeline
-            .warm_local_chunk_index(chunk_store, &[(file_hash, 0)], &[shard_hash])
+            .warm_local_chunk_index(
+                chunk_store,
+                vec![required_chunks.to_vec()],
+                &placement_snapshot,
+                &[shard_hash],
+            )
             .await;
 
         let persistent = PersistentChunkIndex::open_or_create(&cache_path).expect("open sqlite");

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -11212,6 +11212,17 @@ impl PushPipeline {
             return Ok(XorbPackSummary::default());
         }
 
+        // Recipe roots are immutable after lookup_staging. Snapshot the
+        // small per-file map once so the pack read schedule does not await
+        // the cache mutex for every pointer in a large repository.
+        let recipe_cache = {
+            let cache = self.chunk_cache.lock().await;
+            cache
+                .iter()
+                .map(|(file_hash, cached)| (*file_hash, cached.recipe.clone()))
+                .collect::<HashMap<_, _>>()
+        };
+
         let residual_add_plan_chunks = self
             .new_chunk_hashes
             .lock()
@@ -11268,7 +11279,13 @@ impl PushPipeline {
             for (file_idx, ptr) in pointers.iter().enumerate() {
                 check_cancelled(&self.cancel)?;
                 let file_hash = MerkleHash::from(ptr.file_hash);
-                let Some(recipe) = self.cached_recipe_for_file(&file_hash).await? else {
+                let cached = recipe_cache.get(&file_hash).ok_or_else(|| {
+                    CrabError::Internal(format!(
+                        "push pipeline invariant violated: verified recipe root missing for file {}; lookup_staging must run first",
+                        file_hash.hex()
+                    ))
+                })?;
+                let Some(recipe) = cached else {
                     debug!(file_hash = %file_hash.hex(), "no staged chunks for pointer, skipping");
                     if let Some(ref p) = self.progress {
                         p.inc_pack_file();

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -12299,7 +12299,7 @@ impl PushPipeline {
                 )?;
 
                 terms
-                    .iter()
+                    .into_iter()
                     .map(|t| {
                         FileDataSequenceEntry::new(
                             t.xorb_hash,

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -13769,9 +13769,18 @@ impl PushPipeline {
             if candidates.placements.is_empty() {
                 return HashMap::new();
             }
-            candidates
-                .source_anchors
-                .values()
+            let referenced_anchor_ids = placements
+                .keys()
+                .filter_map(|chunk_hash| {
+                    candidates
+                        .placements
+                        .get(chunk_hash)
+                        .map(|placement| placement.source_anchor_id)
+                })
+                .collect::<HashSet<_>>();
+            referenced_anchor_ids
+                .into_iter()
+                .filter_map(|anchor_id| candidates.source_anchors.get(&anchor_id))
                 .map(|anchor| {
                     (
                         anchor.source_repo_prefix.clone(),

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -10636,9 +10636,24 @@ impl PushPipeline {
 
             let mut remote_authority_hashes = Vec::new();
             let mut next_occurrence = 0u64;
+            const REMOTE_AUTHORITY_BATCH_PAGES: u64 = 16;
+            let page_entries = crab_staging::recipe::RECIPE_PAGE_ENTRIES as u64;
+            let batch_entries = page_entries
+                .checked_mul(REMOTE_AUTHORITY_BATCH_PAGES)
+                .ok_or_else(|| {
+                    CrabError::StagingCorrupt("remote authority batch range overflow".to_owned())
+                })?;
             while next_occurrence < recipe.chunk_count() {
+                let end_occurrence = next_occurrence
+                    .checked_add(batch_entries)
+                    .ok_or_else(|| {
+                        CrabError::StagingCorrupt(
+                            "remote authority batch range overflow".to_owned(),
+                        )
+                    })?
+                    .min(recipe.chunk_count());
                 for (chunk_hash, candidate) in
-                    staging.recipe_remote_chunk_page(&recipe, next_occurrence)?
+                    staging.recipe_remote_chunk_range(&recipe, next_occurrence, end_occurrence)?
                 {
                     let size = expected_sizes.get(&chunk_hash).copied().ok_or_else(|| {
                         CrabError::StagingCorrupt(format!(
@@ -10673,13 +10688,7 @@ impl PushPipeline {
                         }
                     }
                 }
-                next_occurrence = next_occurrence
-                    .checked_add(crab_staging::recipe::RECIPE_PAGE_ENTRIES as u64)
-                    .ok_or_else(|| {
-                        CrabError::StagingCorrupt(
-                            "remote authority recipe page overflow".to_owned(),
-                        )
-                    })?;
+                next_occurrence = end_occurrence;
             }
             self.record_add_plan_adopted();
             needed_plans.push((

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -10062,8 +10062,8 @@ impl PushPipeline {
     }
 
     async fn prove_all_origin_xorbs_for_publish(&self) -> Result<()> {
-        let placements = self.merged_placement.lock().await.clone();
-        if placements.is_empty() {
+        let by_xorb = self.snapshot_placements_by_xorb().await;
+        if by_xorb.is_empty() {
             self.origin_receipts.lock().await.clear();
             return Ok(());
         }
@@ -10074,13 +10074,6 @@ impl PushPipeline {
                 key: "push store".to_owned(),
                 origin: "canonical-origin proof requires a remote store".to_owned(),
             })?;
-        let mut by_xorb: HashMap<MerkleHash, Vec<ChunkPlacement>> = HashMap::new();
-        for placement in placements.values() {
-            by_xorb
-                .entry(placement.xorb_hash)
-                .or_default()
-                .push(placement.clone());
-        }
         let mut candidates = by_xorb
             .into_iter()
             .map(|(hash, placements)| RemoteXorbCandidate { hash, placements })
@@ -10112,8 +10105,8 @@ impl PushPipeline {
     }
 
     async fn prove_all_xorbs_for_protected_push(&self) -> Result<()> {
-        let placements = self.merged_placement.lock().await.clone();
-        if placements.is_empty() {
+        let by_xorb = self.snapshot_placements_by_xorb().await;
+        if by_xorb.is_empty() {
             self.origin_receipts.lock().await.clear();
             return Ok(());
         }
@@ -10129,13 +10122,7 @@ impl PushPipeline {
             .into_iter()
             .map(|write| (write.canonical_key.clone(), write))
             .collect::<HashMap<_, _>>();
-        let mut by_xorb: HashMap<MerkleHash, Vec<ChunkPlacement>> = HashMap::new();
-        for placement in placements.values() {
-            by_xorb
-                .entry(placement.xorb_hash)
-                .or_default()
-                .push(placement.clone());
-        }
+        let required_xorb_count = by_xorb.len();
         let mut canonical_candidates = Vec::new();
         let mut receipts = HashMap::new();
         for (hash, placements) in by_xorb {
@@ -10195,11 +10182,7 @@ impl PushPipeline {
         )
         .await?;
         receipts.extend(canonical);
-        let required = placements
-            .values()
-            .map(|placement| placement.xorb_hash)
-            .collect::<HashSet<_>>();
-        if receipts.len() != required.len() {
+        if receipts.len() != required_xorb_count {
             return Err(CrabError::CorruptObject {
                 path: self.router.repo_prefix().to_owned(),
                 reason: "protected push lacks staged or canonical proof for a candidate xorb"
@@ -10208,6 +10191,18 @@ impl PushPipeline {
         }
         *self.origin_receipts.lock().await = receipts;
         Ok(())
+    }
+
+    async fn snapshot_placements_by_xorb(&self) -> HashMap<MerkleHash, Vec<ChunkPlacement>> {
+        let placements = self.merged_placement.lock().await;
+        let mut by_xorb = HashMap::new();
+        for placement in placements.values() {
+            by_xorb
+                .entry(placement.xorb_hash)
+                .or_insert_with(Vec::new)
+                .push(placement.clone());
+        }
+        by_xorb
     }
 
     async fn verify_cache_service_xorb_refs(

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -5064,8 +5064,6 @@ impl UploadedXorb {
     }
 }
 
-const PREPARED_XORB_VERIFY_BUFFER_BYTES: usize = 1024 * 1024;
-
 async fn verify_prepared_xorb_plan(
     path: &Path,
     file_hash: &MerkleHash,
@@ -5116,75 +5114,16 @@ async fn verify_prepared_xorb_plan(
         )));
     }
 
-    file.seek(SeekFrom::Start(0)).await?;
-    let mut hasher = blake3::Hasher::new();
-    let mut buffer = vec![0u8; PREPARED_XORB_VERIFY_BUFFER_BYTES];
-    let mut offset = 0u64;
-    loop {
-        let read = file.read(&mut buffer).await?;
-        if read == 0 {
-            break;
-        }
-        let read_len = read;
-        let read = u64::try_from(read_len).map_err(|_| {
-            CrabError::Internal("prepared xorb read length does not fit u64".to_owned())
-        })?;
-        let end = offset
-            .checked_add(read)
-            .ok_or_else(|| CrabError::StagingCorrupt("prepared xorb length overflow".to_owned()))?;
-        if end > expected_len {
-            return Err(CrabError::StagingCorrupt(format!(
-                "prepared xorb {} for file {} grew while being verified",
-                xorb_hash.hex(),
-                file_hash.hex()
-            )));
-        }
-        hasher.update(&buffer[..read_len]);
-
-        let overlap_start = offset.max(metadata_start);
-        let overlap_end = end.min(metadata_end);
-        if overlap_start < overlap_end {
-            let source_start = usize::try_from(overlap_start - offset).map_err(|_| {
-                CrabError::Internal(
-                    "prepared xorb metadata source offset does not fit usize".to_owned(),
-                )
-            })?;
-            let destination_start =
-                usize::try_from(overlap_start - metadata_start).map_err(|_| {
-                    CrabError::Internal(
-                        "prepared xorb metadata destination offset does not fit usize".to_owned(),
-                    )
-                })?;
-            let overlap_len = usize::try_from(overlap_end - overlap_start).map_err(|_| {
-                CrabError::Internal("prepared xorb metadata overlap does not fit usize".to_owned())
-            })?;
-            metadata[destination_start..destination_start + overlap_len]
-                .copy_from_slice(&buffer[source_start..source_start + overlap_len]);
-        }
-        offset = end;
-    }
-    if offset != expected_len {
-        return Err(CrabError::StagingCorrupt(format!(
-            "prepared xorb {} for file {} changed size while being verified",
-            xorb_hash.hex(),
-            file_hash.hex()
-        )));
-    }
-    let payload_hash = *hasher.finalize().as_bytes();
-    if blake3::Hash::from(payload_hash) != expected_payload_hash {
-        return Err(CrabError::StagingCorrupt(format!(
-            "prepared xorb {} for file {} has payload hash {}, plan says {}",
-            xorb_hash.hex(),
-            file_hash.hex(),
-            blake3::Hash::from(payload_hash).to_hex(),
-            planned.payload_hash
-        )));
-    }
+    file.seek(SeekFrom::Start(metadata_start)).await?;
+    file.read_exact(&mut metadata).await?;
     let placements = push_plan::validate_prepared_xorb_metadata(
         len, &footer, &metadata, file_hash, xorb_hash, planned,
     )?;
 
-    Ok((placements, payload_hash))
+    // The upload boundary hashes this file immediately before sending it.
+    // Hashing here too would reread every large prepared body without adding
+    // protection against a later mutation.
+    Ok((placements, *expected_payload_hash.as_bytes()))
 }
 
 #[derive(Debug)]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -10517,6 +10517,7 @@ impl PushPipeline {
                 continue;
             }
 
+            let mut remote_authority_hashes = Vec::new();
             let mut next_occurrence = 0u64;
             while next_occurrence < recipe.chunk_count() {
                 for (chunk_hash, candidate) in
@@ -10537,13 +10538,15 @@ impl PushPipeline {
                             candidate.xorb_ref.uncompressed_size
                         )));
                     }
-                    if let Some(existing) = candidate_refs.insert(chunk_hash, candidate)
-                        && existing != candidate
-                    {
-                        return Err(CrabError::StagingCorrupt(format!(
-                            "add-time push plans disagree on remote placement proof for chunk {}",
-                            chunk_hash.hex()
-                        )));
+                    match candidate_refs.insert(chunk_hash, candidate) {
+                        None => remote_authority_hashes.push(chunk_hash),
+                        Some(existing) if existing == candidate => {}
+                        Some(_) => {
+                            return Err(CrabError::StagingCorrupt(format!(
+                                "add-time push plans disagree on remote placement proof for chunk {}",
+                                chunk_hash.hex()
+                            )));
+                        }
                     }
                 }
                 next_occurrence = next_occurrence
@@ -10555,7 +10558,14 @@ impl PushPipeline {
                     })?;
             }
             self.record_add_plan_adopted();
-            needed_plans.push((file_hash, recipe, plan, file_sizes, prepared));
+            needed_plans.push((
+                file_hash,
+                recipe,
+                plan,
+                file_sizes,
+                prepared,
+                remote_authority_hashes,
+            ));
         }
         if needed_plans.is_empty() {
             return Ok(false);
@@ -10632,7 +10642,7 @@ impl PushPipeline {
         let mut placement_map = HashMap::new();
         let mut unusable_prepared_xorbs = 0usize;
         let mut skipped_existing_prepared_xorbs = 0usize;
-        for (file_hash, recipe, plan, chunks, prepared) in &needed_plans {
+        for (file_hash, recipe, plan, chunks, prepared, _) in &needed_plans {
             for (planned_xorb, (prepared_hash, planned_placements)) in plan
                 .prepared_xorbs
                 .iter()
@@ -10721,37 +10731,27 @@ impl PushPipeline {
                 )
             })
             .collect();
-        for (file_hash, recipe, _, chunks, _) in &needed_plans {
-            let mut next_occurrence = 0u64;
-            while next_occurrence < recipe.chunk_count() {
-                for (chunk_hash, _) in staging.recipe_remote_chunk_page(recipe, next_occurrence)? {
-                    if verified_placement.contains_key(&chunk_hash)
-                        || placement_map.contains_key(&chunk_hash)
-                    {
-                        continue;
-                    }
-                    let size = chunks.get(&chunk_hash).copied().ok_or_else(|| {
-                        CrabError::StagingCorrupt(format!(
-                            "remote authority for chunk {} escaped file {} recipe coverage",
-                            chunk_hash.hex(),
-                            file_hash.hex()
-                        ))
-                    })?;
-                    if !staging.has_segment_payload(&chunk_hash, size)? {
-                        return Err(CrabError::StagingCorrupt(format!(
-                            "add-time remote proof for chunk {} in file {} is stale and no local payload copy exists; run crab add again",
-                            chunk_hash.hex(),
-                            file_hash.hex()
-                        )));
-                    }
+        for (file_hash, _, _, chunks, _, remote_authority_hashes) in &needed_plans {
+            for chunk_hash in remote_authority_hashes {
+                if verified_placement.contains_key(chunk_hash)
+                    || placement_map.contains_key(chunk_hash)
+                {
+                    continue;
                 }
-                next_occurrence = next_occurrence
-                    .checked_add(crab_staging::recipe::RECIPE_PAGE_ENTRIES as u64)
-                    .ok_or_else(|| {
-                        CrabError::StagingCorrupt(
-                            "remote authority recipe page overflow".to_owned(),
-                        )
-                    })?;
+                let size = chunks.get(chunk_hash).copied().ok_or_else(|| {
+                    CrabError::StagingCorrupt(format!(
+                        "remote authority for chunk {} escaped file {} recipe coverage",
+                        chunk_hash.hex(),
+                        file_hash.hex()
+                    ))
+                })?;
+                if !staging.has_segment_payload(chunk_hash, size)? {
+                    return Err(CrabError::StagingCorrupt(format!(
+                        "add-time remote proof for chunk {} in file {} is stale and no local payload copy exists; run crab add again",
+                        chunk_hash.hex(),
+                        file_hash.hex()
+                    )));
+                }
             }
             for chunk_hash in chunks.keys() {
                 if placement_map.contains_key(chunk_hash)

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -12202,6 +12202,7 @@ impl PushPipeline {
             debug!("step 8: no pointers, skipping shard build");
             return Ok(());
         }
+        let recipe_snapshot = self.cached_recipe_snapshot().await;
 
         // `chunk_placement` can contain immutable xorbs uploaded for a ref
         // that lost a non-atomic manifest-CAS race. Only chunks reachable
@@ -12213,7 +12214,7 @@ impl PushPipeline {
             if remote_only.contains(file_hash) {
                 continue;
             }
-            if let Some(recipe) = self.cached_recipe_for_file(file_hash).await? {
+            if let Some(recipe) = Self::recipe_from_snapshot(&recipe_snapshot, file_hash)? {
                 self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
                     required_chunks.insert(chunk_hash);
                     Ok(())
@@ -12322,50 +12323,45 @@ impl PushPipeline {
                 );
                 continue;
             }
-            let recipe = self.cached_recipe_for_file(file_hash).await?;
+            let recipe = Self::recipe_from_snapshot(&recipe_snapshot, file_hash)?;
 
-            let entries: Vec<FileDataSequenceEntry> = if recipe
-                .as_ref()
-                .is_none_or(|recipe| recipe.chunk_count() == 0)
-            {
-                if *size != 0 {
-                    return Err(CrabError::PointerMissingStaging {
-                        total: pointer_specs.len(),
-                        missing: 1,
-                        example_file_hash: file_hash.hex(),
-                        example_size: *size,
-                    });
+            let entries: Vec<FileDataSequenceEntry> = match recipe {
+                Some(recipe) if recipe.chunk_count() > 0 => {
+                    let terms = self.build_file_terms_for_recipe(
+                        file_hash,
+                        recipe,
+                        &mut merged_placement,
+                        &verified_existing,
+                        !verified_existing.is_empty(),
+                    )?;
+
+                    terms
+                        .into_iter()
+                        .map(|t| {
+                            FileDataSequenceEntry::new(
+                                t.xorb_hash,
+                                t.unpacked_bytes,
+                                t.chunk_start,
+                                t.chunk_end,
+                            )
+                        })
+                        .collect()
                 }
-                debug!(
-                    file_hash = %file_hash.hex(),
-                    "step 8: adding zero-byte file reconstruction entry"
-                );
-                Vec::new()
-            } else {
-                let recipe = recipe.as_ref().ok_or_else(|| {
-                    CrabError::Internal(
-                        "non-empty recipe disappeared during shard build".to_owned(),
-                    )
-                })?;
-                let terms = self.build_file_terms_for_recipe(
-                    file_hash,
-                    recipe,
-                    &mut merged_placement,
-                    &verified_existing,
-                    !verified_existing.is_empty(),
-                )?;
-
-                terms
-                    .into_iter()
-                    .map(|t| {
-                        FileDataSequenceEntry::new(
-                            t.xorb_hash,
-                            t.unpacked_bytes,
-                            t.chunk_start,
-                            t.chunk_end,
-                        )
-                    })
-                    .collect()
+                _ => {
+                    if *size != 0 {
+                        return Err(CrabError::PointerMissingStaging {
+                            total: pointer_specs.len(),
+                            missing: 1,
+                            example_file_hash: file_hash.hex(),
+                            example_size: *size,
+                        });
+                    }
+                    debug!(
+                        file_hash = %file_hash.hex(),
+                        "step 8: adding zero-byte file reconstruction entry"
+                    );
+                    Vec::new()
+                }
             };
             let mut dependency_hashes = entries
                 .iter()

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4747,6 +4747,11 @@ impl CachedFileRecipe {
     }
 }
 
+struct ClassifiedChunkStats {
+    size: u64,
+    new_occurrences: u64,
+}
+
 async fn pack_decoded_chunk_group(
     ordered: Vec<(Chunk, RunId)>,
     mut builder: XorbBuilder,
@@ -10885,14 +10890,13 @@ impl PushPipeline {
             }
         }
         let mut occurrence_bytes = 0u64;
-        let mut chunk_sizes = HashMap::new();
+        let mut chunk_stats = HashMap::new();
 
         let mut total_chunks = 0u64;
         let mut existing = 0u64;
         let mut staged = 0u64;
         let mut new_chunks = 0u64;
         let mut new_set = std::collections::HashSet::new();
-        let mut new_counts = HashMap::new();
         let mut existing_candidates: HashMap<MerkleHash, (XorbRef, u64)> = HashMap::new();
 
         {
@@ -10915,14 +10919,18 @@ impl PushPipeline {
                                     .to_owned(),
                             )
                         })?;
-                    match chunk_sizes.insert(chunk_hash, chunk_size) {
-                        Some(existing) if existing != chunk_size => {
-                            return Err(CrabError::StagingCorrupt(format!(
-                                "chunk {} has conflicting staged sizes {existing} and {chunk_size}",
-                                chunk_hash.hex()
-                            )));
-                        }
-                        _ => {}
+                    let stats = chunk_stats
+                        .entry(chunk_hash)
+                        .or_insert(ClassifiedChunkStats {
+                            size: chunk_size,
+                            new_occurrences: 0,
+                        });
+                    if stats.size != chunk_size {
+                        return Err(CrabError::StagingCorrupt(format!(
+                            "chunk {} has conflicting staged sizes {} and {chunk_size}",
+                            chunk_hash.hex(),
+                            stats.size,
+                        )));
                     }
                     total_chunks += 1;
                     let class = classifier.classify_with_context(&chunk_hash, &dedup_ctx);
@@ -10937,7 +10945,7 @@ impl PushPipeline {
                         ChunkClass::New => {
                             new_chunks += 1;
                             new_set.insert(chunk_hash);
-                            *new_counts.entry(chunk_hash).or_insert(0) += 1;
+                            stats.new_occurrences += 1;
                         }
                     }
                     classifier.mark_seen(chunk_hash);
@@ -10959,7 +10967,9 @@ impl PushPipeline {
                 stale_existing += count;
                 if new_set.insert(chunk_hash) {
                     new_chunks += 1;
-                    new_counts.insert(chunk_hash, 1);
+                    if let Some(stats) = chunk_stats.get_mut(&chunk_hash) {
+                        stats.new_occurrences = 1;
+                    }
                 }
                 staged += count.saturating_sub(1);
             }
@@ -10980,7 +10990,10 @@ impl PushPipeline {
             let mut newly_existing = 0u64;
             for chunk_hash in verified_cache_service_hits.keys() {
                 if new_set.remove(chunk_hash) {
-                    let count = new_counts.remove(chunk_hash).unwrap_or(1);
+                    let count = chunk_stats
+                        .get_mut(chunk_hash)
+                        .map(|stats| std::mem::take(&mut stats.new_occurrences))
+                        .unwrap_or(1);
                     newly_existing += count;
                 }
             }
@@ -11013,7 +11026,10 @@ impl PushPipeline {
             let mut newly_existing = 0u64;
             for chunk_hash in verified_base_shard_hits.keys() {
                 if new_set.remove(chunk_hash) {
-                    let count = new_counts.remove(chunk_hash).unwrap_or(1);
+                    let count = chunk_stats
+                        .get_mut(chunk_hash)
+                        .map(|stats| std::mem::take(&mut stats.new_occurrences))
+                        .unwrap_or(1);
                     newly_existing += count;
                 }
             }
@@ -11043,13 +11059,16 @@ impl PushPipeline {
         let verified_global_hit_count = verified_global_hits.len();
         let global_dedup_bytes = verified_global_hits
             .keys()
-            .map(|hash| chunk_sizes.get(hash).copied().unwrap_or(0))
+            .map(|hash| chunk_stats.get(hash).map_or(0, |stats| stats.size))
             .sum::<u64>();
         if !verified_global_hits.is_empty() {
             let mut newly_existing = 0u64;
             for chunk_hash in verified_global_hits.keys() {
                 if new_set.remove(chunk_hash) {
-                    let count = new_counts.remove(chunk_hash).unwrap_or(1);
+                    let count = chunk_stats
+                        .get_mut(chunk_hash)
+                        .map(|stats| std::mem::take(&mut stats.new_occurrences))
+                        .unwrap_or(1);
                     newly_existing += count;
                 }
             }
@@ -11091,7 +11110,7 @@ impl PushPipeline {
         );
         let new_bytes = new_set
             .iter()
-            .map(|hash| chunk_sizes.get(hash).copied().unwrap_or(0))
+            .map(|hash| chunk_stats.get(hash).map_or(0, |stats| stats.size))
             .sum::<u64>();
         self.planned_xorb_bytes
             .store(new_bytes, std::sync::atomic::Ordering::Relaxed);

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -15488,94 +15488,94 @@ impl PushPipeline {
         // that shard for the session-local ChunkIndex.
         let shard_entries = match self.precomputed_chunk_index_entries.lock().await.take() {
             Some(entries) => entries,
-            None => Arc::new({
-                let shard_results = self.shard_results.lock().await;
-                let placement_map = self.merged_placement.lock().await;
-                let file_shard_index = self.file_shard_index.lock().await;
-                let pointers = self.pointers.lock().await;
+            None => {
+                let recipe_snapshot = self.cached_recipe_snapshot().await;
+                Arc::new({
+                    let shard_results = self.shard_results.lock().await;
+                    let placement_map = self.merged_placement.lock().await;
+                    let file_shard_index = self.file_shard_index.lock().await;
+                    let pointers = self.pointers.lock().await;
 
-                if shard_results.is_empty() || placement_map.is_empty() {
-                    Vec::new()
-                } else {
-                    // Per-shard entry buckets. A `Vec<Vec<...>>` indexed by
-                    // shard index is cheaper than a HashMap for the small
-                    // shard counts in practice (usually 1, up to a handful).
-                    let mut per_shard: Vec<Vec<(MerkleHash, crab_xet::xorb::format::XorbRef)>> =
-                        vec![Vec::new(); shard_results.len()];
+                    if shard_results.is_empty() || placement_map.is_empty() {
+                        Vec::new()
+                    } else {
+                        // Per-shard entry buckets. A `Vec<Vec<...>>` indexed by
+                        // shard index is cheaper than a HashMap for the small
+                        // shard counts in practice (usually 1, up to a handful).
+                        let mut per_shard: Vec<Vec<(MerkleHash, crab_xet::xorb::format::XorbRef)>> =
+                            vec![Vec::new(); shard_results.len()];
 
-                    // Dedup pointers by file_hash to match `build_shard`'s
-                    // added_files guard. Without this, a file appearing at
-                    // multiple paths in the tree would produce duplicate
-                    // chunk entries across the per-shard buckets.
-                    let mut seen_files: HashSet<MerkleHash> = HashSet::new();
+                        // Dedup pointers by file_hash to match `build_shard`'s
+                        // added_files guard. Without this, a file appearing at
+                        // multiple paths in the tree would produce duplicate
+                        // chunk entries across the per-shard buckets.
+                        let mut seen_files: HashSet<MerkleHash> = HashSet::new();
 
-                    for ptr in pointers.iter() {
-                        let file_hash = MerkleHash::from(ptr.file_hash);
-                        if !seen_files.insert(file_hash) {
-                            continue;
-                        }
-                        let Some(&shard_idx) = file_shard_index.get(&file_hash) else {
-                            // Remote-only pointers (verified durable by step 2)
-                            // have no shard entry — skip them here; their
-                            // chunks are already durable elsewhere.
-                            continue;
-                        };
-                        if shard_idx >= per_shard.len() {
-                            // Defense in depth: log and skip rather than panic.
-                            warn!(
-                                file_hash = %file_hash.hex(),
-                                shard_idx,
-                                shards = shard_results.len(),
-                                "step 13: file_shard_index points past shard_results, skipping"
-                            );
-                            continue;
-                        }
-
-                        let recipe = {
-                            let cache = self.chunk_cache.lock().await;
-                            cache
-                                .get(&file_hash)
-                                .and_then(|cached| cached.recipe.clone())
-                        };
-                        let Some(recipe) = recipe else {
-                            continue;
-                        };
-
-                        if let Err(error) = self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
-                            let Some(p) = placement_map.get(&chunk_hash) else {
-                                // Invariant: build_shard guarantees every
-                                // chunk has a placement. Log and skip — the
-                                // push already succeeded at this point so we
-                                // are defensive about cleanup warnings.
-                                return Ok(());
+                        for ptr in pointers.iter() {
+                            let file_hash = MerkleHash::from(ptr.file_hash);
+                            if !seen_files.insert(file_hash) {
+                                continue;
+                            }
+                            let Some(&shard_idx) = file_shard_index.get(&file_hash) else {
+                                // Remote-only pointers (verified durable by step 2)
+                                // have no shard entry — skip them here; their
+                                // chunks are already durable elsewhere.
+                                continue;
                             };
-                            per_shard[shard_idx].push((
-                                chunk_hash,
-                                crab_xet::xorb::format::XorbRef {
-                                    xorb_hash: p.xorb_hash,
-                                    chunk_index: p.chunk_index,
-                                    uncompressed_size: p.uncompressed_size,
-                                },
-                            ));
-                            Ok(())
-                        }) {
-                            warn!(
-                                file_hash = %file_hash.hex(),
-                                error = %error,
-                                "step 13: failed to page recipe for local cache update"
-                            );
-                        }
-                    }
+                            if shard_idx >= per_shard.len() {
+                                // Defense in depth: log and skip rather than panic.
+                                warn!(
+                                    file_hash = %file_hash.hex(),
+                                    shard_idx,
+                                    shards = shard_results.len(),
+                                    "step 13: file_shard_index points past shard_results, skipping"
+                                );
+                                continue;
+                            }
 
-                    shard_results
-                        .iter()
-                        .zip(per_shard.into_iter())
-                        .map(|((_, shard_hash), entries)| (*shard_hash, entries))
-                        .collect()
-                }
-                // shard_results / placement_map / file_shard_index / pointers
-                // locks dropped here.
-            }),
+                            let recipe = recipe_snapshot.get(&file_hash).and_then(Option::as_ref);
+                            let Some(recipe) = recipe else {
+                                continue;
+                            };
+
+                            if let Err(error) =
+                                self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
+                                    let Some(p) = placement_map.get(&chunk_hash) else {
+                                        // Invariant: build_shard guarantees every
+                                        // chunk has a placement. Log and skip — the
+                                        // push already succeeded at this point so we
+                                        // are defensive about cleanup warnings.
+                                        return Ok(());
+                                    };
+                                    per_shard[shard_idx].push((
+                                        chunk_hash,
+                                        crab_xet::xorb::format::XorbRef {
+                                            xorb_hash: p.xorb_hash,
+                                            chunk_index: p.chunk_index,
+                                            uncompressed_size: p.uncompressed_size,
+                                        },
+                                    ));
+                                    Ok(())
+                                })
+                            {
+                                warn!(
+                                    file_hash = %file_hash.hex(),
+                                    error = %error,
+                                    "step 13: failed to page recipe for local cache update"
+                                );
+                            }
+                        }
+
+                        shard_results
+                            .iter()
+                            .zip(per_shard.into_iter())
+                            .map(|((_, shard_hash), entries)| (*shard_hash, entries))
+                            .collect()
+                    }
+                    // shard_results / placement_map / file_shard_index / pointers
+                    // locks dropped here.
+                })
+            }
         };
 
         if !shard_entries.is_empty() {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -9517,7 +9517,11 @@ impl PushPipeline {
         let published_recipes = Arc::new(staging.published_recipes_for_files(&file_hashes)?);
         let recipe_hashes = published_recipes
             .values()
-            .filter_map(|recipe| recipe.as_ref().map(FileRecipe::hash))
+            .filter_map(|recipe| {
+                recipe
+                    .as_ref()
+                    .map(|recipe| MerkleHash::from(recipe.hash()))
+            })
             .collect::<Vec<_>>();
         let prepared_xorbs = match staging.prepared_xorbs_for_recipes(&recipe_hashes) {
             Ok(prepared_xorbs) => Some(Arc::new(prepared_xorbs)),
@@ -9589,7 +9593,7 @@ impl PushPipeline {
                     let add_push_plan = prepared_xorbs.as_ref().and_then(|prepared_xorbs| {
                         let mut plan = FilePushPlan::new_verified_recipe(&recipe);
                         plan.prepared_xorbs = prepared_xorbs
-                            .get(&recipe.hash())
+                            .get(&MerkleHash::from(recipe.hash()))
                             .cloned()
                             .unwrap_or_default();
                         if add_push_plan_matches_staging(

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -5059,8 +5059,6 @@ impl UploadedXorb {
     }
 }
 
-const PREPARED_XORB_HASH_BUFFER_BYTES: usize = 1024 * 1024;
-
 async fn verify_prepared_xorb_plan(
     path: &Path,
     file_hash: &MerkleHash,
@@ -5068,18 +5066,6 @@ async fn verify_prepared_xorb_plan(
     planned: &PlannedXorb,
     len: usize,
 ) -> Result<(Vec<ChunkPlacement>, [u8; 32])> {
-    let payload_hash = hash_prepared_xorb_file(path).await?;
-    let payload_hash_hex = blake3::Hash::from(payload_hash).to_hex().to_string();
-    if payload_hash_hex != planned.payload_hash {
-        return Err(CrabError::StagingCorrupt(format!(
-            "prepared xorb {} for file {} has payload hash {}, plan says {}",
-            xorb_hash.hex(),
-            file_hash.hex(),
-            payload_hash_hex,
-            planned.payload_hash
-        )));
-    }
-
     if len < FOOTER_SIZE {
         return Err(CrabError::StagingCorrupt(format!(
             "prepared xorb {} for file {} is too small for a footer",
@@ -5096,31 +5082,95 @@ async fn verify_prepared_xorb_plan(
     let mut footer = vec![0u8; FOOTER_SIZE];
     file.read_exact(&mut footer).await?;
     let region = xorb_metadata_region(len, &footer)?;
-    file.seek(SeekFrom::Start(u64::try_from(region.offset).map_err(
-        |_| CrabError::Internal("prepared xorb metadata offset does not fit u64".to_owned()),
-    )?))
-    .await?;
     let mut metadata = vec![0u8; region.len];
-    file.read_exact(&mut metadata).await?;
-    let placements = push_plan::validate_prepared_xorb_metadata(
-        len, &footer, &metadata, file_hash, xorb_hash, planned,
-    )?;
+    let metadata_start = u64::try_from(region.offset).map_err(|_| {
+        CrabError::Internal("prepared xorb metadata offset does not fit u64".to_owned())
+    })?;
+    let metadata_end = metadata_start
+        .checked_add(u64::try_from(region.len).map_err(|_| {
+            CrabError::Internal("prepared xorb metadata length does not fit u64".to_owned())
+        })?)
+        .ok_or_else(|| CrabError::Internal("prepared xorb metadata range overflow".to_owned()))?;
 
-    Ok((placements, payload_hash))
-}
-
-async fn hash_prepared_xorb_file(path: &Path) -> Result<[u8; 32]> {
-    let mut file = tokio::fs::File::open(path).await?;
+    file.seek(SeekFrom::Start(0)).await?;
     let mut hasher = blake3::Hasher::new();
-    let mut buffer = vec![0u8; PREPARED_XORB_HASH_BUFFER_BYTES];
+    let mut buffer = vec![0u8; 1024 * 1024];
+    let expected_len = u64::try_from(len)
+        .map_err(|_| CrabError::Internal("prepared xorb length does not fit u64".to_owned()))?;
+    let mut offset = 0u64;
     loop {
         let read = file.read(&mut buffer).await?;
         if read == 0 {
             break;
         }
-        hasher.update(&buffer[..read]);
+        let read_len = read;
+        let read = u64::try_from(read_len).map_err(|_| {
+            CrabError::Internal("prepared xorb read length does not fit u64".to_owned())
+        })?;
+        let end = offset
+            .checked_add(read)
+            .ok_or_else(|| CrabError::StagingCorrupt("prepared xorb length overflow".to_owned()))?;
+        if end > expected_len {
+            return Err(CrabError::StagingCorrupt(format!(
+                "prepared xorb {} for file {} grew while being verified",
+                xorb_hash.hex(),
+                file_hash.hex()
+            )));
+        }
+        hasher.update(&buffer[..read_len]);
+
+        let overlap_start = offset.max(metadata_start);
+        let overlap_end = end.min(metadata_end);
+        if overlap_start < overlap_end {
+            let source_start = usize::try_from(overlap_start - offset).map_err(|_| {
+                CrabError::Internal(
+                    "prepared xorb metadata source offset does not fit usize".to_owned(),
+                )
+            })?;
+            let destination_start =
+                usize::try_from(overlap_start - metadata_start).map_err(|_| {
+                    CrabError::Internal(
+                        "prepared xorb metadata destination offset does not fit usize".to_owned(),
+                    )
+                })?;
+            let overlap_len = usize::try_from(overlap_end - overlap_start).map_err(|_| {
+                CrabError::Internal("prepared xorb metadata overlap does not fit usize".to_owned())
+            })?;
+            metadata[destination_start..destination_start + overlap_len]
+                .copy_from_slice(&buffer[source_start..source_start + overlap_len]);
+        }
+        offset = end;
     }
-    Ok(*hasher.finalize().as_bytes())
+    if offset != expected_len {
+        return Err(CrabError::StagingCorrupt(format!(
+            "prepared xorb {} for file {} changed size while being verified",
+            xorb_hash.hex(),
+            file_hash.hex()
+        )));
+    }
+    let payload_hash = *hasher.finalize().as_bytes();
+    let expected_payload_hash = blake3::Hash::from_hex(&planned.payload_hash).map_err(|error| {
+        CrabError::StagingCorrupt(format!(
+            "prepared xorb {} for file {} has invalid planned payload hash {}: {error}",
+            xorb_hash.hex(),
+            file_hash.hex(),
+            planned.payload_hash
+        ))
+    })?;
+    if blake3::Hash::from(payload_hash) != expected_payload_hash {
+        return Err(CrabError::StagingCorrupt(format!(
+            "prepared xorb {} for file {} has payload hash {}, plan says {}",
+            xorb_hash.hex(),
+            file_hash.hex(),
+            blake3::Hash::from(payload_hash).to_hex(),
+            planned.payload_hash
+        )));
+    }
+    let placements = push_plan::validate_prepared_xorb_metadata(
+        len, &footer, &metadata, file_hash, xorb_hash, planned,
+    )?;
+
+    Ok((placements, payload_hash))
 }
 
 #[derive(Debug)]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -5059,6 +5059,8 @@ impl UploadedXorb {
     }
 }
 
+const PREPARED_XORB_VERIFY_BUFFER_BYTES: usize = 1024 * 1024;
+
 async fn verify_prepared_xorb_plan(
     path: &Path,
     file_hash: &MerkleHash,
@@ -5091,12 +5093,19 @@ async fn verify_prepared_xorb_plan(
             CrabError::Internal("prepared xorb metadata length does not fit u64".to_owned())
         })?)
         .ok_or_else(|| CrabError::Internal("prepared xorb metadata range overflow".to_owned()))?;
+    let expected_len = u64::try_from(len)
+        .map_err(|_| CrabError::Internal("prepared xorb length does not fit u64".to_owned()))?;
+    if metadata_end > expected_len {
+        return Err(CrabError::StagingCorrupt(format!(
+            "prepared xorb {} for file {} has metadata outside its payload",
+            xorb_hash.hex(),
+            file_hash.hex()
+        )));
+    }
 
     file.seek(SeekFrom::Start(0)).await?;
     let mut hasher = blake3::Hasher::new();
-    let mut buffer = vec![0u8; 1024 * 1024];
-    let expected_len = u64::try_from(len)
-        .map_err(|_| CrabError::Internal("prepared xorb length does not fit u64".to_owned()))?;
+    let mut buffer = vec![0u8; PREPARED_XORB_VERIFY_BUFFER_BYTES];
     let mut offset = 0u64;
     loop {
         let read = file.read(&mut buffer).await?;

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -10851,13 +10851,13 @@ impl PushPipeline {
             );
         }
 
-        let cache_lookup_candidates: Vec<MerkleHash> = expected_sizes
+        let mut lookup_candidates: Vec<MerkleHash> = expected_sizes
             .keys()
             .filter(|chunk_hash| !verified_refs.contains_key(chunk_hash))
             .copied()
             .collect();
         let verified_cache_service_hits = self
-            .lookup_cache_service_chunk_refs(&cache_lookup_candidates)
+            .lookup_cache_service_chunk_refs(&lookup_candidates)
             .await?;
         let verified_cache_service_hit_count = verified_cache_service_hits.len();
         if !verified_cache_service_hits.is_empty() {
@@ -10867,17 +10867,12 @@ impl PushPipeline {
                     chunk_index.insert(*chunk_hash, *xorb_ref);
                 }
             }
-            {}
             verified_refs.extend(verified_cache_service_hits);
         }
 
-        let global_lookup_candidates: Vec<MerkleHash> = expected_sizes
-            .keys()
-            .filter(|chunk_hash| !verified_refs.contains_key(chunk_hash))
-            .copied()
-            .collect();
+        lookup_candidates.retain(|chunk_hash| !verified_refs.contains_key(chunk_hash));
         let global_lookup = self
-            .lookup_verified_global_chunk_refs(&global_lookup_candidates)
+            .lookup_verified_global_chunk_refs(&lookup_candidates)
             .await?;
         if global_lookup.stale_hits > 0 {
             warn!(

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6788,12 +6788,38 @@ impl PushPipeline {
 
     fn build_file_terms_for_recipe(
         &self,
+        file_hash: &MerkleHash,
         recipe: &FileRecipe,
-        placement: &ChunkPlacementMap,
+        placement: &mut ChunkPlacementMap,
+        verified_existing: &ChunkPlacementMap,
     ) -> Result<Vec<FileTerm>> {
         let mut builder = crab_xet::reconstruction::FileTermBuilder::new();
+        let mut chunk_index = 0usize;
         self.visit_recipe_chunks(recipe, |chunk_hash, _| {
-            builder.push(chunk_hash, placement).map_err(CrabError::from)
+            if !placement.contains_key(&chunk_hash) {
+                match verified_existing.get(&chunk_hash) {
+                    Some(existing) => {
+                        placement.insert(chunk_hash, existing.clone());
+                    }
+                    None => {
+                        return Err(CrabError::IncompleteShardReconstruction {
+                            file_hash: file_hash.hex(),
+                            path: None,
+                            uncovered_chunks: 1,
+                            example_chunk_hash: chunk_hash.hex(),
+                            example_chunk_index: usize_to_shard_u32(
+                                "file chunk index",
+                                chunk_index,
+                            )?,
+                        });
+                    }
+                }
+            }
+            builder
+                .push(chunk_hash, placement)
+                .map_err(CrabError::from)?;
+            chunk_index = chunk_index.saturating_add(1);
+            Ok(())
         })?;
         builder
             .finish(&recipe.file_hash(), recipe.chunk_count())
@@ -12160,44 +12186,12 @@ impl PushPipeline {
                 .collect::<ChunkPlacementMap>()
         };
         let mut merged_from_index = 0u64;
-        if !verified_existing.is_empty() {
-            for (file_hash, _) in &pointer_specs {
-                if remote_only.contains(file_hash) {
-                    continue;
-                }
-                let Some(recipe) = self.cached_recipe_for_file(file_hash).await? else {
-                    continue;
-                };
-                let mut idx = 0usize;
-                self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
-                    if !merged_placement.contains_key(&chunk_hash) {
-                        match verified_existing.get(&chunk_hash) {
-                            Some(placement) => {
-                                merged_placement.insert(chunk_hash, placement.clone());
-                                merged_from_index += 1;
-                            }
-                            None => {
-                                // Invariant 6: shard reconstruction terms must
-                                // cover ALL chunks. If a chunk for this file is
-                                // absent from both the new placement map and
-                                // the verified existing-placement set, we cannot
-                                // build a complete shard.
-                                return Err(CrabError::IncompleteShardReconstruction {
-                                    file_hash: file_hash.hex(),
-                                    path: None,
-                                    uncovered_chunks: 1,
-                                    example_chunk_hash: chunk_hash.hex(),
-                                    example_chunk_index: usize_to_shard_u32(
-                                        "file chunk index",
-                                        idx,
-                                    )?,
-                                });
-                            }
-                        }
-                    }
-                    idx = idx.saturating_add(1);
-                    Ok(())
-                })?;
+        for (chunk_hash, placement) in &verified_existing {
+            if let std::collections::hash_map::Entry::Vacant(entry) =
+                merged_placement.entry(*chunk_hash)
+            {
+                entry.insert(placement.clone());
+                merged_from_index += 1;
             }
         }
         info!(
@@ -12297,7 +12291,12 @@ impl PushPipeline {
                         "non-empty recipe disappeared during shard build".to_owned(),
                     )
                 })?;
-                let terms = self.build_file_terms_for_recipe(recipe, &merged_placement)?;
+                let terms = self.build_file_terms_for_recipe(
+                    file_hash,
+                    recipe,
+                    &mut merged_placement,
+                    &verified_existing,
+                )?;
 
                 terms
                     .iter()

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4389,7 +4389,9 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
             }
         }
 
-        if let Some(cache) = &self.candidate_cache {
+        if !misses.is_empty()
+            && let Some(cache) = &self.candidate_cache
+        {
             let mut remote_misses = Vec::with_capacity(misses.len());
             let persistent_lookup = {
                 let cache = Arc::clone(cache);

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -14863,8 +14863,6 @@ impl PushPipeline {
             ));
         }
 
-        let placement_snapshot = self.verified_placement_snapshot().await;
-
         let gc_registry_generation = self
             .push_commit_receipt
             .lock()
@@ -14907,6 +14905,9 @@ impl PushPipeline {
                 Ok(())
             })?;
         }
+        let placement_snapshot = self
+            .verified_placement_snapshot_for(chunk_sources.keys())
+            .await;
         for chunk_hash in chunk_sources.keys() {
             let placement = placement_snapshot.get(chunk_hash).ok_or_else(|| {
                 CrabError::IncompleteShardReconstruction {
@@ -15076,13 +15077,11 @@ impl PushPipeline {
         file_index_plan: &[(MerkleHash, usize)],
         shard_hashes: &[MerkleHash],
     ) {
-        let mut per_shard_chunks: Vec<Vec<(MerkleHash, XorbRef)>> =
-            vec![Vec::new(); shard_hashes.len()];
+        let mut per_shard_hashes: Vec<Vec<MerkleHash>> = vec![Vec::new(); shard_hashes.len()];
         if self.staging.is_none() {
             return;
         }
-        let placement_snapshot = self.verified_placement_snapshot().await;
-
+        let mut required_chunks = HashSet::new();
         for (file_hash, shard_idx) in file_index_plan {
             let recipe = match self.cached_recipe_for_file(file_hash).await {
                 Ok(Some(recipe)) => recipe,
@@ -15096,19 +15095,18 @@ impl PushPipeline {
                     continue;
                 }
             };
-            let Some(bucket) = per_shard_chunks.get_mut(*shard_idx) else {
+            let Some(bucket) = per_shard_hashes.get_mut(*shard_idx) else {
                 warn!(
                     file_hash = %file_hash.hex(),
                     shard_idx,
-                    shards = per_shard_chunks.len(),
+                    shards = per_shard_hashes.len(),
                     "candidate metadata file-index plan points past uploaded shard hashes, skipping local warm"
                 );
                 continue;
             };
             if let Err(error) = self.visit_recipe_chunks(&recipe, |chunk_hash, _| {
-                if let Some(p) = placement_snapshot.get(&chunk_hash) {
-                    bucket.push((chunk_hash, Self::xorb_ref_from_placement(p)));
-                }
+                required_chunks.insert(chunk_hash);
+                bucket.push(chunk_hash);
                 Ok(())
             }) {
                 warn!(
@@ -15118,14 +15116,24 @@ impl PushPipeline {
                 );
             }
         }
-        // De-dup within each shard bucket so `install_shard` doesn't
-        // re-register the same chunk→xorb_ref pair multiple times.
-        for bucket in &mut per_shard_chunks {
-            let mut seen: std::collections::HashSet<MerkleHash> =
-                std::collections::HashSet::with_capacity(bucket.len());
-            bucket.retain(|(h, _)| seen.insert(*h));
-        }
-
+        let placement_snapshot = self
+            .verified_placement_snapshot_for(required_chunks.iter())
+            .await;
+        let per_shard_chunks: Vec<Vec<(MerkleHash, XorbRef)>> = per_shard_hashes
+            .into_iter()
+            .map(|hashes| {
+                let mut seen = HashSet::with_capacity(hashes.len());
+                hashes
+                    .into_iter()
+                    .filter(|chunk_hash| seen.insert(*chunk_hash))
+                    .filter_map(|chunk_hash| {
+                        placement_snapshot
+                            .get(&chunk_hash)
+                            .map(|placement| (chunk_hash, Self::xorb_ref_from_placement(placement)))
+                    })
+                    .collect()
+            })
+            .collect();
         for (idx, shard_hash) in shard_hashes.iter().enumerate() {
             let entries = &per_shard_chunks[idx];
             if entries.is_empty() {
@@ -15142,14 +15150,31 @@ impl PushPipeline {
         }
     }
 
-    async fn verified_placement_snapshot(&self) -> ChunkPlacementMap {
+    async fn verified_placement_snapshot_for<'a, I>(&self, required: I) -> ChunkPlacementMap
+    where
+        I: IntoIterator<Item = &'a MerkleHash>,
+    {
+        let required = required.into_iter().collect::<HashSet<_>>();
+        if required.is_empty() {
+            return ChunkPlacementMap::new();
+        }
         let merged = self.merged_placement.lock().await;
         if !merged.is_empty() {
-            return merged.clone();
+            return merged
+                .iter()
+                .filter(|(chunk_hash, _)| required.contains(chunk_hash))
+                .map(|(chunk_hash, placement)| (*chunk_hash, placement.clone()))
+                .collect();
         }
         drop(merged);
 
-        self.chunk_placement.lock().await.clone()
+        self.chunk_placement
+            .lock()
+            .await
+            .iter()
+            .filter(|(chunk_hash, _)| required.contains(chunk_hash))
+            .map(|(chunk_hash, placement)| (*chunk_hash, placement.clone()))
+            .collect()
     }
 
     /// Step 10b: Verify every object reachable from each ref tip exists

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -11405,8 +11405,9 @@ impl PushPipeline {
         let already_exist = head_batch(&planned_hashes, &head_store, &config).await?;
         let existing_candidates: Vec<RemoteXorbCandidate> = xorbs
             .iter()
-            .filter(|xorb| already_exist.existing.contains(&xorb.hash.hex()))
-            .map(|xorb| RemoteXorbCandidate {
+            .zip(planned_hashes.iter())
+            .filter(|(_, planned_hash)| already_exist.existing.contains(*planned_hash))
+            .map(|(xorb, _)| RemoteXorbCandidate {
                 hash: xorb.hash,
                 placements: xorb.placements.clone(),
             })

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4363,11 +4363,10 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
             }
         }
 
-        let mut misses = unique_chunks.clone();
+        let mut misses = Vec::new();
         if let Some(cache) = &self.candidate_cache {
             match cache.memory_get_batch(&unique_chunks) {
                 Ok(cached) => {
-                    misses.clear();
                     for chunk_hash in &unique_chunks {
                         match cached.get(chunk_hash).copied() {
                             Some(Some(candidate)) => {
@@ -4385,8 +4384,11 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                 }
                 Err(error) => {
                     warn!(error = %error, "add remote candidate memory cache lookup failed");
+                    misses = unique_chunks.clone();
                 }
             }
+        } else {
+            misses = unique_chunks.clone();
         }
 
         if !misses.is_empty()

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -95,6 +95,9 @@ use crab_xet::xorb::format::{
 };
 use crab_xet::xorb::parser::{XorbParser, xorb_metadata_region};
 
+const RECIPE_PAGE_CACHE_BYTES: usize = 64 * 1024 * 1024;
+const RECIPE_PAGE_CACHE_ENTRY_OVERHEAD: usize = 128;
+
 fn bulk_data_bytes(bulk: &BulkData) -> u64 {
     let shard_segment_bytes: u64 = bulk
         .shard_index
@@ -6809,16 +6812,27 @@ impl PushPipeline {
         &self,
         recipe: &FileRecipe,
         pages: &mut HashMap<([u8; 32], u64), Arc<crab_staging::recipe::RecipePage>>,
+        cached_bytes: &mut usize,
         mut visit: impl FnMut(MerkleHash, u64) -> Result<()>,
     ) -> Result<()> {
         let recipe_hash = recipe.hash();
         let mut next = 0u64;
         while next < recipe.chunk_count() {
-            let page = match pages.entry((recipe_hash, next)) {
-                std::collections::hash_map::Entry::Occupied(entry) => Arc::clone(entry.get()),
-                std::collections::hash_map::Entry::Vacant(entry) => entry
-                    .insert(Arc::new(self.recipe_page(recipe, next)?))
-                    .clone(),
+            let key = (recipe_hash, next);
+            let page = if let Some(page) = pages.get(&key) {
+                Arc::clone(page)
+            } else {
+                let page = Arc::new(self.recipe_page(recipe, next)?);
+                let estimated_bytes = page
+                    .chunks
+                    .len()
+                    .saturating_mul(std::mem::size_of::<crab_staging::recipe::RecipeChunk>())
+                    .saturating_add(RECIPE_PAGE_CACHE_ENTRY_OVERHEAD);
+                if (*cached_bytes).saturating_add(estimated_bytes) <= RECIPE_PAGE_CACHE_BYTES {
+                    *cached_bytes = (*cached_bytes).saturating_add(estimated_bytes);
+                    pages.insert(key, Arc::clone(&page));
+                }
+                page
             };
             for chunk in &page.chunks {
                 visit(chunk.chunk_hash, chunk.len)?;
@@ -6833,13 +6847,14 @@ impl PushPipeline {
         file_hash: &MerkleHash,
         recipe: &FileRecipe,
         pages: &mut HashMap<([u8; 32], u64), Arc<crab_staging::recipe::RecipePage>>,
+        cached_bytes: &mut usize,
         placement: &mut ChunkPlacementMap,
         verified_existing: &ChunkPlacementMap,
         fail_fast_on_missing: bool,
     ) -> Result<Vec<FileTerm>> {
         let mut builder = crab_xet::reconstruction::FileTermBuilder::new();
         let mut chunk_index = 0usize;
-        self.visit_recipe_chunks_cached(recipe, pages, |chunk_hash, _| {
+        self.visit_recipe_chunks_cached(recipe, pages, cached_bytes, |chunk_hash, _| {
             if fail_fast_on_missing {
                 let resolved = if let Some(existing) = placement.get(&chunk_hash) {
                     Some(existing)
@@ -12229,8 +12244,9 @@ impl PushPipeline {
         // ordinary orphans, but must not become generation dependencies.
         // The push reader snapshot pins these roots, so a page validated in
         // the reachability pass remains immutable for term construction.
-        // Keep the cache local to bound its lifetime to shard assembly.
+        // Keep the cache local and budgeted to bound its lifetime and memory.
         let mut recipe_pages = HashMap::new();
+        let mut recipe_page_cache_bytes = 0usize;
         let mut required_chunks = HashSet::new();
         let mut seen_recipe_files = HashSet::new();
         for (file_hash, _) in &pointer_specs {
@@ -12238,10 +12254,15 @@ impl PushPipeline {
                 continue;
             }
             if let Some(recipe) = Self::recipe_from_snapshot(&recipe_snapshot, file_hash)? {
-                self.visit_recipe_chunks_cached(&recipe, &mut recipe_pages, |chunk_hash, _| {
-                    required_chunks.insert(chunk_hash);
-                    Ok(())
-                })?;
+                self.visit_recipe_chunks_cached(
+                    &recipe,
+                    &mut recipe_pages,
+                    &mut recipe_page_cache_bytes,
+                    |chunk_hash, _| {
+                        required_chunks.insert(chunk_hash);
+                        Ok(())
+                    },
+                )?;
             }
         }
         // Build a merged placement map that includes both new chunks and
@@ -12354,6 +12375,7 @@ impl PushPipeline {
                         file_hash,
                         recipe,
                         &mut recipe_pages,
+                        &mut recipe_page_cache_bytes,
                         &mut merged_placement,
                         &verified_existing,
                         !verified_existing.is_empty(),

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -14465,7 +14465,16 @@ impl PushPipeline {
             }
         };
         if skipped_remote > 0 {
-            return Ok(Some((HashMap::new(), chunk_hashes.len())));
+            // Local and persistent tiers are already exact placements. Keep
+            // those hits even when the remote candidate phase is over budget;
+            // each retained ref still crosses the normal origin-proof check.
+            let hits = chunk_hashes
+                .iter()
+                .copied()
+                .zip(refs)
+                .filter_map(|(chunk_hash, xorb_ref)| xorb_ref.map(|value| (chunk_hash, value)))
+                .collect();
+            return Ok(Some((hits, skipped_remote)));
         }
 
         {
@@ -28887,6 +28896,65 @@ mod tests {
         assert!(lookup.refs.is_empty());
         assert!(lookup.lookup_unavailable);
         assert_eq!(lookup.skipped_after_unavailable, chunk_hashes.len());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verified_global_lookup_keeps_local_hits_when_remote_budget_is_exceeded() {
+        let inner: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let store = Store::new(inner);
+        let router = StoreLayout::new(store.clone(), "repo-bounded-local".to_owned());
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            vec![],
+            Some(store.clone()),
+            None,
+            None,
+            "repo-bounded-local".to_owned(),
+            router.clone(),
+            None,
+            CancellationToken::new(),
+            None,
+        );
+        let (local_hash, xorb_bytes, xorb_hash, xorb_ref) =
+            test_single_chunk_xorb(b"bounded local global lookup");
+        store
+            .put(&router.xorb_path(&xorb_hash), xorb_bytes)
+            .await
+            .expect("seed durable xorb");
+        let guard = build_push_metadb_guard(
+            &store,
+            &router,
+            None,
+            &crate::core::config::MetaDbTomlConfig::default(),
+            false,
+        );
+        let chunk_store = guard.chunk_index().await.expect("chunk index store");
+        chunk_store
+            .warm_local_shard(
+                MerkleHash::from([0xB0, 0xD6, 0xE7, 0x01]),
+                &[(local_hash, xorb_ref)],
+            )
+            .await
+            .expect("warm local chunk index");
+        pipeline.install_metadb(guard);
+
+        let mut chunk_hashes = (0..=(GLOBAL_CHUNK_LOOKUP_REMOTE_BATCH_SIZE + 1))
+            .map(|index| MerkleHash::from([index as u64, 0xB0D6E7, 0xCA11, 0xD0]))
+            .collect::<Vec<_>>();
+        chunk_hashes[0] = local_hash;
+        let lookup = pipeline
+            .lookup_verified_global_chunk_refs(&chunk_hashes)
+            .await
+            .expect("bounded lookup");
+
+        assert_eq!(lookup.refs.get(&local_hash), Some(&xorb_ref));
+        assert!(lookup.lookup_unavailable);
+        assert_eq!(
+            lookup.skipped_after_unavailable,
+            chunk_hashes.len().saturating_sub(1)
+        );
+        pipeline.close_metadb().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6791,12 +6791,12 @@ impl PushPipeline {
         file_hash: &MerkleHash,
         recipe: &FileRecipe,
         placement: &mut ChunkPlacementMap,
-        verified_existing: &ChunkPlacementMap,
+        fail_fast_on_missing: bool,
     ) -> Result<Vec<FileTerm>> {
         let mut builder = crab_xet::reconstruction::FileTermBuilder::new();
         let mut chunk_index = 0usize;
         self.visit_recipe_chunks(recipe, |chunk_hash, _| {
-            if !placement.contains_key(&chunk_hash) && !verified_existing.is_empty() {
+            if fail_fast_on_missing && !placement.contains_key(&chunk_hash) {
                 match verified_existing.get(&chunk_hash) {
                     Some(existing) => {
                         placement.insert(chunk_hash, existing.clone());
@@ -12295,7 +12295,7 @@ impl PushPipeline {
                     file_hash,
                     recipe,
                     &mut merged_placement,
-                    &verified_existing,
+                    !verified_existing.is_empty(),
                 )?;
 
                 terms

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6791,33 +6791,43 @@ impl PushPipeline {
         file_hash: &MerkleHash,
         recipe: &FileRecipe,
         placement: &mut ChunkPlacementMap,
+        verified_existing: &ChunkPlacementMap,
         fail_fast_on_missing: bool,
     ) -> Result<Vec<FileTerm>> {
         let mut builder = crab_xet::reconstruction::FileTermBuilder::new();
         let mut chunk_index = 0usize;
         self.visit_recipe_chunks(recipe, |chunk_hash, _| {
-            if fail_fast_on_missing && !placement.contains_key(&chunk_hash) {
-                match verified_existing.get(&chunk_hash) {
-                    Some(existing) => {
-                        placement.insert(chunk_hash, existing.clone());
+            if fail_fast_on_missing {
+                let resolved = if let Some(existing) = placement.get(&chunk_hash) {
+                    Some(existing)
+                } else {
+                    match verified_existing.get(&chunk_hash) {
+                        Some(existing) => {
+                            placement.insert(chunk_hash, existing.clone());
+                            placement.get(&chunk_hash)
+                        }
+                        None => {
+                            return Err(CrabError::IncompleteShardReconstruction {
+                                file_hash: file_hash.hex(),
+                                path: None,
+                                uncovered_chunks: 1,
+                                example_chunk_hash: chunk_hash.hex(),
+                                example_chunk_index: usize_to_shard_u32(
+                                    "file chunk index",
+                                    chunk_index,
+                                )?,
+                            });
+                        }
                     }
-                    None => {
-                        return Err(CrabError::IncompleteShardReconstruction {
-                            file_hash: file_hash.hex(),
-                            path: None,
-                            uncovered_chunks: 1,
-                            example_chunk_hash: chunk_hash.hex(),
-                            example_chunk_index: usize_to_shard_u32(
-                                "file chunk index",
-                                chunk_index,
-                            )?,
-                        });
-                    }
-                }
+                };
+                builder
+                    .push_with_placement(chunk_hash, resolved)
+                    .map_err(CrabError::from)?;
+            } else {
+                builder
+                    .push(chunk_hash, placement)
+                    .map_err(CrabError::from)?;
             }
-            builder
-                .push(chunk_hash, placement)
-                .map_err(CrabError::from)?;
             chunk_index = chunk_index.saturating_add(1);
             Ok(())
         })?;
@@ -12295,6 +12305,7 @@ impl PushPipeline {
                     file_hash,
                     recipe,
                     &mut merged_placement,
+                    &verified_existing,
                     !verified_existing.is_empty(),
                 )?;
 

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4419,6 +4419,11 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
             };
             match persistent_lookup {
                 Ok(Ok(persisted)) => {
+                    if persisted.is_empty() {
+                        // Preserve the cold-cache all-miss fast path without
+                        // reserving this repository-sized buffer for warm hits.
+                        remote_misses.reserve(lookup_hashes.len());
+                    }
                     // Persisted misses are not inserted into memory; only grow
                     // this buffer for rows that actually came back from SQLite.
                     let mut memory_updates = Vec::new();

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -15728,6 +15728,37 @@ impl PushPipeline {
         };
 
         if !shard_entries.is_empty() {
+            // Only successful visibility publication invalidates cached misses.
+            // Reuse the prepared shard membership; do not rescan recipes or
+            // promote pre-CAS candidates into add-time remote authority.
+            let cache_path = crate::cache::add_remote_candidate_cache_path(
+                &crate::cache::default_cache_root(),
+                &self.router.store().bucket_identity(),
+                self.router.global_prefix(),
+            );
+            if self.store.is_some() && cache_path.is_file() {
+                let published = Arc::clone(&shard_entries);
+                let invalidation = tokio::task::spawn_blocking(move || -> Result<()> {
+                    let cache = crate::cache::add_remote_candidates::AddRemoteCandidateCache::open(
+                        &cache_path,
+                    )?;
+                    for (_, entries) in published.iter() {
+                        for batch in entries.chunks(CANDIDATE_METADATA_BATCH_SIZE) {
+                            let hashes = batch.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
+                            cache.forget_negatives(&hashes)?;
+                        }
+                    }
+                    Ok(())
+                })
+                .await;
+                match invalidation {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        warn!(error = %error, "failed to invalidate committed add cache misses")
+                    }
+                    Err(error) => warn!(error = %error, "add cache invalidation task failed"),
+                }
+            }
             let mut chunk_index = self.chunk_index.lock().await;
             for (shard_hash, entries) in shard_entries.iter() {
                 let already_installed = chunk_index.has_shard(shard_hash);

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -7892,15 +7892,8 @@ impl PushPipeline {
                     .as_bytes(),
             );
         }
-        let staged_recipes = self
-            .chunk_cache
-            .lock()
-            .await
-            .values()
-            .filter_map(|cached| cached.recipe.clone())
-            .collect::<Vec<_>>();
         let mut staged_hashes = HashSet::new();
-        for recipe in &staged_recipes {
+        for recipe in recipe_snapshot.values().filter_map(Option::as_ref) {
             self.visit_recipe_chunks(recipe, |chunk_hash, _| {
                 staged_hashes.insert(chunk_hash);
                 Ok(())

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6825,7 +6825,7 @@ impl PushPipeline {
                 let page = Arc::new(self.recipe_page(recipe, next)?);
                 let estimated_bytes = page
                     .chunks
-                    .len()
+                    .capacity()
                     .saturating_mul(std::mem::size_of::<crab_staging::recipe::RecipeChunk>())
                     .saturating_add(RECIPE_PAGE_CACHE_ENTRY_OVERHEAD);
                 if (*cached_bytes).saturating_add(estimated_bytes) <= RECIPE_PAGE_CACHE_BYTES {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4354,7 +4354,7 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
         if chunks.is_empty() {
             return Ok(Vec::new());
         }
-        let mut candidates = HashMap::new();
+        let mut candidates = HashMap::with_capacity(chunks.len());
         let mut unique_chunks = Vec::with_capacity(chunks.len());
         let mut seen = HashSet::with_capacity(chunks.len());
         for (chunk_hash, _) in chunks {
@@ -4363,7 +4363,7 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
             }
         }
 
-        let mut misses = Vec::new();
+        let mut misses = Vec::with_capacity(unique_chunks.len());
         if let Some(cache) = &self.candidate_cache {
             match cache.memory_get_batch(&unique_chunks) {
                 Ok(cached) => {
@@ -4384,11 +4384,11 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                 }
                 Err(error) => {
                     warn!(error = %error, "add remote candidate memory cache lookup failed");
-                    misses = unique_chunks.clone();
+                    misses = unique_chunks;
                 }
             }
         } else {
-            misses = unique_chunks.clone();
+            misses = unique_chunks;
         }
 
         if !misses.is_empty()
@@ -4403,7 +4403,7 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
             };
             match persistent_lookup {
                 Ok(Ok(persisted)) => {
-                    let mut memory_updates = Vec::new();
+                    let mut memory_updates = Vec::with_capacity(lookup_hashes.len());
                     for &chunk_hash in lookup_hashes.iter() {
                         match persisted.get(&chunk_hash).copied() {
                             Some(Some(candidate)) => {

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -4374,6 +4374,7 @@ impl crab_staging::push_plan::ExistingChunkLookup for AddRemoteChunkClassifier {
                 unique_chunks.push(*chunk_hash);
             }
         }
+        drop(seen);
 
         let mut candidates = HashMap::with_capacity(unique_chunks.len());
         let mut misses = Vec::with_capacity(unique_chunks.len());

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -11252,10 +11252,10 @@ impl PushPipeline {
             );
         }
 
-        let verified_cache_service_hits = {
-            let candidates: Vec<MerkleHash> = new_set.iter().copied().collect();
-            self.lookup_cache_service_chunk_refs(&candidates).await?
-        };
+        let mut lookup_candidates: Vec<MerkleHash> = new_set.iter().copied().collect();
+        let verified_cache_service_hits = self
+            .lookup_cache_service_chunk_refs(&lookup_candidates)
+            .await?;
         let verified_cache_service_hit_count = verified_cache_service_hits.len();
         if !verified_cache_service_hits.is_empty() {
             let mut newly_existing = 0u64;
@@ -11309,10 +11309,10 @@ impl PushPipeline {
             verified_refs.extend(verified_base_shard_hits);
         }
 
-        let global_lookup = {
-            let candidates: Vec<MerkleHash> = new_set.iter().copied().collect();
-            self.lookup_verified_global_chunk_refs(&candidates).await?
-        };
+        lookup_candidates.retain(|chunk_hash| new_set.contains(chunk_hash));
+        let global_lookup = self
+            .lookup_verified_global_chunk_refs(&lookup_candidates)
+            .await?;
         let stale_global_hits = global_lookup.stale_hits;
         if stale_global_hits > 0 {
             warn!(

--- a/crab/src/metadata/metadb/stores/chunk_index.rs
+++ b/crab/src/metadata/metadb/stores/chunk_index.rs
@@ -1260,8 +1260,8 @@ mod tests {
         }
         assert_eq!(
             metrics.snapshot().metadb_batch_get_count,
-            2,
-            "one head lookup and one proof-record lookup should cover all remote misses"
+            4,
+            "two pages require one head lookup and one proof-record lookup each"
         );
 
         ctx.db.close().await.expect("close");

--- a/crab/src/metadata/metadb/stores/chunk_index.rs
+++ b/crab/src/metadata/metadb/stores/chunk_index.rs
@@ -145,20 +145,20 @@ impl ChunkIndexStore {
     }
 
     /// Resolve local candidates first, then consult remote receipt heads only
-    /// when the remaining miss set fits the caller's proof budget.
-    pub(crate) async fn get_batch_with_candidates_bounded(
+    /// in bounded pages until the caller's deadline, retaining completed hits.
+    pub(crate) async fn get_batch_with_candidates_until(
         &self,
         chunk_hashes: &[MerkleHash],
-        remote_candidate_limit: usize,
+        deadline: tokio::time::Instant,
     ) -> Result<(Vec<Option<XorbRef>>, CommittedChunkCandidateBatch, usize)> {
-        self.get_batch_with_candidates_inner(chunk_hashes, Some(remote_candidate_limit))
+        self.get_batch_with_candidates_inner(chunk_hashes, Some(deadline))
             .await
     }
 
     async fn get_batch_with_candidates_inner(
         &self,
         chunk_hashes: &[MerkleHash],
-        remote_candidate_limit: Option<usize>,
+        deadline: Option<tokio::time::Instant>,
     ) -> Result<(Vec<Option<XorbRef>>, CommittedChunkCandidateBatch, usize)> {
         if chunk_hashes.is_empty() {
             return Ok((Vec::new(), CommittedChunkCandidateBatch::default(), 0));
@@ -242,18 +242,40 @@ impl ChunkIndexStore {
             m.add_metadb_chunk_index_cache_hits(cache_hits);
             m.add_metadb_chunk_index_cache_misses(remote_miss_count);
         }
-        if remote_candidate_limit.is_some_and(|limit| remote_todo.len() > limit) {
-            return Ok((
-                results,
-                CommittedChunkCandidateBatch::default(),
-                remote_todo.len(),
-            ));
+        let mut candidates = CommittedChunkCandidateBatch::default();
+        let mut skipped_remote = remote_todo.len();
+        for batch in remote_todo.chunks(GET_BATCH_TIER_CHUNK_LIMIT) {
+            let remote_hashes = batch
+                .iter()
+                .map(|&idx| chunk_hashes[idx])
+                .collect::<Vec<_>>();
+            let page = if let Some(deadline) = deadline {
+                // Check before polling: an immediately ready read can otherwise
+                // succeed after the deadline and keep an arbitrarily large loop alive.
+                if tokio::time::Instant::now() >= deadline {
+                    break;
+                }
+                match tokio::time::timeout_at(
+                    deadline,
+                    self.get_committed_candidates_page(&remote_hashes),
+                )
+                .await
+                {
+                    Ok(Ok(page)) => page,
+                    Ok(Err(error)) => {
+                        tracing::debug!(error = %error, skipped_remote, "remote candidate page unavailable");
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            } else {
+                self.get_committed_candidates_page(&remote_hashes).await?
+            };
+            candidates.placements.extend(page.placements);
+            candidates.origin_proofs.extend(page.origin_proofs);
+            candidates.source_anchors.extend(page.source_anchors);
+            skipped_remote -= batch.len();
         }
-        let remote_hashes = remote_todo
-            .iter()
-            .map(|&idx| chunk_hashes[idx])
-            .collect::<Vec<_>>();
-        let candidates = self.get_committed_candidates_batch(&remote_hashes).await?;
         let mut lazy_fills = 0u64;
         let mut warm_entries: Vec<(MerkleHash, XorbRef)> =
             Vec::with_capacity(GET_BATCH_TIER_CHUNK_LIMIT);
@@ -290,7 +312,7 @@ impl ChunkIndexStore {
             m.add_metadb_chunk_index_cache_lazy_fills(lazy_fills);
         }
 
-        Ok((results, candidates, 0))
+        Ok((results, candidates, skipped_remote))
     }
 
     /// Read immutable committed receipts for each queried chunk hash.
@@ -1113,7 +1135,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bounded_lookup_resolves_persistent_hits_before_skipping_remote_misses() {
+    async fn expired_lookup_preserves_persistent_hits() {
         let ctx = new_ctx().await;
         let local_hash = hash_from_seed(70_000);
         let local_ref = xorb_ref_for(80_000, 7, 8192);
@@ -1127,13 +1149,51 @@ mod tests {
 
         let (placements, candidates, skipped_remote) = ctx
             .store
-            .get_batch_with_candidates_bounded(&query, 256)
+            .get_batch_with_candidates_until(&query, tokio::time::Instant::now())
             .await
             .expect("bounded lookup");
 
         assert_eq!(placements.last(), Some(&Some(local_ref)));
         assert!(candidates.placements.is_empty());
         assert_eq!(skipped_remote, 257);
+        ctx.db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn remote_page_failure_preserves_completed_proofs_and_local_hits() {
+        let ctx = new_ctx().await;
+        let mut query = (0..=GET_BATCH_TIER_CHUNK_LIMIT as u64)
+            .map(|index| hash_from_seed(200_000 + index))
+            .collect::<Vec<_>>();
+        let remote_ref = xorb_ref_for(210_000, 0, 4096);
+        seed_remote(&ctx.db, &query[0], &remote_ref).await;
+        let mut corrupt = slatedb::WriteBatch::new();
+        corrupt.put(
+            encode_committed_chunk_head_key(query.last().unwrap()).as_slice(),
+            b"invalid".as_slice(),
+        );
+        ctx.db
+            .write(corrupt)
+            .await
+            .expect("seed corrupt second page");
+        let local_hash = hash_from_seed(220_000);
+        let local_ref = xorb_ref_for(230_000, 0, 4096);
+        ctx.persistent
+            .insert(&local_hash, &local_ref)
+            .expect("local hit");
+        query.push(local_hash);
+        let (placements, candidates, skipped) = ctx
+            .store
+            .get_batch_with_candidates_until(
+                &query,
+                tokio::time::Instant::now() + std::time::Duration::from_secs(60),
+            )
+            .await
+            .expect("partial lookup");
+        assert_eq!(placements[0], Some(remote_ref));
+        assert_eq!(placements.last(), Some(&Some(local_ref)));
+        assert_eq!(candidates.placements.len(), 1);
+        assert_eq!(skipped, 1);
         ctx.db.close().await.expect("close");
     }
 
@@ -1165,7 +1225,10 @@ mod tests {
 
         let (_, candidates, skipped) = ctx
             .store
-            .get_batch_with_candidates_bounded(&query, query.len())
+            .get_batch_with_candidates_until(
+                &query,
+                tokio::time::Instant::now() + std::time::Duration::from_secs(60),
+            )
             .await
             .expect("candidate batch");
 

--- a/crab/src/metadata/metadb/stores/chunk_index.rs
+++ b/crab/src/metadata/metadb/stores/chunk_index.rs
@@ -303,6 +303,20 @@ impl ChunkIndexStore {
         chunk_hashes: &[MerkleHash],
     ) -> Result<CommittedChunkCandidateBatch> {
         let mut out = CommittedChunkCandidateBatch::default();
+        for batch in chunk_hashes.chunks(GET_BATCH_TIER_CHUNK_LIMIT) {
+            let page = self.get_committed_candidates_page(batch).await?;
+            out.placements.extend(page.placements);
+            out.origin_proofs.extend(page.origin_proofs);
+            out.source_anchors.extend(page.source_anchors);
+        }
+        Ok(out)
+    }
+
+    async fn get_committed_candidates_page(
+        &self,
+        chunk_hashes: &[MerkleHash],
+    ) -> Result<CommittedChunkCandidateBatch> {
+        let mut out = CommittedChunkCandidateBatch::default();
         if chunk_hashes.is_empty() {
             return Ok(out);
         }
@@ -385,6 +399,20 @@ impl ChunkIndexStore {
     /// exact proof selected during add even when another repository later
     /// publishes a newer candidate for the same chunk.
     pub(crate) async fn get_committed_candidates_by_id_batch(
+        &self,
+        candidates: &[(MerkleHash, [u8; 32])],
+    ) -> Result<CommittedChunkCandidateBatch> {
+        let mut out = CommittedChunkCandidateBatch::default();
+        for batch in candidates.chunks(GET_BATCH_TIER_CHUNK_LIMIT) {
+            let page = self.get_committed_candidates_by_id_page(batch).await?;
+            out.placements.extend(page.placements);
+            out.origin_proofs.extend(page.origin_proofs);
+            out.source_anchors.extend(page.source_anchors);
+        }
+        Ok(out)
+    }
+
+    async fn get_committed_candidates_by_id_page(
         &self,
         candidates: &[(MerkleHash, [u8; 32])],
     ) -> Result<CommittedChunkCandidateBatch> {
@@ -1145,6 +1173,57 @@ mod tests {
         assert_eq!(candidates.placements.len(), query.len());
         assert_eq!(candidates.origin_proofs.len(), 1);
         assert_eq!(candidates.source_anchors.len(), 1);
+        ctx.db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn committed_candidate_batches_page_large_queries() {
+        let ctx = new_ctx_without_persistent().await;
+        let xorb_hash = hash_from_seed(130_000);
+        let entries = (0..=GET_BATCH_TIER_CHUNK_LIMIT as u64)
+            .map(|index| {
+                let chunk_hash = hash_from_seed(131_000 + index);
+                let xorb_ref = XorbRef {
+                    xorb_hash,
+                    chunk_index: index as u32,
+                    uncompressed_size: 4096,
+                };
+                (chunk_hash, committed_receipt(chunk_hash, xorb_ref))
+            })
+            .collect::<Vec<_>>();
+        let mut txn = Transaction::new();
+        ctx.store
+            .save_committed_receipts(&mut txn, &entries)
+            .expect("save receipts");
+        let (_, batch) = crate::metadata::metadb::transaction::into_per_db_batches(txn);
+        ctx.db.write(batch).await.expect("write receipts");
+
+        let query = entries
+            .iter()
+            .map(|(chunk_hash, _)| *chunk_hash)
+            .collect::<Vec<_>>();
+        let got = ctx
+            .store
+            .get_committed_candidates_batch(&query)
+            .await
+            .expect("candidate batch");
+        assert_eq!(got.placements.len(), query.len());
+        assert_eq!(got.origin_proofs.len(), 1);
+        assert_eq!(got.source_anchors.len(), 1);
+
+        let exact = entries
+            .iter()
+            .map(|(chunk_hash, receipt)| (*chunk_hash, receipt.compact_placement().placement_id()))
+            .collect::<Vec<_>>();
+        let got_exact = ctx
+            .store
+            .get_committed_candidates_by_id_batch(&exact)
+            .await
+            .expect("exact candidate batch");
+        assert_eq!(got_exact.placements.len(), query.len());
+        assert_eq!(got_exact.origin_proofs.len(), 1);
+        assert_eq!(got_exact.source_anchors.len(), 1);
+
         ctx.db.close().await.expect("close");
     }
 

--- a/crates/crab-cache-store/src/lib.rs
+++ b/crates/crab-cache-store/src/lib.rs
@@ -935,11 +935,16 @@ impl CachingStore {
                 unique_hashes.push(hash);
                 input_indexes.push(vec![input_index]);
             }
-            if let Some(known_unique) = self.query_dedup_batches(repo_path, &unique_hashes).await {
+            if let Some(result) = self.query_dedup_batches(repo_path, &unique_hashes).await {
+                let known_by_index = result
+                    .known
+                    .into_iter()
+                    .map(|hit| (hit.index, hit))
+                    .collect::<HashMap<_, _>>();
                 let mut known = Vec::new();
                 let mut unknown = Vec::new();
                 for (unique_index, occurrences) in input_indexes.into_iter().enumerate() {
-                    match known_unique[unique_index].as_ref() {
+                    match known_by_index.get(&unique_index) {
                         Some(hit) => {
                             known.extend(occurrences.into_iter().map(|index| {
                                 crab_cache::KnownChunk {
@@ -981,18 +986,8 @@ impl CachingStore {
         let _ = repo_path;
 
         #[cfg(feature = "remote-client")]
-        if let Some(known_by_index) = self.query_dedup_batches(repo_path, hashes).await {
-            let mut known = Vec::new();
-            let mut unknown = Vec::new();
-            for (index, hit) in known_by_index.into_iter().enumerate() {
-                if let Some(mut hit) = hit {
-                    hit.index = index;
-                    known.push(hit);
-                } else {
-                    unknown.push(index);
-                }
-            }
-            return Ok(DedupQueryResult { known, unknown });
+        if let Some(result) = self.query_dedup_batches(repo_path, hashes).await {
+            return Ok(result);
         }
 
         Ok(DedupQueryResult {
@@ -1006,14 +1001,18 @@ impl CachingStore {
         &self,
         repo_path: &str,
         hashes: &[[u8; 32]],
-    ) -> Option<Vec<Option<crab_cache::KnownChunk>>> {
+    ) -> Option<DedupQueryResult> {
         if !self.dedup_enabled() {
             return None;
         }
         let client = self.cache_client.as_ref()?;
-        let mut known_by_index = (0..hashes.len()).map(|_| None).collect::<Vec<_>>();
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        let mut batch_slots = Vec::new();
         for (batch_index, batch) in hashes.chunks(DEDUP_QUERY_MAX_UNIQUE_HASHES).enumerate() {
             let batch_start = batch_index * DEDUP_QUERY_MAX_UNIQUE_HASHES;
+            batch_slots.clear();
+            batch_slots.resize_with(batch.len(), || None);
             match client.dedup_query(repo_path, batch).await {
                 Ok(result) => {
                     for mut known in result.known {
@@ -1027,7 +1026,7 @@ impl CachingStore {
                             );
                             continue;
                         };
-                        let Some(slot) = known_by_index.get_mut(index) else {
+                        let Some(slot) = batch_slots.get_mut(known.index) else {
                             tracing::warn!(
                                 repo_path = %repo_path,
                                 batch = batch_index,
@@ -1040,6 +1039,13 @@ impl CachingStore {
                         known.index = index;
                         *slot = Some(known);
                     }
+                    for (batch_offset, hit) in batch_slots.drain(..).enumerate() {
+                        if let Some(hit) = hit {
+                            known.push(hit);
+                        } else {
+                            unknown.push(batch_start + batch_offset);
+                        }
+                    }
                 }
                 Err(error) => {
                     // Dedup is advisory. Preserve successes from other
@@ -1051,10 +1057,13 @@ impl CachingStore {
                         error = %error,
                         "dedup query batch failed, treating this batch as unknown",
                     );
+                    unknown.extend(batch_start..batch_start + batch.len());
                 }
             }
         }
-        Some(known_by_index)
+        known.sort_unstable_by_key(|hit| hit.index);
+        unknown.sort_unstable();
+        Some(DedupQueryResult { known, unknown })
     }
 
     /// Query the cache service for cache-local dedup candidates.

--- a/crates/crab-cache-store/src/lib.rs
+++ b/crates/crab-cache-store/src/lib.rs
@@ -242,7 +242,7 @@ impl CachingStore {
         };
 
         #[cfg(feature = "remote-client")]
-        {
+        if self.dedup_enabled() && self.cache_client.is_some() {
             let mut cs = cs;
             // Health-check the remote cache service. If unhealthy, disable
             // the remote client but keep the local cache active.
@@ -921,8 +921,6 @@ impl CachingStore {
         let _ = repo_path;
 
         #[cfg(feature = "remote-client")]
-        if self.dedup_enabled()
-            && let Some(client) = &self.cache_client
         {
             let mut unique_indexes: HashMap<[u8; 32], usize> = HashMap::with_capacity(hashes.len());
             let mut unique_hashes = Vec::with_capacity(hashes.len());
@@ -937,63 +935,29 @@ impl CachingStore {
                 unique_hashes.push(hash);
                 input_indexes.push(vec![input_index]);
             }
-
-            let mut known_unique: Vec<Option<crab_cache::KnownChunk>> =
-                (0..unique_hashes.len()).map(|_| None).collect();
-            for (batch_index, batch) in unique_hashes
-                .chunks(DEDUP_QUERY_MAX_UNIQUE_HASHES)
-                .enumerate()
-            {
-                let batch_start = batch_index * DEDUP_QUERY_MAX_UNIQUE_HASHES;
-                match client.dedup_query(repo_path, batch).await {
-                    Ok(result) => {
-                        for known in result.known {
-                            let Some(slot) = known_unique.get_mut(batch_start + known.index) else {
-                                tracing::warn!(
-                                    repo_path = %repo_path,
-                                    batch = batch_index,
-                                    index = known.index,
-                                    count = batch.len(),
-                                    "cache service dedup response referenced an out-of-range batch index"
-                                );
-                                continue;
-                            };
-                            *slot = Some(known);
+            if let Some(known_unique) = self.query_dedup_batches(repo_path, &unique_hashes).await {
+                let mut known = Vec::new();
+                let mut unknown = Vec::new();
+                for (unique_index, occurrences) in input_indexes.into_iter().enumerate() {
+                    match known_unique[unique_index].as_ref() {
+                        Some(hit) => {
+                            known.extend(occurrences.into_iter().map(|index| {
+                                crab_cache::KnownChunk {
+                                    index,
+                                    xorb_hash: hit.xorb_hash.clone(),
+                                    chunk_index: hit.chunk_index,
+                                    length: hit.length,
+                                    cache_verified: hit.cache_verified,
+                                }
+                            }));
                         }
-                    }
-                    Err(e) => {
-                        // Dedup is advisory. Preserve successes from other
-                        // batches and classify only this batch as unknown.
-                        tracing::warn!(
-                            repo_path = %repo_path,
-                            batch = batch_index,
-                            count = batch.len(),
-                            error = %e,
-                            "dedup query batch failed, treating this batch as unknown",
-                        );
+                        None => unknown.extend(occurrences),
                     }
                 }
+                known.sort_unstable_by_key(|hit| hit.index);
+                unknown.sort_unstable();
+                return Ok(DedupQueryResult { known, unknown });
             }
-
-            let mut known = Vec::new();
-            let mut unknown = Vec::new();
-            for (unique_index, occurrences) in input_indexes.into_iter().enumerate() {
-                match known_unique[unique_index].as_ref() {
-                    Some(hit) => {
-                        known.extend(occurrences.into_iter().map(|index| crab_cache::KnownChunk {
-                            index,
-                            xorb_hash: hit.xorb_hash.clone(),
-                            chunk_index: hit.chunk_index,
-                            length: hit.length,
-                            cache_verified: hit.cache_verified,
-                        }));
-                    }
-                    None => unknown.extend(occurrences),
-                }
-            }
-            known.sort_unstable_by_key(|hit| hit.index);
-            unknown.sort_unstable();
-            return Ok(DedupQueryResult { known, unknown });
         }
 
         // All unknown - indices 0..N.
@@ -1001,6 +965,96 @@ impl CachingStore {
             known: Vec::new(),
             unknown: (0..hashes.len()).collect(),
         })
+    }
+
+    /// Query the cache service when the input hashes are already unique.
+    ///
+    /// Push classification supplies unique hashes, so this path avoids the
+    /// duplicate-expansion maps and occurrence vectors required by
+    /// [`Self::dedup_query`]. Callers must not pass duplicate hashes.
+    pub async fn dedup_query_unique(
+        &self,
+        repo_path: &str,
+        hashes: &[[u8; 32]],
+    ) -> Result<DedupQueryResult> {
+        #[cfg(not(feature = "remote-client"))]
+        let _ = repo_path;
+
+        #[cfg(feature = "remote-client")]
+        if let Some(known_by_index) = self.query_dedup_batches(repo_path, hashes).await {
+            let mut known = Vec::new();
+            let mut unknown = Vec::new();
+            for (index, hit) in known_by_index.into_iter().enumerate() {
+                if let Some(mut hit) = hit {
+                    hit.index = index;
+                    known.push(hit);
+                } else {
+                    unknown.push(index);
+                }
+            }
+            return Ok(DedupQueryResult { known, unknown });
+        }
+
+        Ok(DedupQueryResult {
+            known: Vec::new(),
+            unknown: (0..hashes.len()).collect(),
+        })
+    }
+
+    #[cfg(feature = "remote-client")]
+    async fn query_dedup_batches(
+        &self,
+        repo_path: &str,
+        hashes: &[[u8; 32]],
+    ) -> Option<Vec<Option<crab_cache::KnownChunk>>> {
+        if !self.dedup_enabled() {
+            return None;
+        }
+        let client = self.cache_client.as_ref()?;
+        let mut known_by_index = (0..hashes.len()).map(|_| None).collect::<Vec<_>>();
+        for (batch_index, batch) in hashes.chunks(DEDUP_QUERY_MAX_UNIQUE_HASHES).enumerate() {
+            let batch_start = batch_index * DEDUP_QUERY_MAX_UNIQUE_HASHES;
+            match client.dedup_query(repo_path, batch).await {
+                Ok(result) => {
+                    for mut known in result.known {
+                        let Some(index) = batch_start.checked_add(known.index) else {
+                            tracing::warn!(
+                                repo_path = %repo_path,
+                                batch = batch_index,
+                                index = known.index,
+                                count = batch.len(),
+                                "cache service dedup response index overflowed"
+                            );
+                            continue;
+                        };
+                        let Some(slot) = known_by_index.get_mut(index) else {
+                            tracing::warn!(
+                                repo_path = %repo_path,
+                                batch = batch_index,
+                                index = known.index,
+                                count = batch.len(),
+                                "cache service dedup response referenced an out-of-range batch index"
+                            );
+                            continue;
+                        };
+                        known.index = index;
+                        *slot = Some(known);
+                    }
+                }
+                Err(error) => {
+                    // Dedup is advisory. Preserve successes from other
+                    // batches and classify only this batch as unknown.
+                    tracing::warn!(
+                        repo_path = %repo_path,
+                        batch = batch_index,
+                        count = batch.len(),
+                        error = %error,
+                        "dedup query batch failed, treating this batch as unknown",
+                    );
+                }
+            }
+        }
+        Some(known_by_index)
     }
 
     /// Query the cache service for cache-local dedup candidates.
@@ -4076,6 +4130,10 @@ mod tests {
         let result = cs.dedup_query("org/repo", &hashes).await.unwrap();
         assert!(result.known.is_empty());
         assert_eq!(result.unknown, vec![0, 1]);
+
+        let unique_result = cs.dedup_query_unique("org/repo", &hashes).await.unwrap();
+        assert!(unique_result.known.is_empty());
+        assert_eq!(unique_result.unknown, vec![0, 1]);
     }
 
     #[cfg(feature = "remote-client")]
@@ -4095,7 +4153,7 @@ mod tests {
         let store = CachingStore::new(origin_store(), &config).unwrap();
         let hashes = (0..150_001).map(unique_hash).collect::<Vec<_>>();
 
-        store.dedup_query("org/repo", &hashes).await.unwrap();
+        store.dedup_query_unique("org/repo", &hashes).await.unwrap();
 
         let sizes = server
             .request_sizes
@@ -4103,6 +4161,39 @@ mod tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone();
         assert_eq!(sizes, vec![50_000, 50_000, 50_000, 1]);
+        if let Some(shutdown) = server.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
+
+    #[cfg(feature = "remote-client")]
+    #[tokio::test]
+    async fn dedup_query_unique_preserves_known_and_unknown_indices() {
+        let mut server = start_batched_dedup_server(None).await;
+        let config = CacheConfig {
+            max_bytes: Some(10 * 1024 * 1024 * 1024),
+            service_url: Some(format!("http://{}", server.addr)),
+            service_mode: CacheServiceMode::Dedup,
+            push_warming: false,
+            service_auth: CacheServiceAuth::None,
+            service_ca_cert: None,
+            service_client_cert: None,
+            service_client_key: None,
+        };
+        let store = CachingStore::new(origin_store(), &config).unwrap();
+        let hashes = vec![unique_hash(0), unique_hash(1), unique_hash(2)];
+
+        let result = store.dedup_query_unique("org/repo", &hashes).await.unwrap();
+
+        assert_eq!(
+            result
+                .known
+                .iter()
+                .map(|known| known.index)
+                .collect::<Vec<_>>(),
+            vec![0]
+        );
+        assert_eq!(result.unknown, vec![1, 2]);
         if let Some(shutdown) = server.shutdown.take() {
             let _ = shutdown.send(());
         }

--- a/crates/crab-cache-store/src/lib.rs
+++ b/crates/crab-cache-store/src/lib.rs
@@ -242,7 +242,7 @@ impl CachingStore {
         };
 
         #[cfg(feature = "remote-client")]
-        if self.dedup_enabled() && self.cache_client.is_some() {
+        {
             let mut cs = cs;
             // Health-check the remote cache service. If unhealthy, disable
             // the remote client but keep the local cache active.
@@ -921,7 +921,7 @@ impl CachingStore {
         let _ = repo_path;
 
         #[cfg(feature = "remote-client")]
-        {
+        if self.dedup_enabled() && self.cache_client.is_some() {
             let mut unique_indexes: HashMap<[u8; 32], usize> = HashMap::with_capacity(hashes.len());
             let mut unique_hashes = Vec::with_capacity(hashes.len());
             let mut input_indexes: Vec<Vec<usize>> = Vec::with_capacity(hashes.len());

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -781,7 +781,7 @@ async fn prepare_one_file_plan_with_existing_refs(
     let mut cache_chunks = 0u64;
     let mut cache_xorbs = 0u64;
     let mut cache_link_misses = 0u64;
-    let mut unusable_cached_xorb_sources = HashSet::new();
+    let mut unusable_cached_candidates = HashSet::new();
     let mut exclusive_payloads = HashMap::new();
     for (index, (chunk_hash, size)) in chunks.iter().enumerate() {
         let existing_ref = existing_refs
@@ -823,7 +823,7 @@ async fn prepare_one_file_plan_with_existing_refs(
             chunk_hash,
             *size,
             &chunk_states,
-            &unusable_cached_xorb_sources,
+            &unusable_cached_candidates,
         );
         let mut used_cached_candidate = false;
         for choice in choices {
@@ -875,7 +875,7 @@ async fn prepare_one_file_plan_with_existing_refs(
                 break;
             }
 
-            unusable_cached_xorb_sources.insert((candidate.xorb_hash, candidate.source.clone()));
+            unusable_cached_candidates.insert(prepared_candidate_id(candidate));
             cache_link_misses += 1;
         }
         if used_cached_candidate {
@@ -947,11 +947,11 @@ fn ranked_prepared_candidates<'a>(
     chunk_hash: &MerkleHash,
     expected_size: u64,
     chunk_states: &HashMap<MerkleHash, FileChunkState>,
-    unusable_cached_xorb_sources: &HashSet<(MerkleHash, PreparedXorbSource)>,
+    unusable_cached_candidates: &HashSet<*const PreparedXorbCandidate>,
 ) -> Vec<PreparedCandidateChoice<'a>> {
     let mut choices = Vec::new();
     for candidate in prepared_cache.candidates_for_chunk(chunk_hash) {
-        if unusable_cached_xorb_sources.contains(&(candidate.xorb_hash, candidate.source.clone())) {
+        if unusable_cached_candidates.contains(&prepared_candidate_id(candidate)) {
             continue;
         }
         let Some(placement) = candidate.placement_for(chunk_hash) else {
@@ -988,6 +988,12 @@ fn ranked_prepared_candidates<'a>(
             })
     });
     choices
+}
+
+fn prepared_candidate_id(candidate: &PreparedXorbCandidate) -> *const PreparedXorbCandidate {
+    // Candidates live in Arc allocations owned by the cache for this plan;
+    // identity avoids cloning LocalCache paths on every chunk lookup.
+    std::ptr::from_ref(candidate)
 }
 
 fn matching_file_chunks(
@@ -1705,13 +1711,18 @@ mod tests {
         let choices =
             ranked_prepared_candidates(&cache, &chunk_hash, 10, &chunk_states, &HashSet::new());
         assert_eq!(choices.len(), 2);
+        let first_candidate = choices
+            .iter()
+            .find(|choice| choice.candidate.source == first_source)
+            .expect("first source candidate")
+            .candidate;
 
         let filtered = ranked_prepared_candidates(
             &cache,
             &chunk_hash,
             10,
             &chunk_states,
-            &HashSet::from([(xorb_hash, first_source.clone())]),
+            &HashSet::from([prepared_candidate_id(first_candidate)]),
         );
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].candidate.source, second_source);

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -54,7 +54,7 @@ pub trait LocalXorbCandidateLookup: Send + Sync {
     async fn load_candidates(
         &self,
         prepared_cache: &mut PreparedXorbCache,
-        wanted_chunks: &HashSet<MerkleHash>,
+        wanted_chunks: &[(MerkleHash, u64)],
     ) -> Result<()>;
 }
 
@@ -98,17 +98,8 @@ pub async fn prepare_file_push_plans_with_progress(
         return Ok(AddPushPlanSummary::default());
     }
 
-    let (wanted_prepared_chunks, unique_file_chunks) = if files.len() > 1 {
-        let (wanted, unique) = collect_unique_file_chunks(files);
-        (wanted, Some(unique))
-    } else {
-        let wanted = files[0]
-            .chunks
-            .iter()
-            .map(|(chunk_hash, _)| *chunk_hash)
-            .collect();
-        (wanted, None)
-    };
+    let unique_file_chunks = (files.len() > 1).then(|| collect_unique_file_chunks(files));
+    let wanted_prepared_chunks = unique_file_chunks.as_deref().unwrap_or(files[0].chunks);
     let mut summary = AddPushPlanSummary {
         remote_lookup: remote_lookup.is_some(),
         ..AddPushPlanSummary::default()
@@ -116,11 +107,10 @@ pub async fn prepare_file_push_plans_with_progress(
     if let Some(callback) = on_progress.as_deref_mut() {
         callback(&summary);
     }
-    let mut prepared_cache =
-        staging.load_prepared_xorb_cache_for_chunks(&wanted_prepared_chunks)?;
+    let mut prepared_cache = staging.load_prepared_xorb_cache_for_chunks(wanted_prepared_chunks)?;
     if let Some(local_lookup) = local_lookup {
         local_lookup
-            .load_candidates(&mut prepared_cache, &wanted_prepared_chunks)
+            .load_candidates(&mut prepared_cache, wanted_prepared_chunks)
             .await?;
     }
     if files.len() > 1 {
@@ -346,9 +336,7 @@ struct UncachedFilePlan<'a> {
     plan: FilePushPlan,
 }
 
-fn collect_unique_file_chunks(
-    files: &[AddPlanFile<'_>],
-) -> (HashSet<MerkleHash>, Vec<(MerkleHash, u64)>) {
+fn collect_unique_file_chunks(files: &[AddPlanFile<'_>]) -> Vec<(MerkleHash, u64)> {
     let mut wanted = HashSet::new();
     let mut unique = Vec::new();
     for file in files {
@@ -358,7 +346,7 @@ fn collect_unique_file_chunks(
             }
         }
     }
-    (wanted, unique)
+    unique
 }
 
 fn index_existing_refs(
@@ -1346,7 +1334,7 @@ mod tests {
                 chunks: &second_chunks,
             },
         ];
-        let (_, unique) = collect_unique_file_chunks(&files);
+        let unique = collect_unique_file_chunks(&files);
         assert_eq!(unique.len(), 3);
         assert_eq!(
             unique
@@ -1779,13 +1767,9 @@ mod tests {
         let retired = staging.retire_file(&file_hash).expect("retire file");
         assert_eq!(retired.rows_deleted, 1);
 
-        let wanted_chunks = chunk_pairs
-            .iter()
-            .map(|(chunk_hash, _)| *chunk_hash)
-            .collect::<std::collections::HashSet<_>>();
         assert!(
             !staging
-                .load_prepared_xorb_cache_for_chunks(&wanted_chunks)
+                .load_prepared_xorb_cache_for_chunks(&chunk_pairs)
                 .expect("load prepared cache after retire")
                 .is_empty()
         );

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -279,6 +279,14 @@ struct PreparedCandidateChoice {
     covered_chunks: Vec<MerkleHash>,
 }
 
+#[derive(Clone, Copy, Default)]
+struct FileChunkState {
+    size: u64,
+    remote: bool,
+    covered: bool,
+    read_needed: bool,
+}
+
 struct ReadBatchScratch {
     hashes: Vec<MerkleHash>,
     to_pack: Vec<(Chunk, RunId)>,
@@ -714,29 +722,30 @@ async fn prepare_one_file_plan_with_existing_refs(
     let mut plan = FilePushPlan::new_verified_recipe(&recipe);
     let recipe_hash = recipe.hash();
 
-    let mut file_chunk_sizes = HashMap::new();
-    for (chunk_hash, size) in chunks {
-        file_chunk_sizes.entry(*chunk_hash).or_insert(*size);
-    }
-    let remote_existing_chunks: HashSet<MerkleHash> = chunks
-        .iter()
-        .zip(existing_refs.iter())
-        .filter_map(|((chunk_hash, size), existing_ref)| {
-            existing_ref
-                .as_ref()
-                .filter(|candidate| u64::from(candidate.xorb_ref.uncompressed_size) == *size)
-                .map(|_| *chunk_hash)
-        })
-        .collect();
-    let mut new_chunks = HashSet::new();
+    let mut chunk_states = HashMap::<MerkleHash, FileChunkState>::new();
     let mut planned_prepared_xorbs = HashSet::new();
-    let mut covered_by_prepared_cache = HashSet::new();
     let mut cache_chunks = 0u64;
     let mut cache_xorbs = 0u64;
     let mut cache_link_misses = 0u64;
     let mut unusable_cached_xorb_sources = HashSet::new();
     let mut exclusive_payloads = HashMap::new();
     for ((chunk_hash, size), existing_ref) in chunks.iter().zip(existing_refs.iter()) {
+        let state = chunk_states.entry(*chunk_hash).or_insert(FileChunkState {
+            size: *size,
+            ..FileChunkState::default()
+        });
+        if existing_ref
+            .as_ref()
+            .is_some_and(|candidate| u64::from(candidate.xorb_ref.uncompressed_size) == *size)
+        {
+            state.remote = true;
+        }
+    }
+    for ((chunk_hash, size), existing_ref) in chunks.iter().zip(existing_refs.iter()) {
+        let state = chunk_states.entry(*chunk_hash).or_insert(FileChunkState {
+            size: *size,
+            ..FileChunkState::default()
+        });
         if let Some(candidate) = existing_ref
             && u64::from(candidate.xorb_ref.uncompressed_size) == *size
         {
@@ -746,31 +755,26 @@ async fn prepare_one_file_plan_with_existing_refs(
             ));
             continue;
         }
-        if remote_existing_chunks.contains(chunk_hash)
-            || covered_by_prepared_cache.contains(chunk_hash)
-        {
+        if state.remote || state.covered || state.read_needed {
             continue;
         }
-        if !new_chunks.insert(*chunk_hash) {
-            continue;
-        }
+        state.read_needed = true;
 
         let choices = ranked_prepared_candidates(
             prepared_cache,
             chunk_hash,
             *size,
-            &file_chunk_sizes,
-            &remote_existing_chunks,
-            &covered_by_prepared_cache,
+            &chunk_states,
             &unusable_cached_xorb_sources,
         );
         let mut used_cached_candidate = false;
         for choice in choices {
             let candidate = choice.candidate;
-            let contains_remote = candidate
-                .placements
-                .iter()
-                .any(|placement| remote_existing_chunks.contains(&placement.chunk_hash));
+            let contains_remote = candidate.placements.iter().any(|placement| {
+                chunk_states
+                    .get(&placement.chunk_hash)
+                    .is_some_and(|state| state.remote)
+            });
             let exclusive = if contains_remote {
                 if let Some(exclusive) = exclusive_payloads.get(&candidate.xorb_hash) {
                     *exclusive
@@ -787,11 +791,8 @@ async fn prepare_one_file_plan_with_existing_refs(
                 continue;
             }
             if planned_prepared_xorbs.contains(&candidate.xorb_hash) {
-                cache_chunks += mark_prepared_cache_coverage(
-                    &choice.covered_chunks,
-                    &mut covered_by_prepared_cache,
-                    &mut new_chunks,
-                );
+                cache_chunks +=
+                    mark_prepared_cache_coverage(&choice.covered_chunks, &mut chunk_states);
                 used_cached_candidate = true;
                 break;
             }
@@ -809,11 +810,8 @@ async fn prepare_one_file_plan_with_existing_refs(
                     plan.prepared_xorbs.push(planned);
                 }
                 planned_prepared_xorbs.insert(candidate.xorb_hash);
-                cache_chunks += mark_prepared_cache_coverage(
-                    &choice.covered_chunks,
-                    &mut covered_by_prepared_cache,
-                    &mut new_chunks,
-                );
+                cache_chunks +=
+                    mark_prepared_cache_coverage(&choice.covered_chunks, &mut chunk_states);
                 cache_xorbs += 1;
                 used_cached_candidate = true;
                 break;
@@ -831,9 +829,15 @@ async fn prepare_one_file_plan_with_existing_refs(
     let mut read_batch = Vec::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
     let mut read_scratch = ReadBatchScratch::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
     for &chunk in chunks {
-        if !new_chunks.remove(&chunk.0) {
+        let Some(state) = chunk_states.get_mut(&chunk.0) else {
+            return Err(StagingError::Internal(
+                "add push-plan chunk state disappeared".to_owned(),
+            ));
+        };
+        if !state.read_needed {
             continue;
         }
+        state.read_needed = false;
         read_batch.push((chunk, RunId(0)));
         if read_batch.len() == ADD_PLAN_READ_BATCH_CHUNKS {
             flush_uncached_read_batch(
@@ -884,9 +888,7 @@ fn ranked_prepared_candidates(
     prepared_cache: &PreparedXorbCache,
     chunk_hash: &MerkleHash,
     expected_size: u64,
-    file_chunk_sizes: &HashMap<MerkleHash, u64>,
-    remote_existing_chunks: &HashSet<MerkleHash>,
-    covered_by_prepared_cache: &HashSet<MerkleHash>,
+    chunk_states: &HashMap<MerkleHash, FileChunkState>,
     unusable_cached_xorb_sources: &HashSet<(MerkleHash, PreparedXorbSource)>,
 ) -> Vec<PreparedCandidateChoice> {
     let mut choices = Vec::new();
@@ -900,12 +902,7 @@ fn ranked_prepared_candidates(
         if u64::from(placement.uncompressed_size) != expected_size {
             continue;
         }
-        let covered_chunks = matching_file_chunks(
-            &candidate,
-            file_chunk_sizes,
-            remote_existing_chunks,
-            covered_by_prepared_cache,
-        );
+        let covered_chunks = matching_file_chunks(&candidate, chunk_states);
         if covered_chunks.is_empty() {
             continue;
         }
@@ -937,23 +934,21 @@ fn ranked_prepared_candidates(
 
 fn matching_file_chunks(
     candidate: &PreparedXorbCandidate,
-    file_chunk_sizes: &HashMap<MerkleHash, u64>,
-    remote_existing_chunks: &HashSet<MerkleHash>,
-    covered_by_prepared_cache: &HashSet<MerkleHash>,
+    chunk_states: &HashMap<MerkleHash, FileChunkState>,
 ) -> Vec<MerkleHash> {
     let mut seen = HashSet::new();
     let mut covered = Vec::new();
     for placement in &candidate.placements {
-        if !seen.insert(placement.chunk_hash)
-            || remote_existing_chunks.contains(&placement.chunk_hash)
-            || covered_by_prepared_cache.contains(&placement.chunk_hash)
-        {
+        if !seen.insert(placement.chunk_hash) {
             continue;
         }
-        let Some(expected_size) = file_chunk_sizes.get(&placement.chunk_hash) else {
+        let Some(state) = chunk_states.get(&placement.chunk_hash) else {
             continue;
         };
-        if u64::from(placement.uncompressed_size) == *expected_size {
+        if state.remote || state.covered {
+            continue;
+        }
+        if u64::from(placement.uncompressed_size) == state.size {
             covered.push(placement.chunk_hash);
         }
     }
@@ -962,13 +957,16 @@ fn matching_file_chunks(
 
 fn mark_prepared_cache_coverage(
     covered_chunks: &[MerkleHash],
-    covered_by_prepared_cache: &mut HashSet<MerkleHash>,
-    new_chunks: &mut HashSet<MerkleHash>,
+    chunk_states: &mut HashMap<MerkleHash, FileChunkState>,
 ) -> u64 {
     let mut newly_covered = 0;
     for chunk_hash in covered_chunks {
-        if covered_by_prepared_cache.insert(*chunk_hash) {
-            new_chunks.remove(chunk_hash);
+        let Some(state) = chunk_states.get_mut(chunk_hash) else {
+            continue;
+        };
+        if !state.covered {
+            state.covered = true;
+            state.read_needed = false;
             newly_covered += 1;
         }
     }
@@ -1627,26 +1625,22 @@ mod tests {
             .insert_cached_xorb("second.xorb".into(), &planned)
             .expect("insert second source");
 
-        let file_chunk_sizes = HashMap::from([(chunk_hash, 10)]);
-        let empty_chunks = HashSet::new();
-        let choices = ranked_prepared_candidates(
-            &cache,
-            &chunk_hash,
-            10,
-            &file_chunk_sizes,
-            &empty_chunks,
-            &empty_chunks,
-            &HashSet::new(),
-        );
+        let chunk_states = HashMap::from([(
+            chunk_hash,
+            FileChunkState {
+                size: 10,
+                ..FileChunkState::default()
+            },
+        )]);
+        let choices =
+            ranked_prepared_candidates(&cache, &chunk_hash, 10, &chunk_states, &HashSet::new());
         assert_eq!(choices.len(), 2);
 
         let filtered = ranked_prepared_candidates(
             &cache,
             &chunk_hash,
             10,
-            &file_chunk_sizes,
-            &empty_chunks,
-            &empty_chunks,
+            &chunk_states,
             &HashSet::from([(xorb_hash, first_source.clone())]),
         );
         assert_eq!(filtered.len(), 1);

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -820,33 +820,21 @@ async fn prepare_one_file_plan_with_existing_refs(
     }
 
     let mut builder = build_xorb_builder();
-
-    let mut pending_new_chunks = Vec::with_capacity(new_chunks.len());
+    let mut read_batch = Vec::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
     for chunk in located_chunks {
-        if new_chunks.remove(&chunk.0) {
-            pending_new_chunks.push(chunk);
+        if !new_chunks.remove(&chunk.0) {
+            continue;
+        }
+        read_batch.push((chunk, RunId(0)));
+        if read_batch.len() == ADD_PLAN_READ_BATCH_CHUNKS {
+            flush_uncached_read_batch(staging, &mut read_batch, &mut builder, cancel).await?;
+            write_completed_xorbs(staging, &mut builder, &mut plan, prepared_cache).await?;
         }
     }
 
-    for batch in pending_new_chunks.chunks(ADD_PLAN_READ_BATCH_CHUNKS) {
-        check_cancelled(cancel)?;
-        let hashes = batch.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
-        let payloads = staging.get_chunks_batch(&hashes).await?;
-        let mut to_pack = Vec::with_capacity(payloads.len());
-        for (actual_hash, data) in payloads {
-            to_pack.push((
-                Chunk {
-                    hash: actual_hash,
-                    data,
-                },
-                RunId(0),
-            ));
-        }
-
-        if !to_pack.is_empty() {
-            builder.push_batch(&to_pack)?;
-            write_completed_xorbs(staging, &mut builder, &mut plan, prepared_cache).await?;
-        }
+    if !read_batch.is_empty() {
+        flush_uncached_read_batch(staging, &mut read_batch, &mut builder, cancel).await?;
+        write_completed_xorbs(staging, &mut builder, &mut plan, prepared_cache).await?;
     }
 
     for result in builder.finalize()? {

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -279,6 +279,20 @@ struct PreparedCandidateChoice {
     covered_chunks: Vec<MerkleHash>,
 }
 
+struct ReadBatchScratch {
+    hashes: Vec<MerkleHash>,
+    to_pack: Vec<(Chunk, RunId)>,
+}
+
+impl ReadBatchScratch {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            hashes: Vec::with_capacity(capacity),
+            to_pack: Vec::with_capacity(capacity),
+        }
+    }
+}
+
 struct UncachedFilePlan<'a> {
     file_hash: MerkleHash,
     chunks: &'a [(MerkleHash, u64)],
@@ -362,6 +376,7 @@ async fn prepare_uncached_file_plans_with_progress(
     let chunk_owners = build_uncached_chunk_owners(&file_plans);
     let mut queued_chunks = HashSet::new();
     let mut read_batch = Vec::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
+    let mut read_scratch = ReadBatchScratch::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
     for file_idx in 0..file_plans.len() {
         let run_id = RunId(file_idx as u64);
         for &chunk in file_plans[file_idx].chunks {
@@ -373,7 +388,14 @@ async fn prepare_uncached_file_plans_with_progress(
             }
             read_batch.push((chunk, run_id));
             if read_batch.len() >= ADD_PLAN_READ_BATCH_CHUNKS {
-                flush_uncached_read_batch(staging, &mut read_batch, &mut builder, cancel).await?;
+                flush_uncached_read_batch(
+                    staging,
+                    &mut read_batch,
+                    &mut read_scratch,
+                    &mut builder,
+                    cancel,
+                )
+                .await?;
                 write_completed_uncached_xorbs(
                     staging,
                     &mut file_plans,
@@ -384,7 +406,14 @@ async fn prepare_uncached_file_plans_with_progress(
             }
         }
     }
-    flush_uncached_read_batch(staging, &mut read_batch, &mut builder, cancel).await?;
+    flush_uncached_read_batch(
+        staging,
+        &mut read_batch,
+        &mut read_scratch,
+        &mut builder,
+        cancel,
+    )
+    .await?;
     write_completed_uncached_xorbs(staging, &mut file_plans, &chunk_owners, &mut builder).await?;
     for result in builder.finalize()? {
         record_uncached_prepared_xorb(staging, &mut file_plans, &chunk_owners, result).await?;
@@ -514,6 +543,7 @@ async fn verified_staged_chunks(
 async fn flush_uncached_read_batch(
     staging: &StagingArea,
     read_batch: &mut Vec<((MerkleHash, u64), RunId)>,
+    scratch: &mut ReadBatchScratch,
     builder: &mut XorbBuilder,
     cancel: &CancellationToken,
 ) -> Result<()> {
@@ -521,14 +551,14 @@ async fn flush_uncached_read_batch(
         return Ok(());
     }
     check_cancelled(cancel)?;
-    let hashes = read_batch
-        .iter()
-        .map(|((hash, _), _)| *hash)
-        .collect::<Vec<_>>();
-    let payloads = staging.get_chunks_batch(&hashes).await?;
-    let mut to_pack = Vec::with_capacity(read_batch.len());
+    scratch.hashes.clear();
+    scratch
+        .hashes
+        .extend(read_batch.iter().map(|((hash, _), _)| *hash));
+    let payloads = staging.get_chunks_batch(&scratch.hashes).await?;
+    scratch.to_pack.clear();
     for ((expected, run_id), (actual_hash, data)) in read_batch.iter().zip(payloads) {
-        to_pack.push((
+        scratch.to_pack.push((
             Chunk {
                 hash: actual_hash,
                 data,
@@ -537,7 +567,7 @@ async fn flush_uncached_read_batch(
         ));
         debug_assert_eq!(actual_hash, expected.0);
     }
-    builder.push_batch(&to_pack)?;
+    builder.push_batch(&scratch.to_pack)?;
     read_batch.clear();
     Ok(())
 }
@@ -807,19 +837,34 @@ async fn prepare_one_file_plan_with_existing_refs(
 
     let mut builder = build_xorb_builder();
     let mut read_batch = Vec::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
+    let mut read_scratch = ReadBatchScratch::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
     for &chunk in chunks {
         if !new_chunks.remove(&chunk.0) {
             continue;
         }
         read_batch.push((chunk, RunId(0)));
         if read_batch.len() == ADD_PLAN_READ_BATCH_CHUNKS {
-            flush_uncached_read_batch(staging, &mut read_batch, &mut builder, cancel).await?;
+            flush_uncached_read_batch(
+                staging,
+                &mut read_batch,
+                &mut read_scratch,
+                &mut builder,
+                cancel,
+            )
+            .await?;
             write_completed_xorbs(staging, &mut builder, &mut plan, prepared_cache).await?;
         }
     }
 
     if !read_batch.is_empty() {
-        flush_uncached_read_batch(staging, &mut read_batch, &mut builder, cancel).await?;
+        flush_uncached_read_batch(
+            staging,
+            &mut read_batch,
+            &mut read_scratch,
+            &mut builder,
+            cancel,
+        )
+        .await?;
         write_completed_xorbs(staging, &mut builder, &mut plan, prepared_cache).await?;
     }
 

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -177,6 +177,12 @@ struct FilePlanSummary {
     prepared_bytes: u64,
 }
 
+struct PreparedFilePlan {
+    plan: FilePushPlan,
+    recipe: crate::recipe::FileRecipe,
+    summary: FilePlanSummary,
+}
+
 async fn prepare_cached_file_plans_with_progress(
     staging: &StagingArea,
     files: &[AddPlanFile<'_>],
@@ -188,6 +194,7 @@ async fn prepare_cached_file_plans_with_progress(
     mut on_progress: Option<&mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
 ) -> Result<AddPushPlanSummary> {
     let mut ref_offset = 0usize;
+    let mut prepared_plans = Vec::with_capacity(files.len());
     for file in files {
         check_cancelled(cancel)?;
         let next_offset = ref_offset.checked_add(file.chunks.len()).ok_or_else(|| {
@@ -196,7 +203,7 @@ async fn prepare_cached_file_plans_with_progress(
         let file_existing_refs = existing_refs.get(ref_offset..next_offset).ok_or_else(|| {
             StagingError::Internal("add push-plan remote lookup length changed".to_owned())
         })?;
-        let file_summary = prepare_one_file_plan_with_existing_refs(
+        let prepared = prepare_one_file_plan_with_existing_refs(
             staging,
             file,
             file_existing_refs,
@@ -206,15 +213,25 @@ async fn prepare_cached_file_plans_with_progress(
         )
         .await?;
         ref_offset = next_offset;
-        accumulate_file_summary(&mut summary, file_summary);
-        if let Some(callback) = on_progress.as_deref_mut() {
-            callback(&summary);
-        }
+        prepared_plans.push(prepared);
     }
     if ref_offset != existing_refs.len() {
         return Err(StagingError::Internal(
             "add push-plan remote lookup returned extra candidates".to_owned(),
         ));
+    }
+    let plan_pairs = prepared_plans
+        .iter()
+        .map(|prepared| (&prepared.plan, &prepared.recipe))
+        .collect::<Vec<_>>();
+    staging
+        .write_file_push_plans_for_recipes(&plan_pairs)
+        .await?;
+    for prepared in prepared_plans {
+        accumulate_file_summary(&mut summary, prepared.summary);
+        if let Some(callback) = on_progress.as_deref_mut() {
+            callback(&summary);
+        }
     }
 
     debug_file_summary(&summary);
@@ -336,17 +353,27 @@ async fn prepare_uncached_file_plans_with_progress(
         remote_lookup,
         ..AddPushPlanSummary::default()
     };
+    let recipes = file_plans
+        .iter()
+        .map(|file_plan| {
+            crate::recipe::FileRecipe::from_staged_chunks(
+                crate::recipe::ChunkingPolicyId::XetGearV1_64KiB,
+                file_plan.file_hash,
+                file_plan.plan.file_size,
+                file_plan.chunks,
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let plan_pairs = file_plans
+        .iter()
+        .zip(recipes.iter())
+        .map(|(file_plan, recipe)| (&file_plan.plan, recipe))
+        .collect::<Vec<_>>();
+    staging
+        .write_file_push_plans_for_recipes(&plan_pairs)
+        .await?;
     let mut summarized_prepared_xorbs = HashSet::new();
     for file_plan in &file_plans {
-        let recipe = crate::recipe::FileRecipe::from_staged_chunks(
-            crate::recipe::ChunkingPolicyId::XetGearV1_64KiB,
-            file_plan.file_hash,
-            file_plan.plan.file_size,
-            file_plan.chunks,
-        )?;
-        staging
-            .write_file_push_plan_for_recipe(&file_plan.plan, &recipe)
-            .await?;
         summary.files += 1;
         summary.chunks += file_plan.chunks.len() as u64;
         summary.existing_candidates += file_plan.plan.existing.len() as u64;
@@ -578,7 +605,7 @@ async fn prepare_one_file_plan(
     cancel: &CancellationToken,
 ) -> Result<FilePlanSummary> {
     let existing_refs = lookup_existing_candidates(file.chunks, remote_lookup).await?;
-    prepare_one_file_plan_with_existing_refs(
+    let prepared = prepare_one_file_plan_with_existing_refs(
         staging,
         file,
         &existing_refs,
@@ -586,7 +613,11 @@ async fn prepare_one_file_plan(
         prepared_cache,
         cancel,
     )
-    .await
+    .await?;
+    staging
+        .write_file_push_plan_for_recipe(&prepared.plan, &prepared.recipe)
+        .await?;
+    Ok(prepared.summary)
 }
 
 async fn prepare_one_file_plan_with_existing_refs(
@@ -596,7 +627,7 @@ async fn prepare_one_file_plan_with_existing_refs(
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     prepared_cache: &mut PreparedXorbCache,
     cancel: &CancellationToken,
-) -> Result<FilePlanSummary> {
+) -> Result<PreparedFilePlan> {
     if existing_refs.len() != file.chunks.len() {
         return Err(StagingError::Internal(format!(
             "add push-plan remote lookup returned {} candidates for {} requested chunks",
@@ -766,10 +797,11 @@ async fn prepare_one_file_plan_with_existing_refs(
         prepared_xorbs: plan.prepared_xorbs.len() as u64,
         prepared_bytes: plan.prepared_xorbs.iter().map(|xorb| xorb.bytes).sum(),
     };
-    staging
-        .write_file_push_plan_for_recipe(&plan, &recipe)
-        .await?;
-    Ok(file_summary)
+    Ok(PreparedFilePlan {
+        plan,
+        recipe,
+        summary: file_summary,
+    })
 }
 
 fn ranked_prepared_candidates(

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -140,15 +140,12 @@ pub async fn prepare_file_push_plans_with_progress(
         return prepare_cached_file_plans_with_progress(
             staging,
             files,
-            CachedFilePlanContext {
-                existing_refs: &existing_refs,
-                build_xorb_builder,
-                prepared_cache: &mut prepared_cache,
-                summary,
-                verified_sequences: &mut verified_sequences,
-                cancel,
-                on_progress,
-            },
+            &existing_refs,
+            build_xorb_builder,
+            &mut prepared_cache,
+            summary,
+            cancel,
+            on_progress,
         )
         .await;
     }
@@ -194,30 +191,17 @@ struct PreparedFilePlan {
     summary: FilePlanSummary,
 }
 
-struct CachedFilePlanContext<'existing, 'builder, 'cache, 'verified, 'cancel, 'progress> {
-    existing_refs: &'existing Option<HashMap<MerkleHash, Option<ExistingChunkCandidate>>>,
-    build_xorb_builder: &'builder (dyn Fn() -> XorbBuilder + Send + Sync),
-    prepared_cache: &'cache mut PreparedXorbCache,
-    summary: AddPushPlanSummary,
-    verified_sequences: &'verified mut HashSet<(MerkleHash, [u8; 32], u64)>,
-    cancel: &'cancel CancellationToken,
-    on_progress: Option<&'progress mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
-}
-
 async fn prepare_cached_file_plans_with_progress(
     staging: &StagingArea,
     files: &[AddPlanFile<'_>],
-    context: CachedFilePlanContext<'_, '_, '_, '_, '_, '_>,
+    existing_refs: &Option<HashMap<MerkleHash, Option<ExistingChunkCandidate>>>,
+    build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
+    prepared_cache: &mut PreparedXorbCache,
+    mut summary: AddPushPlanSummary,
+    cancel: &CancellationToken,
+    mut on_progress: Option<&mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
 ) -> Result<AddPushPlanSummary> {
-    let CachedFilePlanContext {
-        existing_refs,
-        build_xorb_builder,
-        prepared_cache,
-        mut summary,
-        verified_sequences,
-        cancel,
-        mut on_progress,
-    } = context;
+    let mut verified_sequences = HashSet::new();
     let mut prepared_plans = Vec::with_capacity(files.len());
     let mut ownership_cache = HashMap::new();
     for file in files {
@@ -249,7 +233,7 @@ async fn prepare_cached_file_plans_with_progress(
             file_existing_refs,
             build_xorb_builder,
             prepared_cache,
-            verified_sequences,
+            &mut verified_sequences,
             &mut ownership_cache,
             cancel,
         )

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -568,6 +568,7 @@ async fn flush_uncached_read_batch(
         debug_assert_eq!(actual_hash, expected.0);
     }
     builder.push_batch(&scratch.to_pack)?;
+    scratch.to_pack.clear();
     read_batch.clear();
     Ok(())
 }

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -732,6 +732,7 @@ async fn prepare_one_file_plan_with_existing_refs(
     )
     .await?;
     let mut plan = FilePushPlan::new_verified_recipe(&recipe);
+    let recipe_hash = recipe.hash();
 
     let mut file_chunk_sizes = HashMap::new();
     for (chunk_hash, size) in chunks {
@@ -754,6 +755,7 @@ async fn prepare_one_file_plan_with_existing_refs(
     let mut cache_xorbs = 0u64;
     let mut cache_link_misses = 0u64;
     let mut unusable_cached_xorb_sources = HashSet::new();
+    let mut exclusive_payloads = HashMap::new();
     for ((chunk_hash, size), existing_ref) in chunks.iter().zip(existing_refs.iter()) {
         if let Some(candidate) = existing_ref
             && u64::from(candidate.xorb_ref.uncompressed_size) == *size
@@ -789,10 +791,19 @@ async fn prepare_one_file_plan_with_existing_refs(
                 .placements
                 .iter()
                 .any(|placement| remote_existing_chunks.contains(&placement.chunk_hash));
-            if contains_remote
-                && staging
-                    .prepared_payload_exclusive_to_recipe(&candidate.xorb_hash, &recipe.hash())?
-            {
+            let exclusive = if contains_remote {
+                if let Some(exclusive) = exclusive_payloads.get(&candidate.xorb_hash) {
+                    *exclusive
+                } else {
+                    let exclusive = staging
+                        .prepared_payload_exclusive_to_recipe(&candidate.xorb_hash, &recipe_hash)?;
+                    exclusive_payloads.insert(candidate.xorb_hash, exclusive);
+                    exclusive
+                }
+            } else {
+                false
+            };
+            if exclusive {
                 continue;
             }
             if planned_prepared_xorbs.contains(&candidate.xorb_hash) {

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -300,6 +300,7 @@ async fn prepare_uncached_file_plans_with_progress(
     }
 
     let mut builder = build_xorb_builder();
+    let chunk_owners = build_uncached_chunk_owners(&file_plans);
     let mut queued_chunks = HashSet::new();
     let mut read_batch = Vec::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
     for file_idx in 0..file_plans.len() {
@@ -315,14 +316,20 @@ async fn prepare_uncached_file_plans_with_progress(
             read_batch.push((chunk, run_id));
             if read_batch.len() >= ADD_PLAN_READ_BATCH_CHUNKS {
                 flush_uncached_read_batch(staging, &mut read_batch, &mut builder, cancel).await?;
-                write_completed_uncached_xorbs(staging, &mut file_plans, &mut builder).await?;
+                write_completed_uncached_xorbs(
+                    staging,
+                    &mut file_plans,
+                    &chunk_owners,
+                    &mut builder,
+                )
+                .await?;
             }
         }
     }
     flush_uncached_read_batch(staging, &mut read_batch, &mut builder, cancel).await?;
-    write_completed_uncached_xorbs(staging, &mut file_plans, &mut builder).await?;
+    write_completed_uncached_xorbs(staging, &mut file_plans, &chunk_owners, &mut builder).await?;
     for result in builder.finalize()? {
-        record_uncached_prepared_xorb(staging, &mut file_plans, result).await?;
+        record_uncached_prepared_xorb(staging, &mut file_plans, &chunk_owners, result).await?;
     }
 
     let mut summary = AddPushPlanSummary {
@@ -469,17 +476,34 @@ async fn flush_uncached_read_batch(
 async fn write_completed_uncached_xorbs(
     staging: &StagingArea,
     file_plans: &mut [UncachedFilePlan<'_>],
+    chunk_owners: &HashMap<MerkleHash, Vec<usize>>,
     builder: &mut XorbBuilder,
 ) -> Result<()> {
     while let Some(result) = builder.take_completed() {
-        record_uncached_prepared_xorb(staging, file_plans, result).await?;
+        record_uncached_prepared_xorb(staging, file_plans, chunk_owners, result).await?;
     }
     Ok(())
+}
+
+fn build_uncached_chunk_owners(
+    file_plans: &[UncachedFilePlan<'_>],
+) -> HashMap<MerkleHash, Vec<usize>> {
+    let mut owners = HashMap::new();
+    for (file_idx, file_plan) in file_plans.iter().enumerate() {
+        for chunk_hash in &file_plan.uncovered_chunks {
+            owners
+                .entry(*chunk_hash)
+                .or_insert_with(Vec::new)
+                .push(file_idx);
+        }
+    }
+    owners
 }
 
 async fn record_uncached_prepared_xorb(
     staging: &StagingArea,
     file_plans: &mut [UncachedFilePlan<'_>],
+    chunk_owners: &HashMap<MerkleHash, Vec<usize>>,
     result: crab_xet::xorb::builder::XorbResult,
 ) -> Result<()> {
     let bytes = result.bytes.len() as u64;
@@ -497,32 +521,52 @@ async fn record_uncached_prepared_xorb(
         placements,
     };
 
-    let recipients: Vec<usize> = file_plans
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, file_plan)| {
-            result
-                .placements
-                .iter()
-                .any(|placement| file_plan.uncovered_chunks.contains(&placement.chunk_hash))
-                .then_some(idx)
-        })
-        .collect();
+    let recipients = recipient_indices(file_plans.len(), &result.placements, chunk_owners);
     let Some((&owner_idx, linked_idxs)) = recipients.split_first() else {
         return Err(StagingError::Internal(
             "prepared xorb has no owning add file".to_owned(),
         ));
     };
-    write_prepared_xorb(staging.root(), &result.hash, result.bytes.clone()).await?;
-    file_plans[owner_idx]
-        .plan
-        .prepared_xorbs
-        .push(planned.clone());
+    write_prepared_xorb(staging.root(), &result.hash, result.bytes).await?;
+    file_plans[owner_idx].plan.prepared_xorbs.push(planned);
 
-    for idx in linked_idxs {
-        file_plans[*idx].plan.prepared_xorbs.push(planned.clone());
+    if !linked_idxs.is_empty() {
+        let linked_plan = file_plans[owner_idx]
+            .plan
+            .prepared_xorbs
+            .last()
+            .cloned()
+            .ok_or_else(|| {
+                StagingError::Internal("prepared xorb owner record disappeared".to_owned())
+            })?;
+        for idx in linked_idxs {
+            file_plans[*idx]
+                .plan
+                .prepared_xorbs
+                .push(linked_plan.clone());
+        }
     }
     Ok(())
+}
+
+fn recipient_indices(
+    file_count: usize,
+    placements: &[crab_xet::xorb::format::ChunkPlacement],
+    chunk_owners: &HashMap<MerkleHash, Vec<usize>>,
+) -> Vec<usize> {
+    let mut recipient_flags = vec![false; file_count];
+    for placement in placements {
+        if let Some(owners) = chunk_owners.get(&placement.chunk_hash) {
+            for &owner in owners {
+                recipient_flags[owner] = true;
+            }
+        }
+    }
+    recipient_flags
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, is_recipient)| is_recipient.then_some(idx))
+        .collect()
 }
 
 async fn prepare_one_file_plan(
@@ -1052,6 +1096,54 @@ mod tests {
             placement_id: numbered_hash(seed + 2_000_000).into(),
             origin_proof_id: numbered_hash(seed + 3_000_000).into(),
         }
+    }
+
+    #[test]
+    fn uncached_xorb_recipients_follow_chunk_ownership() {
+        let shared = numbered_hash(1);
+        let first_only = numbered_hash(2);
+        let mut first_chunks = HashSet::new();
+        first_chunks.insert(shared);
+        first_chunks.insert(first_only);
+        let mut second_chunks = HashSet::new();
+        second_chunks.insert(shared);
+        let file_plans = vec![
+            UncachedFilePlan {
+                file_hash: numbered_hash(10),
+                chunks: &[],
+                located_chunks: Vec::new(),
+                uncovered_chunks: first_chunks,
+                plan: FilePushPlan::new_verified_staging(numbered_hash(10), 0, &[]),
+            },
+            UncachedFilePlan {
+                file_hash: numbered_hash(11),
+                chunks: &[],
+                located_chunks: Vec::new(),
+                uncovered_chunks: second_chunks,
+                plan: FilePushPlan::new_verified_staging(numbered_hash(11), 0, &[]),
+            },
+        ];
+        let owners = build_uncached_chunk_owners(&file_plans);
+        let placements = vec![
+            crab_xet::xorb::format::ChunkPlacement {
+                chunk_hash: shared,
+                xorb_hash: numbered_hash(20),
+                chunk_index: 0,
+                uncompressed_size: 1,
+            },
+            crab_xet::xorb::format::ChunkPlacement {
+                chunk_hash: first_only,
+                xorb_hash: numbered_hash(20),
+                chunk_index: 1,
+                uncompressed_size: 1,
+            },
+        ];
+
+        assert_eq!(owners.get(&shared), Some(&vec![0, 1]));
+        assert_eq!(
+            recipient_indices(file_plans.len(), &placements, &owners),
+            vec![0, 1]
+        );
     }
 
     async fn stage_synthetic_file(

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -131,7 +131,8 @@ pub async fn prepare_file_push_plans_with_progress(
         })?;
         let unique_existing_refs =
             lookup_existing_candidates(unique_file_chunks, remote_lookup).await?;
-        let existing_refs = index_existing_refs(unique_file_chunks, &unique_existing_refs)?;
+        let existing_refs =
+            index_existing_refs(unique_file_chunks, unique_existing_refs.as_deref())?;
         if prepared_cache.is_empty() {
             return prepare_uncached_file_plans_with_progress(
                 staging,
@@ -201,7 +202,7 @@ struct PreparedFilePlan {
 async fn prepare_cached_file_plans_with_progress(
     staging: &StagingArea,
     files: &[AddPlanFile<'_>],
-    existing_refs: &HashMap<MerkleHash, Option<ExistingChunkCandidate>>,
+    existing_refs: &Option<HashMap<MerkleHash, Option<ExistingChunkCandidate>>>,
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     prepared_cache: &mut PreparedXorbCache,
     mut summary: AddPushPlanSummary,
@@ -212,21 +213,31 @@ async fn prepare_cached_file_plans_with_progress(
     let mut prepared_plans = Vec::with_capacity(files.len());
     for file in files {
         check_cancelled(cancel)?;
-        let file_existing_refs = file
-            .chunks
-            .iter()
-            .map(|(chunk_hash, _)| {
-                existing_refs.get(chunk_hash).copied().ok_or_else(|| {
-                    StagingError::Internal(
-                        "existing chunk lookup lost a requested chunk".to_owned(),
-                    )
-                })
+        let file_existing_refs = existing_refs
+            .as_ref()
+            .map(|existing_refs| {
+                file.chunks
+                    .iter()
+                    .map(|(chunk_hash, _)| {
+                        existing_refs.get(chunk_hash).copied().ok_or_else(|| {
+                            StagingError::Internal(
+                                "existing chunk lookup lost a requested chunk".to_owned(),
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()
             })
-            .collect::<Result<Vec<_>>>()?;
+            .transpose()?;
+        let file_existing_refs = file_existing_refs
+            .as_deref()
+            .map(ExistingRefs::Values)
+            .unwrap_or(ExistingRefs::Missing {
+                len: file.chunks.len(),
+            });
         let prepared = prepare_one_file_plan_with_existing_refs(
             staging,
             file,
-            &file_existing_refs,
+            file_existing_refs,
             build_xorb_builder,
             prepared_cache,
             verified_sequences,
@@ -292,6 +303,29 @@ struct FileChunkState {
     read_needed: bool,
 }
 
+#[derive(Clone, Copy)]
+// Keep all-missing lookups allocation-free when no remote classifier is configured.
+enum ExistingRefs<'a> {
+    Missing { len: usize },
+    Values(&'a [Option<ExistingChunkCandidate>]),
+}
+
+impl ExistingRefs<'_> {
+    fn len(self) -> usize {
+        match self {
+            Self::Missing { len } => len,
+            Self::Values(values) => values.len(),
+        }
+    }
+
+    fn at(self, index: usize) -> Option<Option<ExistingChunkCandidate>> {
+        match self {
+            Self::Missing { len } => (index < len).then_some(None),
+            Self::Values(values) => values.get(index).copied(),
+        }
+    }
+}
+
 struct ReadBatchScratch {
     hashes: Vec<MerkleHash>,
     to_pack: Vec<(Chunk, RunId)>,
@@ -330,24 +364,29 @@ fn collect_unique_file_chunks(
 
 fn index_existing_refs(
     unique_chunks: &[(MerkleHash, u64)],
-    unique_refs: &[Option<ExistingChunkCandidate>],
-) -> Result<HashMap<MerkleHash, Option<ExistingChunkCandidate>>> {
+    unique_refs: Option<&[Option<ExistingChunkCandidate>]>,
+) -> Result<Option<HashMap<MerkleHash, Option<ExistingChunkCandidate>>>> {
+    let Some(unique_refs) = unique_refs else {
+        return Ok(None);
+    };
     if unique_chunks.len() != unique_refs.len() {
         return Err(StagingError::Internal(
             "existing chunk lookup returned a different unique chunk count".to_owned(),
         ));
     }
-    Ok(unique_chunks
-        .iter()
-        .map(|(chunk_hash, _)| *chunk_hash)
-        .zip(unique_refs.iter().copied())
-        .collect())
+    Ok(Some(
+        unique_chunks
+            .iter()
+            .map(|(chunk_hash, _)| *chunk_hash)
+            .zip(unique_refs.iter().copied())
+            .collect(),
+    ))
 }
 
 async fn prepare_uncached_file_plans_with_progress(
     staging: &StagingArea,
     files: &[AddPlanFile<'_>],
-    existing_refs: &HashMap<MerkleHash, Option<ExistingChunkCandidate>>,
+    existing_refs: &Option<HashMap<MerkleHash, Option<ExistingChunkCandidate>>>,
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     remote_lookup: bool,
     verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
@@ -357,19 +396,29 @@ async fn prepare_uncached_file_plans_with_progress(
     let mut file_plans = Vec::with_capacity(files.len());
     for file in files {
         check_cancelled(cancel)?;
-        let file_existing_refs = file
-            .chunks
-            .iter()
-            .map(|(chunk_hash, _)| {
-                existing_refs.get(chunk_hash).copied().ok_or_else(|| {
-                    StagingError::Internal(
-                        "existing chunk lookup lost a requested chunk".to_owned(),
-                    )
-                })
+        let file_existing_refs = existing_refs
+            .as_ref()
+            .map(|existing_refs| {
+                file.chunks
+                    .iter()
+                    .map(|(chunk_hash, _)| {
+                        existing_refs.get(chunk_hash).copied().ok_or_else(|| {
+                            StagingError::Internal(
+                                "existing chunk lookup lost a requested chunk".to_owned(),
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()
             })
-            .collect::<Result<Vec<_>>>()?;
+            .transpose()?;
+        let file_existing_refs = file_existing_refs
+            .as_deref()
+            .map(ExistingRefs::Values)
+            .unwrap_or(ExistingRefs::Missing {
+                len: file.chunks.len(),
+            });
         file_plans.push(
-            verified_uncached_file_plan(staging, file, &file_existing_refs, verified_sequences)
+            verified_uncached_file_plan(staging, file, file_existing_refs, verified_sequences)
                 .await?,
         );
     }
@@ -465,9 +514,16 @@ async fn prepare_uncached_file_plans_with_progress(
 async fn verified_uncached_file_plan<'a>(
     staging: &StagingArea,
     file: &'a AddPlanFile<'_>,
-    existing_refs: &[Option<ExistingChunkCandidate>],
+    existing_refs: ExistingRefs<'_>,
     verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
 ) -> Result<UncachedFilePlan<'a>> {
+    if existing_refs.len() != file.chunks.len() {
+        return Err(StagingError::Internal(format!(
+            "add push-plan remote lookup returned {} candidates for {} requested chunks",
+            existing_refs.len(),
+            file.chunks.len()
+        )));
+    }
     let file_hash = MerkleHash::from(file.file_hash);
     let mut plan = FilePushPlan::new_verified_staging(file_hash, file.size, file.chunks);
     let verification_key = (file_hash, plan.sequence_hash()?, file.size);
@@ -482,7 +538,10 @@ async fn verified_uncached_file_plan<'a>(
         .await?;
     }
     let mut uncovered_chunks = HashSet::new();
-    for ((chunk_hash, size), existing_ref) in file.chunks.iter().zip(existing_refs.iter()) {
+    for (index, (chunk_hash, size)) in file.chunks.iter().enumerate() {
+        let existing_ref = existing_refs
+            .at(index)
+            .ok_or_else(|| StagingError::Internal("missing existing chunk candidate".to_owned()))?;
         if let Some(candidate) = existing_ref
             && u64::from(candidate.xorb_ref.uncompressed_size) == *size
         {
@@ -672,10 +731,16 @@ async fn prepare_one_file_plan(
     cancel: &CancellationToken,
 ) -> Result<FilePlanSummary> {
     let existing_refs = lookup_existing_candidates(file.chunks, remote_lookup).await?;
+    let existing_refs = existing_refs
+        .as_deref()
+        .map(ExistingRefs::Values)
+        .unwrap_or(ExistingRefs::Missing {
+            len: file.chunks.len(),
+        });
     let prepared = prepare_one_file_plan_with_existing_refs(
         staging,
         file,
-        &existing_refs,
+        existing_refs,
         build_xorb_builder,
         prepared_cache,
         verified_sequences,
@@ -691,7 +756,7 @@ async fn prepare_one_file_plan(
 async fn prepare_one_file_plan_with_existing_refs(
     staging: &StagingArea,
     file: &AddPlanFile<'_>,
-    existing_refs: &[Option<ExistingChunkCandidate>],
+    existing_refs: ExistingRefs<'_>,
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     prepared_cache: &mut PreparedXorbCache,
     verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
@@ -733,7 +798,10 @@ async fn prepare_one_file_plan_with_existing_refs(
     let mut cache_link_misses = 0u64;
     let mut unusable_cached_xorb_sources = HashSet::new();
     let mut exclusive_payloads = HashMap::new();
-    for ((chunk_hash, size), existing_ref) in chunks.iter().zip(existing_refs.iter()) {
+    for (index, (chunk_hash, size)) in chunks.iter().enumerate() {
+        let existing_ref = existing_refs
+            .at(index)
+            .ok_or_else(|| StagingError::Internal("missing existing chunk candidate".to_owned()))?;
         let state = chunk_states.entry(*chunk_hash).or_insert(FileChunkState {
             size: *size,
             ..FileChunkState::default()
@@ -745,7 +813,10 @@ async fn prepare_one_file_plan_with_existing_refs(
             state.remote = true;
         }
     }
-    for ((chunk_hash, size), existing_ref) in chunks.iter().zip(existing_refs.iter()) {
+    for (index, (chunk_hash, size)) in chunks.iter().enumerate() {
+        let existing_ref = existing_refs
+            .at(index)
+            .ok_or_else(|| StagingError::Internal("missing existing chunk candidate".to_owned()))?;
         let state = chunk_states.entry(*chunk_hash).or_insert(FileChunkState {
             size: *size,
             ..FileChunkState::default()
@@ -1025,9 +1096,9 @@ async fn record_prepared_xorb(
 async fn lookup_existing_candidates(
     chunks: &[(MerkleHash, u64)],
     remote_lookup: Option<&dyn ExistingChunkLookup>,
-) -> Result<Vec<Option<ExistingChunkCandidate>>> {
+) -> Result<Option<Vec<Option<ExistingChunkCandidate>>>> {
     let Some(remote_lookup) = remote_lookup else {
-        return Ok(vec![None; chunks.len()]);
+        return Ok(None);
     };
     let refs = remote_lookup.lookup_existing_candidates(chunks).await?;
     if refs.len() != chunks.len() {
@@ -1037,7 +1108,7 @@ async fn lookup_existing_candidates(
             chunks.len()
         )));
     }
-    Ok(refs)
+    Ok(Some(refs))
 }
 
 #[cfg(test)]
@@ -1306,11 +1377,22 @@ mod tests {
                     .flatten()
             })
             .collect::<Vec<_>>();
-        let indexed = index_existing_refs(&unique, &unique_refs).expect("index refs");
+        let indexed = index_existing_refs(&unique, Some(&unique_refs))
+            .expect("index refs")
+            .expect("indexed refs");
         assert_eq!(indexed.len(), 3);
         assert_eq!(indexed.get(&shared), Some(&shared_candidate));
         assert_eq!(indexed.get(&first_only), Some(&None));
         assert_eq!(indexed.get(&second_only), Some(&None));
+    }
+
+    #[test]
+    fn absent_remote_lookup_keeps_candidate_index_unallocated() {
+        let unique = vec![(numbered_hash(9), 1)];
+
+        let indexed = index_existing_refs(&unique, None).expect("index refs");
+
+        assert!(indexed.is_none());
     }
 
     async fn stage_synthetic_file(

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -99,7 +99,17 @@ pub async fn prepare_file_push_plans_with_progress(
         return Ok(AddPushPlanSummary::default());
     }
 
-    let (wanted_prepared_chunks, unique_file_chunks) = collect_unique_file_chunks(files);
+    let (wanted_prepared_chunks, unique_file_chunks) = if files.len() > 1 {
+        let (wanted, unique) = collect_unique_file_chunks(files);
+        (wanted, Some(unique))
+    } else {
+        let wanted = files[0]
+            .chunks
+            .iter()
+            .map(|(chunk_hash, _)| *chunk_hash)
+            .collect();
+        (wanted, None)
+    };
     let mut summary = AddPushPlanSummary {
         remote_lookup: remote_lookup.is_some(),
         ..AddPushPlanSummary::default()
@@ -115,10 +125,12 @@ pub async fn prepare_file_push_plans_with_progress(
             .await?;
     }
     if files.len() > 1 {
+        let unique_file_chunks = unique_file_chunks.as_deref().ok_or_else(|| {
+            StagingError::Internal("missing unique multi-file chunk collection".to_owned())
+        })?;
         let unique_existing_refs =
-            lookup_existing_candidates(&unique_file_chunks, remote_lookup).await?;
-        let existing_refs =
-            expand_existing_refs(files, &unique_file_chunks, &unique_existing_refs)?;
+            lookup_existing_candidates(unique_file_chunks, remote_lookup).await?;
+        let existing_refs = expand_existing_refs(files, unique_file_chunks, &unique_existing_refs)?;
         if prepared_cache.is_empty() {
             return prepare_uncached_file_plans_with_progress(
                 staging,

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -950,13 +950,10 @@ fn ranked_prepared_candidates<'a>(
     unusable_cached_candidates: &HashSet<*const PreparedXorbCandidate>,
 ) -> Vec<PreparedCandidateChoice<'a>> {
     let mut choices = Vec::new();
-    for candidate in prepared_cache.candidates_for_chunk(chunk_hash) {
+    for (candidate, placement) in prepared_cache.candidate_placements_for_chunk(chunk_hash) {
         if unusable_cached_candidates.contains(&prepared_candidate_id(candidate)) {
             continue;
         }
-        let Some(placement) = candidate.placement_for(chunk_hash) else {
-            continue;
-        };
         if u64::from(placement.uncompressed_size) != expected_size {
             continue;
         }

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -131,7 +131,7 @@ pub async fn prepare_file_push_plans_with_progress(
         })?;
         let unique_existing_refs =
             lookup_existing_candidates(unique_file_chunks, remote_lookup).await?;
-        let existing_refs = expand_existing_refs(files, unique_file_chunks, &unique_existing_refs)?;
+        let existing_refs = index_existing_refs(unique_file_chunks, &unique_existing_refs)?;
         if prepared_cache.is_empty() {
             return prepare_uncached_file_plans_with_progress(
                 staging,
@@ -201,7 +201,7 @@ struct PreparedFilePlan {
 async fn prepare_cached_file_plans_with_progress(
     staging: &StagingArea,
     files: &[AddPlanFile<'_>],
-    existing_refs: &[Option<ExistingChunkCandidate>],
+    existing_refs: &HashMap<MerkleHash, Option<ExistingChunkCandidate>>,
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     prepared_cache: &mut PreparedXorbCache,
     mut summary: AddPushPlanSummary,
@@ -209,33 +209,31 @@ async fn prepare_cached_file_plans_with_progress(
     cancel: &CancellationToken,
     mut on_progress: Option<&mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
 ) -> Result<AddPushPlanSummary> {
-    let mut ref_offset = 0usize;
     let mut prepared_plans = Vec::with_capacity(files.len());
     for file in files {
         check_cancelled(cancel)?;
-        let next_offset = ref_offset.checked_add(file.chunks.len()).ok_or_else(|| {
-            StagingError::Internal("add push-plan chunk count overflow".to_owned())
-        })?;
-        let file_existing_refs = existing_refs.get(ref_offset..next_offset).ok_or_else(|| {
-            StagingError::Internal("add push-plan remote lookup length changed".to_owned())
-        })?;
+        let file_existing_refs = file
+            .chunks
+            .iter()
+            .map(|(chunk_hash, _)| {
+                existing_refs.get(chunk_hash).copied().ok_or_else(|| {
+                    StagingError::Internal(
+                        "existing chunk lookup lost a requested chunk".to_owned(),
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
         let prepared = prepare_one_file_plan_with_existing_refs(
             staging,
             file,
-            file_existing_refs,
+            &file_existing_refs,
             build_xorb_builder,
             prepared_cache,
             verified_sequences,
             cancel,
         )
         .await?;
-        ref_offset = next_offset;
         prepared_plans.push(prepared);
-    }
-    if ref_offset != existing_refs.len() {
-        return Err(StagingError::Internal(
-            "add push-plan remote lookup returned extra candidates".to_owned(),
-        ));
     }
     let plan_pairs = prepared_plans
         .iter()
@@ -330,39 +328,26 @@ fn collect_unique_file_chunks(
     (wanted, unique)
 }
 
-fn expand_existing_refs(
-    files: &[AddPlanFile<'_>],
+fn index_existing_refs(
     unique_chunks: &[(MerkleHash, u64)],
     unique_refs: &[Option<ExistingChunkCandidate>],
-) -> Result<Vec<Option<ExistingChunkCandidate>>> {
+) -> Result<HashMap<MerkleHash, Option<ExistingChunkCandidate>>> {
     if unique_chunks.len() != unique_refs.len() {
         return Err(StagingError::Internal(
             "existing chunk lookup returned a different unique chunk count".to_owned(),
         ));
     }
-    let by_hash = unique_chunks
+    Ok(unique_chunks
         .iter()
         .map(|(chunk_hash, _)| *chunk_hash)
         .zip(unique_refs.iter().copied())
-        .collect::<HashMap<_, _>>();
-    files
-        .iter()
-        .flat_map(|file| {
-            file.chunks.iter().map(|(chunk_hash, _)| {
-                by_hash.get(chunk_hash).copied().ok_or_else(|| {
-                    StagingError::Internal(
-                        "existing chunk lookup lost a requested chunk".to_owned(),
-                    )
-                })
-            })
-        })
-        .collect()
+        .collect())
 }
 
 async fn prepare_uncached_file_plans_with_progress(
     staging: &StagingArea,
     files: &[AddPlanFile<'_>],
-    existing_refs: &[Option<ExistingChunkCandidate>],
+    existing_refs: &HashMap<MerkleHash, Option<ExistingChunkCandidate>>,
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     remote_lookup: bool,
     verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
@@ -370,25 +355,23 @@ async fn prepare_uncached_file_plans_with_progress(
     mut on_progress: Option<&mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
 ) -> Result<AddPushPlanSummary> {
     let mut file_plans = Vec::with_capacity(files.len());
-    let mut ref_offset = 0usize;
     for file in files {
         check_cancelled(cancel)?;
-        let next_offset = ref_offset.checked_add(file.chunks.len()).ok_or_else(|| {
-            StagingError::Internal("add push-plan chunk count overflow".to_owned())
-        })?;
-        let file_existing_refs = existing_refs.get(ref_offset..next_offset).ok_or_else(|| {
-            StagingError::Internal("add push-plan remote lookup length changed".to_owned())
-        })?;
+        let file_existing_refs = file
+            .chunks
+            .iter()
+            .map(|(chunk_hash, _)| {
+                existing_refs.get(chunk_hash).copied().ok_or_else(|| {
+                    StagingError::Internal(
+                        "existing chunk lookup lost a requested chunk".to_owned(),
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
         file_plans.push(
-            verified_uncached_file_plan(staging, file, file_existing_refs, verified_sequences)
+            verified_uncached_file_plan(staging, file, &file_existing_refs, verified_sequences)
                 .await?,
         );
-        ref_offset = next_offset;
-    }
-    if ref_offset != existing_refs.len() {
-        return Err(StagingError::Internal(
-            "add push-plan remote lookup returned extra candidates".to_owned(),
-        ));
     }
 
     let mut builder = build_xorb_builder();
@@ -1323,10 +1306,11 @@ mod tests {
                     .flatten()
             })
             .collect::<Vec<_>>();
-        let expanded = expand_existing_refs(&files, &unique, &unique_refs).expect("expand refs");
-        assert_eq!(expanded.len(), 4);
-        assert_eq!(expanded[0], shared_candidate);
-        assert_eq!(expanded[2], shared_candidate);
+        let indexed = index_existing_refs(&unique, &unique_refs).expect("index refs");
+        assert_eq!(indexed.len(), 3);
+        assert_eq!(indexed.get(&shared), Some(&shared_candidate));
+        assert_eq!(indexed.get(&first_only), Some(&None));
+        assert_eq!(indexed.get(&second_only), Some(&None));
     }
 
     async fn stage_synthetic_file(

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -99,10 +99,7 @@ pub async fn prepare_file_push_plans_with_progress(
         return Ok(AddPushPlanSummary::default());
     }
 
-    let wanted_prepared_chunks: HashSet<MerkleHash> = files
-        .iter()
-        .flat_map(|file| file.chunks.iter().map(|(chunk_hash, _)| *chunk_hash))
-        .collect();
+    let (wanted_prepared_chunks, unique_file_chunks) = collect_unique_file_chunks(files);
     let mut summary = AddPushPlanSummary {
         remote_lookup: remote_lookup.is_some(),
         ..AddPushPlanSummary::default()
@@ -118,9 +115,10 @@ pub async fn prepare_file_push_plans_with_progress(
             .await?;
     }
     if files.len() > 1 {
-        let all_chunks = all_file_chunks(files);
-        let unique_existing_refs = lookup_existing_candidates(&all_chunks, remote_lookup).await?;
-        let existing_refs = expand_existing_refs(files, &all_chunks, &unique_existing_refs)?;
+        let unique_existing_refs =
+            lookup_existing_candidates(&unique_file_chunks, remote_lookup).await?;
+        let existing_refs =
+            expand_existing_refs(files, &unique_file_chunks, &unique_existing_refs)?;
         if prepared_cache.is_empty() {
             return prepare_uncached_file_plans_with_progress(
                 staging,
@@ -281,13 +279,19 @@ struct VerifiedStagedChunks {
     chunks: Vec<(MerkleHash, u64)>,
 }
 
-fn all_file_chunks(files: &[AddPlanFile<'_>]) -> Vec<(MerkleHash, u64)> {
-    let mut seen = HashSet::new();
-    files
-        .iter()
-        .flat_map(|file| file.chunks.iter().copied())
-        .filter(|(chunk_hash, _)| seen.insert(*chunk_hash))
-        .collect()
+fn collect_unique_file_chunks(
+    files: &[AddPlanFile<'_>],
+) -> (HashSet<MerkleHash>, Vec<(MerkleHash, u64)>) {
+    let mut wanted = HashSet::new();
+    let mut unique = Vec::new();
+    for file in files {
+        for &(chunk_hash, size) in file.chunks {
+            if wanted.insert(chunk_hash) {
+                unique.push((chunk_hash, size));
+            }
+        }
+    }
+    (wanted, unique)
 }
 
 fn expand_existing_refs(
@@ -1257,7 +1261,7 @@ mod tests {
                 chunks: &second_chunks,
             },
         ];
-        let unique = all_file_chunks(&files);
+        let (_, unique) = collect_unique_file_chunks(&files);
         assert_eq!(unique.len(), 3);
         assert_eq!(
             unique

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -282,13 +282,8 @@ struct PreparedCandidateChoice {
 struct UncachedFilePlan<'a> {
     file_hash: MerkleHash,
     chunks: &'a [(MerkleHash, u64)],
-    located_chunks: Vec<(MerkleHash, u64)>,
     uncovered_chunks: HashSet<MerkleHash>,
     plan: FilePushPlan,
-}
-
-struct VerifiedStagedChunks {
-    chunks: Vec<(MerkleHash, u64)>,
 }
 
 fn collect_unique_file_chunks(
@@ -369,8 +364,7 @@ async fn prepare_uncached_file_plans_with_progress(
     let mut read_batch = Vec::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
     for file_idx in 0..file_plans.len() {
         let run_id = RunId(file_idx as u64);
-        for chunk_idx in 0..file_plans[file_idx].located_chunks.len() {
-            let chunk = file_plans[file_idx].located_chunks[chunk_idx];
+        for &chunk in file_plans[file_idx].chunks {
             if !file_plans[file_idx].uncovered_chunks.contains(&chunk.0) {
                 continue;
             }
@@ -444,7 +438,7 @@ async fn verified_uncached_file_plan<'a>(
 ) -> Result<UncachedFilePlan<'a>> {
     let file_hash = MerkleHash::from(file.file_hash);
     let mut plan = FilePushPlan::new_verified_staging(file_hash, file.size, file.chunks);
-    let verified = verified_staged_chunks(
+    verified_staged_chunks(
         staging,
         file_hash,
         file.size,
@@ -468,7 +462,6 @@ async fn verified_uncached_file_plan<'a>(
     Ok(UncachedFilePlan {
         file_hash,
         chunks: file.chunks,
-        located_chunks: verified.chunks,
         uncovered_chunks,
         plan,
     })
@@ -480,15 +473,13 @@ async fn verified_staged_chunks(
     file_size: u64,
     expected_chunks: &[(MerkleHash, u64)],
     expected_sequence_hash: [u8; 32],
-) -> Result<VerifiedStagedChunks> {
+) -> Result<()> {
     if let Some(plan) = staging.load_file_push_plan(&file_hash).await?
         && plan.chunk_count == expected_chunks.len() as u64
         && plan.sequence_hash()? == expected_sequence_hash
         && plan.file_size == file_size
     {
-        return Ok(VerifiedStagedChunks {
-            chunks: expected_chunks.to_vec(),
-        });
+        return Ok(());
     }
     let located_chunks = staging.chunks_for_file_with_locators(&file_hash)?;
     if located_chunks.len() != expected_chunks.len()
@@ -516,12 +507,7 @@ async fn verified_staged_chunks(
             file_hash.hex()
         )));
     }
-    Ok(VerifiedStagedChunks {
-        chunks: located_chunks
-            .into_iter()
-            .map(|chunk| (chunk.hash, chunk.size))
-            .collect(),
-    })
+    Ok(())
 }
 
 async fn flush_uncached_read_batch(
@@ -705,7 +691,7 @@ async fn prepare_one_file_plan_with_existing_refs(
         file.size,
         chunks,
     )?;
-    let verified = verified_staged_chunks(
+    verified_staged_chunks(
         staging,
         file_hash,
         file.size,
@@ -713,7 +699,6 @@ async fn prepare_one_file_plan_with_existing_refs(
         recipe.sequence_hash(),
     )
     .await?;
-    let located_chunks = verified.chunks;
     let mut plan = FilePushPlan::new_verified_recipe(&recipe);
 
     let mut file_chunk_sizes = HashMap::new();
@@ -821,7 +806,7 @@ async fn prepare_one_file_plan_with_existing_refs(
 
     let mut builder = build_xorb_builder();
     let mut read_batch = Vec::with_capacity(ADD_PLAN_READ_BATCH_CHUNKS);
-    for chunk in located_chunks {
+    for &chunk in chunks {
         if !new_chunks.remove(&chunk.0) {
             continue;
         }
@@ -1203,14 +1188,12 @@ mod tests {
             UncachedFilePlan {
                 file_hash: numbered_hash(10),
                 chunks: &[],
-                located_chunks: Vec::new(),
                 uncovered_chunks: first_chunks,
                 plan: FilePushPlan::new_verified_staging(numbered_hash(10), 0, &[]),
             },
             UncachedFilePlan {
                 file_hash: numbered_hash(11),
                 chunks: &[],
-                located_chunks: Vec::new(),
                 uncovered_chunks: second_chunks,
                 plan: FilePushPlan::new_verified_staging(numbered_hash(11), 0, &[]),
             },

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -10,7 +10,6 @@ use crate::error::{Result, StagingError};
 use crate::push_plan::{
     ExistingChunkCandidate, FilePushPlan, PlannedExistingChunk, PlannedPlacement, PlannedXorb,
     PreparedXorbCache, PreparedXorbCandidate, PreparedXorbSource, materialize_prepared_xorb,
-    write_prepared_xorb,
 };
 use crab_xet::hash::MerkleHash;
 use crab_xet::xorb::builder::{RunId, XorbBuilder};
@@ -534,7 +533,8 @@ async fn record_uncached_prepared_xorb(
     result: crab_xet::xorb::builder::XorbResult,
 ) -> Result<()> {
     let bytes = result.bytes.len() as u64;
-    let payload_hash = blake3::hash(&result.bytes).to_hex().to_string();
+    let payload_hash_bytes = *blake3::hash(&result.bytes).as_bytes();
+    let payload_hash = blake3::Hash::from(payload_hash_bytes).to_hex().to_string();
     let placements: Vec<PlannedPlacement> = result
         .placements
         .iter()
@@ -554,7 +554,13 @@ async fn record_uncached_prepared_xorb(
             "prepared xorb has no owning add file".to_owned(),
         ));
     };
-    write_prepared_xorb(staging.root(), &result.hash, result.bytes).await?;
+    crate::push_plan::write_prepared_xorb_with_payload_hash(
+        staging.root(),
+        &result.hash,
+        result.bytes,
+        payload_hash_bytes,
+    )
+    .await?;
     file_plans[owner_idx].plan.prepared_xorbs.push(planned);
 
     if !linked_idxs.is_empty() {
@@ -918,13 +924,20 @@ async fn record_prepared_xorb(
     result: crab_xet::xorb::builder::XorbResult,
 ) -> Result<()> {
     let bytes = result.bytes.len() as u64;
-    let payload_hash = blake3::hash(&result.bytes).to_hex().to_string();
+    let payload_hash_bytes = *blake3::hash(&result.bytes).as_bytes();
+    let payload_hash = blake3::Hash::from(payload_hash_bytes).to_hex().to_string();
     let placements: Vec<PlannedPlacement> = result
         .placements
         .iter()
         .map(PlannedPlacement::from_placement)
         .collect();
-    write_prepared_xorb(staging.root(), &result.hash, result.bytes).await?;
+    crate::push_plan::write_prepared_xorb_with_payload_hash(
+        staging.root(),
+        &result.hash,
+        result.bytes,
+        payload_hash_bytes,
+    )
+    .await?;
     let planned = PlannedXorb {
         hash: result.hash.hex(),
         payload_hash,

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -511,29 +511,9 @@ async fn verified_staged_chunks(
     {
         return Ok(());
     }
-    let located_chunks = staging.chunks_for_file_with_locators(&file_hash)?;
-    if located_chunks.len() != expected_chunks.len()
-        || located_chunks
-            .iter()
-            .zip(expected_chunks.iter())
-            .any(|(located, expected)| located.hash != expected.0 || located.size != expected.1)
-    {
+    if !staging.file_chunks_match(&file_hash, expected_chunks, file_size)? {
         return Err(StagingError::StagingCorrupt(format!(
             "staged chunk rows for file {} changed while preparing add push plan",
-            file_hash.hex()
-        )));
-    }
-    let planned_size = located_chunks.iter().try_fold(0u64, |acc, chunk| {
-        acc.checked_add(chunk.size).ok_or_else(|| {
-            StagingError::StagingCorrupt(format!(
-                "staged chunk sizes overflow for file {} while preparing add push plan",
-                file_hash.hex()
-            ))
-        })
-    })?;
-    if planned_size != file_size {
-        return Err(StagingError::StagingCorrupt(format!(
-            "staged chunk rows for file {} total {planned_size} bytes, expected {file_size}",
             file_hash.hex()
         )));
     }

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+#[cfg(test)]
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -290,8 +291,8 @@ fn debug_file_summary(summary: &AddPushPlanSummary) {
     );
 }
 
-struct PreparedCandidateChoice {
-    candidate: Arc<PreparedXorbCandidate>,
+struct PreparedCandidateChoice<'a> {
+    candidate: &'a PreparedXorbCandidate,
     covered_chunks: Vec<MerkleHash>,
 }
 
@@ -961,7 +962,7 @@ fn ranked_prepared_candidates(
     expected_size: u64,
     chunk_states: &HashMap<MerkleHash, FileChunkState>,
     unusable_cached_xorb_sources: &HashSet<(MerkleHash, PreparedXorbSource)>,
-) -> Vec<PreparedCandidateChoice> {
+) -> Vec<PreparedCandidateChoice<'_>> {
     let mut choices = Vec::new();
     for candidate in prepared_cache.candidates_for_chunk(chunk_hash) {
         if unusable_cached_xorb_sources.contains(&(candidate.xorb_hash, candidate.source.clone())) {
@@ -973,7 +974,7 @@ fn ranked_prepared_candidates(
         if u64::from(placement.uncompressed_size) != expected_size {
             continue;
         }
-        let covered_chunks = matching_file_chunks(&candidate, chunk_states);
+        let covered_chunks = matching_file_chunks(candidate, chunk_states);
         if covered_chunks.is_empty() {
             continue;
         }

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -1,6 +1,4 @@
 use std::collections::{HashMap, HashSet};
-#[cfg(test)]
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio_util::sync::CancellationToken;

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -427,8 +427,15 @@ async fn verified_uncached_file_plan<'a>(
     existing_refs: &[Option<ExistingChunkCandidate>],
 ) -> Result<UncachedFilePlan<'a>> {
     let file_hash = MerkleHash::from(file.file_hash);
-    let verified = verified_staged_chunks(staging, file_hash, file.size, file.chunks).await?;
     let mut plan = FilePushPlan::new_verified_staging(file_hash, file.size, file.chunks);
+    let verified = verified_staged_chunks(
+        staging,
+        file_hash,
+        file.size,
+        file.chunks,
+        plan.sequence_hash()?,
+    )
+    .await?;
     let mut uncovered_chunks = HashSet::new();
     for ((chunk_hash, size), existing_ref) in file.chunks.iter().zip(existing_refs.iter()) {
         if let Some(candidate) = existing_ref
@@ -456,10 +463,11 @@ async fn verified_staged_chunks(
     file_hash: MerkleHash,
     file_size: u64,
     expected_chunks: &[(MerkleHash, u64)],
+    expected_sequence_hash: [u8; 32],
 ) -> Result<VerifiedStagedChunks> {
     if let Some(plan) = staging.load_file_push_plan(&file_hash).await?
         && plan.chunk_count == expected_chunks.len() as u64
-        && plan.sequence_hash()? == crate::push_plan::chunk_sequence_hash(expected_chunks)
+        && plan.sequence_hash()? == expected_sequence_hash
         && plan.file_size == file_size
     {
         return Ok(VerifiedStagedChunks {
@@ -675,15 +683,22 @@ async fn prepare_one_file_plan_with_existing_refs(
     }
     let file_hash = MerkleHash::from(file.file_hash);
     let chunks = file.chunks;
-    let verified = verified_staged_chunks(staging, file_hash, file.size, chunks).await?;
-    let located_chunks = verified.chunks;
-    let mut plan = FilePushPlan::new_verified_staging(file_hash, file.size, chunks);
     let recipe = crate::recipe::FileRecipe::from_staged_chunks(
         crate::recipe::ChunkingPolicyId::XetGearV1_64KiB,
         file_hash,
         file.size,
         chunks,
     )?;
+    let verified = verified_staged_chunks(
+        staging,
+        file_hash,
+        file.size,
+        chunks,
+        recipe.sequence_hash(),
+    )
+    .await?;
+    let located_chunks = verified.chunks;
+    let mut plan = FilePushPlan::new_verified_recipe(&recipe);
 
     let mut file_chunk_sizes = HashMap::new();
     for (chunk_hash, size) in chunks {

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -140,13 +140,15 @@ pub async fn prepare_file_push_plans_with_progress(
         return prepare_cached_file_plans_with_progress(
             staging,
             files,
-            &existing_refs,
-            build_xorb_builder,
-            &mut prepared_cache,
-            summary,
-            &mut verified_sequences,
-            cancel,
-            on_progress,
+            CachedFilePlanContext {
+                existing_refs: &existing_refs,
+                build_xorb_builder,
+                prepared_cache: &mut prepared_cache,
+                summary,
+                verified_sequences: &mut verified_sequences,
+                cancel,
+                on_progress,
+            },
         )
         .await;
     }
@@ -192,17 +194,30 @@ struct PreparedFilePlan {
     summary: FilePlanSummary,
 }
 
+struct CachedFilePlanContext<'existing, 'builder, 'cache, 'verified, 'cancel, 'progress> {
+    existing_refs: &'existing Option<HashMap<MerkleHash, Option<ExistingChunkCandidate>>>,
+    build_xorb_builder: &'builder (dyn Fn() -> XorbBuilder + Send + Sync),
+    prepared_cache: &'cache mut PreparedXorbCache,
+    summary: AddPushPlanSummary,
+    verified_sequences: &'verified mut HashSet<(MerkleHash, [u8; 32], u64)>,
+    cancel: &'cancel CancellationToken,
+    on_progress: Option<&'progress mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
+}
+
 async fn prepare_cached_file_plans_with_progress(
     staging: &StagingArea,
     files: &[AddPlanFile<'_>],
-    existing_refs: &Option<HashMap<MerkleHash, Option<ExistingChunkCandidate>>>,
-    build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
-    prepared_cache: &mut PreparedXorbCache,
-    mut summary: AddPushPlanSummary,
-    verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
-    cancel: &CancellationToken,
-    mut on_progress: Option<&mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
+    context: CachedFilePlanContext<'_, '_, '_, '_, '_, '_>,
 ) -> Result<AddPushPlanSummary> {
+    let CachedFilePlanContext {
+        existing_refs,
+        build_xorb_builder,
+        prepared_cache,
+        mut summary,
+        verified_sequences,
+        cancel,
+        mut on_progress,
+    } = context;
     let mut prepared_plans = Vec::with_capacity(files.len());
     let mut ownership_cache = HashMap::new();
     for file in files {
@@ -866,7 +881,7 @@ async fn prepare_one_file_plan_with_existing_refs(
                 break;
             }
 
-            if materialize_prepared_xorb(staging.root(), &candidate).await? {
+            if materialize_prepared_xorb(staging.root(), candidate).await? {
                 let mut planned = candidate.planned.clone();
                 planned.upload = true;
                 if let Some(authority) = plan
@@ -951,24 +966,6 @@ async fn prepare_one_file_plan_with_existing_refs(
         recipe,
         summary: file_summary,
     })
-}
-
-fn ranked_prepared_candidates<'a>(
-    prepared_cache: &'a PreparedXorbCache,
-    chunk_hash: &MerkleHash,
-    expected_size: u64,
-    chunk_states: &HashMap<MerkleHash, FileChunkState>,
-    unusable_cached_candidates: &HashSet<*const PreparedXorbCandidate>,
-) -> Vec<PreparedCandidateChoice<'a>> {
-    let mut matching_scratch = HashSet::new();
-    ranked_prepared_candidates_with_scratch(
-        prepared_cache,
-        chunk_hash,
-        expected_size,
-        chunk_states,
-        unusable_cached_candidates,
-        &mut matching_scratch,
-    )
 }
 
 fn ranked_prepared_candidates_with_scratch<'a>(
@@ -1736,8 +1733,15 @@ mod tests {
                 ..FileChunkState::default()
             },
         )]);
-        let choices =
-            ranked_prepared_candidates(&cache, &chunk_hash, 10, &chunk_states, &HashSet::new());
+        let mut matching_scratch = HashSet::new();
+        let choices = ranked_prepared_candidates_with_scratch(
+            &cache,
+            &chunk_hash,
+            10,
+            &chunk_states,
+            &HashSet::new(),
+            &mut matching_scratch,
+        );
         assert_eq!(choices.len(), 2);
         let first_candidate = choices
             .iter()
@@ -1745,12 +1749,13 @@ mod tests {
             .expect("first source candidate")
             .candidate;
 
-        let filtered = ranked_prepared_candidates(
+        let filtered = ranked_prepared_candidates_with_scratch(
             &cache,
             &chunk_hash,
             10,
             &chunk_states,
             &HashSet::from([prepared_candidate_id(first_candidate)]),
+            &mut matching_scratch,
         );
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].candidate.source, second_source);
@@ -1998,7 +2003,7 @@ mod tests {
         let file_hash = MerkleHash::from(staged.file_hash);
         assert!(
             staging
-                .chunks_for_file_with_locators(&file_hash)
+                .segment_payloads_exist(&staged_pairs)
                 .expect("raw chunk rows")
                 .is_empty(),
             "direct staging must not retain a raw segment copy"

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -6,9 +6,11 @@ use tracing::debug;
 
 use crate::StagingArea;
 use crate::error::{Result, StagingError};
+#[cfg(test)]
+use crate::push_plan::PreparedXorbSource;
 use crate::push_plan::{
     ExistingChunkCandidate, FilePushPlan, PlannedExistingChunk, PlannedPlacement, PlannedXorb,
-    PreparedXorbCache, PreparedXorbCandidate, PreparedXorbSource, materialize_prepared_xorb,
+    PreparedXorbCache, PreparedXorbCandidate, materialize_prepared_xorb,
 };
 use crab_xet::hash::MerkleHash;
 use crab_xet::xorb::builder::{RunId, XorbBuilder};
@@ -717,7 +719,7 @@ async fn prepare_one_file_plan(
     remote_lookup: Option<&dyn ExistingChunkLookup>,
     prepared_cache: &mut PreparedXorbCache,
     verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
-    ownership_cache: &mut HashMap<(MerkleHash, MerkleHash), bool>,
+    ownership_cache: &mut HashMap<(MerkleHash, [u8; 32]), bool>,
     cancel: &CancellationToken,
 ) -> Result<FilePlanSummary> {
     let existing_refs = lookup_existing_candidates(file.chunks, remote_lookup).await?;
@@ -751,7 +753,7 @@ async fn prepare_one_file_plan_with_existing_refs(
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     prepared_cache: &mut PreparedXorbCache,
     verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
-    ownership_cache: &mut HashMap<(MerkleHash, MerkleHash), bool>,
+    ownership_cache: &mut HashMap<(MerkleHash, [u8; 32]), bool>,
     cancel: &CancellationToken,
 ) -> Result<PreparedFilePlan> {
     if existing_refs.len() != file.chunks.len() {

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -980,8 +980,8 @@ fn ranked_prepared_candidates<'a>(
             .then_with(|| {
                 left.candidate
                     .xorb_hash
-                    .hex()
-                    .cmp(&right.candidate.xorb_hash.hex())
+                    .as_bytes()
+                    .cmp(right.candidate.xorb_hash.as_bytes())
             })
     });
     choices

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -956,13 +956,13 @@ async fn prepare_one_file_plan_with_existing_refs(
     })
 }
 
-fn ranked_prepared_candidates(
-    prepared_cache: &PreparedXorbCache,
+fn ranked_prepared_candidates<'a>(
+    prepared_cache: &'a PreparedXorbCache,
     chunk_hash: &MerkleHash,
     expected_size: u64,
     chunk_states: &HashMap<MerkleHash, FileChunkState>,
     unusable_cached_xorb_sources: &HashSet<(MerkleHash, PreparedXorbSource)>,
-) -> Vec<PreparedCandidateChoice<'_>> {
+) -> Vec<PreparedCandidateChoice<'a>> {
     let mut choices = Vec::new();
     for candidate in prepared_cache.candidates_for_chunk(chunk_hash) {
         if unusable_cached_xorb_sources.contains(&(candidate.xorb_hash, candidate.source.clone())) {

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -822,9 +822,8 @@ async fn prepare_one_file_plan_with_existing_refs(
     let mut builder = build_xorb_builder();
 
     let mut pending_new_chunks = Vec::with_capacity(new_chunks.len());
-    let mut queued_new_chunks = HashSet::new();
     for chunk in located_chunks {
-        if new_chunks.contains(&chunk.0) && queued_new_chunks.insert(chunk.0) {
+        if new_chunks.remove(&chunk.0) {
             pending_new_chunks.push(chunk);
         }
     }

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -782,6 +782,7 @@ async fn prepare_one_file_plan_with_existing_refs(
     let mut cache_xorbs = 0u64;
     let mut cache_link_misses = 0u64;
     let mut unusable_cached_candidates = HashSet::new();
+    let mut matching_scratch = HashSet::new();
     let mut exclusive_payloads = HashMap::new();
     for (index, (chunk_hash, size)) in chunks.iter().enumerate() {
         let existing_ref = existing_refs
@@ -818,12 +819,13 @@ async fn prepare_one_file_plan_with_existing_refs(
         }
         state.read_needed = true;
 
-        let choices = ranked_prepared_candidates(
+        let choices = ranked_prepared_candidates_with_scratch(
             prepared_cache,
             chunk_hash,
             *size,
             &chunk_states,
             &unusable_cached_candidates,
+            &mut matching_scratch,
         );
         let mut used_cached_candidate = false;
         for choice in choices {
@@ -949,6 +951,25 @@ fn ranked_prepared_candidates<'a>(
     chunk_states: &HashMap<MerkleHash, FileChunkState>,
     unusable_cached_candidates: &HashSet<*const PreparedXorbCandidate>,
 ) -> Vec<PreparedCandidateChoice<'a>> {
+    let mut matching_scratch = HashSet::new();
+    ranked_prepared_candidates_with_scratch(
+        prepared_cache,
+        chunk_hash,
+        expected_size,
+        chunk_states,
+        unusable_cached_candidates,
+        &mut matching_scratch,
+    )
+}
+
+fn ranked_prepared_candidates_with_scratch<'a>(
+    prepared_cache: &'a PreparedXorbCache,
+    chunk_hash: &MerkleHash,
+    expected_size: u64,
+    chunk_states: &HashMap<MerkleHash, FileChunkState>,
+    unusable_cached_candidates: &HashSet<*const PreparedXorbCandidate>,
+    matching_scratch: &mut HashSet<MerkleHash>,
+) -> Vec<PreparedCandidateChoice<'a>> {
     let mut choices = Vec::new();
     for (candidate, placement) in prepared_cache.candidate_placements_for_chunk(chunk_hash) {
         if unusable_cached_candidates.contains(&prepared_candidate_id(candidate)) {
@@ -957,7 +978,7 @@ fn ranked_prepared_candidates<'a>(
         if u64::from(placement.uncompressed_size) != expected_size {
             continue;
         }
-        let covered_chunks = matching_file_chunks(candidate, chunk_states);
+        let covered_chunks = matching_file_chunks(candidate, chunk_states, matching_scratch);
         if covered_chunks.is_empty() {
             continue;
         }
@@ -996,8 +1017,9 @@ fn prepared_candidate_id(candidate: &PreparedXorbCandidate) -> *const PreparedXo
 fn matching_file_chunks(
     candidate: &PreparedXorbCandidate,
     chunk_states: &HashMap<MerkleHash, FileChunkState>,
+    seen: &mut HashSet<MerkleHash>,
 ) -> Vec<MerkleHash> {
-    let mut seen = HashSet::new();
+    seen.clear();
     let mut covered = Vec::new();
     for placement in &candidate.placements {
         if !seen.insert(placement.chunk_hash) {

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -125,6 +125,7 @@ pub async fn prepare_file_push_plans_with_progress(
             .await?;
     }
     if files.len() > 1 {
+        let mut verified_sequences = HashSet::new();
         let unique_file_chunks = unique_file_chunks.as_deref().ok_or_else(|| {
             StagingError::Internal("missing unique multi-file chunk collection".to_owned())
         })?;
@@ -138,6 +139,7 @@ pub async fn prepare_file_push_plans_with_progress(
                 &existing_refs,
                 build_xorb_builder,
                 summary.remote_lookup,
+                &mut verified_sequences,
                 cancel,
                 on_progress,
             )
@@ -150,11 +152,13 @@ pub async fn prepare_file_push_plans_with_progress(
             build_xorb_builder,
             &mut prepared_cache,
             summary,
+            &mut verified_sequences,
             cancel,
             on_progress,
         )
         .await;
     }
+    let mut verified_sequences = HashSet::new();
     for file in files {
         check_cancelled(cancel)?;
         let file_summary = prepare_one_file_plan(
@@ -163,6 +167,7 @@ pub async fn prepare_file_push_plans_with_progress(
             build_xorb_builder,
             remote_lookup,
             &mut prepared_cache,
+            &mut verified_sequences,
             cancel,
         )
         .await?;
@@ -200,6 +205,7 @@ async fn prepare_cached_file_plans_with_progress(
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     prepared_cache: &mut PreparedXorbCache,
     mut summary: AddPushPlanSummary,
+    verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
     cancel: &CancellationToken,
     mut on_progress: Option<&mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
 ) -> Result<AddPushPlanSummary> {
@@ -219,6 +225,7 @@ async fn prepare_cached_file_plans_with_progress(
             file_existing_refs,
             build_xorb_builder,
             prepared_cache,
+            verified_sequences,
             cancel,
         )
         .await?;
@@ -358,6 +365,7 @@ async fn prepare_uncached_file_plans_with_progress(
     existing_refs: &[Option<ExistingChunkCandidate>],
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     remote_lookup: bool,
+    verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
     cancel: &CancellationToken,
     mut on_progress: Option<&mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
 ) -> Result<AddPushPlanSummary> {
@@ -371,7 +379,10 @@ async fn prepare_uncached_file_plans_with_progress(
         let file_existing_refs = existing_refs.get(ref_offset..next_offset).ok_or_else(|| {
             StagingError::Internal("add push-plan remote lookup length changed".to_owned())
         })?;
-        file_plans.push(verified_uncached_file_plan(staging, file, file_existing_refs).await?);
+        file_plans.push(
+            verified_uncached_file_plan(staging, file, file_existing_refs, verified_sequences)
+                .await?,
+        );
         ref_offset = next_offset;
     }
     if ref_offset != existing_refs.len() {
@@ -472,17 +483,21 @@ async fn verified_uncached_file_plan<'a>(
     staging: &StagingArea,
     file: &'a AddPlanFile<'_>,
     existing_refs: &[Option<ExistingChunkCandidate>],
+    verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
 ) -> Result<UncachedFilePlan<'a>> {
     let file_hash = MerkleHash::from(file.file_hash);
     let mut plan = FilePushPlan::new_verified_staging(file_hash, file.size, file.chunks);
-    verified_staged_chunks(
-        staging,
-        file_hash,
-        file.size,
-        file.chunks,
-        plan.sequence_hash()?,
-    )
-    .await?;
+    let verification_key = (file_hash, plan.sequence_hash()?, file.size);
+    if verified_sequences.insert(verification_key) {
+        verified_staged_chunks(
+            staging,
+            file_hash,
+            file.size,
+            file.chunks,
+            plan.sequence_hash()?,
+        )
+        .await?;
+    }
     let mut uncovered_chunks = HashSet::new();
     for ((chunk_hash, size), existing_ref) in file.chunks.iter().zip(existing_refs.iter()) {
         if let Some(candidate) = existing_ref
@@ -670,6 +685,7 @@ async fn prepare_one_file_plan(
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     remote_lookup: Option<&dyn ExistingChunkLookup>,
     prepared_cache: &mut PreparedXorbCache,
+    verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
     cancel: &CancellationToken,
 ) -> Result<FilePlanSummary> {
     let existing_refs = lookup_existing_candidates(file.chunks, remote_lookup).await?;
@@ -679,6 +695,7 @@ async fn prepare_one_file_plan(
         &existing_refs,
         build_xorb_builder,
         prepared_cache,
+        verified_sequences,
         cancel,
     )
     .await?;
@@ -694,6 +711,7 @@ async fn prepare_one_file_plan_with_existing_refs(
     existing_refs: &[Option<ExistingChunkCandidate>],
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     prepared_cache: &mut PreparedXorbCache,
+    verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
     cancel: &CancellationToken,
 ) -> Result<PreparedFilePlan> {
     if existing_refs.len() != file.chunks.len() {
@@ -711,14 +729,17 @@ async fn prepare_one_file_plan_with_existing_refs(
         file.size,
         chunks,
     )?;
-    verified_staged_chunks(
-        staging,
-        file_hash,
-        file.size,
-        chunks,
-        recipe.sequence_hash(),
-    )
-    .await?;
+    let verification_key = (file_hash, recipe.sequence_hash(), file.size);
+    if verified_sequences.insert(verification_key) {
+        verified_staged_chunks(
+            staging,
+            file_hash,
+            file.size,
+            chunks,
+            recipe.sequence_hash(),
+        )
+        .await?;
+    }
     let mut plan = FilePushPlan::new_verified_recipe(&recipe);
     let recipe_hash = recipe.hash();
 

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -149,6 +149,7 @@ pub async fn prepare_file_push_plans_with_progress(
         .await;
     }
     let mut verified_sequences = HashSet::new();
+    let mut ownership_cache = HashMap::new();
     for file in files {
         check_cancelled(cancel)?;
         let file_summary = prepare_one_file_plan(
@@ -158,6 +159,7 @@ pub async fn prepare_file_push_plans_with_progress(
             remote_lookup,
             &mut prepared_cache,
             &mut verified_sequences,
+            &mut ownership_cache,
             cancel,
         )
         .await?;
@@ -200,6 +202,7 @@ async fn prepare_cached_file_plans_with_progress(
     mut on_progress: Option<&mut (dyn FnMut(&AddPushPlanSummary) + Send)>,
 ) -> Result<AddPushPlanSummary> {
     let mut prepared_plans = Vec::with_capacity(files.len());
+    let mut ownership_cache = HashMap::new();
     for file in files {
         check_cancelled(cancel)?;
         let file_existing_refs = existing_refs
@@ -230,6 +233,7 @@ async fn prepare_cached_file_plans_with_progress(
             build_xorb_builder,
             prepared_cache,
             verified_sequences,
+            &mut ownership_cache,
             cancel,
         )
         .await?;
@@ -713,6 +717,7 @@ async fn prepare_one_file_plan(
     remote_lookup: Option<&dyn ExistingChunkLookup>,
     prepared_cache: &mut PreparedXorbCache,
     verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
+    ownership_cache: &mut HashMap<(MerkleHash, MerkleHash), bool>,
     cancel: &CancellationToken,
 ) -> Result<FilePlanSummary> {
     let existing_refs = lookup_existing_candidates(file.chunks, remote_lookup).await?;
@@ -729,6 +734,7 @@ async fn prepare_one_file_plan(
         build_xorb_builder,
         prepared_cache,
         verified_sequences,
+        ownership_cache,
         cancel,
     )
     .await?;
@@ -745,6 +751,7 @@ async fn prepare_one_file_plan_with_existing_refs(
     build_xorb_builder: &(dyn Fn() -> XorbBuilder + Send + Sync),
     prepared_cache: &mut PreparedXorbCache,
     verified_sequences: &mut HashSet<(MerkleHash, [u8; 32], u64)>,
+    ownership_cache: &mut HashMap<(MerkleHash, MerkleHash), bool>,
     cancel: &CancellationToken,
 ) -> Result<PreparedFilePlan> {
     if existing_refs.len() != file.chunks.len() {
@@ -783,7 +790,6 @@ async fn prepare_one_file_plan_with_existing_refs(
     let mut cache_link_misses = 0u64;
     let mut unusable_cached_candidates = HashSet::new();
     let mut matching_scratch = HashSet::new();
-    let mut exclusive_payloads = HashMap::new();
     for (index, (chunk_hash, size)) in chunks.iter().enumerate() {
         let existing_ref = existing_refs
             .at(index)
@@ -836,12 +842,13 @@ async fn prepare_one_file_plan_with_existing_refs(
                     .is_some_and(|state| state.remote)
             });
             let exclusive = if contains_remote {
-                if let Some(exclusive) = exclusive_payloads.get(&candidate.xorb_hash) {
+                let key = (candidate.xorb_hash, recipe_hash);
+                if let Some(exclusive) = ownership_cache.get(&key) {
                     *exclusive
                 } else {
                     let exclusive = staging
                         .prepared_payload_exclusive_to_recipe(&candidate.xorb_hash, &recipe_hash)?;
-                    exclusive_payloads.insert(candidate.xorb_hash, exclusive);
+                    ownership_cache.insert(key, exclusive);
                     exclusive
                 }
             } else {

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -119,7 +119,8 @@ pub async fn prepare_file_push_plans_with_progress(
     }
     if files.len() > 1 {
         let all_chunks = all_file_chunks(files);
-        let existing_refs = lookup_existing_candidates(&all_chunks, remote_lookup).await?;
+        let unique_existing_refs = lookup_existing_candidates(&all_chunks, remote_lookup).await?;
+        let existing_refs = expand_existing_refs(files, &all_chunks, &unique_existing_refs)?;
         if prepared_cache.is_empty() {
             return prepare_uncached_file_plans_with_progress(
                 staging,
@@ -281,9 +282,40 @@ struct VerifiedStagedChunks {
 }
 
 fn all_file_chunks(files: &[AddPlanFile<'_>]) -> Vec<(MerkleHash, u64)> {
+    let mut seen = HashSet::new();
     files
         .iter()
         .flat_map(|file| file.chunks.iter().copied())
+        .filter(|(chunk_hash, _)| seen.insert(*chunk_hash))
+        .collect()
+}
+
+fn expand_existing_refs(
+    files: &[AddPlanFile<'_>],
+    unique_chunks: &[(MerkleHash, u64)],
+    unique_refs: &[Option<ExistingChunkCandidate>],
+) -> Result<Vec<Option<ExistingChunkCandidate>>> {
+    if unique_chunks.len() != unique_refs.len() {
+        return Err(StagingError::Internal(
+            "existing chunk lookup returned a different unique chunk count".to_owned(),
+        ));
+    }
+    let by_hash = unique_chunks
+        .iter()
+        .map(|(chunk_hash, _)| *chunk_hash)
+        .zip(unique_refs.iter().copied())
+        .collect::<HashMap<_, _>>();
+    files
+        .iter()
+        .flat_map(|file| {
+            file.chunks.iter().map(|(chunk_hash, _)| {
+                by_hash.get(chunk_hash).copied().ok_or_else(|| {
+                    StagingError::Internal(
+                        "existing chunk lookup lost a requested chunk".to_owned(),
+                    )
+                })
+            })
+        })
         .collect()
 }
 
@@ -1189,6 +1221,57 @@ mod tests {
             recipient_indices(file_plans.len(), &placements, &owners),
             vec![0, 1]
         );
+    }
+
+    #[test]
+    fn multi_file_remote_lookup_deduplicates_shared_chunks() {
+        let shared = numbered_hash(3);
+        let first_only = numbered_hash(4);
+        let second_only = numbered_hash(5);
+        let first_chunks = [(shared, 1), (first_only, 1)];
+        let second_chunks = [(shared, 1), (second_only, 1)];
+        let files = [
+            AddPlanFile {
+                file_hash: numbered_hash(6).into(),
+                size: 2,
+                chunks: &first_chunks,
+            },
+            AddPlanFile {
+                file_hash: numbered_hash(7).into(),
+                size: 2,
+                chunks: &second_chunks,
+            },
+        ];
+        let unique = all_file_chunks(&files);
+        assert_eq!(unique.len(), 3);
+        assert_eq!(
+            unique
+                .iter()
+                .map(|(chunk_hash, _)| *chunk_hash)
+                .collect::<HashSet<_>>()
+                .len(),
+            unique.len()
+        );
+        let shared_candidate = Some(existing_candidate(
+            XorbRef {
+                xorb_hash: numbered_hash(8),
+                chunk_index: 0,
+                uncompressed_size: 1,
+            },
+            8,
+        ));
+        let unique_refs = unique
+            .iter()
+            .map(|(chunk_hash, _)| {
+                (*chunk_hash == shared)
+                    .then_some(shared_candidate)
+                    .flatten()
+            })
+            .collect::<Vec<_>>();
+        let expanded = expand_existing_refs(&files, &unique, &unique_refs).expect("expand refs");
+        assert_eq!(expanded.len(), 4);
+        assert_eq!(expanded[0], shared_candidate);
+        assert_eq!(expanded[2], shared_candidate);
     }
 
     async fn stage_synthetic_file(

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -545,10 +545,8 @@ async fn verified_uncached_file_plan<'a>(
         if let Some(candidate) = existing_ref
             && u64::from(candidate.xorb_ref.uncompressed_size) == *size
         {
-            plan.existing.push(PlannedExistingChunk::from_candidate(
-                *chunk_hash,
-                *candidate,
-            ));
+            plan.existing
+                .push(PlannedExistingChunk::from_candidate(*chunk_hash, candidate));
             continue;
         }
         uncovered_chunks.insert(*chunk_hash);
@@ -824,10 +822,8 @@ async fn prepare_one_file_plan_with_existing_refs(
         if let Some(candidate) = existing_ref
             && u64::from(candidate.xorb_ref.uncompressed_size) == *size
         {
-            plan.existing.push(PlannedExistingChunk::from_candidate(
-                *chunk_hash,
-                *candidate,
-            ));
+            plan.existing
+                .push(PlannedExistingChunk::from_candidate(*chunk_hash, candidate));
             continue;
         }
         if state.remote || state.covered || state.read_needed {

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -731,7 +731,6 @@ async fn prepare_one_file_plan_with_existing_refs(
         })
         .collect();
     let mut new_chunks = HashSet::new();
-    let mut seen = HashSet::new();
     let mut planned_prepared_xorbs = HashSet::new();
     let mut covered_by_prepared_cache = HashSet::new();
     let mut cache_chunks = 0u64;
@@ -746,14 +745,14 @@ async fn prepare_one_file_plan_with_existing_refs(
                 *chunk_hash,
                 *candidate,
             ));
-            seen.insert(*chunk_hash);
             continue;
         }
-        if !seen.insert(*chunk_hash) {
+        if remote_existing_chunks.contains(chunk_hash)
+            || covered_by_prepared_cache.contains(chunk_hash)
+        {
             continue;
         }
-
-        if covered_by_prepared_cache.contains(chunk_hash) {
+        if !new_chunks.insert(*chunk_hash) {
             continue;
         }
 
@@ -818,8 +817,6 @@ async fn prepare_one_file_plan_with_existing_refs(
         if used_cached_candidate {
             continue;
         }
-
-        new_chunks.insert(*chunk_hash);
     }
 
     let mut builder = build_xorb_builder();

--- a/crates/crab-staging/src/add_push_plan.rs
+++ b/crates/crab-staging/src/add_push_plan.rs
@@ -475,6 +475,7 @@ async fn verified_staged_chunks(
     expected_sequence_hash: [u8; 32],
 ) -> Result<()> {
     if let Some(plan) = staging.load_file_push_plan(&file_hash).await?
+        && plan.staged_chunk_sequence_verified
         && plan.chunk_count == expected_chunks.len() as u64
         && plan.sequence_hash()? == expected_sequence_hash
         && plan.file_size == file_size

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6874,7 +6874,7 @@ impl Index {
                     "failed to prepare recipe remote authority: {error}"
                 ))
             })?;
-        statement
+        let rows = statement
             .query_map(
                 params![recipe_hash.as_slice(), start_occurrence, end_occurrence],
                 |row| {
@@ -6890,38 +6890,37 @@ impl Index {
             )
             .map_err(|error| {
                 StagingError::Internal(format!("failed to query recipe remote authority: {error}"))
-            })?
-            .map(|row| {
-                let (
-                    chunk_hash,
-                    xorb_hash,
-                    chunk_index,
-                    uncompressed_size,
-                    placement_id,
-                    origin_proof_id,
-                ) = row.map_err(|error| {
-                    StagingError::Internal(format!(
-                        "failed to read recipe remote authority: {error}"
+            })?;
+        let mut out = Vec::with_capacity(crate::recipe::RECIPE_PAGE_ENTRIES);
+        for row in rows {
+            let (
+                chunk_hash,
+                xorb_hash,
+                chunk_index,
+                uncompressed_size,
+                placement_id,
+                origin_proof_id,
+            ) = row.map_err(|error| {
+                StagingError::Internal(format!("failed to read recipe remote authority: {error}"))
+            })?;
+            out.push(ExistingChunkWrite {
+                chunk_hash: decode_hash_blob("remote chunk hash", chunk_hash)?,
+                xorb_hash: decode_hash_blob("remote xorb hash", xorb_hash)?,
+                chunk_index: u32::try_from(chunk_index).map_err(|_| {
+                    StagingError::StagingCorrupt(format!(
+                        "remote chunk index is invalid: {chunk_index}"
                     ))
-                })?;
-                Ok(ExistingChunkWrite {
-                    chunk_hash: decode_hash_blob("remote chunk hash", chunk_hash)?,
-                    xorb_hash: decode_hash_blob("remote xorb hash", xorb_hash)?,
-                    chunk_index: u32::try_from(chunk_index).map_err(|_| {
-                        StagingError::StagingCorrupt(format!(
-                            "remote chunk index is invalid: {chunk_index}"
-                        ))
-                    })?,
-                    uncompressed_size: u32::try_from(uncompressed_size).map_err(|_| {
-                        StagingError::StagingCorrupt(format!(
-                            "remote chunk size is invalid: {uncompressed_size}"
-                        ))
-                    })?,
-                    placement_id: decode_hash_blob("remote placement id", placement_id)?,
-                    origin_proof_id: decode_hash_blob("remote origin proof id", origin_proof_id)?,
-                })
-            })
-            .collect()
+                })?,
+                uncompressed_size: u32::try_from(uncompressed_size).map_err(|_| {
+                    StagingError::StagingCorrupt(format!(
+                        "remote chunk size is invalid: {uncompressed_size}"
+                    ))
+                })?,
+                placement_id: decode_hash_blob("remote placement id", placement_id)?,
+                origin_proof_id: decode_hash_blob("remote origin proof id", origin_proof_id)?,
+            });
+        }
+        Ok(out)
     }
 
     pub fn recipe_remote_chunk_count(&self, recipe_hash: &[u8; 32]) -> Result<u64> {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -5996,7 +5996,7 @@ impl Index {
                         crab_xet::hash::MerkleHash::from(*file_hash).hex()
                     )));
                 }
-                insert_statement
+                let inserted = insert_statement
                     .execute(params![
                         owner,
                         chunk_hash,
@@ -6011,29 +6011,31 @@ impl Index {
                             "failed to store planned existing chunk: {error}"
                         ))
                     })?;
-                let matches: bool = verify_statement
-                    .query_row(
-                        params![
-                            owner,
-                            chunk_hash,
-                            existing.xorb_hash.as_slice(),
-                            i64::from(existing.chunk_index),
-                            i64::from(existing.uncompressed_size),
-                            existing.placement_id.as_slice(),
-                            existing.origin_proof_id.as_slice(),
-                        ],
-                        |row| row.get(0),
-                    )
-                    .map_err(|error| {
-                        StagingError::Internal(format!(
-                            "failed to verify planned existing chunk: {error}"
-                        ))
-                    })?;
-                if !matches {
-                    return Err(StagingError::StagingCorrupt(format!(
-                        "planned existing chunk {} has conflicting proof authority",
-                        crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex()
-                    )));
+                if inserted == 0 {
+                    let matches: bool = verify_statement
+                        .query_row(
+                            params![
+                                owner,
+                                chunk_hash,
+                                existing.xorb_hash.as_slice(),
+                                i64::from(existing.chunk_index),
+                                i64::from(existing.uncompressed_size),
+                                existing.placement_id.as_slice(),
+                                existing.origin_proof_id.as_slice(),
+                            ],
+                            |row| row.get(0),
+                        )
+                        .map_err(|error| {
+                            StagingError::Internal(format!(
+                                "failed to verify planned existing chunk: {error}"
+                            ))
+                        })?;
+                    if !matches {
+                        return Err(StagingError::StagingCorrupt(format!(
+                            "planned existing chunk {} has conflicting proof authority",
+                            crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex()
+                        )));
+                    }
                 }
             }
             drop(coverage_statement);
@@ -6051,33 +6053,70 @@ impl Index {
                 })?;
             }
 
+            let mut payload_insert = tx
+                .prepare_cached(
+                    "INSERT OR IGNORE INTO prepared_payloads
+                 (xorb_hash, payload_hash, bytes) VALUES (?1, ?2, ?3)",
+                )
+                .map_err(|e| {
+                    StagingError::Internal(format!(
+                        "failed to prepare prepared payload insert: {e}"
+                    ))
+                })?;
+            let mut payload_verify = tx
+                .prepare_cached(
+                    "SELECT payload_hash = ?2 AND bytes = ?3
+                 FROM prepared_payloads WHERE xorb_hash = ?1",
+                )
+                .map_err(|e| {
+                    StagingError::Internal(format!(
+                        "failed to prepare prepared payload verification: {e}"
+                    ))
+                })?;
+            let mut chunk_insert = tx
+                .prepare_cached(
+                    "INSERT OR IGNORE INTO prepared_payload_chunks
+                 (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
+                 VALUES (?1, ?2, ?3, ?4)",
+                )
+                .map_err(|e| {
+                    StagingError::Internal(format!(
+                        "failed to prepare prepared payload chunk insert: {e}"
+                    ))
+                })?;
+            let mut chunk_verify = tx
+                .prepare_cached(
+                    "SELECT xorb_hash, chunk_index, uncompressed_size
+                 FROM prepared_payload_chunks WHERE chunk_hash = ?1",
+                )
+                .map_err(|e| {
+                    StagingError::Internal(format!(
+                        "failed to prepare prepared payload chunk verification: {e}"
+                    ))
+                })?;
             for prepared in prepared_xorbs {
                 let xorb_hash: &[u8] = &prepared.xorb_hash;
                 let payload_hash: &[u8] = &prepared.payload_hash;
                 let bytes = sqlite_i64("prepared xorb bytes", prepared.bytes)?;
-                tx.execute(
-                    "INSERT OR IGNORE INTO prepared_payloads
-                 (xorb_hash, payload_hash, bytes) VALUES (?1, ?2, ?3)",
-                    params![xorb_hash, payload_hash, bytes],
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!("failed to store prepared payload: {e}"))
-                })?;
-                let payload_matches: bool = tx
-                    .query_row(
-                        "SELECT payload_hash = ?2 AND bytes = ?3
-                     FROM prepared_payloads WHERE xorb_hash = ?1",
-                        params![xorb_hash, payload_hash, bytes],
-                        |row| row.get(0),
-                    )
+                let inserted = payload_insert
+                    .execute(params![xorb_hash, payload_hash, bytes])
                     .map_err(|e| {
-                        StagingError::Internal(format!("failed to verify prepared payload: {e}"))
+                        StagingError::Internal(format!("failed to store prepared payload: {e}"))
                     })?;
-                if !payload_matches {
-                    return Err(StagingError::StagingCorrupt(format!(
-                        "prepared xorb payload identity collision for {}",
-                        crab_xet::hash::MerkleHash::from(prepared.xorb_hash).hex()
-                    )));
+                if inserted == 0 {
+                    let payload_matches: bool = payload_verify
+                        .query_row(params![xorb_hash, payload_hash, bytes], |row| row.get(0))
+                        .map_err(|e| {
+                            StagingError::Internal(format!(
+                                "failed to verify prepared payload: {e}"
+                            ))
+                        })?;
+                    if !payload_matches {
+                        return Err(StagingError::StagingCorrupt(format!(
+                            "prepared xorb payload identity collision for {}",
+                            crab_xet::hash::MerkleHash::from(prepared.xorb_hash).hex()
+                        )));
+                    }
                 }
                 let mut covers_recipe = false;
                 for placement in &prepared.placements {
@@ -6125,42 +6164,37 @@ impl Index {
                             })?
                         };
                     }
-                    tx.execute(
-                        "INSERT OR IGNORE INTO prepared_payload_chunks
-                     (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
-                     VALUES (?1, ?2, ?3, ?4)",
-                        params![
+                    let inserted = chunk_insert
+                        .execute(params![
                             xorb_hash,
                             i64::from(placement.chunk_index),
                             chunk_hash,
                             i64::from(placement.uncompressed_size),
-                        ],
-                    )
-                    .map_err(|e| {
-                        StagingError::Internal(format!(
-                            "failed to store prepared payload chunk: {e}"
-                        ))
-                    })?;
-                    let stored: (Vec<u8>, i64, i64) = tx
-                        .query_row(
-                            "SELECT xorb_hash, chunk_index, uncompressed_size
-                         FROM prepared_payload_chunks WHERE chunk_hash = ?1",
-                            params![chunk_hash],
-                            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-                        )
+                        ])
                         .map_err(|e| {
                             StagingError::Internal(format!(
-                                "failed to verify canonical prepared chunk placement: {e}"
+                                "failed to store prepared payload chunk: {e}"
                             ))
                         })?;
-                    if stored.0.as_slice() != xorb_hash
-                        || stored.1 != i64::from(placement.chunk_index)
-                        || stored.2 != i64::from(placement.uncompressed_size)
-                    {
-                        return Err(StagingError::StagingCorrupt(format!(
-                            "prepared chunk {} already belongs to another canonical xorb",
-                            crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
-                        )));
+                    if inserted == 0 {
+                        let stored: (Vec<u8>, i64, i64) = chunk_verify
+                            .query_row(params![chunk_hash], |row| {
+                                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                            })
+                            .map_err(|e| {
+                                StagingError::Internal(format!(
+                                    "failed to verify canonical prepared chunk placement: {e}"
+                                ))
+                            })?;
+                        if stored.0.as_slice() != xorb_hash
+                            || stored.1 != i64::from(placement.chunk_index)
+                            || stored.2 != i64::from(placement.uncompressed_size)
+                        {
+                            return Err(StagingError::StagingCorrupt(format!(
+                                "prepared chunk {} already belongs to another canonical xorb",
+                                crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
+                            )));
+                        }
                     }
                 }
                 if !covers_recipe {
@@ -6181,6 +6215,10 @@ impl Index {
                     })?;
                 }
             }
+            drop(payload_insert);
+            drop(payload_verify);
+            drop(chunk_insert);
+            drop(chunk_verify);
         }
         let removed_payloads = if cleanup_needed {
             // A single sweep avoids repeatedly scanning the global payload

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6959,8 +6959,8 @@ impl Index {
             }
         }
 
-        let mut seen = HashSet::new();
-        let mut rows = Vec::new();
+        let mut seen = HashSet::with_capacity(unique_chunk_hashes.len());
+        let mut rows = Vec::with_capacity(unique_chunk_hashes.len());
         for batch in unique_chunk_hashes.chunks(PREPARED_XORB_QUERY_BATCH) {
             let placeholders = vec!["?"; batch.len()].join(",");
             let sql = format!(

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -7518,7 +7518,7 @@ impl Index {
 
     /// Batch locator lookup across `chunks` and `pending_chunks`.
     ///
-    /// Issues a single `WHERE chunk_hash IN (?, ?, ...)` query per table
+    /// Issues bounded `WHERE chunk_hash IN (?, ?, ...)` queries per table
     /// instead of one round-trip per hash. Returns locators in the same
     /// order as `hashes`, with `None` for chunks absent from both tables.
     ///

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6163,7 +6163,6 @@ impl Index {
                     }
                 }
             }
-            drop(coverage_statement);
             drop(insert_statement);
             drop(verify_statement);
 
@@ -6206,47 +6205,16 @@ impl Index {
                 for placement in &prepared.placements {
                     let chunk_hash: &[u8] = &placement.chunk_hash;
                     if !covers_recipe {
-                        covers_recipe = if recipe_is_indexed {
-                            tx.query_row(
-                                "SELECT EXISTS(
-                                 SELECT 1 FROM recipe_occurrences
-                                 WHERE recipe_hash = ?1
-                                   AND chunk_hash = ?2
-                                   AND chunk_size = ?3
-                             )",
-                                params![
-                                    recipe_hash.as_slice(),
-                                    chunk_hash,
-                                    i64::from(placement.uncompressed_size)
-                                ],
+                        covers_recipe = coverage_statement
+                            .query_row(
+                                params![owner, chunk_hash, i64::from(placement.uncompressed_size)],
                                 |row| row.get::<_, bool>(0),
                             )
                             .map_err(|error| {
                                 StagingError::Internal(format!(
                                     "failed to validate prepared xorb recipe coverage: {error}"
                                 ))
-                            })?
-                        } else {
-                            tx.query_row(
-                                "SELECT EXISTS(
-                                 SELECT 1 FROM recipe_recording_terms
-                                 WHERE batch_id = ?1
-                                   AND chunk_hash = ?2
-                                   AND chunk_size = ?3
-                             )",
-                                params![
-                                    recording_batch_id,
-                                    chunk_hash,
-                                    i64::from(placement.uncompressed_size)
-                                ],
-                                |row| row.get::<_, bool>(0),
-                            )
-                            .map_err(|error| {
-                                StagingError::Internal(format!(
-                                    "failed to validate prepared xorb recipe coverage: {error}"
-                                ))
-                            })?
-                        };
+                            })?;
                     }
                     let inserted = chunk_insert
                         .execute(params![
@@ -6299,6 +6267,7 @@ impl Index {
                     })?;
                 }
             }
+            drop(coverage_statement);
         }
         drop(payload_insert);
         drop(payload_verify);

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -5847,157 +5847,155 @@ impl Index {
 
     /// Replace one recipe's normalized remote and prepared authority.
     pub fn insert_file_push_plan(&self, write: FilePushPlanWrite<'_>) -> Result<Vec<[u8; 32]>> {
-        let FilePushPlanWrite {
-            file_hash,
-            recipe_hash,
-            recording_batch_id,
-            existing_chunks,
-            prepared_xorbs,
-        } = write;
-        let fh: &[u8] = file_hash;
+        self.insert_file_push_plans(std::slice::from_ref(&write))
+    }
+
+    /// Replace several recipes' normalized remote and prepared authority atomically.
+    pub fn insert_file_push_plans(
+        &self,
+        writes: &[FilePushPlanWrite<'_>],
+    ) -> Result<Vec<[u8; 32]>> {
+        if writes.is_empty() {
+            return Ok(Vec::new());
+        }
         let tx = self.conn.unchecked_transaction().map_err(|e| {
             StagingError::Internal(format!("failed to begin file push plan tx: {e}"))
         })?;
-        let recipe_is_indexed: bool = tx
-            .query_row(
-                "SELECT EXISTS(
+        let mut cleanup_needed = false;
+        for write in writes {
+            let FilePushPlanWrite {
+                file_hash,
+                recipe_hash,
+                recording_batch_id,
+                existing_chunks,
+                prepared_xorbs,
+            } = *write;
+            let fh: &[u8] = file_hash;
+            let recipe_is_indexed: bool = tx
+                .query_row(
+                    "SELECT EXISTS(
                      SELECT 1 FROM file_recipes
                      WHERE recipe_hash = ?1 AND file_hash = ?2
                  )",
-                params![recipe_hash.as_slice(), fh],
-                |row| row.get(0),
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to resolve prepared recipe: {e}"))
-            })?;
-        if !recipe_is_indexed {
-            let Some(batch_id) = recording_batch_id else {
-                return Err(StagingError::StagingCorrupt(format!(
-                    "cannot persist prepared authority before recipe {} is indexed",
-                    crab_xet::hash::MerkleHash::from(*recipe_hash).hex()
-                )));
-            };
-            let recording_is_open: bool = tx
-                .query_row(
-                    "SELECT EXISTS(
-                         SELECT 1 FROM staging_batches
-                         WHERE batch_id = ?1 AND state = 'open'
-                     )",
-                    params![batch_id],
+                    params![recipe_hash.as_slice(), fh],
                     |row| row.get(0),
                 )
                 .map_err(|e| {
-                    StagingError::Internal(format!(
-                        "failed to resolve prepared recipe recording: {e}"
-                    ))
+                    StagingError::Internal(format!("failed to resolve prepared recipe: {e}"))
                 })?;
-            if !recording_is_open {
-                return Err(StagingError::NotFound {
-                    path: format!("open staging batch {batch_id}"),
-                });
+            if !recipe_is_indexed {
+                let Some(batch_id) = recording_batch_id else {
+                    return Err(StagingError::StagingCorrupt(format!(
+                        "cannot persist prepared authority before recipe {} is indexed",
+                        crab_xet::hash::MerkleHash::from(*recipe_hash).hex()
+                    )));
+                };
+                let recording_is_open: bool = tx
+                    .query_row(
+                        "SELECT EXISTS(
+                         SELECT 1 FROM staging_batches
+                         WHERE batch_id = ?1 AND state = 'open'
+                     )",
+                        params![batch_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(|e| {
+                        StagingError::Internal(format!(
+                            "failed to resolve prepared recipe recording: {e}"
+                        ))
+                    })?;
+                if !recording_is_open {
+                    return Err(StagingError::NotFound {
+                        path: format!("open staging batch {batch_id}"),
+                    });
+                }
             }
-        }
 
-        let recipe_owner = recipe_hash.as_slice();
-        let recording_owner = recording_batch_id.unwrap_or_default();
-        let (table, owner_column, owner, coverage_sql): (&str, &str, &dyn ToSql, &str) =
-            if recipe_is_indexed {
-                (
-                    "recipe_remote_chunks",
-                    "recipe_hash",
-                    &recipe_owner,
-                    "SELECT EXISTS(
+            let recipe_owner = recipe_hash.as_slice();
+            let recording_owner = recording_batch_id.unwrap_or_default();
+            let (table, owner_column, owner, coverage_sql): (&str, &str, &dyn ToSql, &str) =
+                if recipe_is_indexed {
+                    (
+                        "recipe_remote_chunks",
+                        "recipe_hash",
+                        &recipe_owner,
+                        "SELECT EXISTS(
                          SELECT 1 FROM recipe_occurrences
                          WHERE recipe_hash = ?1
                            AND chunk_hash = ?2
                            AND chunk_size = ?3
                      )",
-                )
-            } else {
-                (
-                    "recording_remote_chunks",
-                    "batch_id",
-                    &recording_owner,
-                    "SELECT EXISTS(
+                    )
+                } else {
+                    (
+                        "recording_remote_chunks",
+                        "batch_id",
+                        &recording_owner,
+                        "SELECT EXISTS(
                          SELECT 1 FROM recipe_recording_terms
                          WHERE batch_id = ?1
                            AND chunk_hash = ?2
                            AND chunk_size = ?3
                      )",
-                )
-            };
-        let insert_sql = format!(
-            "INSERT OR IGNORE INTO {table}
+                    )
+                };
+            let insert_sql = format!(
+                "INSERT OR IGNORE INTO {table}
              ({owner_column}, chunk_hash, xorb_hash, chunk_index,
               uncompressed_size, placement_id, origin_proof_id)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)"
-        );
-        let verify_sql = format!(
-            "SELECT xorb_hash = ?3
+            );
+            let verify_sql = format!(
+                "SELECT xorb_hash = ?3
                     AND chunk_index = ?4
                     AND uncompressed_size = ?5
                     AND placement_id = ?6
                     AND origin_proof_id = ?7
              FROM {table}
              WHERE {owner_column} = ?1 AND chunk_hash = ?2"
-        );
-        let mut coverage_statement = tx.prepare_cached(coverage_sql).map_err(|error| {
-            StagingError::Internal(format!(
-                "failed to prepare planned existing coverage: {error}"
-            ))
-        })?;
-        let mut insert_statement = tx.prepare_cached(&insert_sql).map_err(|error| {
-            StagingError::Internal(format!(
-                "failed to prepare planned existing insert: {error}"
-            ))
-        })?;
-        let mut verify_statement = tx.prepare_cached(&verify_sql).map_err(|error| {
-            StagingError::Internal(format!(
-                "failed to prepare planned existing verification: {error}"
-            ))
-        })?;
-        for existing in existing_chunks {
-            if existing.placement_id == [0; 32] || existing.origin_proof_id == [0; 32] {
-                return Err(StagingError::StagingCorrupt(
-                    "planned existing chunk has an empty placement or origin proof id".to_owned(),
-                ));
-            }
-            let chunk_hash: &[u8] = &existing.chunk_hash;
-            let covers_recipe = coverage_statement
-                .query_row(
-                    params![owner, chunk_hash, i64::from(existing.uncompressed_size)],
-                    |row| row.get::<_, bool>(0),
-                )
-                .map_err(|error| {
-                    StagingError::Internal(format!(
-                        "failed to validate planned existing recipe coverage: {error}"
-                    ))
-                })?;
-            if !covers_recipe {
-                return Err(StagingError::StagingCorrupt(format!(
-                    "planned existing chunk {} does not cover file {}",
-                    crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex(),
-                    crab_xet::hash::MerkleHash::from(*file_hash).hex()
-                )));
-            }
-            insert_statement
-                .execute(params![
-                    owner,
-                    chunk_hash,
-                    existing.xorb_hash.as_slice(),
-                    i64::from(existing.chunk_index),
-                    i64::from(existing.uncompressed_size),
-                    existing.placement_id.as_slice(),
-                    existing.origin_proof_id.as_slice(),
-                ])
-                .map_err(|error| {
-                    StagingError::Internal(format!(
-                        "failed to store planned existing chunk: {error}"
-                    ))
-                })?;
-            let matches: bool = verify_statement
-                .query_row(
-                    params![
+            );
+            let mut coverage_statement = tx.prepare_cached(coverage_sql).map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare planned existing coverage: {error}"
+                ))
+            })?;
+            let mut insert_statement = tx.prepare_cached(&insert_sql).map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare planned existing insert: {error}"
+                ))
+            })?;
+            let mut verify_statement = tx.prepare_cached(&verify_sql).map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare planned existing verification: {error}"
+                ))
+            })?;
+            for existing in existing_chunks {
+                if existing.placement_id == [0; 32] || existing.origin_proof_id == [0; 32] {
+                    return Err(StagingError::StagingCorrupt(
+                        "planned existing chunk has an empty placement or origin proof id"
+                            .to_owned(),
+                    ));
+                }
+                let chunk_hash: &[u8] = &existing.chunk_hash;
+                let covers_recipe = coverage_statement
+                    .query_row(
+                        params![owner, chunk_hash, i64::from(existing.uncompressed_size)],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to validate planned existing recipe coverage: {error}"
+                        ))
+                    })?;
+                if !covers_recipe {
+                    return Err(StagingError::StagingCorrupt(format!(
+                        "planned existing chunk {} does not cover file {}",
+                        crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex(),
+                        crab_xet::hash::MerkleHash::from(*file_hash).hex()
+                    )));
+                }
+                insert_statement
+                    .execute(params![
                         owner,
                         chunk_hash,
                         existing.xorb_hash.as_slice(),
@@ -6005,71 +6003,220 @@ impl Index {
                         i64::from(existing.uncompressed_size),
                         existing.placement_id.as_slice(),
                         existing.origin_proof_id.as_slice(),
-                    ],
-                    |row| row.get(0),
-                )
-                .map_err(|error| {
-                    StagingError::Internal(format!(
-                        "failed to verify planned existing chunk: {error}"
-                    ))
-                })?;
-            if !matches {
-                return Err(StagingError::StagingCorrupt(format!(
-                    "planned existing chunk {} has conflicting proof authority",
-                    crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex()
-                )));
-            }
-        }
-        drop(coverage_statement);
-        drop(insert_statement);
-        drop(verify_statement);
-
-        let mut retired_payloads = Vec::new();
-        if recipe_is_indexed {
-            tx.execute(
-                "DELETE FROM prepared_leases WHERE recipe_hash = ?1",
-                params![recipe_hash.as_slice()],
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to replace prepared leases: {e}"))
-            })?;
-            retired_payloads = {
-                let mut statement = tx
-                    .prepare_cached(
-                        "SELECT xorb_hash
-                         FROM prepared_payloads AS payload
-                         WHERE NOT EXISTS (
-                                   SELECT 1 FROM prepared_leases AS lease
-                                   WHERE lease.xorb_hash = payload.xorb_hash
-                               )
-                           AND NOT EXISTS (
-                                   SELECT 1 FROM preparation_payloads AS preparation
-                                   WHERE preparation.xorb_hash = payload.xorb_hash
-                               )
-                         ORDER BY xorb_hash",
+                    ])
+                    .map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to store planned existing chunk: {error}"
+                        ))
+                    })?;
+                let matches: bool = verify_statement
+                    .query_row(
+                        params![
+                            owner,
+                            chunk_hash,
+                            existing.xorb_hash.as_slice(),
+                            i64::from(existing.chunk_index),
+                            i64::from(existing.uncompressed_size),
+                            existing.placement_id.as_slice(),
+                            existing.origin_proof_id.as_slice(),
+                        ],
+                        |row| row.get(0),
                     )
                     .map_err(|error| {
                         StagingError::Internal(format!(
-                            "failed to prepare replaced payload query: {error}"
+                            "failed to verify planned existing chunk: {error}"
                         ))
                     })?;
-                statement
-                    .query_map([], |row| row.get::<_, Vec<u8>>(0))
-                    .map_err(|error| {
+                if !matches {
+                    return Err(StagingError::StagingCorrupt(format!(
+                        "planned existing chunk {} has conflicting proof authority",
+                        crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex()
+                    )));
+                }
+            }
+            drop(coverage_statement);
+            drop(insert_statement);
+            drop(verify_statement);
+
+            if recipe_is_indexed {
+                cleanup_needed = true;
+                tx.execute(
+                    "DELETE FROM prepared_leases WHERE recipe_hash = ?1",
+                    params![recipe_hash.as_slice()],
+                )
+                .map_err(|e| {
+                    StagingError::Internal(format!("failed to replace prepared leases: {e}"))
+                })?;
+            }
+
+            for prepared in prepared_xorbs {
+                let xorb_hash: &[u8] = &prepared.xorb_hash;
+                let payload_hash: &[u8] = &prepared.payload_hash;
+                let bytes = sqlite_i64("prepared xorb bytes", prepared.bytes)?;
+                tx.execute(
+                    "INSERT OR IGNORE INTO prepared_payloads
+                 (xorb_hash, payload_hash, bytes) VALUES (?1, ?2, ?3)",
+                    params![xorb_hash, payload_hash, bytes],
+                )
+                .map_err(|e| {
+                    StagingError::Internal(format!("failed to store prepared payload: {e}"))
+                })?;
+                let payload_matches: bool = tx
+                    .query_row(
+                        "SELECT payload_hash = ?2 AND bytes = ?3
+                     FROM prepared_payloads WHERE xorb_hash = ?1",
+                        params![xorb_hash, payload_hash, bytes],
+                        |row| row.get(0),
+                    )
+                    .map_err(|e| {
+                        StagingError::Internal(format!("failed to verify prepared payload: {e}"))
+                    })?;
+                if !payload_matches {
+                    return Err(StagingError::StagingCorrupt(format!(
+                        "prepared xorb payload identity collision for {}",
+                        crab_xet::hash::MerkleHash::from(prepared.xorb_hash).hex()
+                    )));
+                }
+                let mut covers_recipe = false;
+                for placement in &prepared.placements {
+                    let chunk_hash: &[u8] = &placement.chunk_hash;
+                    if !covers_recipe {
+                        covers_recipe = if recipe_is_indexed {
+                            tx.query_row(
+                                "SELECT EXISTS(
+                                 SELECT 1 FROM recipe_occurrences
+                                 WHERE recipe_hash = ?1
+                                   AND chunk_hash = ?2
+                                   AND chunk_size = ?3
+                             )",
+                                params![
+                                    recipe_hash.as_slice(),
+                                    chunk_hash,
+                                    i64::from(placement.uncompressed_size)
+                                ],
+                                |row| row.get::<_, bool>(0),
+                            )
+                            .map_err(|error| {
+                                StagingError::Internal(format!(
+                                    "failed to validate prepared xorb recipe coverage: {error}"
+                                ))
+                            })?
+                        } else {
+                            tx.query_row(
+                                "SELECT EXISTS(
+                                 SELECT 1 FROM recipe_recording_terms
+                                 WHERE batch_id = ?1
+                                   AND chunk_hash = ?2
+                                   AND chunk_size = ?3
+                             )",
+                                params![
+                                    recording_batch_id,
+                                    chunk_hash,
+                                    i64::from(placement.uncompressed_size)
+                                ],
+                                |row| row.get::<_, bool>(0),
+                            )
+                            .map_err(|error| {
+                                StagingError::Internal(format!(
+                                    "failed to validate prepared xorb recipe coverage: {error}"
+                                ))
+                            })?
+                        };
+                    }
+                    tx.execute(
+                        "INSERT OR IGNORE INTO prepared_payload_chunks
+                     (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
+                     VALUES (?1, ?2, ?3, ?4)",
+                        params![
+                            xorb_hash,
+                            i64::from(placement.chunk_index),
+                            chunk_hash,
+                            i64::from(placement.uncompressed_size),
+                        ],
+                    )
+                    .map_err(|e| {
                         StagingError::Internal(format!(
-                            "failed to query replaced prepared payloads: {error}"
+                            "failed to store prepared payload chunk: {e}"
                         ))
-                    })?
-                    .collect::<std::result::Result<Vec<_>, _>>()
-                    .map_err(|error| {
-                        StagingError::Internal(format!(
-                            "failed to collect replaced prepared payloads: {error}"
-                        ))
-                    })?
-                    .into_iter()
-                    .map(|hash| decode_hash_blob("replaced prepared payload", hash))
-                    .collect::<Result<Vec<_>>>()?
-            };
+                    })?;
+                    let stored: (Vec<u8>, i64, i64) = tx
+                        .query_row(
+                            "SELECT xorb_hash, chunk_index, uncompressed_size
+                         FROM prepared_payload_chunks WHERE chunk_hash = ?1",
+                            params![chunk_hash],
+                            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                        )
+                        .map_err(|e| {
+                            StagingError::Internal(format!(
+                                "failed to verify canonical prepared chunk placement: {e}"
+                            ))
+                        })?;
+                    if stored.0.as_slice() != xorb_hash
+                        || stored.1 != i64::from(placement.chunk_index)
+                        || stored.2 != i64::from(placement.uncompressed_size)
+                    {
+                        return Err(StagingError::StagingCorrupt(format!(
+                            "prepared chunk {} already belongs to another canonical xorb",
+                            crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
+                        )));
+                    }
+                }
+                if !covers_recipe {
+                    return Err(StagingError::StagingCorrupt(format!(
+                        "prepared xorb {} does not cover file {}",
+                        crab_xet::hash::MerkleHash::from(prepared.xorb_hash).hex(),
+                        crab_xet::hash::MerkleHash::from(*file_hash).hex()
+                    )));
+                }
+                if recipe_is_indexed {
+                    tx.execute(
+                        "INSERT OR IGNORE INTO prepared_leases (recipe_hash, xorb_hash)
+                     VALUES (?1, ?2)",
+                        params![recipe_hash.as_slice(), xorb_hash],
+                    )
+                    .map_err(|e| {
+                        StagingError::Internal(format!("failed to store prepared lease: {e}"))
+                    })?;
+                }
+            }
+        }
+        let removed_payloads = if cleanup_needed {
+            let mut statement = tx
+                .prepare_cached(
+                    "SELECT xorb_hash
+                     FROM prepared_payloads AS payload
+                     WHERE NOT EXISTS (
+                               SELECT 1 FROM prepared_leases AS lease
+                               WHERE lease.xorb_hash = payload.xorb_hash
+                           )
+                       AND NOT EXISTS (
+                               SELECT 1 FROM preparation_payloads AS preparation
+                               WHERE preparation.xorb_hash = payload.xorb_hash
+                           )
+                     ORDER BY xorb_hash",
+                )
+                .map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to prepare replaced payload query: {error}"
+                    ))
+                })?;
+            let removed = statement
+                .query_map([], |row| row.get::<_, Vec<u8>>(0))
+                .map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to query replaced prepared payloads: {error}"
+                    ))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to collect replaced prepared payloads: {error}"
+                    ))
+                })?
+                .into_iter()
+                .map(|hash| decode_hash_blob("replaced prepared payload", hash))
+                .collect::<Result<Vec<_>>>()?;
+            drop(statement);
             tx.execute(
                 "DELETE FROM prepared_payloads
                  WHERE NOT EXISTS (
@@ -6087,154 +6234,10 @@ impl Index {
                     "failed to retire replaced prepared payloads: {error}"
                 ))
             })?;
-        }
-
-        for prepared in prepared_xorbs {
-            let xorb_hash: &[u8] = &prepared.xorb_hash;
-            let payload_hash: &[u8] = &prepared.payload_hash;
-            let bytes = sqlite_i64("prepared xorb bytes", prepared.bytes)?;
-            tx.execute(
-                "INSERT OR IGNORE INTO prepared_payloads
-                 (xorb_hash, payload_hash, bytes) VALUES (?1, ?2, ?3)",
-                params![xorb_hash, payload_hash, bytes],
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to store prepared payload: {e}"))
-            })?;
-            let payload_matches: bool = tx
-                .query_row(
-                    "SELECT payload_hash = ?2 AND bytes = ?3
-                     FROM prepared_payloads WHERE xorb_hash = ?1",
-                    params![xorb_hash, payload_hash, bytes],
-                    |row| row.get(0),
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!("failed to verify prepared payload: {e}"))
-                })?;
-            if !payload_matches {
-                return Err(StagingError::StagingCorrupt(format!(
-                    "prepared xorb payload identity collision for {}",
-                    crab_xet::hash::MerkleHash::from(prepared.xorb_hash).hex()
-                )));
-            }
-            let mut covers_recipe = false;
-            for placement in &prepared.placements {
-                let chunk_hash: &[u8] = &placement.chunk_hash;
-                if !covers_recipe {
-                    covers_recipe = if recipe_is_indexed {
-                        tx.query_row(
-                            "SELECT EXISTS(
-                                 SELECT 1 FROM recipe_occurrences
-                                 WHERE recipe_hash = ?1
-                                   AND chunk_hash = ?2
-                                   AND chunk_size = ?3
-                             )",
-                            params![
-                                recipe_hash.as_slice(),
-                                chunk_hash,
-                                i64::from(placement.uncompressed_size)
-                            ],
-                            |row| row.get::<_, bool>(0),
-                        )
-                        .map_err(|error| {
-                            StagingError::Internal(format!(
-                                "failed to validate prepared xorb recipe coverage: {error}"
-                            ))
-                        })?
-                    } else {
-                        tx.query_row(
-                            "SELECT EXISTS(
-                                 SELECT 1 FROM recipe_recording_terms
-                                 WHERE batch_id = ?1
-                                   AND chunk_hash = ?2
-                                   AND chunk_size = ?3
-                             )",
-                            params![
-                                recording_batch_id,
-                                chunk_hash,
-                                i64::from(placement.uncompressed_size)
-                            ],
-                            |row| row.get::<_, bool>(0),
-                        )
-                        .map_err(|error| {
-                            StagingError::Internal(format!(
-                                "failed to validate prepared xorb recipe coverage: {error}"
-                            ))
-                        })?
-                    };
-                }
-                tx.execute(
-                    "INSERT OR IGNORE INTO prepared_payload_chunks
-                     (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
-                     VALUES (?1, ?2, ?3, ?4)",
-                    params![
-                        xorb_hash,
-                        i64::from(placement.chunk_index),
-                        chunk_hash,
-                        i64::from(placement.uncompressed_size),
-                    ],
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!("failed to store prepared payload chunk: {e}"))
-                })?;
-                let stored: (Vec<u8>, i64, i64) = tx
-                    .query_row(
-                        "SELECT xorb_hash, chunk_index, uncompressed_size
-                         FROM prepared_payload_chunks WHERE chunk_hash = ?1",
-                        params![chunk_hash],
-                        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-                    )
-                    .map_err(|e| {
-                        StagingError::Internal(format!(
-                            "failed to verify canonical prepared chunk placement: {e}"
-                        ))
-                    })?;
-                if stored.0.as_slice() != xorb_hash
-                    || stored.1 != i64::from(placement.chunk_index)
-                    || stored.2 != i64::from(placement.uncompressed_size)
-                {
-                    return Err(StagingError::StagingCorrupt(format!(
-                        "prepared chunk {} already belongs to another canonical xorb",
-                        crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
-                    )));
-                }
-            }
-            if !covers_recipe {
-                return Err(StagingError::StagingCorrupt(format!(
-                    "prepared xorb {} does not cover file {}",
-                    crab_xet::hash::MerkleHash::from(prepared.xorb_hash).hex(),
-                    crab_xet::hash::MerkleHash::from(*file_hash).hex()
-                )));
-            }
-            if recipe_is_indexed {
-                tx.execute(
-                    "INSERT OR IGNORE INTO prepared_leases (recipe_hash, xorb_hash)
-                     VALUES (?1, ?2)",
-                    params![recipe_hash.as_slice(), xorb_hash],
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!("failed to store prepared lease: {e}"))
-                })?;
-            }
-        }
-
-        let mut removed_payloads = Vec::new();
-        for xorb_hash in retired_payloads {
-            let exists = tx
-                .query_row(
-                    "SELECT EXISTS(SELECT 1 FROM prepared_payloads WHERE xorb_hash = ?1)",
-                    params![xorb_hash.as_slice()],
-                    |row| row.get::<_, bool>(0),
-                )
-                .map_err(|error| {
-                    StagingError::Internal(format!(
-                        "failed to verify replaced prepared payload: {error}"
-                    ))
-                })?;
-            if !exists {
-                removed_payloads.push(xorb_hash);
-            }
-        }
+            removed
+        } else {
+            Vec::new()
+        };
         tx.commit().map_err(|e| {
             StagingError::Internal(format!("failed to commit file push plan tx: {e}"))
         })?;

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2163,7 +2163,7 @@ impl Index {
                 StagingError::Internal(format!("decode file chunk index: {error}"))
             })?;
             validate_chunk_index(expected_index, chunk_index)?;
-            let actual_hash = decode_chunk_hash_blob(raw_hash)?;
+            let actual_hash = crab_xet::hash::MerkleHash::from(decode_chunk_hash_blob(raw_hash)?);
             let actual_size = u64::try_from(size)
                 .map_err(|_| StagingError::StagingCorrupt("chunk size is negative".to_owned()))?;
             if actual_hash != *expected_hash || actual_size != *expected_chunk_size {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -3934,6 +3934,7 @@ impl Index {
                     recipe.chunk_count, recipe.sequence_hash,
                     recipe.page_count, recipe.page_root_hash, recipe.policy_id
              FROM file_recipes AS recipe
+             JOIN files AS file USING (file_hash)
              JOIN verified_recipes AS verified USING (recipe_hash)
              JOIN path_heads AS head USING (recipe_hash)
              JOIN staging_batches AS batch USING (batch_id)

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -398,42 +398,97 @@ fn remove_empty_published_batches(tx: &rusqlite::Transaction<'_>) -> Result<()> 
     .map_err(|e| StagingError::Internal(format!("failed to remove superseded empty batches: {e}")))
 }
 
-fn ensure_pending_collision_is_idempotent(
+fn ensure_pending_collision_batch_is_idempotent(
     tx: &rusqlite::Transaction<'_>,
-    row: &PendingRow,
+    rows: &[PendingRow],
 ) -> Result<()> {
-    let fh: &[u8] = &row.file_hash;
-    let existing: Option<(Vec<u8>, i64, u64, u64)> = tx
-        .query_row(
-            "SELECT chunk_hash, size, segment_id, segment_offset
-             FROM pending_chunks
-             WHERE file_hash = ?1 AND chunk_index = ?2",
-            params![fh, row.chunk_index],
-            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
-        )
-        .optional()
-        .map_err(|e| StagingError::Internal(format!("failed to inspect pending collision: {e}")))?;
-
-    let Some((existing_hash, existing_size, existing_segment_id, existing_offset)) = existing
-    else {
-        return Err(StagingError::Internal(
-            "pending insert reported a conflict but the existing row was not found".to_owned(),
-        ));
-    };
-
-    let existing_hash = decode_hash_blob("pending chunk hash", existing_hash)?;
-    if existing_hash == row.chunk_hash
-        && existing_size == row.size
-        && existing_segment_id == row.segment_id
-        && existing_offset == row.segment_offset
-    {
+    if rows.is_empty() {
         return Ok(());
     }
 
-    Err(StagingError::StagingCorrupt(format!(
-        "pending chunk collision at chunk_index {}: existing row differs from new staging row",
-        row.chunk_index
-    )))
+    // Keep the conflict probe below SQLite's default bind-parameter limit.
+    const COLLISION_QUERY_BATCH: usize = 400;
+    for batch in rows.chunks(COLLISION_QUERY_BATCH) {
+        let placeholders = std::iter::repeat_n("(?, ?)", batch.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let query = format!(
+            "SELECT file_hash, chunk_index, chunk_hash, size, segment_id, segment_offset
+             FROM pending_chunks
+             WHERE (file_hash, chunk_index) IN ({placeholders})"
+        );
+        let mut statement = tx.prepare_cached(&query).map_err(|error| {
+            StagingError::Internal(format!(
+                "failed to prepare pending collision probe: {error}"
+            ))
+        })?;
+        let file_hashes = batch
+            .iter()
+            .map(|row| row.file_hash.as_slice())
+            .collect::<Vec<_>>();
+        let mut values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() * 2);
+        for (index, row) in batch.iter().enumerate() {
+            values.push(&file_hashes[index]);
+            values.push(&row.chunk_index);
+        }
+        let rows = statement
+            .query_map(params_from_iter(values), |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, u64>(4)?,
+                    row.get::<_, u64>(5)?,
+                ))
+            })
+            .map_err(|error| {
+                StagingError::Internal(format!("failed to query pending collision probe: {error}"))
+            })?;
+        let mut existing = HashMap::with_capacity(batch.len());
+        for row in rows {
+            let (file_hash, chunk_index, chunk_hash, size, segment_id, segment_offset) = row
+                .map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to read pending collision probe: {error}"
+                    ))
+                })?;
+            existing.insert(
+                (
+                    decode_hash_blob("pending file hash", file_hash)?,
+                    chunk_index,
+                ),
+                (
+                    decode_hash_blob("pending chunk hash", chunk_hash)?,
+                    size,
+                    segment_id,
+                    segment_offset,
+                ),
+            );
+        }
+        for row in batch {
+            let Some((existing_hash, existing_size, existing_segment_id, existing_offset)) =
+                existing.get(&(row.file_hash, row.chunk_index))
+            else {
+                return Err(StagingError::Internal(
+                    "pending insert reported a conflict but the existing row was not found"
+                        .to_owned(),
+                ));
+            };
+            if *existing_hash == row.chunk_hash
+                && *existing_size == row.size
+                && *existing_segment_id == row.segment_id
+                && *existing_offset == row.segment_offset
+            {
+                continue;
+            }
+            return Err(StagingError::StagingCorrupt(format!(
+                "pending chunk collision at chunk_index {}: existing row differs from new staging row",
+                row.chunk_index
+            )));
+        }
+    }
+    Ok(())
 }
 
 impl Index {
@@ -1227,6 +1282,7 @@ impl Index {
             StagingError::Internal(format!("failed to begin pending insert tx: {e}"))
         })?;
 
+        let mut conflicts = Vec::new();
         {
             let mut stmt = tx
                 .prepare_cached(
@@ -1255,10 +1311,11 @@ impl Index {
                         StagingError::Internal(format!("failed to insert pending chunk: {e}",))
                     })?;
                 if inserted == 0 {
-                    ensure_pending_collision_is_idempotent(&tx, row)?;
+                    conflicts.push(row.clone());
                 }
             }
         }
+        ensure_pending_collision_batch_is_idempotent(&tx, &conflicts)?;
 
         tx.commit().map_err(|e| {
             StagingError::Internal(format!("failed to commit pending insert tx: {e}"))
@@ -9821,6 +9878,36 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM pending_chunks", [], |r| r.get(0))
             .expect("count pending");
         assert_eq!(pending_count, 1);
+    }
+
+    #[test]
+    fn insert_pending_validates_large_retry_in_bounded_batches() {
+        const ROWS: usize = 801;
+
+        let idx = open_in_memory();
+        let seg_id = idx.allocate_segment_id().expect("alloc");
+        let file_hash = test_hash(0xF5);
+        let file_size = i64::try_from(ROWS * 8).expect("file size");
+        insert_test_file(&idx, &file_hash, file_size);
+        let rows = (0..ROWS)
+            .map(|index| PendingRow {
+                chunk_hash: test_hash(u8::try_from(index % 256).expect("chunk hash seed")),
+                file_hash,
+                chunk_index: i64::try_from(index).expect("chunk index"),
+                size: 8,
+                segment_id: seg_id,
+                segment_offset: u64::try_from(index * 8).expect("segment offset"),
+            })
+            .collect::<Vec<_>>();
+
+        idx.insert_pending(&rows).expect("first insert");
+        idx.insert_pending(&rows).expect("identical retry");
+
+        let pending_count: i64 = idx
+            .conn
+            .query_row("SELECT COUNT(*) FROM pending_chunks", [], |row| row.get(0))
+            .expect("count pending");
+        assert_eq!(pending_count, i64::try_from(ROWS).expect("row count"));
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -5861,6 +5861,8 @@ impl Index {
         let tx = self.conn.unchecked_transaction().map_err(|e| {
             StagingError::Internal(format!("failed to begin file push plan tx: {e}"))
         })?;
+        // Defer retirement until every plan in this transaction has restored
+        // its leases; shared prepared xorbs can move between files in a batch.
         let mut cleanup_needed = false;
         for write in writes {
             let FilePushPlanWrite {
@@ -6181,6 +6183,9 @@ impl Index {
             }
         }
         let removed_payloads = if cleanup_needed {
+            // A single sweep avoids repeatedly scanning the global payload
+            // table and cannot retire a body that another plan in this batch
+            // has just leased.
             let mut statement = tx
                 .prepare_cached(
                     "SELECT xorb_hash

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6716,6 +6716,33 @@ impl Index {
 
             if recipe_is_indexed {
                 cleanup_needed = true;
+                // Release only the replaced recipe's canonical rows. The
+                // chunk hash is globally unique, so an unleased old row would
+                // reject the replacement as an ownership conflict; narrowing
+                // by the old leases avoids scanning every prepared chunk for
+                // each file in a multi-file replacement batch.
+                tx.execute(
+                    "DELETE FROM prepared_payload_chunks
+                     WHERE xorb_hash IN (
+                               SELECT xorb_hash FROM prepared_leases
+                               WHERE recipe_hash = ?1
+                           )
+                       AND NOT EXISTS (
+                               SELECT 1 FROM prepared_leases AS other
+                               WHERE other.xorb_hash = prepared_payload_chunks.xorb_hash
+                                 AND other.recipe_hash != ?1
+                           )
+                       AND NOT EXISTS (
+                               SELECT 1 FROM preparation_payloads
+                               WHERE preparation_payloads.xorb_hash = prepared_payload_chunks.xorb_hash
+                           )",
+                    params![recipe_hash.as_slice()],
+                )
+                .map_err(|e| {
+                    StagingError::Internal(format!(
+                        "failed to release replaced prepared chunks: {e}"
+                    ))
+                })?;
                 tx.execute(
                     "DELETE FROM prepared_leases WHERE recipe_hash = ?1",
                     params![recipe_hash.as_slice()],
@@ -10034,6 +10061,17 @@ mod tests {
         let second_xorb = test_hash(0xD2);
         let first_chunk = test_hash(0xE1);
         let second_chunk = test_hash(0xE2);
+        for recipe_hash in [first_recipe, second_recipe] {
+            idx.conn
+                .execute(
+                    "INSERT INTO file_recipes
+                     (recipe_hash, file_hash, file_size, chunk_count, sequence_hash,
+                      page_count, page_root_hash, policy_id)
+                     VALUES (?1, ?1, 0, 0, ?1, 0, ?1, 'test')",
+                    params![recipe_hash.as_slice()],
+                )
+                .expect("file recipe");
+        }
         for (recipe_hash, xorb_hash, chunk_hash) in [
             (first_recipe, first_xorb, first_chunk),
             (second_recipe, second_xorb, second_chunk),
@@ -10084,7 +10122,7 @@ mod tests {
         );
         assert_eq!(grouped[&second_recipe][1].xorb_hash, second_xorb);
         assert_eq!(
-            grouped[&second_recipe][0].placements[0].chunk_hash,
+            grouped[&second_recipe][1].placements[0].chunk_hash,
             second_chunk
         );
     }

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2261,10 +2261,11 @@ impl Index {
             }
         }
         let unique_hashes = sizes.keys().copied().collect::<Vec<_>>();
-        let placeholders = vec!["?"; unique_hashes.len()].join(",");
+        const CLAIM_LOOKUP_BATCH: usize = 400;
 
         let mut prepared = HashMap::<[u8; 32], PreparedChunkLocator>::new();
-        {
+        for hash_batch in unique_hashes.chunks(CLAIM_LOOKUP_BATCH) {
+            let placeholders = vec!["?"; hash_batch.len()].join(",");
             let sql = format!(
                 "SELECT chunk.chunk_hash, chunk.xorb_hash, payload.payload_hash,
                         payload.bytes, chunk.chunk_index, chunk.uncompressed_size
@@ -2279,7 +2280,7 @@ impl Index {
             })?;
             let rows = statement
                 .query_map(
-                    params_from_iter(unique_hashes.iter().map(|hash| hash.as_slice())),
+                    params_from_iter(hash_batch.iter().map(|hash| hash.as_slice())),
                     |row| {
                         Ok((
                             row.get::<_, Vec<u8>>(0)?,
@@ -2329,7 +2330,8 @@ impl Index {
         }
 
         let mut segments = HashMap::<[u8; 32], u64>::new();
-        {
+        for hash_batch in unique_hashes.chunks(CLAIM_LOOKUP_BATCH) {
+            let placeholders = vec!["?"; hash_batch.len()].join(",");
             let sql = format!(
                 "SELECT chunk_hash, size FROM chunk_payloads
                  WHERE chunk_hash IN ({placeholders})"
@@ -2341,7 +2343,7 @@ impl Index {
             })?;
             let rows = statement
                 .query_map(
-                    params_from_iter(unique_hashes.iter().map(|hash| hash.as_slice())),
+                    params_from_iter(hash_batch.iter().map(|hash| hash.as_slice())),
                     |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?)),
                 )
                 .map_err(|error| {
@@ -2363,7 +2365,8 @@ impl Index {
         }
 
         let mut claims = HashMap::<[u8; 32], (String, u64)>::new();
-        {
+        for hash_batch in unique_hashes.chunks(CLAIM_LOOKUP_BATCH) {
+            let placeholders = vec!["?"; hash_batch.len()].join(",");
             let sql = format!(
                 "SELECT chunk_hash, preparation_id, uncompressed_size
                  FROM prepared_chunk_claims WHERE chunk_hash IN ({placeholders})"
@@ -2373,7 +2376,7 @@ impl Index {
             })?;
             let rows = statement
                 .query_map(
-                    params_from_iter(unique_hashes.iter().map(|hash| hash.as_slice())),
+                    params_from_iter(hash_batch.iter().map(|hash| hash.as_slice())),
                     |row| {
                         Ok((
                             row.get::<_, Vec<u8>>(0)?,
@@ -8962,6 +8965,35 @@ mod tests {
             )
             .expect("claim repeated chunk"),
             vec![PreparedChunkClaim::Claimed, PreparedChunkClaim::Pending]
+        );
+    }
+
+    #[test]
+    fn prepared_claim_pages_large_unique_batch() {
+        const CLAIMS: usize = 1024;
+
+        let idx = open_in_memory();
+        idx.insert_add_preparation("preparation-large")
+            .expect("preparation");
+        idx.insert_batch("batch-large").expect("batch");
+        idx.attach_add_preparation_batch("preparation-large", "batch-large")
+            .expect("attach batch");
+        let chunks = (0..CLAIMS)
+            .map(|index| {
+                let mut hash = [0; 32];
+                hash[..8].copy_from_slice(&u64::try_from(index).expect("hash index").to_le_bytes());
+                (hash, 8)
+            })
+            .collect::<Vec<_>>();
+
+        let outcomes = idx
+            .claim_prepared_chunks("preparation-large", "batch-large", &chunks)
+            .expect("paged prepared claims");
+        assert_eq!(outcomes.len(), CLAIMS);
+        assert!(
+            outcomes
+                .iter()
+                .all(|outcome| *outcome == PreparedChunkClaim::Claimed)
         );
     }
 

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -7533,13 +7533,13 @@ impl Index {
             index_by_hash.entry(*h).or_default().push(i);
         }
 
-        let unique_hashes: Vec<[u8; 32]> = index_by_hash.keys().copied().collect();
-        let placeholders = vec!["?"; unique_hashes.len()].join(",");
-
+        let unique_hashes = index_by_hash.keys().copied().collect::<Vec<_>>();
         let mut out: Vec<Option<ChunkLocator>> = vec![None; hashes.len()];
+        const LOCATE_QUERY_BATCH: usize = 400;
 
         // Query committed chunks first.
-        {
+        for hash_batch in unique_hashes.chunks(LOCATE_QUERY_BATCH) {
+            let placeholders = vec!["?"; hash_batch.len()].join(",");
             let sql = format!(
                 "SELECT chunk_hash, segment_id, segment_offset, size
                  FROM chunks
@@ -7551,7 +7551,7 @@ impl Index {
                 .map_err(|e| StagingError::Internal(format!("prepare locate_batch: {e}")))?;
             let rows = stmt
                 .query_map(
-                    params_from_iter(unique_hashes.iter().map(|h| h.as_slice())),
+                    params_from_iter(hash_batch.iter().map(|h| h.as_slice())),
                     |row| {
                         let blob: Vec<u8> = row.get(0)?;
                         let seg_id: u64 = row.get(1)?;
@@ -7584,18 +7584,14 @@ impl Index {
         }
 
         // Query pending chunks for hashes still missing.
-        let missing_hashes: Vec<[u8; 32]> = unique_hashes
+        let missing_hashes: Vec<[u8; 32]> = index_by_hash
             .iter()
-            .copied()
-            .filter(|h| {
-                index_by_hash
-                    .get(h)
-                    .is_some_and(|indices| indices.iter().any(|&i| out[i].is_none()))
-            })
+            .filter(|(_, indices)| indices.iter().any(|&i| out[i].is_none()))
+            .map(|(h, _)| *h)
             .collect();
 
-        if !missing_hashes.is_empty() {
-            let pending_placeholders = vec!["?"; missing_hashes.len()].join(",");
+        for hash_batch in missing_hashes.chunks(LOCATE_QUERY_BATCH) {
+            let pending_placeholders = vec!["?"; hash_batch.len()].join(",");
             let sql = format!(
                 "SELECT chunk_hash, segment_id, segment_offset, size
                  FROM pending_chunks
@@ -7606,7 +7602,7 @@ impl Index {
             })?;
             let rows = stmt
                 .query_map(
-                    params_from_iter(missing_hashes.iter().map(|h| h.as_slice())),
+                    params_from_iter(hash_batch.iter().map(|h| h.as_slice())),
                     |row| {
                         let blob: Vec<u8> = row.get(0)?;
                         let seg_id: u64 = row.get(1)?;
@@ -7658,58 +7654,63 @@ impl Index {
             indices_by_hash.entry(*hash).or_default().push(index);
         }
         let unique_hashes = indices_by_hash.keys().copied().collect::<Vec<_>>();
-        let placeholders = vec!["?"; unique_hashes.len()].join(",");
-        let sql = format!(
-            "SELECT chunk_hash, xorb_hash, payload_hash, bytes,
-                    chunk_index, uncompressed_size
-             FROM prepared_payload_chunks AS chunk
-             JOIN prepared_payloads AS xorb USING (xorb_hash)
-             WHERE chunk.chunk_hash IN ({placeholders})"
-        );
-        let mut statement = self.conn.prepare(&sql).map_err(|error| {
-            StagingError::Internal(format!("prepare prepared chunk batch lookup: {error}"))
-        })?;
-        let rows = statement
-            .query_map(
-                params_from_iter(unique_hashes.iter().map(|hash| hash.as_slice())),
-                |row| {
-                    Ok((
-                        row.get::<_, Vec<u8>>(0)?,
-                        row.get::<_, Vec<u8>>(1)?,
-                        row.get::<_, Vec<u8>>(2)?,
-                        row.get::<_, i64>(3)?,
-                        row.get::<_, i64>(4)?,
-                        row.get::<_, i64>(5)?,
-                    ))
-                },
-            )
-            .map_err(|error| {
-                StagingError::Internal(format!("query prepared chunk batch lookup: {error}"))
-            })?;
-
         let mut out = vec![None; hashes.len()];
-        for row in rows {
-            let (chunk_hash, xorb_hash, payload_hash, bytes, chunk_index, size) =
-                row.map_err(|error| {
-                    StagingError::Internal(format!("read prepared chunk batch lookup row: {error}"))
+        const LOCATE_QUERY_BATCH: usize = 400;
+        for hash_batch in unique_hashes.chunks(LOCATE_QUERY_BATCH) {
+            let placeholders = vec!["?"; hash_batch.len()].join(",");
+            let sql = format!(
+                "SELECT chunk_hash, xorb_hash, payload_hash, bytes,
+                        chunk_index, uncompressed_size
+                 FROM prepared_payload_chunks AS chunk
+                 JOIN prepared_payloads AS xorb USING (xorb_hash)
+                 WHERE chunk.chunk_hash IN ({placeholders})"
+            );
+            let mut statement = self.conn.prepare(&sql).map_err(|error| {
+                StagingError::Internal(format!("prepare prepared chunk batch lookup: {error}"))
+            })?;
+            let rows = statement
+                .query_map(
+                    params_from_iter(hash_batch.iter().map(|hash| hash.as_slice())),
+                    |row| {
+                        Ok((
+                            row.get::<_, Vec<u8>>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, Vec<u8>>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, i64>(4)?,
+                            row.get::<_, i64>(5)?,
+                        ))
+                    },
+                )
+                .map_err(|error| {
+                    StagingError::Internal(format!("query prepared chunk batch lookup: {error}"))
                 })?;
-            let chunk_hash = decode_hash_blob("prepared chunk hash", chunk_hash)?;
-            let locator = PreparedChunkLocator {
-                xorb_hash: decode_hash_blob("prepared chunk xorb hash", xorb_hash)?,
-                payload_hash: decode_hash_blob("prepared chunk payload hash", payload_hash)?,
-                xorb_bytes: u64::try_from(bytes).map_err(|_| {
-                    StagingError::StagingCorrupt("negative prepared xorb size".to_owned())
-                })?,
-                chunk_index: u32::try_from(chunk_index).map_err(|_| {
-                    StagingError::StagingCorrupt("invalid prepared chunk index".to_owned())
-                })?,
-                size: u32::try_from(size).map_err(|_| {
-                    StagingError::StagingCorrupt("invalid prepared chunk size".to_owned())
-                })?,
-            };
-            if let Some(indices) = indices_by_hash.get(&chunk_hash) {
-                for index in indices {
-                    out[*index] = Some(locator);
+
+            for row in rows {
+                let (chunk_hash, xorb_hash, payload_hash, bytes, chunk_index, size) =
+                    row.map_err(|error| {
+                        StagingError::Internal(format!(
+                            "read prepared chunk batch lookup row: {error}"
+                        ))
+                    })?;
+                let chunk_hash = decode_hash_blob("prepared chunk hash", chunk_hash)?;
+                let locator = PreparedChunkLocator {
+                    xorb_hash: decode_hash_blob("prepared chunk xorb hash", xorb_hash)?,
+                    payload_hash: decode_hash_blob("prepared chunk payload hash", payload_hash)?,
+                    xorb_bytes: u64::try_from(bytes).map_err(|_| {
+                        StagingError::StagingCorrupt("negative prepared xorb size".to_owned())
+                    })?,
+                    chunk_index: u32::try_from(chunk_index).map_err(|_| {
+                        StagingError::StagingCorrupt("invalid prepared chunk index".to_owned())
+                    })?,
+                    size: u32::try_from(size).map_err(|_| {
+                        StagingError::StagingCorrupt("invalid prepared chunk size".to_owned())
+                    })?,
+                };
+                if let Some(indices) = indices_by_hash.get(&chunk_hash) {
+                    for index in indices {
+                        out[*index] = Some(locator);
+                    }
                 }
             }
         }
@@ -9766,6 +9767,28 @@ mod tests {
         assert_eq!(stored[1].xorb_hash, second_xorb);
         assert_eq!(stored[1].placements.len(), 1);
         assert_eq!(stored[1].placements[0].chunk_hash, second_chunk);
+    }
+
+    #[test]
+    fn batch_locator_queries_page_large_unique_hashes() {
+        let idx = open_in_memory();
+        let hashes = (0..1024)
+            .map(|index| {
+                let mut hash = [0u8; 32];
+                hash[..8].copy_from_slice(&(index as u64).to_le_bytes());
+                hash
+            })
+            .collect::<Vec<_>>();
+
+        let segment_locators = idx.locate_batch(&hashes).expect("segment locator lookup");
+        assert_eq!(segment_locators.len(), hashes.len());
+        assert!(segment_locators.iter().all(Option::is_none));
+
+        let prepared_locators = idx
+            .locate_prepared_batch(&hashes)
+            .expect("prepared locator lookup");
+        assert_eq!(prepared_locators.len(), hashes.len());
+        assert!(prepared_locators.iter().all(Option::is_none));
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -10639,4 +10639,87 @@ mod tests {
             "changed within one add",
         );
     }
+
+    #[test]
+    fn planned_existing_authority_batch_round_trips_large_file() {
+        const CHUNK_COUNT: usize = 129;
+
+        let idx = open_in_memory();
+        let segment_id = idx.allocate_segment_id().expect("allocate segment");
+        let file_hash = test_hash(0xF0);
+        insert_test_file(
+            &idx,
+            &file_hash,
+            i64::try_from(CHUNK_COUNT * 8).expect("file size"),
+        );
+        let chunks = (0..CHUNK_COUNT)
+            .map(|index| {
+                let chunk_hash = test_hash(u8::try_from(index + 1).expect("chunk seed"));
+                idx.conn
+                    .execute(
+                        "INSERT INTO chunks
+                         (chunk_hash, file_hash, chunk_index, size, segment_id, segment_offset)
+                         VALUES (?1, ?2, ?3, 8, ?4, ?5)",
+                        params![
+                            chunk_hash.as_slice(),
+                            file_hash.as_slice(),
+                            i64::try_from(index).expect("chunk index"),
+                            segment_id,
+                            i64::try_from(index * 8).expect("chunk offset")
+                        ],
+                    )
+                    .expect("insert chunk");
+                (crab_xet::hash::MerkleHash::from(chunk_hash), 8)
+            })
+            .collect::<Vec<_>>();
+        let recipe = crate::recipe::FileRecipe::from_staged_chunks(
+            crate::recipe::ChunkingPolicyId::XetGearV1_64KiB,
+            crab_xet::hash::MerkleHash::from(file_hash),
+            u64::try_from(CHUNK_COUNT * 8).expect("file size"),
+            &chunks,
+        )
+        .expect("recipe");
+        idx.insert_batch("planned-batch").expect("batch");
+        idx.append_recipe_recording_terms("planned-batch", 0, 0, &chunks)
+            .expect("record recipe terms");
+        idx.insert_recipe_lease(
+            "planned-batch",
+            b"large.bin",
+            &recipe,
+            RecipeVerification::CallerVerified,
+        )
+        .expect("recipe lease");
+
+        let existing = chunks
+            .iter()
+            .enumerate()
+            .map(|(index, (chunk_hash, size))| ExistingChunkWrite {
+                chunk_hash: (*chunk_hash).into(),
+                xorb_hash: test_hash(0xD0),
+                chunk_index: u32::try_from(index).expect("chunk index"),
+                uncompressed_size: u32::try_from(*size).expect("chunk size"),
+                placement_id: test_hash(0xD1),
+                origin_proof_id: test_hash(0xD2),
+            })
+            .collect::<Vec<_>>();
+        let recipe_hash: [u8; 32] = recipe.hash().into();
+        idx.insert_file_push_plan(FilePushPlanWrite {
+            file_hash: &file_hash,
+            recipe_hash: &recipe_hash,
+            recording_batch_id: None,
+            existing_chunks: &existing,
+            prepared_xorbs: &[],
+        })
+        .expect("planned existing authority");
+
+        let stored: i64 = idx
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM recipe_remote_chunks WHERE recipe_hash = ?1",
+                params![recipe_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .expect("count planned existing authorities");
+        assert_eq!(stored, i64::try_from(CHUNK_COUNT).expect("chunk count"));
+    }
 }

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -3943,21 +3943,22 @@ impl Index {
         let mut statement = self.conn.prepare_cached(&query).map_err(|e| {
             StagingError::Internal(format!("failed to prepare published recipe query: {e}"))
         })?;
-        let mut query_params: Vec<&dyn ToSql> = Vec::with_capacity(file_hashes.len());
-        query_params.extend(file_hashes.iter().map(|hash| hash.as_slice() as &dyn ToSql));
         let rows = statement
-            .query_map(params_from_iter(query_params), |row| {
-                Ok((
-                    row.get::<_, Vec<u8>>(0)?,
-                    row.get::<_, Vec<u8>>(1)?,
-                    row.get::<_, i64>(2)?,
-                    row.get::<_, i64>(3)?,
-                    row.get::<_, Vec<u8>>(4)?,
-                    row.get::<_, i64>(5)?,
-                    row.get::<_, Vec<u8>>(6)?,
-                    row.get::<_, String>(7)?,
-                ))
-            })
+            .query_map(
+                params_from_iter(file_hashes.iter().map(|hash| hash.as_slice())),
+                |row| {
+                    Ok((
+                        row.get::<_, Vec<u8>>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Vec<u8>>(4)?,
+                        row.get::<_, i64>(5)?,
+                        row.get::<_, Vec<u8>>(6)?,
+                        row.get::<_, String>(7)?,
+                    ))
+                },
+            )
             .map_err(|e| StagingError::Internal(format!("failed to query published recipes: {e}")))?
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -7188,7 +7188,7 @@ impl Index {
         }
         drop(statement);
         let xorb_hashes = rows.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>();
-        let placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
+        let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
         Ok(rows
             .into_iter()
             .map(|(xorb_hash, payload_hash, bytes)| StoredPreparedXorb {
@@ -7266,7 +7266,7 @@ impl Index {
             }
         }
         let xorb_hashes = rows.iter().map(|(_, hash, _, _)| *hash).collect::<Vec<_>>();
-        let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
+        let placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
         let mut out: HashMap<[u8; 32], Vec<StoredPreparedXorb>> = HashMap::new();
         for (recipe_hash, xorb_hash, payload_hash, bytes) in rows {
             out.entry(recipe_hash)

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -1969,25 +1969,22 @@ impl Index {
             .conn
             .prepare_cached(
                 "WITH combined AS (
-                     SELECT chunk_hash, chunk_index, 0 AS priority, rowid
+                     SELECT chunk_hash, chunk_index
                      FROM chunks
                      WHERE file_hash = ?1
                      UNION ALL
-                     SELECT chunk_hash, chunk_index, 1 AS priority, rowid
-                     FROM pending_chunks
-                     WHERE file_hash = ?1
-                 )
-                 SELECT chunk_hash, chunk_index
-                 FROM combined c
-                 WHERE NOT EXISTS (
-                     SELECT 1
-                     FROM combined p
-                     WHERE p.chunk_index = c.chunk_index
-                       AND (
-                           p.priority < c.priority
-                           OR (p.priority = c.priority AND p.rowid < c.rowid)
+                     SELECT pending.chunk_hash, pending.chunk_index
+                     FROM pending_chunks AS pending
+                     WHERE pending.file_hash = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM chunks AS committed
+                           WHERE committed.file_hash = pending.file_hash
+                             AND committed.chunk_index = pending.chunk_index
                        )
                  )
+                 SELECT chunk_hash, chunk_index
+                 FROM combined
                  ORDER BY chunk_index",
             )
             .map_err(|e| StagingError::Internal(format!("prepare chunks_for_file: {e}")))?;
@@ -2037,25 +2034,23 @@ impl Index {
             .conn
             .prepare_cached(
                 "WITH combined AS (
-                     SELECT chunk_hash, size, segment_id, segment_offset, chunk_index, 0 AS priority, rowid
+                     SELECT chunk_hash, size, segment_id, segment_offset, chunk_index
                      FROM chunks
                      WHERE file_hash = ?1
                      UNION ALL
-                     SELECT chunk_hash, size, segment_id, segment_offset, chunk_index, 1 AS priority, rowid
-                     FROM pending_chunks
-                     WHERE file_hash = ?1
-                 )
-                 SELECT chunk_hash, size, segment_id, segment_offset, chunk_index
-                 FROM combined c
-                 WHERE NOT EXISTS (
-                     SELECT 1
-                     FROM combined p
-                     WHERE p.chunk_index = c.chunk_index
-                       AND (
-                           p.priority < c.priority
-                           OR (p.priority = c.priority AND p.rowid < c.rowid)
+                     SELECT pending.chunk_hash, pending.size, pending.segment_id,
+                            pending.segment_offset, pending.chunk_index
+                     FROM pending_chunks AS pending
+                     WHERE pending.file_hash = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM chunks AS committed
+                           WHERE committed.file_hash = pending.file_hash
+                             AND committed.chunk_index = pending.chunk_index
                        )
                  )
+                 SELECT chunk_hash, size, segment_id, segment_offset, chunk_index
+                 FROM combined
                  ORDER BY chunk_index",
             )
             .map_err(|e| {
@@ -2118,25 +2113,22 @@ impl Index {
             .conn
             .prepare_cached(
                 "WITH combined AS (
-                     SELECT chunk_hash, size, chunk_index, 0 AS priority, rowid
+                     SELECT chunk_hash, size, chunk_index
                      FROM chunks
                      WHERE file_hash = ?1
                      UNION ALL
-                     SELECT chunk_hash, size, chunk_index, 1 AS priority, rowid
-                     FROM pending_chunks
-                     WHERE file_hash = ?1
-                 )
-                 SELECT chunk_hash, size, chunk_index
-                 FROM combined c
-                 WHERE NOT EXISTS (
-                     SELECT 1
-                     FROM combined p
-                     WHERE p.chunk_index = c.chunk_index
-                       AND (
-                           p.priority < c.priority
-                           OR (p.priority = c.priority AND p.rowid < c.rowid)
+                     SELECT pending.chunk_hash, pending.size, pending.chunk_index
+                     FROM pending_chunks AS pending
+                     WHERE pending.file_hash = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM chunks AS committed
+                           WHERE committed.file_hash = pending.file_hash
+                             AND committed.chunk_index = pending.chunk_index
                        )
                  )
+                 SELECT chunk_hash, size, chunk_index
+                 FROM combined
                  ORDER BY chunk_index",
             )
             .map_err(|error| {
@@ -4481,28 +4473,24 @@ impl Index {
             .conn
             .prepare_cached(
                 "WITH combined AS (
-                     SELECT chunk_hash, size, chunk_index, 0 AS priority, rowid
+                     SELECT chunk_hash, size, chunk_index
                      FROM chunks
                      WHERE file_hash = ?1 AND chunk_index >= ?2 AND chunk_index < ?3
                      UNION ALL
-                     SELECT chunk_hash, size, chunk_index, 1 AS priority, rowid
-                     FROM pending_chunks
-                     WHERE file_hash = ?1 AND chunk_index >= ?2 AND chunk_index < ?3
-                 )
-                 SELECT chunk_index, chunk_hash, size
-                 FROM combined AS candidate
-                 WHERE NOT EXISTS (
-                     SELECT 1
-                     FROM combined AS preferred
-                     WHERE preferred.chunk_index = candidate.chunk_index
-                       AND (
-                           preferred.priority < candidate.priority
-                           OR (
-                               preferred.priority = candidate.priority
-                               AND preferred.rowid < candidate.rowid
-                           )
+                     SELECT pending.chunk_hash, pending.size, pending.chunk_index
+                     FROM pending_chunks AS pending
+                     WHERE pending.file_hash = ?1
+                       AND pending.chunk_index >= ?2
+                       AND pending.chunk_index < ?3
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM chunks AS committed
+                           WHERE committed.file_hash = pending.file_hash
+                             AND committed.chunk_index = pending.chunk_index
                        )
                  )
+                 SELECT chunk_index, chunk_hash, size
+                 FROM combined
                  ORDER BY chunk_index",
             )
             .map_err(|e| {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6376,7 +6376,7 @@ impl Index {
             let mut stmt = self.conn.prepare(&sql).map_err(|e| {
                 StagingError::Internal(format!("prepare prepared xorb lookup: {e}"))
             })?;
-            let rows = stmt
+            let mapped_rows = stmt
                 .query_map(
                     params_from_iter(batch.iter().map(|hash| hash.as_slice())),
                     |row| {
@@ -6389,7 +6389,7 @@ impl Index {
                 )
                 .map_err(|e| StagingError::Internal(format!("query prepared xorb lookup: {e}")))?;
 
-            for row in rows {
+            for row in mapped_rows {
                 let (xorb_hash, payload_hash, bytes) = row
                     .map_err(|e| StagingError::Internal(format!("read prepared xorb row: {e}")))?;
                 let xorb_hash = decode_hash_blob("prepared xorb hash", xorb_hash)?;
@@ -6554,7 +6554,8 @@ impl Index {
         &self,
         xorb_hashes: &[[u8; 32]],
     ) -> Result<HashMap<[u8; 32], Vec<PreparedXorbPlacementWrite>>> {
-        let mut placements = HashMap::with_capacity(xorb_hashes.len());
+        let mut placements: HashMap<[u8; 32], Vec<PreparedXorbPlacementWrite>> =
+            HashMap::with_capacity(xorb_hashes.len());
         for batch in xorb_hashes.chunks(PREPARED_XORB_QUERY_BATCH) {
             let placeholders = vec!["?"; batch.len()].join(",");
             let sql = format!(

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -7107,7 +7107,8 @@ impl Index {
             .map_err(|error| {
                 StagingError::Internal(format!("failed to prepare recipe prepared xorbs: {error}"))
             })?;
-        let rows = statement
+        let mut rows = Vec::new();
+        let mapped_rows = statement
             .query_map(params![recipe_hash.as_slice()], |row| {
                 Ok((
                     row.get::<_, Vec<u8>>(0)?,
@@ -7117,23 +7118,18 @@ impl Index {
             })
             .map_err(|error| {
                 StagingError::Internal(format!("failed to query recipe prepared xorbs: {error}"))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|error| {
-                StagingError::Internal(format!("failed to collect recipe prepared xorbs: {error}"))
             })?;
+        for row in mapped_rows {
+            let (xorb_hash, payload_hash, bytes) = row.map_err(|error| {
+                StagingError::Internal(format!("failed to read recipe prepared xorb: {error}"))
+            })?;
+            rows.push((
+                decode_hash_blob("recipe prepared xorb hash", xorb_hash)?,
+                decode_hash_blob("recipe prepared payload hash", payload_hash)?,
+                nonnegative_count("recipe prepared payload bytes", bytes)?,
+            ));
+        }
         drop(statement);
-
-        let rows = rows
-            .into_iter()
-            .map(|(xorb_hash, payload_hash, bytes)| {
-                Ok((
-                    decode_hash_blob("recipe prepared xorb hash", xorb_hash)?,
-                    decode_hash_blob("recipe prepared payload hash", payload_hash)?,
-                    nonnegative_count("recipe prepared payload bytes", bytes)?,
-                ))
-            })
-            .collect::<Result<Vec<_>>>()?;
         let xorb_hashes = rows.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>();
         let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
         Ok(rows

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2976,62 +2976,139 @@ impl Index {
                 path: format!("open staging batch {batch_id}"),
             });
         }
-        for chunk in chunks {
-            if chunk.placement_id == [0; 32] || chunk.origin_proof_id == [0; 32] {
-                return Err(StagingError::StagingCorrupt(
-                    "remote authority has an empty placement or origin proof id".to_owned(),
-                ));
+        // Seven parameters per row stay below SQLite's default limit.
+        const REMOTE_AUTHORITY_BATCH: usize = 128;
+        for batch in chunks.chunks(REMOTE_AUTHORITY_BATCH) {
+            for chunk in batch {
+                if chunk.placement_id == [0; 32] || chunk.origin_proof_id == [0; 32] {
+                    return Err(StagingError::StagingCorrupt(
+                        "remote authority has an empty placement or origin proof id".to_owned(),
+                    ));
+                }
             }
-            tx.execute(
+
+            let values_sql = std::iter::repeat_n("(?,?,?,?,?,?,?)", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let insert_sql = format!(
                 "INSERT OR IGNORE INTO recording_remote_chunks
                  (batch_id, chunk_hash, xorb_hash, chunk_index,
                   uncompressed_size, placement_id, origin_proof_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                params![
-                    batch_id,
-                    chunk.chunk_hash.as_slice(),
-                    chunk.xorb_hash.as_slice(),
-                    i64::from(chunk.chunk_index),
-                    i64::from(chunk.uncompressed_size),
-                    chunk.placement_id.as_slice(),
-                    chunk.origin_proof_id.as_slice(),
-                ],
-            )
-            .map_err(|error| {
+                 VALUES {values_sql}"
+            );
+            let mut insert_statement = tx.prepare_cached(&insert_sql).map_err(|error| {
                 StagingError::Internal(format!(
-                    "failed to append recording remote authority: {error}"
+                    "failed to prepare recording remote authority batch: {error}"
                 ))
             })?;
-            let matches: bool = tx
-                .query_row(
-                    "SELECT xorb_hash = ?3
-                            AND chunk_index = ?4
-                            AND uncompressed_size = ?5
-                            AND placement_id = ?6
-                            AND origin_proof_id = ?7
-                     FROM recording_remote_chunks
-                     WHERE batch_id = ?1 AND chunk_hash = ?2",
-                    params![
-                        batch_id,
-                        chunk.chunk_hash.as_slice(),
-                        chunk.xorb_hash.as_slice(),
-                        i64::from(chunk.chunk_index),
-                        i64::from(chunk.uncompressed_size),
-                        chunk.placement_id.as_slice(),
-                        chunk.origin_proof_id.as_slice(),
-                    ],
-                    |row| row.get(0),
-                )
+            let indices = batch
+                .iter()
+                .map(|chunk| i64::from(chunk.chunk_index))
+                .collect::<Vec<_>>();
+            let sizes = batch
+                .iter()
+                .map(|chunk| i64::from(chunk.uncompressed_size))
+                .collect::<Vec<_>>();
+            let mut values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() * 7);
+            for (index, chunk) in batch.iter().enumerate() {
+                values.push(batch_id);
+                values.push(chunk.chunk_hash.as_slice());
+                values.push(chunk.xorb_hash.as_slice());
+                values.push(&indices[index]);
+                values.push(&sizes[index]);
+                values.push(chunk.placement_id.as_slice());
+                values.push(chunk.origin_proof_id.as_slice());
+            }
+            insert_statement
+                .execute(params_from_iter(values))
                 .map_err(|error| {
                     StagingError::Internal(format!(
-                        "failed to verify recording remote authority: {error}"
+                        "failed to append recording remote authority batch: {error}"
                     ))
                 })?;
-            if !matches {
-                return Err(StagingError::StagingCorrupt(format!(
-                    "remote authority for chunk {} changed within one add",
-                    crab_xet::hash::MerkleHash::from(chunk.chunk_hash).hex()
-                )));
+            drop(insert_statement);
+
+            let placeholders = std::iter::repeat_n("?", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let verify_sql = format!(
+                "SELECT chunk_hash, xorb_hash, chunk_index, uncompressed_size,
+                        placement_id, origin_proof_id
+                 FROM recording_remote_chunks
+                 WHERE batch_id = ? AND chunk_hash IN ({placeholders})"
+            );
+            let mut verify_statement = tx.prepare_cached(&verify_sql).map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare recording remote authority verification: {error}"
+                ))
+            })?;
+            let mut verify_values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() + 1);
+            verify_values.push(batch_id);
+            verify_values.extend(
+                batch
+                    .iter()
+                    .map(|chunk| chunk.chunk_hash.as_slice() as &dyn ToSql),
+            );
+            let rows = verify_statement
+                .query_map(params_from_iter(verify_values), |row| {
+                    Ok((
+                        row.get::<_, Vec<u8>>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Vec<u8>>(4)?,
+                        row.get::<_, Vec<u8>>(5)?,
+                    ))
+                })
+                .map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to verify recording remote authority batch: {error}"
+                    ))
+                })?;
+            let mut stored =
+                HashMap::<[u8; 32], ([u8; 32], i64, i64, [u8; 32], [u8; 32])>::with_capacity(
+                    batch.len(),
+                );
+            for row in rows {
+                let (chunk_hash, xorb_hash, index, size, placement_id, origin_proof_id) = row
+                    .map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to read recording remote authority batch: {error}"
+                        ))
+                    })?;
+                stored.insert(
+                    decode_hash_blob("recording remote authority chunk hash", chunk_hash)?,
+                    (
+                        decode_hash_blob("recording remote authority xorb hash", xorb_hash)?,
+                        index,
+                        size,
+                        decode_hash_blob("recording remote authority placement id", placement_id)?,
+                        decode_hash_blob(
+                            "recording remote authority origin proof id",
+                            origin_proof_id,
+                        )?,
+                    ),
+                );
+            }
+            for chunk in batch {
+                let Some((stored_xorb, index, size, placement_id, origin_proof_id)) =
+                    stored.get(&chunk.chunk_hash)
+                else {
+                    return Err(StagingError::Internal(
+                        "recording remote authority row disappeared during verification".to_owned(),
+                    ));
+                };
+                if *stored_xorb != chunk.xorb_hash
+                    || *index != i64::from(chunk.chunk_index)
+                    || *size != i64::from(chunk.uncompressed_size)
+                    || *placement_id != chunk.placement_id
+                    || *origin_proof_id != chunk.origin_proof_id
+                {
+                    return Err(StagingError::StagingCorrupt(format!(
+                        "remote authority for chunk {} changed within one add",
+                        crab_xet::hash::MerkleHash::from(chunk.chunk_hash).hex()
+                    )));
+                }
             }
         }
         tx.commit().map_err(|error| {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6181,105 +6181,219 @@ impl Index {
                      )",
                     )
                 };
-            let insert_sql = format!(
-                "INSERT OR IGNORE INTO {table}
-             ({owner_column}, chunk_hash, xorb_hash, chunk_index,
-              uncompressed_size, placement_id, origin_proof_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)"
-            );
-            let verify_sql = format!(
-                "SELECT xorb_hash = ?3
-                    AND chunk_index = ?4
-                    AND uncompressed_size = ?5
-                    AND placement_id = ?6
-                    AND origin_proof_id = ?7
-             FROM {table}
-             WHERE {owner_column} = ?1 AND chunk_hash = ?2"
-            );
+            let coverage_table = if recipe_is_indexed {
+                "recipe_occurrences"
+            } else {
+                "recipe_recording_terms"
+            };
             let mut coverage_statement = tx.prepare_cached(coverage_sql).map_err(|error| {
                 StagingError::Internal(format!(
                     "failed to prepare planned existing coverage: {error}"
                 ))
             })?;
-            let mut insert_statement = tx.prepare_cached(&insert_sql).map_err(|error| {
-                StagingError::Internal(format!(
-                    "failed to prepare planned existing insert: {error}"
-                ))
-            })?;
-            let mut verify_statement = tx.prepare_cached(&verify_sql).map_err(|error| {
-                StagingError::Internal(format!(
-                    "failed to prepare planned existing verification: {error}"
-                ))
-            })?;
-            for existing in existing_chunks {
-                if existing.placement_id == [0; 32] || existing.origin_proof_id == [0; 32] {
-                    return Err(StagingError::StagingCorrupt(
-                        "planned existing chunk has an empty placement or origin proof id"
-                            .to_owned(),
-                    ));
+            // Seven parameters per row keep 128-row inserts below SQLite's default limit.
+            const EXISTING_CHUNK_BATCH: usize = 128;
+            for batch in existing_chunks.chunks(EXISTING_CHUNK_BATCH) {
+                for existing in batch {
+                    if existing.placement_id == [0; 32] || existing.origin_proof_id == [0; 32] {
+                        return Err(StagingError::StagingCorrupt(
+                            "planned existing chunk has an empty placement or origin proof id"
+                                .to_owned(),
+                        ));
+                    }
                 }
-                let chunk_hash: &[u8] = &existing.chunk_hash;
-                let covers_recipe = coverage_statement
-                    .query_row(
-                        params![owner, chunk_hash, i64::from(existing.uncompressed_size)],
-                        |row| row.get::<_, bool>(0),
-                    )
-                    .map_err(|error| {
+                let chunk_hashes = batch
+                    .iter()
+                    .map(|existing| existing.chunk_hash.as_slice())
+                    .collect::<Vec<_>>();
+                let placeholders = std::iter::repeat_n("?", batch.len())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let coverage_batch_sql = format!(
+                    "SELECT chunk_hash, chunk_size
+                     FROM {coverage_table}
+                     WHERE {owner_column} = ? AND chunk_hash IN ({placeholders})"
+                );
+                let mut coverage_batch_statement =
+                    tx.prepare_cached(&coverage_batch_sql).map_err(|error| {
                         StagingError::Internal(format!(
-                            "failed to validate planned existing recipe coverage: {error}"
+                            "failed to prepare planned existing coverage batch: {error}"
                         ))
                     })?;
-                if !covers_recipe {
-                    return Err(StagingError::StagingCorrupt(format!(
-                        "planned existing chunk {} does not cover file {}",
-                        crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex(),
-                        crab_xet::hash::MerkleHash::from(*file_hash).hex()
-                    )));
-                }
-                let inserted = insert_statement
-                    .execute(params![
-                        owner,
-                        chunk_hash,
-                        existing.xorb_hash.as_slice(),
-                        i64::from(existing.chunk_index),
-                        i64::from(existing.uncompressed_size),
-                        existing.placement_id.as_slice(),
-                        existing.origin_proof_id.as_slice(),
-                    ])
+                let mut coverage_params: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() + 1);
+                coverage_params.push(owner);
+                coverage_params.extend(chunk_hashes.iter().map(|hash| hash as &dyn ToSql));
+                let rows = coverage_batch_statement
+                    .query_map(params_from_iter(coverage_params), |row| {
+                        Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?))
+                    })
                     .map_err(|error| {
                         StagingError::Internal(format!(
-                            "failed to store planned existing chunk: {error}"
+                            "failed to validate planned existing recipe coverage batch: {error}"
                         ))
                     })?;
-                if inserted == 0 {
-                    let matches: bool = verify_statement
-                        .query_row(
-                            params![
-                                owner,
-                                chunk_hash,
-                                existing.xorb_hash.as_slice(),
-                                i64::from(existing.chunk_index),
-                                i64::from(existing.uncompressed_size),
-                                existing.placement_id.as_slice(),
-                                existing.origin_proof_id.as_slice(),
-                            ],
-                            |row| row.get(0),
-                        )
-                        .map_err(|error| {
+                let mut covered = HashMap::<[u8; 32], Vec<i64>>::with_capacity(batch.len());
+                for row in rows {
+                    let (chunk_hash, size) = row.map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to read planned existing recipe coverage batch: {error}"
+                        ))
+                    })?;
+                    covered
+                        .entry(decode_hash_blob(
+                            "planned existing coverage chunk hash",
+                            chunk_hash,
+                        )?)
+                        .or_default()
+                        .push(size);
+                }
+                drop(coverage_batch_statement);
+                for existing in batch {
+                    let size = i64::from(existing.uncompressed_size);
+                    if !covered
+                        .get(&existing.chunk_hash)
+                        .is_some_and(|sizes| sizes.contains(&size))
+                    {
+                        return Err(StagingError::StagingCorrupt(format!(
+                            "planned existing chunk {} does not cover file {}",
+                            crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex(),
+                            crab_xet::hash::MerkleHash::from(*file_hash).hex()
+                        )));
+                    }
+                }
+
+                let values_sql = std::iter::repeat_n("(?,?,?,?,?,?,?)", batch.len())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let insert_sql = format!(
+                    "INSERT OR IGNORE INTO {table}
+                     ({owner_column}, chunk_hash, xorb_hash, chunk_index,
+                      uncompressed_size, placement_id, origin_proof_id)
+                     VALUES {values_sql}"
+                );
+                let mut insert_statement = tx.prepare_cached(&insert_sql).map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to prepare planned existing insert batch: {error}"
+                    ))
+                })?;
+                let xorb_hashes = batch
+                    .iter()
+                    .map(|existing| existing.xorb_hash.as_slice())
+                    .collect::<Vec<_>>();
+                let indices = batch
+                    .iter()
+                    .map(|existing| i64::from(existing.chunk_index))
+                    .collect::<Vec<_>>();
+                let sizes = batch
+                    .iter()
+                    .map(|existing| i64::from(existing.uncompressed_size))
+                    .collect::<Vec<_>>();
+                let placement_ids = batch
+                    .iter()
+                    .map(|existing| existing.placement_id.as_slice())
+                    .collect::<Vec<_>>();
+                let origin_proof_ids = batch
+                    .iter()
+                    .map(|existing| existing.origin_proof_id.as_slice())
+                    .collect::<Vec<_>>();
+                let mut insert_params: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() * 7);
+                for index in 0..batch.len() {
+                    insert_params.push(owner);
+                    insert_params.push(&chunk_hashes[index]);
+                    insert_params.push(&xorb_hashes[index]);
+                    insert_params.push(&indices[index]);
+                    insert_params.push(&sizes[index]);
+                    insert_params.push(&placement_ids[index]);
+                    insert_params.push(&origin_proof_ids[index]);
+                }
+                insert_statement
+                    .execute(params_from_iter(insert_params))
+                    .map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to store planned existing chunk batch: {error}"
+                        ))
+                    })?;
+                drop(insert_statement);
+
+                let verify_sql = format!(
+                    "SELECT chunk_hash, xorb_hash, chunk_index, uncompressed_size,
+                            placement_id, origin_proof_id
+                     FROM {table}
+                     WHERE {owner_column} = ? AND chunk_hash IN ({placeholders})"
+                );
+                let mut verify_statement = tx.prepare_cached(&verify_sql).map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to prepare planned existing verification batch: {error}"
+                    ))
+                })?;
+                let mut verify_params: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() + 1);
+                verify_params.push(owner);
+                verify_params.extend(chunk_hashes.iter().map(|hash| hash as &dyn ToSql));
+                let rows = verify_statement
+                    .query_map(params_from_iter(verify_params), |row| {
+                        Ok((
+                            row.get::<_, Vec<u8>>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, Vec<u8>>(4)?,
+                            row.get::<_, Vec<u8>>(5)?,
+                        ))
+                    })
+                    .map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to verify planned existing chunk batch: {error}"
+                        ))
+                    })?;
+                let mut stored =
+                    HashMap::<[u8; 32], ([u8; 32], i64, i64, [u8; 32], [u8; 32])>::with_capacity(
+                        batch.len(),
+                    );
+                for row in rows {
+                    let (chunk_hash, xorb_hash, index, size, placement_id, origin_proof_id) =
+                        row.map_err(|error| {
                             StagingError::Internal(format!(
-                                "failed to verify planned existing chunk: {error}"
+                                "failed to read planned existing chunk batch: {error}"
                             ))
                         })?;
-                    if !matches {
+                    stored.insert(
+                        decode_hash_blob("planned existing chunk hash", chunk_hash)?,
+                        (
+                            decode_hash_blob("planned existing xorb hash", xorb_hash)?,
+                            index,
+                            size,
+                            decode_hash_blob("planned existing placement id", placement_id)?,
+                            decode_hash_blob("planned existing origin proof id", origin_proof_id)?,
+                        ),
+                    );
+                }
+                for (index, existing) in batch.iter().enumerate() {
+                    let Some((
+                        stored_xorb,
+                        stored_index,
+                        stored_size,
+                        stored_placement,
+                        stored_proof,
+                    )) = stored.get(&existing.chunk_hash)
+                    else {
+                        return Err(StagingError::Internal(
+                            "planned existing chunk row disappeared during verification".to_owned(),
+                        ));
+                    };
+                    if *stored_xorb != existing.xorb_hash
+                        || *stored_index != indices[index]
+                        || *stored_size != sizes[index]
+                        || *stored_placement != existing.placement_id
+                        || *stored_proof != existing.origin_proof_id
+                    {
                         return Err(StagingError::StagingCorrupt(format!(
                             "planned existing chunk {} has conflicting proof authority",
                             crab_xet::hash::MerkleHash::from(existing.chunk_hash).hex()
                         )));
                     }
                 }
+                drop(verify_statement);
             }
-            drop(insert_statement);
-            drop(verify_statement);
 
             if recipe_is_indexed {
                 cleanup_needed = true;

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -7059,7 +7059,7 @@ impl Index {
         }
 
         let xorb_hashes = rows.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>();
-        let placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
+        let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
         Ok(rows
             .into_iter()
             .map(|(xorb_hash, payload_hash, bytes)| StoredPreparedXorb {
@@ -7188,7 +7188,7 @@ impl Index {
         }
         drop(statement);
         let xorb_hashes = rows.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>();
-        let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
+        let placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
         Ok(rows
             .into_iter()
             .map(|(xorb_hash, payload_hash, bytes)| StoredPreparedXorb {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -7199,6 +7199,87 @@ impl Index {
             .collect())
     }
 
+    /// Load prepared xorb candidates for several recipes in one index read.
+    pub fn prepared_xorbs_for_recipes(
+        &self,
+        recipe_hashes: &[[u8; 32]],
+    ) -> Result<HashMap<[u8; 32], Vec<StoredPreparedXorb>>> {
+        if recipe_hashes.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut unique = Vec::with_capacity(recipe_hashes.len());
+        let mut requested = HashSet::with_capacity(recipe_hashes.len());
+        for hash in recipe_hashes {
+            if requested.insert(*hash) {
+                unique.push(*hash);
+            }
+        }
+        let mut rows = Vec::new();
+        let mut seen = HashSet::new();
+        for batch in unique.chunks(PREPARED_XORB_QUERY_BATCH) {
+            let placeholders = vec!["?"; batch.len()].join(",");
+            let sql = format!(
+                "SELECT lease.recipe_hash, payload.xorb_hash, payload.payload_hash, payload.bytes
+                 FROM prepared_leases AS lease
+                 JOIN prepared_payloads AS payload USING (xorb_hash)
+                 WHERE lease.recipe_hash IN ({placeholders})
+                 ORDER BY lease.recipe_hash, payload.xorb_hash"
+            );
+            let mut statement = self.conn.prepare_cached(&sql).map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare recipe prepared xorb batch: {error}"
+                ))
+            })?;
+            let mapped = statement
+                .query_map(
+                    params_from_iter(batch.iter().map(|hash| hash.as_slice())),
+                    |row| {
+                        Ok((
+                            row.get::<_, Vec<u8>>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, Vec<u8>>(2)?,
+                            row.get::<_, i64>(3)?,
+                        ))
+                    },
+                )
+                .map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to query recipe prepared xorbs: {error}"
+                    ))
+                })?;
+            for row in mapped {
+                let (recipe_hash, xorb_hash, payload_hash, bytes) = row.map_err(|error| {
+                    StagingError::Internal(format!("failed to read recipe prepared xorb: {error}"))
+                })?;
+                let recipe_hash =
+                    decode_hash_blob("recipe prepared xorb recipe hash", recipe_hash)?;
+                let xorb_hash = decode_hash_blob("recipe prepared xorb hash", xorb_hash)?;
+                if seen.insert((recipe_hash, xorb_hash)) {
+                    rows.push((
+                        recipe_hash,
+                        xorb_hash,
+                        decode_hash_blob("recipe prepared payload hash", payload_hash)?,
+                        nonnegative_count("recipe prepared payload bytes", bytes)?,
+                    ));
+                }
+            }
+        }
+        let xorb_hashes = rows.iter().map(|(_, hash, _, _)| *hash).collect::<Vec<_>>();
+        let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
+        let mut out: HashMap<[u8; 32], Vec<StoredPreparedXorb>> = HashMap::new();
+        for (recipe_hash, xorb_hash, payload_hash, bytes) in rows {
+            out.entry(recipe_hash)
+                .or_default()
+                .push(StoredPreparedXorb {
+                    placements: placements.get(&xorb_hash).cloned().unwrap_or_default(),
+                    xorb_hash,
+                    payload_hash,
+                    bytes,
+                });
+        }
+        Ok(out)
+    }
+
     fn prepared_payload_placements_for_xorbs(
         &self,
         xorb_hashes: &[[u8; 32]],
@@ -9839,6 +9920,70 @@ mod tests {
         assert_eq!(stored[1].xorb_hash, second_xorb);
         assert_eq!(stored[1].placements.len(), 1);
         assert_eq!(stored[1].placements[0].chunk_hash, second_chunk);
+    }
+
+    #[test]
+    fn prepared_xorb_recipe_lookup_returns_grouped_authority() {
+        let idx = open_in_memory();
+        let first_recipe = test_hash(0xC1);
+        let second_recipe = test_hash(0xC2);
+        let first_xorb = test_hash(0xD1);
+        let second_xorb = test_hash(0xD2);
+        let first_chunk = test_hash(0xE1);
+        let second_chunk = test_hash(0xE2);
+        for (recipe_hash, xorb_hash, chunk_hash) in [
+            (first_recipe, first_xorb, first_chunk),
+            (second_recipe, second_xorb, second_chunk),
+        ] {
+            idx.conn
+                .execute(
+                    "INSERT INTO prepared_payloads (xorb_hash, payload_hash, bytes)
+                     VALUES (?1, ?2, 64)",
+                    params![xorb_hash.as_slice(), xorb_hash.as_slice()],
+                )
+                .expect("prepared payload");
+            idx.conn
+                .execute(
+                    "INSERT INTO prepared_leases (recipe_hash, xorb_hash) VALUES (?1, ?2)",
+                    params![recipe_hash.as_slice(), xorb_hash.as_slice()],
+                )
+                .expect("prepared lease");
+            idx.conn
+                .execute(
+                    "INSERT INTO prepared_payload_chunks
+                     (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
+                     VALUES (?1, 0, ?2, 32)",
+                    params![xorb_hash.as_slice(), chunk_hash.as_slice()],
+                )
+                .expect("prepared placement");
+        }
+        idx.conn
+            .execute(
+                "INSERT INTO prepared_leases (recipe_hash, xorb_hash) VALUES (?1, ?2)",
+                params![second_recipe.as_slice(), first_xorb.as_slice()],
+            )
+            .expect("shared prepared lease");
+
+        let grouped = idx
+            .prepared_xorbs_for_recipes(&[first_recipe, second_recipe, first_recipe])
+            .expect("prepared recipe lookup");
+        assert_eq!(grouped.len(), 2);
+        assert_eq!(grouped[&first_recipe][0].xorb_hash, first_xorb);
+        assert_eq!(
+            grouped[&first_recipe][0].placements[0].chunk_hash,
+            first_chunk
+        );
+        assert_eq!(grouped[&second_recipe].len(), 2);
+        assert_eq!(grouped[&second_recipe][0].xorb_hash, first_xorb);
+        assert_eq!(
+            grouped[&second_recipe][0].placements[0].chunk_hash,
+            first_chunk
+        );
+        assert_eq!(grouped[&second_recipe][1].xorb_hash, second_xorb);
+        assert_eq!(
+            grouped[&second_recipe][0].placements[0].chunk_hash,
+            second_chunk
+        );
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -222,7 +222,7 @@ pub(crate) struct StoredPublicationIntent {
 pub(crate) type BatchDedupExisting = (usize, [u8; 32], ChunkLocator, bool);
 pub(crate) type BatchDedupResult = (Vec<BatchDedupExisting>, Vec<usize>);
 
-const PREPARED_XORB_QUERY_CHUNK_BATCH: usize = 500;
+const PREPARED_XORB_QUERY_BATCH: usize = 500;
 
 /// Per-file staging information returned by [`Index::list_files_with_chunks`].
 #[derive(Debug, Clone)]
@@ -6363,8 +6363,8 @@ impl Index {
         }
 
         let mut seen = std::collections::HashSet::new();
-        let mut out = Vec::new();
-        for batch in chunk_hashes.chunks(PREPARED_XORB_QUERY_CHUNK_BATCH) {
+        let mut rows = Vec::new();
+        for batch in chunk_hashes.chunks(PREPARED_XORB_QUERY_BATCH) {
             let placeholders = vec!["?"; batch.len()].join(",");
             let sql = format!(
                 "SELECT DISTINCT px.xorb_hash, px.payload_hash, px.bytes
@@ -6396,16 +6396,25 @@ impl Index {
                 if !seen.insert(xorb_hash) {
                     continue;
                 }
-                out.push(StoredPreparedXorb {
+                rows.push((
                     xorb_hash,
-                    payload_hash: decode_hash_blob("prepared xorb payload hash", payload_hash)?,
-                    bytes: nonnegative_count("prepared xorb bytes", bytes)?,
-                    placements: self.prepared_payload_placements(&xorb_hash)?,
-                });
+                    decode_hash_blob("prepared xorb payload hash", payload_hash)?,
+                    nonnegative_count("prepared xorb bytes", bytes)?,
+                ));
             }
         }
 
-        Ok(out)
+        let xorb_hashes = rows.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>();
+        let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
+        Ok(rows
+            .into_iter()
+            .map(|(xorb_hash, payload_hash, bytes)| StoredPreparedXorb {
+                placements: placements.remove(&xorb_hash).unwrap_or_default(),
+                xorb_hash,
+                payload_hash,
+                bytes,
+            })
+            .collect())
     }
 
     pub fn prepared_payload_exclusive_to_recipe(
@@ -6518,50 +6527,73 @@ impl Index {
             })?;
         drop(statement);
 
-        let mut out = Vec::with_capacity(rows.len());
-        for (xorb_hash, payload_hash, bytes) in rows {
-            let xorb_hash = decode_hash_blob("recipe prepared xorb hash", xorb_hash)?;
-            out.push(StoredPreparedXorb {
-                xorb_hash,
-                payload_hash: decode_hash_blob("recipe prepared payload hash", payload_hash)?,
-                bytes: nonnegative_count("recipe prepared payload bytes", bytes)?,
-                placements: self.prepared_payload_placements(&xorb_hash)?,
-            });
-        }
-        Ok(out)
-    }
-
-    fn prepared_payload_placements(
-        &self,
-        xorb_hash: &[u8; 32],
-    ) -> Result<Vec<PreparedXorbPlacementWrite>> {
-        let mut statement = self
-            .conn
-            .prepare_cached(
-                "SELECT chunk_hash, chunk_index, uncompressed_size
-                 FROM prepared_payload_chunks
-                 WHERE xorb_hash = ?1
-                 ORDER BY chunk_index",
-            )
-            .map_err(|error| {
-                StagingError::Internal(format!("failed to prepare payload placements: {error}"))
-            })?;
-        statement
-            .query_map(params![xorb_hash.as_slice()], |row| {
+        let rows = rows
+            .into_iter()
+            .map(|(xorb_hash, payload_hash, bytes)| {
                 Ok((
-                    row.get::<_, Vec<u8>>(0)?,
-                    row.get::<_, i64>(1)?,
-                    row.get::<_, i64>(2)?,
+                    decode_hash_blob("recipe prepared xorb hash", xorb_hash)?,
+                    decode_hash_blob("recipe prepared payload hash", payload_hash)?,
+                    nonnegative_count("recipe prepared payload bytes", bytes)?,
                 ))
             })
-            .map_err(|error| {
-                StagingError::Internal(format!("failed to query payload placements: {error}"))
-            })?
-            .map(|row| {
-                let (chunk_hash, chunk_index, uncompressed_size) = row.map_err(|error| {
-                    StagingError::Internal(format!("failed to read payload placement: {error}"))
+            .collect::<Result<Vec<_>>>()?;
+        let xorb_hashes = rows.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>();
+        let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
+        Ok(rows
+            .into_iter()
+            .map(|(xorb_hash, payload_hash, bytes)| StoredPreparedXorb {
+                placements: placements.remove(&xorb_hash).unwrap_or_default(),
+                xorb_hash,
+                payload_hash,
+                bytes,
+            })
+            .collect())
+    }
+
+    fn prepared_payload_placements_for_xorbs(
+        &self,
+        xorb_hashes: &[[u8; 32]],
+    ) -> Result<HashMap<[u8; 32], Vec<PreparedXorbPlacementWrite>>> {
+        let mut placements = HashMap::with_capacity(xorb_hashes.len());
+        for batch in xorb_hashes.chunks(PREPARED_XORB_QUERY_BATCH) {
+            let placeholders = vec!["?"; batch.len()].join(",");
+            let sql = format!(
+                "SELECT xorb_hash, chunk_hash, chunk_index, uncompressed_size
+                 FROM prepared_payload_chunks
+                 WHERE xorb_hash IN ({placeholders})
+                 ORDER BY xorb_hash, chunk_index"
+            );
+            let mut statement = self.conn.prepare(&sql).map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare batched payload placements: {error}"
+                ))
+            })?;
+            let rows = statement
+                .query_map(
+                    params_from_iter(batch.iter().map(|hash| hash.as_slice())),
+                    |row| {
+                        Ok((
+                            row.get::<_, Vec<u8>>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                        ))
+                    },
+                )
+                .map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to query batched payload placements: {error}"
+                    ))
                 })?;
-                Ok(PreparedXorbPlacementWrite {
+            for row in rows {
+                let (xorb_hash, chunk_hash, chunk_index, uncompressed_size) =
+                    row.map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to read batched payload placement: {error}"
+                        ))
+                    })?;
+                let xorb_hash = decode_hash_blob("prepared placement xorb hash", xorb_hash)?;
+                let placement = PreparedXorbPlacementWrite {
                     chunk_hash: decode_hash_blob("prepared placement chunk hash", chunk_hash)?,
                     chunk_index: u32::try_from(chunk_index).map_err(|_| {
                         StagingError::StagingCorrupt(
@@ -6573,9 +6605,11 @@ impl Index {
                             "prepared placement size is invalid".to_owned(),
                         )
                     })?,
-                })
-            })
-            .collect()
+                };
+                placements.entry(xorb_hash).or_default().push(placement);
+            }
+        }
+        Ok(placements)
     }
 
     /// Insert chunk rows for a file, linking them to their segment locators.
@@ -9033,6 +9067,43 @@ mod tests {
             )
             .expect("remaining ownership rows");
         assert_eq!(remaining, (0, 0, 0, 0));
+    }
+
+    #[test]
+    fn prepared_xorb_chunk_lookup_returns_batched_placements() {
+        let idx = open_in_memory();
+        let first_xorb = test_hash(0xA1);
+        let second_xorb = test_hash(0xA2);
+        let first_chunk = test_hash(0xB1);
+        let second_chunk = test_hash(0xB2);
+        for (xorb_hash, chunk_hash) in [(first_xorb, first_chunk), (second_xorb, second_chunk)] {
+            idx.conn
+                .execute(
+                    "INSERT INTO prepared_payloads (xorb_hash, payload_hash, bytes)
+                     VALUES (?1, ?2, 64)",
+                    params![xorb_hash.as_slice(), xorb_hash.as_slice()],
+                )
+                .expect("prepared payload");
+            idx.conn
+                .execute(
+                    "INSERT INTO prepared_payload_chunks
+                     (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
+                     VALUES (?1, 0, ?2, 32)",
+                    params![xorb_hash.as_slice(), chunk_hash.as_slice()],
+                )
+                .expect("prepared placement");
+        }
+
+        let stored = idx
+            .prepared_xorbs_for_chunks(&[first_chunk, second_chunk])
+            .expect("prepared xorb lookup");
+        assert_eq!(stored.len(), 2);
+        assert_eq!(stored[0].xorb_hash, first_xorb);
+        assert_eq!(stored[0].placements.len(), 1);
+        assert_eq!(stored[0].placements[0].chunk_hash, first_chunk);
+        assert_eq!(stored[1].xorb_hash, second_xorb);
+        assert_eq!(stored[1].placements.len(), 1);
+        assert_eq!(stored[1].placements[0].chunk_hash, second_chunk);
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -11031,7 +11031,7 @@ mod tests {
             origin_proof_id: test_hash(0xEA),
         };
 
-        idx.append_recording_batch("remote-batch", 0, 0, &[], &[authority])
+        idx.append_recording_batch("remote-batch", 0, 0, &[], std::slice::from_ref(&authority))
             .expect("initial authority");
         assert_staging_corrupt_contains(
             idx.append_recording_batch(
@@ -11070,7 +11070,7 @@ mod tests {
             0,
             0,
             &[(crab_xet::hash::MerkleHash::from(first_hash), 8)],
-            &[first_authority],
+            std::slice::from_ref(&first_authority),
         )
         .expect("combined recording append");
 
@@ -11089,7 +11089,7 @@ mod tests {
                 9,
                 8,
                 &[(crab_xet::hash::MerkleHash::from(second_hash), 8)],
-                &[second_authority],
+                std::slice::from_ref(&second_authority),
             ),
             "not contiguous",
         );

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -4271,6 +4271,8 @@ impl Index {
                 StagingError::Internal(format!("failed to query recipe page terms: {e}"))
             })?;
         let mut chunks = Vec::with_capacity(occurrence_count as usize);
+        let mut page_hasher =
+            crate::recipe::page_hasher(start_occurrence, start_offset, occurrence_count as usize)?;
         let mut expected_occurrence = start_occurrence;
         let mut expected_offset = start_offset;
         for row in rows {
@@ -4289,6 +4291,7 @@ impl Index {
                 "recipe occurrence hash",
                 raw_hash,
             )?);
+            crate::recipe::update_sequence_hasher(&mut page_hasher, chunk_hash, size);
             chunks.push(crab_diff::chunk_sequence::ChunkSpan {
                 chunk_hash,
                 offset: expected_offset,
@@ -4312,13 +4315,7 @@ impl Index {
                 "recipe page coverage does not match its metadata".to_owned(),
             ));
         }
-        let page_terms = chunks
-            .iter()
-            .map(|chunk| (chunk.chunk_hash, chunk.len))
-            .collect::<Vec<_>>();
-        if crate::recipe::page_hash(start_occurrence, start_offset, &page_terms)?
-            != stored_page_hash
-        {
+        if *page_hasher.finalize().as_bytes() != stored_page_hash {
             return Err(StagingError::StagingCorrupt(
                 "recipe page digest does not match its terms".to_owned(),
             ));

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2378,52 +2378,105 @@ impl Index {
                 path: format!("recording add preparation {preparation_id}/{owner_batch_id}"),
             });
         }
+        if payloads.is_empty() {
+            tx.commit().map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to commit empty prepared payload seal: {error}"
+                ))
+            })?;
+            return Ok(());
+        }
+
+        let mut payload_insert = tx
+            .prepare_cached(
+                "INSERT OR IGNORE INTO prepared_payloads
+                 (xorb_hash, payload_hash, bytes) VALUES (?1, ?2, ?3)",
+            )
+            .map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare prepared payload insert: {error}"
+                ))
+            })?;
+        let mut payload_verify = tx
+            .prepare_cached(
+                "SELECT payload_hash = ?2 AND bytes = ?3
+                 FROM prepared_payloads WHERE xorb_hash = ?1",
+            )
+            .map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare prepared payload verification: {error}"
+                ))
+            })?;
+        let mut preparation_payload_insert = tx
+            .prepare_cached(
+                "INSERT OR IGNORE INTO preparation_payloads (preparation_id, xorb_hash)
+                 VALUES (?1, ?2)",
+            )
+            .map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare preparation payload retention: {error}"
+                ))
+            })?;
+        let mut claim_query = tx
+            .prepare_cached(
+                "SELECT preparation_id, owner_batch_id, uncompressed_size
+                 FROM prepared_chunk_claims WHERE chunk_hash = ?1",
+            )
+            .map_err(|error| {
+                StagingError::Internal(format!("failed to prepare payload claim lookup: {error}"))
+            })?;
+        let mut placement_insert = tx
+            .prepare_cached(
+                "INSERT INTO prepared_payload_chunks
+                 (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
+                 VALUES (?1, ?2, ?3, ?4)",
+            )
+            .map_err(|error| {
+                StagingError::Internal(format!(
+                    "failed to prepare prepared payload placement insert: {error}"
+                ))
+            })?;
+        let mut claim_delete = tx
+            .prepare_cached("DELETE FROM prepared_chunk_claims WHERE chunk_hash = ?1")
+            .map_err(|error| {
+                StagingError::Internal(format!("failed to prepare payload claim removal: {error}"))
+            })?;
 
         for payload in payloads {
             let xorb_hash = payload.xorb_hash.as_slice();
             let payload_hash = payload.payload_hash.as_slice();
             let bytes = sqlite_i64("prepared payload bytes", payload.bytes)?;
-            tx.execute(
-                "INSERT OR IGNORE INTO prepared_payloads
-                 (xorb_hash, payload_hash, bytes) VALUES (?1, ?2, ?3)",
-                params![xorb_hash, payload_hash, bytes],
-            )
-            .map_err(|error| {
-                StagingError::Internal(format!("failed to register prepared payload: {error}"))
-            })?;
-            let matches: bool = tx
-                .query_row(
-                    "SELECT payload_hash = ?2 AND bytes = ?3
-                     FROM prepared_payloads WHERE xorb_hash = ?1",
-                    params![xorb_hash, payload_hash, bytes],
-                    |row| row.get(0),
-                )
+            let inserted = payload_insert
+                .execute(params![xorb_hash, payload_hash, bytes])
                 .map_err(|error| {
-                    StagingError::Internal(format!("failed to verify prepared payload: {error}"))
+                    StagingError::Internal(format!("failed to register prepared payload: {error}"))
                 })?;
-            if !matches {
-                return Err(StagingError::StagingCorrupt(format!(
-                    "prepared payload identity collision for {}",
-                    crab_xet::hash::MerkleHash::from(payload.xorb_hash).hex()
-                )));
+            if inserted == 0 {
+                let matches: bool = payload_verify
+                    .query_row(params![xorb_hash, payload_hash, bytes], |row| row.get(0))
+                    .map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to verify prepared payload: {error}"
+                        ))
+                    })?;
+                if !matches {
+                    return Err(StagingError::StagingCorrupt(format!(
+                        "prepared payload identity collision for {}",
+                        crab_xet::hash::MerkleHash::from(payload.xorb_hash).hex()
+                    )));
+                }
             }
-            tx.execute(
-                "INSERT OR IGNORE INTO preparation_payloads (preparation_id, xorb_hash)
-                 VALUES (?1, ?2)",
-                params![preparation_id, xorb_hash],
-            )
-            .map_err(|error| {
-                StagingError::Internal(format!("failed to retain preparation payload: {error}"))
-            })?;
+            preparation_payload_insert
+                .execute(params![preparation_id, xorb_hash])
+                .map_err(|error| {
+                    StagingError::Internal(format!("failed to retain preparation payload: {error}"))
+                })?;
 
             for placement in &payload.placements {
-                let claim: Option<(String, String, i64)> = tx
-                    .query_row(
-                        "SELECT preparation_id, owner_batch_id, uncompressed_size
-                         FROM prepared_chunk_claims WHERE chunk_hash = ?1",
-                        params![placement.chunk_hash.as_slice()],
-                        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-                    )
+                let claim: Option<(String, String, i64)> = claim_query
+                    .query_row(params![placement.chunk_hash.as_slice()], |row| {
+                        Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                    })
                     .optional()
                     .map_err(|error| {
                         StagingError::Internal(format!("failed to inspect payload claim: {error}"))
@@ -2443,32 +2496,32 @@ impl Index {
                         crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
                     )));
                 }
-                tx.execute(
-                    "INSERT INTO prepared_payload_chunks
-                     (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
-                     VALUES (?1, ?2, ?3, ?4)",
-                    params![
+                placement_insert
+                    .execute(params![
                         xorb_hash,
                         i64::from(placement.chunk_index),
                         placement.chunk_hash.as_slice(),
                         i64::from(placement.uncompressed_size),
-                    ],
-                )
-                .map_err(|error| {
-                    StagingError::StagingCorrupt(format!(
-                        "failed to install canonical prepared placement for {}: {error}",
-                        crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
-                    ))
-                })?;
-                tx.execute(
-                    "DELETE FROM prepared_chunk_claims WHERE chunk_hash = ?1",
-                    params![placement.chunk_hash.as_slice()],
-                )
-                .map_err(|error| {
-                    StagingError::Internal(format!("failed to resolve prepared claim: {error}"))
-                })?;
+                    ])
+                    .map_err(|error| {
+                        StagingError::StagingCorrupt(format!(
+                            "failed to install canonical prepared placement for {}: {error}",
+                            crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
+                        ))
+                    })?;
+                claim_delete
+                    .execute(params![placement.chunk_hash.as_slice()])
+                    .map_err(|error| {
+                        StagingError::Internal(format!("failed to resolve prepared claim: {error}"))
+                    })?;
             }
         }
+        drop(payload_insert);
+        drop(payload_verify);
+        drop(preparation_payload_insert);
+        drop(claim_query);
+        drop(placement_insert);
+        drop(claim_delete);
         tx.commit().map_err(|error| {
             StagingError::Internal(format!("failed to commit prepared payload seal: {error}"))
         })?;

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -293,6 +293,33 @@ fn validate_chunk_index(expected: usize, actual: i64) -> Result<()> {
     Ok(())
 }
 
+fn ensure_recording_batch_open(
+    tx: &rusqlite::Transaction<'_>,
+    batch_id: &str,
+    operation: &str,
+) -> Result<()> {
+    let batch_is_open: bool = tx
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM staging_batches
+                WHERE batch_id = ?1 AND state = 'open'
+             )",
+            params![batch_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| {
+            StagingError::Internal(format!(
+                "failed to inspect {operation} recording batch: {error}"
+            ))
+        })?;
+    if batch_is_open {
+        return Ok(());
+    }
+    Err(StagingError::NotFound {
+        path: format!("open staging batch {batch_id}"),
+    })
+}
+
 fn publication_intent_batch_ids(
     tx: &rusqlite::Transaction<'_>,
     intent_id: &str,
@@ -2894,23 +2921,27 @@ impl Index {
         let tx = self.conn.unchecked_transaction().map_err(|e| {
             StagingError::Internal(format!("failed to begin recipe recording append: {e}"))
         })?;
-        let batch_is_open: bool = tx
-            .query_row(
-                "SELECT EXISTS(
-                    SELECT 1 FROM staging_batches
-                    WHERE batch_id = ?1 AND state = 'open'
-                 )",
-                params![batch_id],
-                |row| row.get(0),
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to inspect recipe recording batch: {e}"))
-            })?;
-        if !batch_is_open {
-            return Err(StagingError::NotFound {
-                path: format!("open staging batch {batch_id}"),
-            });
-        }
+        ensure_recording_batch_open(&tx, batch_id, "recipe")?;
+        Self::append_recipe_recording_terms_in_tx(
+            &tx,
+            batch_id,
+            start_occurrence,
+            start_offset,
+            chunks,
+        )?;
+        tx.commit().map_err(|e| {
+            StagingError::Internal(format!("failed to commit recipe recording append: {e}"))
+        })?;
+        Ok(())
+    }
+
+    fn append_recipe_recording_terms_in_tx(
+        tx: &rusqlite::Transaction<'_>,
+        batch_id: &str,
+        start_occurrence: u64,
+        start_offset: u64,
+        chunks: &[(crab_xet::hash::MerkleHash, u64)],
+    ) -> Result<()> {
         let (stored_count, stored_end): (i64, Option<i64>) = tx
             .query_row(
                 "SELECT COUNT(*), MAX(chunk_offset + chunk_size)
@@ -2981,9 +3012,6 @@ impl Index {
             })?;
             drop(statement);
         }
-        tx.commit().map_err(|e| {
-            StagingError::Internal(format!("failed to commit recipe recording append: {e}"))
-        })?;
         Ok(())
     }
 
@@ -3006,23 +3034,18 @@ impl Index {
         let tx = self.conn.unchecked_transaction().map_err(|error| {
             StagingError::Internal(format!("failed to begin remote authority append: {error}"))
         })?;
-        let batch_is_open: bool = tx
-            .query_row(
-                "SELECT EXISTS(
-                    SELECT 1 FROM staging_batches
-                    WHERE batch_id = ?1 AND state = 'open'
-                 )",
-                params![batch_id],
-                |row| row.get(0),
-            )
-            .map_err(|error| {
-                StagingError::Internal(format!("failed to inspect remote authority batch: {error}"))
-            })?;
-        if !batch_is_open {
-            return Err(StagingError::NotFound {
-                path: format!("open staging batch {batch_id}"),
-            });
-        }
+        ensure_recording_batch_open(&tx, batch_id, "remote authority")?;
+        Self::append_recording_remote_chunks_in_tx(&tx, batch_id, chunks)?;
+        tx.commit().map_err(|error| {
+            StagingError::Internal(format!("failed to commit remote authority append: {error}"))
+        })
+    }
+
+    fn append_recording_remote_chunks_in_tx(
+        tx: &rusqlite::Transaction<'_>,
+        batch_id: &str,
+        chunks: &[ExistingChunkWrite],
+    ) -> Result<()> {
         // Seven parameters per row stay below SQLite's default limit.
         const REMOTE_AUTHORITY_BATCH: usize = 128;
         for batch in chunks.chunks(REMOTE_AUTHORITY_BATCH) {
@@ -3170,8 +3193,49 @@ impl Index {
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Atomically append recipe terms and their proof-bearing remote authorities.
+    pub fn append_recording_batch(
+        &self,
+        batch_id: &str,
+        start_occurrence: u64,
+        start_offset: u64,
+        recipe_chunks: &[(crab_xet::hash::MerkleHash, u64)],
+        remote_chunks: &[ExistingChunkWrite],
+    ) -> Result<()> {
+        if recipe_chunks.is_empty() && remote_chunks.is_empty() {
+            return Ok(());
+        }
+        if recipe_chunks.len() > super::stream::STAGE_BATCH_CHUNKS {
+            return Err(StagingError::StagingCorrupt(format!(
+                "recipe recording append has {} terms, limit is {}",
+                recipe_chunks.len(),
+                super::stream::STAGE_BATCH_CHUNKS
+            )));
+        }
+        if remote_chunks.len() > super::stream::STAGE_BATCH_CHUNKS {
+            return Err(StagingError::StagingCorrupt(format!(
+                "remote authority append has {} terms, limit is {}",
+                remote_chunks.len(),
+                super::stream::STAGE_BATCH_CHUNKS
+            )));
+        }
+        let tx = self.conn.unchecked_transaction().map_err(|error| {
+            StagingError::Internal(format!("failed to begin recording batch append: {error}"))
+        })?;
+        ensure_recording_batch_open(&tx, batch_id, "combined")?;
+        Self::append_recording_remote_chunks_in_tx(&tx, batch_id, remote_chunks)?;
+        Self::append_recipe_recording_terms_in_tx(
+            &tx,
+            batch_id,
+            start_occurrence,
+            start_offset,
+            recipe_chunks,
+        )?;
         tx.commit().map_err(|error| {
-            StagingError::Internal(format!("failed to commit remote authority append: {error}"))
+            StagingError::Internal(format!("failed to commit recording batch append: {error}"))
         })
     }
 
@@ -10713,6 +10777,56 @@ mod tests {
             ),
             "changed within one add",
         );
+    }
+
+    #[test]
+    fn recording_batch_commits_recipe_and_remote_authority_atomically() {
+        let idx = open_in_memory();
+        idx.insert_batch("combined-batch").expect("batch");
+        let first_hash = test_hash(0xF3);
+        let first_authority = ExistingChunkWrite {
+            chunk_hash: first_hash,
+            xorb_hash: test_hash(0xF4),
+            chunk_index: 0,
+            uncompressed_size: 8,
+            placement_id: test_hash(0xF5),
+            origin_proof_id: test_hash(0xF6),
+        };
+        idx.append_recording_batch(
+            "combined-batch",
+            0,
+            0,
+            &[(crab_xet::hash::MerkleHash::from(first_hash), 8)],
+            &[first_authority],
+        )
+        .expect("combined recording append");
+
+        let second_hash = test_hash(0xF7);
+        let second_authority = ExistingChunkWrite {
+            chunk_hash: second_hash,
+            ..first_authority
+        };
+        assert_staging_corrupt_contains(
+            idx.append_recording_batch(
+                "combined-batch",
+                9,
+                8,
+                &[(crab_xet::hash::MerkleHash::from(second_hash), 8)],
+                &[second_authority],
+            ),
+            "not contiguous",
+        );
+        let counts: (i64, i64) = idx
+            .conn
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM recipe_recording_terms),
+                    (SELECT COUNT(*) FROM recording_remote_chunks)",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("combined recording counts");
+        assert_eq!(counts, (1, 1));
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6906,6 +6906,20 @@ impl Index {
             .ok_or_else(|| {
                 StagingError::StagingCorrupt("remote authority page range overflow".to_owned())
             })?;
+        self.recipe_remote_chunk_range(recipe_hash, start_occurrence, end_occurrence)
+    }
+
+    pub fn recipe_remote_chunk_range(
+        &self,
+        recipe_hash: &[u8; 32],
+        start_occurrence: u64,
+        end_occurrence: u64,
+    ) -> Result<Vec<ExistingChunkWrite>> {
+        if end_occurrence < start_occurrence {
+            return Err(StagingError::StagingCorrupt(
+                "remote authority range ends before it starts".to_owned(),
+            ));
+        }
         let start_occurrence = i64::try_from(start_occurrence).map_err(|_| {
             StagingError::StagingCorrupt("remote authority page start is too large".to_owned())
         })?;
@@ -6949,7 +6963,9 @@ impl Index {
             .map_err(|error| {
                 StagingError::Internal(format!("failed to query recipe remote authority: {error}"))
             })?;
-        let mut out = Vec::with_capacity(crate::recipe::RECIPE_PAGE_ENTRIES);
+        let capacity = usize::try_from(end_occurrence.saturating_sub(start_occurrence))
+            .unwrap_or(crate::recipe::RECIPE_PAGE_ENTRIES);
+        let mut out = Vec::with_capacity(capacity);
         for row in rows {
             let (
                 chunk_hash,

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -5,7 +5,7 @@
 //! `rusqlite::Connection` in WAL mode with foreign key enforcement.
 
 use rusqlite::{Connection, OptionalExtension, ToSql, params, params_from_iter};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use tracing::debug;
 
@@ -6067,6 +6067,50 @@ impl Index {
             })
     }
 
+    /// Return the requested chunk hashes whose exact payload size is staged.
+    pub fn chunk_payloads_exist(&self, chunks: &[([u8; 32], u64)]) -> Result<HashSet<[u8; 32]>> {
+        if chunks.is_empty() {
+            return Ok(HashSet::new());
+        }
+        const LOOKUP_BATCH_SIZE: usize = 512;
+        let mut found = HashSet::new();
+        for batch in chunks.chunks(LOOKUP_BATCH_SIZE) {
+            let expected = batch.iter().copied().collect::<HashMap<_, _>>();
+            let placeholders = std::iter::repeat_n("?", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query = format!(
+                "SELECT chunk_hash, size FROM chunk_payloads WHERE chunk_hash IN ({placeholders})"
+            );
+            let mut statement = self.conn.prepare_cached(&query).map_err(|error| {
+                StagingError::Internal(format!("failed to prepare staged payload lookup: {error}"))
+            })?;
+            let hashes = batch.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
+            let rows = statement
+                .query_map(
+                    params_from_iter(hashes.iter().map(|hash| hash.as_slice())),
+                    |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?)),
+                )
+                .map_err(|error| {
+                    StagingError::Internal(format!("failed to query staged payloads: {error}"))
+                })?;
+            for row in rows {
+                let (hash, size) = row.map_err(|error| {
+                    StagingError::Internal(format!("failed to read staged payload row: {error}"))
+                })?;
+                let hash = decode_hash_blob("staged payload chunk hash", hash)?;
+                let size = nonnegative_count("staged payload size", size)?;
+                if expected
+                    .get(&hash)
+                    .is_some_and(|expected_size| *expected_size == size)
+                {
+                    found.insert(hash);
+                }
+            }
+        }
+        Ok(found)
+    }
+
     /// Replace one recipe's normalized remote and prepared authority.
     pub fn insert_file_push_plan(&self, write: FilePushPlanWrite<'_>) -> Result<Vec<[u8; 32]>> {
         self.insert_file_push_plans(std::slice::from_ref(&write))
@@ -9703,6 +9747,37 @@ mod tests {
             idx.chunks_for_file(&fh).expect("chunks"),
             vec![test_hash(0xC4)]
         );
+    }
+
+    #[test]
+    fn chunk_payload_batch_lookup_checks_exact_sizes() {
+        let idx = open_in_memory();
+        let requested = (0..600_u16)
+            .map(|index| {
+                let mut hash = [0; 32];
+                hash[..2].copy_from_slice(&index.to_le_bytes());
+                let size = u64::from(index) + 1;
+                idx.conn
+                    .execute(
+                        "INSERT INTO chunk_payloads
+                         (chunk_hash, size, segment_id, segment_offset)
+                         VALUES (?1, ?2, ?3, ?4)",
+                        params![hash.as_slice(), size as i64, 1_i64, index as i64],
+                    )
+                    .expect("insert payload");
+                (hash, size)
+            })
+            .collect::<Vec<_>>();
+        let mut requested = requested;
+        requested[0].1 += 1;
+
+        let found = idx
+            .chunk_payloads_exist(&requested)
+            .expect("batch payload lookup");
+
+        assert_eq!(found.len(), 599);
+        assert!(!found.contains(&requested[0].0));
+        assert!(requested[1..].iter().all(|(hash, _)| found.contains(hash)));
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2417,14 +2417,6 @@ impl Index {
                     "failed to prepare preparation payload retention: {error}"
                 ))
             })?;
-        let mut claim_query = tx
-            .prepare_cached(
-                "SELECT preparation_id, owner_batch_id, uncompressed_size
-                 FROM prepared_chunk_claims WHERE chunk_hash = ?1",
-            )
-            .map_err(|error| {
-                StagingError::Internal(format!("failed to prepare payload claim lookup: {error}"))
-            })?;
         let mut placement_insert = tx
             .prepare_cached(
                 "INSERT INTO prepared_payload_chunks
@@ -2443,6 +2435,55 @@ impl Index {
             })?;
 
         for payload in payloads {
+            let mut claim_keys = HashMap::<[u8; 32], ()>::with_capacity(payload.placements.len());
+            for placement in &payload.placements {
+                claim_keys.insert(placement.chunk_hash, ());
+            }
+            let claim_hashes = claim_keys.keys().copied().collect::<Vec<_>>();
+            let mut claims =
+                HashMap::<[u8; 32], (String, String, i64)>::with_capacity(claim_hashes.len());
+            // Keep the IN-list below SQLite's default bound-parameter limit.
+            const CLAIM_BATCH_SIZE: usize = 512;
+            for batch in claim_hashes.chunks(CLAIM_BATCH_SIZE) {
+                let placeholders = vec!["?"; batch.len()].join(",");
+                let sql = format!(
+                    "SELECT chunk_hash, preparation_id, owner_batch_id, uncompressed_size
+                     FROM prepared_chunk_claims WHERE chunk_hash IN ({placeholders})"
+                );
+                let mut statement = tx.prepare_cached(&sql).map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to prepare payload claim batch: {error}"
+                    ))
+                })?;
+                let rows = statement
+                    .query_map(
+                        params_from_iter(batch.iter().map(|hash| hash.as_slice())),
+                        |row| {
+                            Ok((
+                                row.get::<_, Vec<u8>>(0)?,
+                                row.get::<_, String>(1)?,
+                                row.get::<_, String>(2)?,
+                                row.get::<_, i64>(3)?,
+                            ))
+                        },
+                    )
+                    .map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to query payload claim batch: {error}"
+                        ))
+                    })?;
+                for row in rows {
+                    let (chunk_hash, preparation, owner, size) = row.map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to read payload claim batch: {error}"
+                        ))
+                    })?;
+                    let chunk_hash =
+                        decode_hash_blob("prepared payload claim chunk hash", chunk_hash)?;
+                    claims.insert(chunk_hash, (preparation, owner, size));
+                }
+            }
+
             let xorb_hash = payload.xorb_hash.as_slice();
             let payload_hash = payload.payload_hash.as_slice();
             let bytes = sqlite_i64("prepared payload bytes", payload.bytes)?;
@@ -2473,23 +2514,15 @@ impl Index {
                 })?;
 
             for placement in &payload.placements {
-                let claim: Option<(String, String, i64)> = claim_query
-                    .query_row(params![placement.chunk_hash.as_slice()], |row| {
-                        Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-                    })
-                    .optional()
-                    .map_err(|error| {
-                        StagingError::Internal(format!("failed to inspect payload claim: {error}"))
-                    })?;
-                let Some((claim_preparation, claim_owner, claim_size)) = claim else {
+                let Some(claim) = claims.get(&placement.chunk_hash) else {
                     return Err(StagingError::StagingCorrupt(format!(
                         "prepared payload chunk {} has no ownership claim",
                         crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
                     )));
                 };
-                if claim_preparation != preparation_id
-                    || claim_owner != owner_batch_id
-                    || claim_size != i64::from(placement.uncompressed_size)
+                if claim.0 != preparation_id
+                    || claim.1 != owner_batch_id
+                    || claim.2 != i64::from(placement.uncompressed_size)
                 {
                     return Err(StagingError::StagingCorrupt(format!(
                         "prepared payload chunk {} escaped its ownership claim",
@@ -2514,12 +2547,12 @@ impl Index {
                     .map_err(|error| {
                         StagingError::Internal(format!("failed to resolve prepared claim: {error}"))
                     })?;
+                claims.remove(&placement.chunk_hash);
             }
         }
         drop(payload_insert);
         drop(payload_verify);
         drop(preparation_payload_insert);
-        drop(claim_query);
         drop(placement_insert);
         drop(claim_delete);
         tx.commit().map_err(|error| {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -103,6 +103,14 @@ const RECIPE_REMOTE_CHUNK_COLUMNS: &[&str] = &[
     "origin_proof_id",
 ];
 
+const STAGING_BATCH_COLUMNS: &[&str] = &[
+    "batch_id",
+    "state",
+    "recording_term_count",
+    "recording_byte_size",
+    "created_at",
+];
+
 /// A row staged in `pending_chunks` before the segment is fsynced.
 ///
 /// Hashes are stored as raw 32-byte arrays to avoid heap-allocated hex
@@ -560,6 +568,14 @@ impl Index {
             {
                 return Err(retired_staging_schema());
             }
+            if self
+                .table_columns("staging_batches")?
+                .iter()
+                .map(String::as_str)
+                .ne(STAGING_BATCH_COLUMNS.iter().copied())
+            {
+                return Err(retired_staging_schema());
+            }
             let version: Option<String> = self
                 .conn
                 .query_row(
@@ -722,9 +738,11 @@ impl Index {
                     ON recipe_remote_chunks(chunk_hash);
 
                 CREATE TABLE IF NOT EXISTS staging_batches (
-                    batch_id    TEXT PRIMARY KEY,
-                    state       TEXT NOT NULL CHECK(state IN ('open', 'published')),
-                    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+                    batch_id             TEXT PRIMARY KEY,
+                    state                TEXT NOT NULL CHECK(state IN ('open', 'published')),
+                    recording_term_count INTEGER NOT NULL DEFAULT 0,
+                    recording_byte_size  INTEGER NOT NULL DEFAULT 0,
+                    created_at           TEXT NOT NULL DEFAULT (datetime('now'))
                 );
 
                 CREATE TABLE IF NOT EXISTS recipe_recording_terms (
@@ -2942,10 +2960,12 @@ impl Index {
         start_offset: u64,
         chunks: &[(crab_xet::hash::MerkleHash, u64)],
     ) -> Result<()> {
-        let (stored_count, stored_end): (i64, Option<i64>) = tx
+        // Keep the recording tail on the batch row so large recordings do not
+        // rescan their term table on every bounded append.
+        let (stored_count, stored_end): (i64, i64) = tx
             .query_row(
-                "SELECT COUNT(*), MAX(chunk_offset + chunk_size)
-                 FROM recipe_recording_terms WHERE batch_id = ?1",
+                "SELECT recording_term_count, recording_byte_size
+                 FROM staging_batches WHERE batch_id = ?1 AND state = 'open'",
                 params![batch_id],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
@@ -2953,10 +2973,7 @@ impl Index {
                 StagingError::Internal(format!("failed to inspect recipe recording tail: {e}"))
             })?;
         let expected_occurrence = nonnegative_count("recipe recording count", stored_count)?;
-        let expected_offset = stored_end
-            .map(|value| nonnegative_count("recipe recording offset", value))
-            .transpose()?
-            .unwrap_or(0);
+        let expected_offset = nonnegative_count("recipe recording offset", stored_end)?;
         if start_occurrence != expected_occurrence || start_offset != expected_offset {
             return Err(StagingError::StagingCorrupt(format!(
                 "recipe recording append is not contiguous: expected occurrence {expected_occurrence} offset {expected_offset}, found occurrence {start_occurrence} offset {start_offset}"
@@ -3011,6 +3028,23 @@ impl Index {
                 StagingError::Internal(format!("failed to append recipe recording term batch: {e}"))
             })?;
             drop(statement);
+        }
+        let recording_term_count = sqlite_i64("recipe recording count", occurrence)?;
+        let recording_byte_size = sqlite_i64("recipe recording offset", offset)?;
+        let updated = tx
+            .execute(
+                "UPDATE staging_batches
+                 SET recording_term_count = ?2, recording_byte_size = ?3
+                 WHERE batch_id = ?1 AND state = 'open'",
+                params![batch_id, recording_term_count, recording_byte_size],
+            )
+            .map_err(|e| {
+                StagingError::Internal(format!("failed to update recipe recording tail: {e}"))
+            })?;
+        if updated != 1 {
+            return Err(StagingError::NotFound {
+                path: format!("open staging batch {batch_id}"),
+            });
         }
         Ok(())
     }
@@ -9416,6 +9450,22 @@ mod tests {
             occurrence += u64::try_from(page.len()).expect("page length");
             offset += page.iter().map(|(_, size)| size).sum::<u64>();
         }
+        let recording_tail: (i64, i64) = idx
+            .conn
+            .query_row(
+                "SELECT recording_term_count, recording_byte_size
+                 FROM staging_batches WHERE batch_id = 'batch-large'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("recording tail");
+        assert_eq!(
+            recording_tail,
+            (
+                i64::try_from(OCCURRENCES).expect("occurrence count"),
+                file_size
+            )
+        );
 
         idx.insert_recipe_lease(
             "batch-large",
@@ -9438,6 +9488,30 @@ mod tests {
         assert_eq!(
             counts,
             (i64::try_from(OCCURRENCES).expect("occurrence count"), 1)
+        );
+    }
+
+    #[test]
+    fn recipe_recording_rejects_corrupt_persisted_tail() {
+        let idx = open_in_memory();
+        idx.insert_batch("batch-tail").expect("batch");
+        idx.conn
+            .execute(
+                "UPDATE staging_batches
+                 SET recording_term_count = -1
+                 WHERE batch_id = 'batch-tail'",
+                [],
+            )
+            .expect("corrupt recording tail");
+
+        assert_staging_corrupt_contains(
+            idx.append_recipe_recording_terms(
+                "batch-tail",
+                0,
+                0,
+                &[(crab_xet::hash::MerkleHash::from(test_hash(0x87)), 8)],
+            ),
+            "recipe recording count is negative",
         );
     }
 

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -10372,4 +10372,31 @@ mod tests {
 
         assert!(chunks.is_empty());
     }
+
+    #[test]
+    fn recording_remote_authority_batch_rejects_conflicting_duplicate() {
+        let idx = open_in_memory();
+        idx.insert_batch("remote-batch").expect("batch");
+        let authority = ExistingChunkWrite {
+            chunk_hash: test_hash(0xE7),
+            xorb_hash: test_hash(0xE8),
+            chunk_index: 3,
+            uncompressed_size: 4096,
+            placement_id: test_hash(0xE9),
+            origin_proof_id: test_hash(0xEA),
+        };
+
+        idx.append_recording_remote_chunks("remote-batch", &[authority])
+            .expect("initial authority");
+        assert_staging_corrupt_contains(
+            idx.append_recording_remote_chunks(
+                "remote-batch",
+                &[ExistingChunkWrite {
+                    xorb_hash: test_hash(0xEB),
+                    ..authority
+                }],
+            ),
+            "changed within one add",
+        );
+    }
 }

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -1927,25 +1927,33 @@ impl Index {
             return Ok(None);
         }
 
-        let placeholders = vec!["?"; chunk_indices.len()].join(",");
-        let sql = format!(
-            "SELECT chunk_index
-             FROM pending_chunks
-             WHERE file_hash = ? AND chunk_index IN ({placeholders})
-             ORDER BY chunk_index
-             LIMIT 1"
-        );
-        let fh: &[u8] = file_hash;
-        let mut query_params: Vec<&dyn ToSql> = Vec::with_capacity(chunk_indices.len() + 1);
-        query_params.push(&fh);
-        query_params.extend(chunk_indices.iter().map(|idx| idx as &dyn ToSql));
-
-        self.conn
-            .query_row(&sql, query_params.as_slice(), |row| row.get(0))
-            .optional()
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to query pending chunk positions: {e}"))
-            })
+        const POSITION_LOOKUP_BATCH: usize = 400;
+        let mut first = None;
+        for batch in chunk_indices.chunks(POSITION_LOOKUP_BATCH) {
+            let placeholders = vec!["?"; batch.len()].join(",");
+            let sql = format!(
+                "SELECT chunk_index
+                 FROM pending_chunks
+                 WHERE file_hash = ? AND chunk_index IN ({placeholders})
+                 ORDER BY chunk_index
+                 LIMIT 1"
+            );
+            let fh: &[u8] = file_hash;
+            let mut query_params: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() + 1);
+            query_params.push(&fh);
+            query_params.extend(batch.iter().map(|idx| idx as &dyn ToSql));
+            let found: Option<i64> = self
+                .conn
+                .query_row(&sql, query_params.as_slice(), |row| row.get(0))
+                .optional()
+                .map_err(|e| {
+                    StagingError::Internal(format!("failed to query pending chunk positions: {e}"))
+                })?;
+            if let Some(found) = found {
+                first = Some(first.map_or(found, |current| current.min(found)));
+            }
+        }
+        Ok(first)
     }
 
     /// Return the ordered list of chunk hashes for a given file.
@@ -9968,6 +9976,44 @@ mod tests {
             .expect("paged batch dedup check");
         assert!(existing.is_empty());
         assert_eq!(new_indices.len(), HASHES);
+    }
+
+    #[test]
+    fn first_pending_position_pages_large_probe() {
+        const POSITIONS: usize = 1024;
+
+        let idx = open_in_memory();
+        let segment_id = idx.allocate_segment_id().expect("alloc segment");
+        let file_hash = test_hash(0xF7);
+        insert_test_file(&idx, &file_hash, 16);
+        idx.insert_pending(&[
+            PendingRow {
+                chunk_hash: test_hash(0xC7),
+                file_hash,
+                chunk_index: 0,
+                size: 8,
+                segment_id,
+                segment_offset: 0,
+            },
+            PendingRow {
+                chunk_hash: test_hash(0xC8),
+                file_hash,
+                chunk_index: 1023,
+                size: 8,
+                segment_id,
+                segment_offset: 8,
+            },
+        ])
+        .expect("seed pending rows");
+        let positions = (0..POSITIONS)
+            .map(|position| i64::try_from(position).expect("position"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            idx.first_pending_position_for_file(&file_hash, &positions)
+                .expect("paged position lookup"),
+            Some(0)
+        );
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -1928,7 +1928,7 @@ impl Index {
         }
 
         const POSITION_LOOKUP_BATCH: usize = 400;
-        let mut first = None;
+        let mut first: Option<i64> = None;
         for batch in chunk_indices.chunks(POSITION_LOOKUP_BATCH) {
             let placeholders = vec!["?"; batch.len()].join(",");
             let sql = format!(

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6495,7 +6495,7 @@ impl Index {
                  WHERE pc.chunk_hash IN ({placeholders})
                  ORDER BY px.xorb_hash"
             );
-            let mut stmt = self.conn.prepare(&sql).map_err(|e| {
+            let mut stmt = self.conn.prepare_cached(&sql).map_err(|e| {
                 StagingError::Internal(format!("prepare prepared xorb lookup: {e}"))
             })?;
             let mapped_rows = stmt
@@ -6686,7 +6686,7 @@ impl Index {
                  WHERE xorb_hash IN ({placeholders})
                  ORDER BY xorb_hash, chunk_index"
             );
-            let mut statement = self.conn.prepare(&sql).map_err(|error| {
+            let mut statement = self.conn.prepare_cached(&sql).map_err(|error| {
                 StagingError::Internal(format!(
                     "failed to prepare batched payload placements: {error}"
                 ))

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6074,27 +6074,6 @@ impl Index {
                     "failed to prepare prepared payload verification: {e}"
                 ))
             })?;
-        let mut chunk_insert = tx
-            .prepare_cached(
-                "INSERT OR IGNORE INTO prepared_payload_chunks
-             (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
-             VALUES (?1, ?2, ?3, ?4)",
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!(
-                    "failed to prepare prepared payload chunk insert: {e}"
-                ))
-            })?;
-        let mut chunk_verify = tx
-            .prepare_cached(
-                "SELECT xorb_hash, chunk_index, uncompressed_size
-             FROM prepared_payload_chunks WHERE chunk_hash = ?1",
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!(
-                    "failed to prepare prepared payload chunk verification: {e}"
-                ))
-            })?;
         for write in writes {
             let FilePushPlanWrite {
                 file_hash,
@@ -6307,46 +6286,143 @@ impl Index {
                         )));
                     }
                 }
-                let mut covers_recipe = false;
-                for placement in &prepared.placements {
-                    let chunk_hash: &[u8] = &placement.chunk_hash;
-                    if !covers_recipe {
-                        covers_recipe = coverage_statement
-                            .query_row(
-                                params![owner, chunk_hash, i64::from(placement.uncompressed_size)],
-                                |row| row.get::<_, bool>(0),
-                            )
-                            .map_err(|error| {
-                                StagingError::Internal(format!(
-                                    "failed to validate prepared xorb recipe coverage: {error}"
-                                ))
-                            })?;
+                let covers_recipe =
+                    prepared
+                        .placements
+                        .iter()
+                        .try_fold(false, |covers_recipe, placement| {
+                            if covers_recipe {
+                                return Ok(true);
+                            }
+                            coverage_statement
+                                .query_row(
+                                    params![
+                                        owner,
+                                        placement.chunk_hash.as_slice(),
+                                        i64::from(placement.uncompressed_size)
+                                    ],
+                                    |row| row.get::<_, bool>(0),
+                                )
+                                .map_err(|error| {
+                                    StagingError::Internal(format!(
+                                        "failed to validate prepared xorb recipe coverage: {error}"
+                                    ))
+                                })
+                        })?;
+                if !covers_recipe {
+                    return Err(StagingError::StagingCorrupt(format!(
+                        "prepared xorb {} does not cover file {}",
+                        crab_xet::hash::MerkleHash::from(prepared.xorb_hash).hex(),
+                        crab_xet::hash::MerkleHash::from(*file_hash).hex()
+                    )));
+                }
+
+                // Four parameters per row keep 128-row inserts below SQLite's default limit.
+                const PREPARED_PLACEMENT_BATCH: usize = 128;
+                for batch in prepared.placements.chunks(PREPARED_PLACEMENT_BATCH) {
+                    let values_sql = std::iter::repeat_n("(?,?,?,?)", batch.len())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let insert_sql = format!(
+                        "INSERT OR IGNORE INTO prepared_payload_chunks
+                         (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
+                         VALUES {values_sql}"
+                    );
+                    let mut insert_statement = tx.prepare_cached(&insert_sql).map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to prepare prepared payload chunk batch: {error}"
+                        ))
+                    })?;
+                    let indices = batch
+                        .iter()
+                        .map(|placement| i64::from(placement.chunk_index))
+                        .collect::<Vec<_>>();
+                    let sizes = batch
+                        .iter()
+                        .map(|placement| i64::from(placement.uncompressed_size))
+                        .collect::<Vec<_>>();
+                    let chunk_hashes = batch
+                        .iter()
+                        .map(|placement| placement.chunk_hash.as_slice())
+                        .collect::<Vec<_>>();
+                    let mut values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() * 4);
+                    for index in 0..batch.len() {
+                        values.push(&xorb_hash);
+                        values.push(&indices[index]);
+                        values.push(&chunk_hashes[index]);
+                        values.push(&sizes[index]);
                     }
-                    let inserted = chunk_insert
-                        .execute(params![
-                            xorb_hash,
-                            i64::from(placement.chunk_index),
-                            chunk_hash,
-                            i64::from(placement.uncompressed_size),
-                        ])
-                        .map_err(|e| {
+                    insert_statement
+                        .execute(params_from_iter(values))
+                        .map_err(|error| {
                             StagingError::Internal(format!(
-                                "failed to store prepared payload chunk: {e}"
+                                "failed to store prepared payload chunk batch: {error}"
                             ))
                         })?;
-                    if inserted == 0 {
-                        let stored: (Vec<u8>, i64, i64) = chunk_verify
-                            .query_row(params![chunk_hash], |row| {
-                                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-                            })
-                            .map_err(|e| {
-                                StagingError::Internal(format!(
-                                    "failed to verify canonical prepared chunk placement: {e}"
+                    drop(insert_statement);
+
+                    let placeholders = std::iter::repeat_n("?", batch.len())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let verify_sql = format!(
+                        "SELECT chunk_hash, xorb_hash, chunk_index, uncompressed_size
+                         FROM prepared_payload_chunks
+                         WHERE chunk_hash IN ({placeholders})"
+                    );
+                    let mut verify_statement = tx.prepare_cached(&verify_sql).map_err(|error| {
+                        StagingError::Internal(format!(
+                            "failed to prepare canonical prepared chunk verification: {error}"
+                        ))
+                    })?;
+                    let rows = verify_statement
+                        .query_map(
+                            params_from_iter(chunk_hashes.iter().map(|hash| hash as &dyn ToSql)),
+                            |row| {
+                                Ok((
+                                    row.get::<_, Vec<u8>>(0)?,
+                                    row.get::<_, Vec<u8>>(1)?,
+                                    row.get::<_, i64>(2)?,
+                                    row.get::<_, i64>(3)?,
                                 ))
-                            })?;
-                        if stored.0.as_slice() != xorb_hash
-                            || stored.1 != i64::from(placement.chunk_index)
-                            || stored.2 != i64::from(placement.uncompressed_size)
+                            },
+                        )
+                        .map_err(|error| {
+                            StagingError::Internal(format!(
+                                "failed to verify canonical prepared chunk batch: {error}"
+                            ))
+                        })?;
+                    let mut stored =
+                        HashMap::<[u8; 32], ([u8; 32], i64, i64)>::with_capacity(batch.len());
+                    for row in rows {
+                        let (chunk_hash, stored_xorb, index, size) = row.map_err(|error| {
+                            StagingError::Internal(format!(
+                                "failed to read canonical prepared chunk batch: {error}"
+                            ))
+                        })?;
+                        stored.insert(
+                            decode_hash_blob("canonical prepared chunk hash", chunk_hash)?,
+                            (
+                                decode_hash_blob(
+                                    "canonical prepared chunk xorb hash",
+                                    stored_xorb,
+                                )?,
+                                index,
+                                size,
+                            ),
+                        );
+                    }
+                    for (index, placement) in batch.iter().enumerate() {
+                        let Some((stored_xorb, stored_index, stored_size)) =
+                            stored.get(&placement.chunk_hash)
+                        else {
+                            return Err(StagingError::Internal(
+                                "prepared payload chunk row disappeared during verification"
+                                    .to_owned(),
+                            ));
+                        };
+                        if *stored_xorb != *xorb_hash
+                            || *stored_index != indices[index]
+                            || *stored_size != sizes[index]
                         {
                             return Err(StagingError::StagingCorrupt(format!(
                                 "prepared chunk {} already belongs to another canonical xorb",
@@ -6354,13 +6430,6 @@ impl Index {
                             )));
                         }
                     }
-                }
-                if !covers_recipe {
-                    return Err(StagingError::StagingCorrupt(format!(
-                        "prepared xorb {} does not cover file {}",
-                        crab_xet::hash::MerkleHash::from(prepared.xorb_hash).hex(),
-                        crab_xet::hash::MerkleHash::from(*file_hash).hex()
-                    )));
                 }
                 if recipe_is_indexed {
                     tx.execute(
@@ -6377,8 +6446,6 @@ impl Index {
         }
         drop(payload_insert);
         drop(payload_verify);
-        drop(chunk_insert);
-        drop(chunk_verify);
         let removed_payloads = if cleanup_needed {
             // A single sweep avoids repeatedly scanning the global payload
             // table and cannot retire a body that another plan in this batch

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -3015,32 +3015,6 @@ impl Index {
         Ok(())
     }
 
-    /// Append a bounded set of generation-pinned remote payload authorities.
-    pub fn append_recording_remote_chunks(
-        &self,
-        batch_id: &str,
-        chunks: &[ExistingChunkWrite],
-    ) -> Result<()> {
-        if chunks.is_empty() {
-            return Ok(());
-        }
-        if chunks.len() > super::stream::STAGE_BATCH_CHUNKS {
-            return Err(StagingError::StagingCorrupt(format!(
-                "remote authority append has {} terms, limit is {}",
-                chunks.len(),
-                super::stream::STAGE_BATCH_CHUNKS
-            )));
-        }
-        let tx = self.conn.unchecked_transaction().map_err(|error| {
-            StagingError::Internal(format!("failed to begin remote authority append: {error}"))
-        })?;
-        ensure_recording_batch_open(&tx, batch_id, "remote authority")?;
-        Self::append_recording_remote_chunks_in_tx(&tx, batch_id, chunks)?;
-        tx.commit().map_err(|error| {
-            StagingError::Internal(format!("failed to commit remote authority append: {error}"))
-        })
-    }
-
     fn append_recording_remote_chunks_in_tx(
         tx: &rusqlite::Transaction<'_>,
         batch_id: &str,
@@ -10753,7 +10727,7 @@ mod tests {
     }
 
     #[test]
-    fn recording_remote_authority_batch_rejects_conflicting_duplicate() {
+    fn recording_batch_rejects_conflicting_remote_authority() {
         let idx = open_in_memory();
         idx.insert_batch("remote-batch").expect("batch");
         let authority = ExistingChunkWrite {
@@ -10765,11 +10739,14 @@ mod tests {
             origin_proof_id: test_hash(0xEA),
         };
 
-        idx.append_recording_remote_chunks("remote-batch", &[authority])
+        idx.append_recording_batch("remote-batch", 0, 0, &[], &[authority])
             .expect("initial authority");
         assert_staging_corrupt_contains(
-            idx.append_recording_remote_chunks(
+            idx.append_recording_batch(
                 "remote-batch",
+                0,
+                0,
+                &[],
                 &[ExistingChunkWrite {
                     chunk_hash: authority.chunk_hash,
                     xorb_hash: test_hash(0xEB),

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6378,11 +6378,6 @@ impl Index {
         Ok(found)
     }
 
-    /// Replace one recipe's normalized remote and prepared authority.
-    pub fn insert_file_push_plan(&self, write: FilePushPlanWrite<'_>) -> Result<Vec<[u8; 32]>> {
-        self.insert_file_push_plans(std::slice::from_ref(&write))
-    }
-
     /// Replace several recipes' normalized remote and prepared authority atomically.
     pub fn insert_file_push_plans(
         &self,
@@ -6993,19 +6988,6 @@ impl Index {
             StagingError::Internal(format!("failed to commit file push plan tx: {e}"))
         })?;
         Ok(removed_payloads)
-    }
-
-    pub fn recipe_remote_chunk_page(
-        &self,
-        recipe_hash: &[u8; 32],
-        start_occurrence: u64,
-    ) -> Result<Vec<ExistingChunkWrite>> {
-        let end_occurrence = start_occurrence
-            .checked_add(crate::recipe::RECIPE_PAGE_ENTRIES as u64)
-            .ok_or_else(|| {
-                StagingError::StagingCorrupt("remote authority page range overflow".to_owned())
-            })?;
-        self.recipe_remote_chunk_range(recipe_hash, start_occurrence, end_occurrence)
     }
 
     pub fn recipe_remote_chunk_range(
@@ -11538,14 +11520,15 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let recipe_hash: [u8; 32] = recipe.hash().into();
-        idx.insert_file_push_plan(FilePushPlanWrite {
+        let write = FilePushPlanWrite {
             file_hash: &file_hash,
             recipe_hash: &recipe_hash,
             recording_batch_id: None,
             existing_chunks: &existing,
             prepared_xorbs: &[],
-        })
-        .expect("planned existing authority");
+        };
+        idx.insert_file_push_plans(std::slice::from_ref(&write))
+            .expect("planned existing authority");
 
         let stored: i64 = idx
             .conn

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2934,11 +2934,15 @@ impl Index {
             let mut statement = tx.prepare_cached(&insert_sql).map_err(|e| {
                 StagingError::Internal(format!("failed to prepare recipe recording insert: {e}"))
             })?;
+            let hash_slices = hashes
+                .iter()
+                .map(|hash| hash.as_slice())
+                .collect::<Vec<_>>();
             let mut values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() * 5);
             for index in 0..batch.len() {
-                values.push(batch_id);
+                values.push(&batch_id);
                 values.push(&occurrences[index]);
-                values.push(hashes[index].as_slice());
+                values.push(&hash_slices[index]);
                 values.push(&offsets[index]);
                 values.push(&sizes[index]);
             }
@@ -3022,15 +3026,31 @@ impl Index {
                 .iter()
                 .map(|chunk| i64::from(chunk.uncompressed_size))
                 .collect::<Vec<_>>();
+            let chunk_hashes = batch
+                .iter()
+                .map(|chunk| chunk.chunk_hash.as_slice())
+                .collect::<Vec<_>>();
+            let xorb_hashes = batch
+                .iter()
+                .map(|chunk| chunk.xorb_hash.as_slice())
+                .collect::<Vec<_>>();
+            let placement_ids = batch
+                .iter()
+                .map(|chunk| chunk.placement_id.as_slice())
+                .collect::<Vec<_>>();
+            let origin_proof_ids = batch
+                .iter()
+                .map(|chunk| chunk.origin_proof_id.as_slice())
+                .collect::<Vec<_>>();
             let mut values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() * 7);
-            for (index, chunk) in batch.iter().enumerate() {
-                values.push(batch_id);
-                values.push(chunk.chunk_hash.as_slice());
-                values.push(chunk.xorb_hash.as_slice());
+            for index in 0..batch.len() {
+                values.push(&batch_id);
+                values.push(&chunk_hashes[index]);
+                values.push(&xorb_hashes[index]);
                 values.push(&indices[index]);
                 values.push(&sizes[index]);
-                values.push(chunk.placement_id.as_slice());
-                values.push(chunk.origin_proof_id.as_slice());
+                values.push(&placement_ids[index]);
+                values.push(&origin_proof_ids[index]);
             }
             insert_statement
                 .execute(params_from_iter(values))
@@ -3056,12 +3076,8 @@ impl Index {
                 ))
             })?;
             let mut verify_values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() + 1);
-            verify_values.push(batch_id);
-            verify_values.extend(
-                batch
-                    .iter()
-                    .map(|chunk| chunk.chunk_hash.as_slice() as &dyn ToSql),
-            );
+            verify_values.push(&batch_id);
+            verify_values.extend(chunk_hashes.iter().map(|hash| hash as &dyn ToSql));
             let rows = verify_statement
                 .query_map(params_from_iter(verify_values), |row| {
                     Ok((

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6954,9 +6954,17 @@ impl Index {
             return Ok(Vec::new());
         }
 
-        let mut seen = std::collections::HashSet::new();
+        let mut unique_chunk_hashes = Vec::with_capacity(chunk_hashes.len());
+        let mut requested = HashSet::with_capacity(chunk_hashes.len());
+        for hash in chunk_hashes {
+            if requested.insert(*hash) {
+                unique_chunk_hashes.push(*hash);
+            }
+        }
+
+        let mut seen = HashSet::new();
         let mut rows = Vec::new();
-        for batch in chunk_hashes.chunks(PREPARED_XORB_QUERY_BATCH) {
+        for batch in unique_chunk_hashes.chunks(PREPARED_XORB_QUERY_BATCH) {
             let placeholders = vec!["?"; batch.len()].join(",");
             let sql = format!(
                 "SELECT DISTINCT px.xorb_hash, px.payload_hash, px.bytes
@@ -9758,7 +9766,7 @@ mod tests {
         }
 
         let stored = idx
-            .prepared_xorbs_for_chunks(&[first_chunk, second_chunk])
+            .prepared_xorbs_for_chunks(&[first_chunk, second_chunk, first_chunk])
             .expect("prepared xorb lookup");
         assert_eq!(stored.len(), 2);
         assert_eq!(stored[0].xorb_hash, first_xorb);

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -11519,7 +11519,7 @@ mod tests {
                 origin_proof_id: test_hash(0xD2),
             })
             .collect::<Vec<_>>();
-        let recipe_hash: [u8; 32] = recipe.hash().into();
+        let recipe_hash: [u8; 32] = recipe.hash();
         let write = FilePushPlanWrite {
             file_hash: &file_hash,
             recipe_hash: &recipe_hash,

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2907,7 +2907,7 @@ impl Index {
         let mut occurrence = start_occurrence;
         let mut offset = start_offset;
         for batch in chunks.chunks(RECIPE_RECORDING_BATCH) {
-            let mut hashes = Vec::with_capacity(batch.len());
+            let mut hashes: Vec<[u8; 32]> = Vec::with_capacity(batch.len());
             let mut occurrences = Vec::with_capacity(batch.len());
             let mut offsets = Vec::with_capacity(batch.len());
             let mut sizes = Vec::with_capacity(batch.len());

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -10771,8 +10771,12 @@ mod tests {
             idx.append_recording_remote_chunks(
                 "remote-batch",
                 &[ExistingChunkWrite {
+                    chunk_hash: authority.chunk_hash,
                     xorb_hash: test_hash(0xEB),
-                    ..authority
+                    chunk_index: authority.chunk_index,
+                    uncompressed_size: authority.uncompressed_size,
+                    placement_id: authority.placement_id,
+                    origin_proof_id: authority.origin_proof_id,
                 }],
             ),
             "changed within one add",
@@ -10804,7 +10808,11 @@ mod tests {
         let second_hash = test_hash(0xF7);
         let second_authority = ExistingChunkWrite {
             chunk_hash: second_hash,
-            ..first_authority
+            xorb_hash: first_authority.xorb_hash,
+            chunk_index: first_authority.chunk_index,
+            uncompressed_size: first_authority.uncompressed_size,
+            placement_id: first_authority.placement_id,
+            origin_proof_id: first_authority.origin_proof_id,
         };
         assert_staging_corrupt_contains(
             idx.append_recording_batch(

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -66,6 +66,7 @@ const CANONICAL_INDEXES: &[&str] = &[
     "pending_by_hash",
     "preparation_payloads_by_xorb",
     "prepared_claims_by_preparation",
+    "prepared_leases_by_xorb",
     "publication_entries_by_batch",
     "recipe_occurrences_by_chunk",
     "recipe_payload_leases_by_chunk",
@@ -1004,6 +1005,9 @@ impl Index {
                         ON DELETE CASCADE,
                     FOREIGN KEY (xorb_hash) REFERENCES prepared_payloads(xorb_hash)
                 );
+
+                CREATE INDEX IF NOT EXISTS prepared_leases_by_xorb
+                    ON prepared_leases(xorb_hash);
 
                 CREATE TABLE IF NOT EXISTS push_snapshots (
                     snapshot_id TEXT PRIMARY KEY,

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2902,38 +2902,51 @@ impl Index {
             )));
         }
 
-        let mut statement = tx
-            .prepare_cached(
-                "INSERT INTO recipe_recording_terms
-                 (batch_id, occurrence, chunk_hash, chunk_offset, chunk_size)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-            )
-            .map_err(|e| {
-                StagingError::Internal(format!("failed to prepare recipe recording insert: {e}"))
-            })?;
+        // Five parameters per row keep 128-row inserts below SQLite's default limit.
+        const RECIPE_RECORDING_BATCH: usize = 128;
         let mut occurrence = start_occurrence;
         let mut offset = start_offset;
-        for (chunk_hash, size) in chunks {
-            let raw_hash: [u8; 32] = (*chunk_hash).into();
-            statement
-                .execute(params![
-                    batch_id,
-                    sqlite_i64("recipe recording occurrence", occurrence)?,
-                    raw_hash.as_slice(),
-                    sqlite_i64("recipe recording offset", offset)?,
-                    sqlite_i64("recipe recording size", *size)?,
-                ])
-                .map_err(|e| {
-                    StagingError::Internal(format!("failed to append recipe recording term: {e}"))
+        for batch in chunks.chunks(RECIPE_RECORDING_BATCH) {
+            let mut hashes = Vec::with_capacity(batch.len());
+            let mut occurrences = Vec::with_capacity(batch.len());
+            let mut offsets = Vec::with_capacity(batch.len());
+            let mut sizes = Vec::with_capacity(batch.len());
+            for (chunk_hash, size) in batch {
+                hashes.push((*chunk_hash).into());
+                occurrences.push(sqlite_i64("recipe recording occurrence", occurrence)?);
+                offsets.push(sqlite_i64("recipe recording offset", offset)?);
+                sizes.push(sqlite_i64("recipe recording size", *size)?);
+                occurrence = occurrence.checked_add(1).ok_or_else(|| {
+                    StagingError::StagingCorrupt("recipe recording occurrence overflow".to_owned())
                 })?;
-            occurrence = occurrence.checked_add(1).ok_or_else(|| {
-                StagingError::StagingCorrupt("recipe recording occurrence overflow".to_owned())
+                offset = offset.checked_add(*size).ok_or_else(|| {
+                    StagingError::StagingCorrupt("recipe recording byte offset overflow".to_owned())
+                })?;
+            }
+            let values_sql = std::iter::repeat_n("(?,?,?,?,?)", batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let insert_sql = format!(
+                "INSERT INTO recipe_recording_terms
+                 (batch_id, occurrence, chunk_hash, chunk_offset, chunk_size)
+                 VALUES {values_sql}"
+            );
+            let mut statement = tx.prepare_cached(&insert_sql).map_err(|e| {
+                StagingError::Internal(format!("failed to prepare recipe recording insert: {e}"))
             })?;
-            offset = offset.checked_add(*size).ok_or_else(|| {
-                StagingError::StagingCorrupt("recipe recording byte offset overflow".to_owned())
+            let mut values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() * 5);
+            for index in 0..batch.len() {
+                values.push(batch_id);
+                values.push(&occurrences[index]);
+                values.push(hashes[index].as_slice());
+                values.push(&offsets[index]);
+                values.push(&sizes[index]);
+            }
+            statement.execute(params_from_iter(values)).map_err(|e| {
+                StagingError::Internal(format!("failed to append recipe recording term batch: {e}"))
             })?;
+            drop(statement);
         }
-        drop(statement);
         tx.commit().map_err(|e| {
             StagingError::Internal(format!("failed to commit recipe recording append: {e}"))
         })?;

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -20,6 +20,7 @@ type ResidualAuthorityRow = (i64, Option<Vec<u8>>, Option<Vec<u8>>, Option<i64>)
 
 /// Canonical pre-release on-disk layout contract.
 const LAYOUT_VERSION: &str = "1";
+const PUBLISHED_RECIPE_LOOKUP_BATCH_SIZE: usize = 512;
 
 const CANONICAL_TABLES: &[&str] = &[
     "add_preparation_batches",
@@ -3865,68 +3866,15 @@ impl Index {
         &self,
         file_hash: &[u8; 32],
     ) -> Result<Option<crate::recipe::FileRecipe>> {
-        let rows = {
-            let mut statement = self
-                .conn
-                .prepare_cached(
-                    "SELECT DISTINCT recipe.recipe_hash, recipe.file_size,
-                            recipe.chunk_count, recipe.sequence_hash,
-                            recipe.page_count, recipe.page_root_hash, recipe.policy_id
-                     FROM file_recipes AS recipe
-                     JOIN verified_recipes AS verified USING (recipe_hash)
-                     JOIN path_heads AS head USING (recipe_hash)
-                     JOIN staging_batches AS batch USING (batch_id)
-                     WHERE recipe.file_hash = ?1 AND batch.state = 'published'
-                     ORDER BY recipe.recipe_hash",
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!("failed to prepare published recipe query: {e}"))
-                })?;
-            statement
-                .query_map(params![file_hash.as_slice()], |row| {
-                    Ok((
-                        row.get::<_, Vec<u8>>(0)?,
-                        row.get::<_, i64>(1)?,
-                        row.get::<_, i64>(2)?,
-                        row.get::<_, Vec<u8>>(3)?,
-                        row.get::<_, i64>(4)?,
-                        row.get::<_, Vec<u8>>(5)?,
-                        row.get::<_, String>(6)?,
-                    ))
-                })
-                .map_err(|e| {
-                    StagingError::Internal(format!("failed to query published recipes: {e}"))
-                })?
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|e| {
-                    StagingError::Internal(format!("failed to collect published recipes: {e}"))
-                })?
-        };
-
         let mut selected = None;
-        for (
-            raw_recipe_hash,
-            raw_file_size,
-            raw_chunk_count,
-            raw_sequence_hash,
-            raw_page_count,
-            raw_page_root_hash,
-            policy_id,
-        ) in rows
+        for (returned_hash, recipe) in
+            self.load_published_recipe_rows(std::slice::from_ref(file_hash))?
         {
-            let stored_recipe_hash = decode_hash_blob("published recipe hash", raw_recipe_hash)?;
-            let recipe = self.load_stored_recipe(
-                &stored_recipe_hash,
-                file_hash,
-                (
-                    raw_file_size,
-                    raw_chunk_count,
-                    raw_sequence_hash,
-                    raw_page_count,
-                    raw_page_root_hash,
-                    policy_id,
-                ),
-            )?;
+            if returned_hash != *file_hash {
+                return Err(StagingError::StagingCorrupt(
+                    "published recipe query returned an unexpected file hash".to_owned(),
+                ));
+            }
             if let Some(prior) = &selected
                 && prior != &recipe
             {
@@ -3937,6 +3885,114 @@ impl Index {
             selected = Some(recipe);
         }
         Ok(selected)
+    }
+
+    /// Load published immutable recipes for several file hashes while holding
+    /// the staging index lock once. Every requested hash appears in the
+    /// result, with `None` for a hash that has no published recipe.
+    pub fn published_recipes_for_files(
+        &self,
+        file_hashes: &[[u8; 32]],
+    ) -> Result<HashMap<[u8; 32], Option<crate::recipe::FileRecipe>>> {
+        let mut recipes = HashMap::with_capacity(file_hashes.len());
+        for batch in file_hashes.chunks(PUBLISHED_RECIPE_LOOKUP_BATCH_SIZE) {
+            for file_hash in batch {
+                recipes.entry(*file_hash).or_insert(None);
+            }
+            for (file_hash, recipe) in self.load_published_recipe_rows(batch)? {
+                match recipes.get_mut(&file_hash) {
+                    Some(slot @ None) => *slot = Some(recipe),
+                    Some(Some(prior)) if prior == &recipe => {}
+                    Some(Some(_)) => {
+                        return Err(StagingError::StagingCorrupt(
+                            "one file hash has conflicting published recipes".to_owned(),
+                        ));
+                    }
+                    None => {
+                        return Err(StagingError::StagingCorrupt(
+                            "published recipe query returned an unexpected file hash".to_owned(),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(recipes)
+    }
+
+    fn load_published_recipe_rows(
+        &self,
+        file_hashes: &[[u8; 32]],
+    ) -> Result<Vec<([u8; 32], crate::recipe::FileRecipe)>> {
+        if file_hashes.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = std::iter::repeat_n("?", file_hashes.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let query = format!(
+            "SELECT DISTINCT recipe.file_hash, recipe.recipe_hash, recipe.file_size,
+                    recipe.chunk_count, recipe.sequence_hash,
+                    recipe.page_count, recipe.page_root_hash, recipe.policy_id
+             FROM file_recipes AS recipe
+             JOIN verified_recipes AS verified USING (recipe_hash)
+             JOIN path_heads AS head USING (recipe_hash)
+             JOIN staging_batches AS batch USING (batch_id)
+             WHERE recipe.file_hash IN ({placeholders}) AND batch.state = 'published'
+             ORDER BY recipe.file_hash, recipe.recipe_hash"
+        );
+        let mut statement = self.conn.prepare_cached(&query).map_err(|e| {
+            StagingError::Internal(format!("failed to prepare published recipe query: {e}"))
+        })?;
+        let mut query_params: Vec<&dyn ToSql> = Vec::with_capacity(file_hashes.len());
+        query_params.extend(file_hashes.iter().map(|hash| hash.as_slice() as &dyn ToSql));
+        let rows = statement
+            .query_map(params_from_iter(query_params), |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Vec<u8>>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, Vec<u8>>(6)?,
+                    row.get::<_, String>(7)?,
+                ))
+            })
+            .map_err(|e| StagingError::Internal(format!("failed to query published recipes: {e}")))?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| {
+                StagingError::Internal(format!("failed to collect published recipes: {e}"))
+            })?;
+
+        let mut recipes = Vec::with_capacity(rows.len());
+        for (
+            raw_file_hash,
+            raw_recipe_hash,
+            raw_file_size,
+            raw_chunk_count,
+            raw_sequence_hash,
+            raw_page_count,
+            raw_page_root_hash,
+            policy_id,
+        ) in rows
+        {
+            let file_hash = decode_hash_blob("published recipe file hash", raw_file_hash)?;
+            let stored_recipe_hash = decode_hash_blob("published recipe hash", raw_recipe_hash)?;
+            let recipe = self.load_stored_recipe(
+                &stored_recipe_hash,
+                &file_hash,
+                (
+                    raw_file_size,
+                    raw_chunk_count,
+                    raw_sequence_hash,
+                    raw_page_count,
+                    raw_page_root_hash,
+                    policy_id,
+                ),
+            )?;
+            recipes.push((file_hash, recipe));
+        }
+        Ok(recipes)
     }
 
     /// Load the newest verified open recipe for a path when every chunk has
@@ -8833,6 +8889,21 @@ mod tests {
         idx.insert_recipe_lease(batch_id, path, &recipe, RecipeVerification::CallerVerified)
             .expect("recipe lease");
         recipe
+    }
+
+    #[test]
+    fn published_recipe_batch_returns_missing_and_published() {
+        let idx = open_in_memory();
+        let recipe = insert_test_recipe_lease(&idx, "batch-a", b"models/a.bin", 0xA1, 0xA2);
+        idx.mark_batch_published("batch-a").expect("publish batch");
+        let file_hash: [u8; 32] = recipe.file_hash().into();
+        let missing_hash = test_hash(0xFF);
+
+        let recipes = idx
+            .published_recipes_for_files(&[file_hash, missing_hash])
+            .expect("batch lookup");
+        assert_eq!(recipes.get(&file_hash), Some(&Some(recipe)));
+        assert_eq!(recipes.get(&missing_hash), Some(&None));
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2105,6 +2105,86 @@ impl Index {
         Ok(chunks)
     }
 
+    /// Verify a file's ordered chunk hashes and sizes without materializing
+    /// segment locators or the complete staged row set.
+    pub(crate) fn file_chunks_match(
+        &self,
+        file_hash: &[u8; 32],
+        expected: &[(crab_xet::hash::MerkleHash, u64)],
+        expected_size: u64,
+    ) -> Result<bool> {
+        let fh: &[u8] = file_hash;
+        let mut statement = self
+            .conn
+            .prepare_cached(
+                "WITH combined AS (
+                     SELECT chunk_hash, size, chunk_index, 0 AS priority, rowid
+                     FROM chunks
+                     WHERE file_hash = ?1
+                     UNION ALL
+                     SELECT chunk_hash, size, chunk_index, 1 AS priority, rowid
+                     FROM pending_chunks
+                     WHERE file_hash = ?1
+                 )
+                 SELECT chunk_hash, size, chunk_index
+                 FROM combined c
+                 WHERE NOT EXISTS (
+                     SELECT 1
+                     FROM combined p
+                     WHERE p.chunk_index = c.chunk_index
+                       AND (
+                           p.priority < c.priority
+                           OR (p.priority = c.priority AND p.rowid < c.rowid)
+                       )
+                 )
+                 ORDER BY chunk_index",
+            )
+            .map_err(|error| {
+                StagingError::Internal(format!("prepare file chunk verification: {error}"))
+            })?;
+        let mut rows = statement.query(params![fh]).map_err(|error| {
+            StagingError::Internal(format!("query file chunk verification: {error}"))
+        })?;
+        let mut total_size = 0u64;
+        for (expected_index, (expected_hash, expected_chunk_size)) in expected.iter().enumerate() {
+            let Some(row) = rows.next().map_err(|error| {
+                StagingError::Internal(format!("read file chunk verification: {error}"))
+            })?
+            else {
+                return Ok(false);
+            };
+            let raw_hash = row.get::<_, Vec<u8>>(0).map_err(|error| {
+                StagingError::Internal(format!("decode file chunk hash: {error}"))
+            })?;
+            let size = row.get::<_, i64>(1).map_err(|error| {
+                StagingError::Internal(format!("decode file chunk size: {error}"))
+            })?;
+            let chunk_index = row.get::<_, i64>(2).map_err(|error| {
+                StagingError::Internal(format!("decode file chunk index: {error}"))
+            })?;
+            validate_chunk_index(expected_index, chunk_index)?;
+            let actual_hash = decode_chunk_hash_blob(raw_hash)?;
+            let actual_size = u64::try_from(size)
+                .map_err(|_| StagingError::StagingCorrupt("chunk size is negative".to_owned()))?;
+            if actual_hash != *expected_hash || actual_size != *expected_chunk_size {
+                return Ok(false);
+            }
+            total_size = total_size.checked_add(actual_size).ok_or_else(|| {
+                StagingError::StagingCorrupt("file chunk sizes overflow".to_owned())
+            })?;
+        }
+        if rows
+            .next()
+            .map_err(|error| {
+                StagingError::Internal(format!("read trailing file chunk row: {error}"))
+            })?
+            .is_some()
+        {
+            return Ok(false);
+        }
+        Ok(total_size == expected_size)
+    }
+
     /// Insert a file row into the `files` table.
     ///
     /// Re-registering a file updates metadata in place so existing
@@ -11061,6 +11141,33 @@ mod tests {
         let chunks = idx.chunks_for_file_with_sizes(&fh).expect("chunks");
 
         assert_eq!(chunks, vec![(test_hash(0xC1), 40), (test_hash(0xC2), 60)]);
+    }
+
+    #[test]
+    fn file_chunks_match_streams_order_and_size_without_locators() {
+        let idx = open_in_memory();
+        let seg_id = idx.allocate_segment_id().expect("alloc");
+        let fh = test_hash(0xA4);
+        insert_test_file(&idx, &fh, 100);
+        idx.conn
+            .execute(
+                "INSERT INTO chunks (chunk_hash, file_hash, chunk_index, size, segment_id, segment_offset)
+                 VALUES (?1, ?2, 1, 60, ?3, 68), (?4, ?2, 0, 40, ?3, 0)",
+                params![
+                    test_hash(0xF2).as_slice(),
+                    fh.as_slice(),
+                    seg_id,
+                    test_hash(0xF1).as_slice()
+                ],
+            )
+            .expect("insert committed chunks");
+
+        let expected = vec![(test_hash(0xF1).into(), 40), (test_hash(0xF2).into(), 60)];
+
+        assert!(
+            idx.file_chunks_match(&fh, &expected, 100)
+                .expect("verify chunks")
+        );
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -7059,7 +7059,7 @@ impl Index {
         }
 
         let xorb_hashes = rows.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>();
-        let mut placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
+        let placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
         Ok(rows
             .into_iter()
             .map(|(xorb_hash, payload_hash, bytes)| StoredPreparedXorb {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -6210,7 +6210,7 @@ impl Index {
                     .collect::<Vec<_>>()
                     .join(",");
                 let coverage_batch_sql = format!(
-                    "SELECT chunk_hash, chunk_size
+                    "SELECT DISTINCT chunk_hash, chunk_size
                      FROM {coverage_table}
                      WHERE {owner_column} = ? AND chunk_hash IN ({placeholders})"
                 );

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -7281,7 +7281,13 @@ impl Index {
                 }
             }
         }
-        let xorb_hashes = rows.iter().map(|(_, hash, _, _)| *hash).collect::<Vec<_>>();
+        let mut xorb_hashes = Vec::new();
+        let mut unique_xorbs = HashSet::new();
+        for (_, xorb_hash, _, _) in &rows {
+            if unique_xorbs.insert(*xorb_hash) {
+                xorb_hashes.push(*xorb_hash);
+            }
+        }
         let placements = self.prepared_payload_placements_for_xorbs(&xorb_hashes)?;
         let mut out: HashMap<[u8; 32], Vec<StoredPreparedXorb>> = HashMap::new();
         for (recipe_hash, xorb_hash, payload_hash, bytes) in rows {

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -8151,10 +8151,10 @@ impl Index {
         // are common for sparse or zero-filled large files; joining
         // every batch row against every existing row for the same hash
         // turns into an O(batch * staged_rows) explosion.
-        let placeholders = vec!["?"; unique_hashes.len()].join(",");
-
         let mut found_set = std::collections::HashSet::new();
-        {
+        const DEDUP_LOOKUP_BATCH: usize = 400;
+        for unique_batch in unique_hashes.chunks(DEDUP_LOOKUP_BATCH) {
+            let placeholders = vec!["?"; unique_batch.len()].join(",");
             let sql = format!(
                 "SELECT picked.chunk_hash, c.segment_id, c.segment_offset, c.size,
                         EXISTS(SELECT 1 FROM chunks c2
@@ -8176,7 +8176,7 @@ impl Index {
             let rows = stmt
                 .query_map(
                     params_from_iter(
-                        std::iter::once(fh).chain(unique_hashes.iter().map(|h| h.as_slice())),
+                        std::iter::once(fh).chain(unique_batch.iter().map(|h| h.as_slice())),
                     ),
                     |row| {
                         let blob: Vec<u8> = row.get(0)?;
@@ -8216,8 +8216,8 @@ impl Index {
             .filter(|hash| !existing_by_hash.contains_key(hash))
             .collect();
 
-        if !missing_hashes.is_empty() {
-            let pending_placeholders = vec!["?"; missing_hashes.len()].join(",");
+        for missing_batch in missing_hashes.chunks(DEDUP_LOOKUP_BATCH) {
+            let pending_placeholders = vec!["?"; missing_batch.len()].join(",");
             let sql = format!(
                 "SELECT picked.chunk_hash, p.segment_id, p.segment_offset, p.size,
                         EXISTS(SELECT 1 FROM pending_chunks p2
@@ -8239,7 +8239,7 @@ impl Index {
             let rows = stmt
                 .query_map(
                     params_from_iter(
-                        std::iter::once(fh).chain(missing_hashes.iter().map(|h| h.as_slice())),
+                        std::iter::once(fh).chain(missing_batch.iter().map(|h| h.as_slice())),
                     ),
                     |row| {
                         let blob: Vec<u8> = row.get(0)?;
@@ -9946,6 +9946,28 @@ mod tests {
             idx.chunks_for_file(&fh).expect("chunks"),
             vec![test_hash(0xC4)]
         );
+    }
+
+    #[test]
+    fn batch_dedup_check_pages_unique_hashes_below_sqlite_bind_limit() {
+        const HASHES: usize = 1024;
+
+        let idx = open_in_memory();
+        let file_hash = test_hash(0xF6);
+        insert_test_file(&idx, &file_hash, i64::try_from(HASHES).expect("file size"));
+        let hashes = (0..HASHES)
+            .map(|index| {
+                let mut hash = [0; 32];
+                hash[..8].copy_from_slice(&u64::try_from(index).expect("hash index").to_le_bytes());
+                (index, hash)
+            })
+            .collect::<Vec<_>>();
+
+        let (existing, new_indices) = idx
+            .batch_dedup_check(&hashes, &file_hash)
+            .expect("paged batch dedup check");
+        assert!(existing.is_empty());
+        assert_eq!(new_indices.len(), HASHES);
     }
 
     #[test]

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -2417,23 +2417,6 @@ impl Index {
                     "failed to prepare preparation payload retention: {error}"
                 ))
             })?;
-        let mut placement_insert = tx
-            .prepare_cached(
-                "INSERT INTO prepared_payload_chunks
-                 (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
-                 VALUES (?1, ?2, ?3, ?4)",
-            )
-            .map_err(|error| {
-                StagingError::Internal(format!(
-                    "failed to prepare prepared payload placement insert: {error}"
-                ))
-            })?;
-        let mut claim_delete = tx
-            .prepare_cached("DELETE FROM prepared_chunk_claims WHERE chunk_hash = ?1")
-            .map_err(|error| {
-                StagingError::Internal(format!("failed to prepare payload claim removal: {error}"))
-            })?;
-
         for payload in payloads {
             let mut claim_keys = HashMap::<[u8; 32], ()>::with_capacity(payload.placements.len());
             for placement in &payload.placements {
@@ -2529,32 +2512,79 @@ impl Index {
                         crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
                     )));
                 }
-                placement_insert
-                    .execute(params![
-                        xorb_hash,
-                        i64::from(placement.chunk_index),
-                        placement.chunk_hash.as_slice(),
-                        i64::from(placement.uncompressed_size),
-                    ])
+                claims.remove(&placement.chunk_hash);
+            }
+
+            // Four parameters per row keep 128-row inserts below SQLite's default limit.
+            const PREPARED_PLACEMENT_BATCH: usize = 128;
+            for batch in payload.placements.chunks(PREPARED_PLACEMENT_BATCH) {
+                let values_sql = std::iter::repeat_n("(?,?,?,?)", batch.len())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let insert_sql = format!(
+                    "INSERT INTO prepared_payload_chunks
+                     (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
+                     VALUES {values_sql}"
+                );
+                let mut insert_statement = tx.prepare_cached(&insert_sql).map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to prepare prepared payload placement batch: {error}"
+                    ))
+                })?;
+                let indices = batch
+                    .iter()
+                    .map(|placement| i64::from(placement.chunk_index))
+                    .collect::<Vec<_>>();
+                let sizes = batch
+                    .iter()
+                    .map(|placement| i64::from(placement.uncompressed_size))
+                    .collect::<Vec<_>>();
+                let chunk_hashes = batch
+                    .iter()
+                    .map(|placement| placement.chunk_hash.as_slice())
+                    .collect::<Vec<_>>();
+                let mut values: Vec<&dyn ToSql> = Vec::with_capacity(batch.len() * 4);
+                for index in 0..batch.len() {
+                    values.push(&xorb_hash);
+                    values.push(&indices[index]);
+                    values.push(&chunk_hashes[index]);
+                    values.push(&sizes[index]);
+                }
+                insert_statement
+                    .execute(params_from_iter(values))
                     .map_err(|error| {
                         StagingError::StagingCorrupt(format!(
-                            "failed to install canonical prepared placement for {}: {error}",
-                            crab_xet::hash::MerkleHash::from(placement.chunk_hash).hex()
+                            "failed to install canonical prepared placement batch: {error}"
                         ))
                     })?;
-                claim_delete
-                    .execute(params![placement.chunk_hash.as_slice()])
+                drop(insert_statement);
+
+                let placeholders = std::iter::repeat_n("?", batch.len())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let delete_sql = format!(
+                    "DELETE FROM prepared_chunk_claims WHERE chunk_hash IN ({placeholders})"
+                );
+                let mut delete_statement = tx.prepare_cached(&delete_sql).map_err(|error| {
+                    StagingError::Internal(format!(
+                        "failed to prepare payload claim batch removal: {error}"
+                    ))
+                })?;
+                delete_statement
+                    .execute(params_from_iter(
+                        chunk_hashes.iter().map(|hash| hash as &dyn ToSql),
+                    ))
                     .map_err(|error| {
-                        StagingError::Internal(format!("failed to resolve prepared claim: {error}"))
+                        StagingError::Internal(format!(
+                            "failed to resolve prepared claim batch: {error}"
+                        ))
                     })?;
-                claims.remove(&placement.chunk_hash);
+                drop(delete_statement);
             }
         }
         drop(payload_insert);
         drop(payload_verify);
         drop(preparation_payload_insert);
-        drop(placement_insert);
-        drop(claim_delete);
         tx.commit().map_err(|error| {
             StagingError::Internal(format!("failed to commit prepared payload seal: {error}"))
         })?;

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -5864,6 +5864,45 @@ impl Index {
         // Defer retirement until every plan in this transaction has restored
         // its leases; shared prepared xorbs can move between files in a batch.
         let mut cleanup_needed = false;
+        let mut payload_insert = tx
+            .prepare_cached(
+                "INSERT OR IGNORE INTO prepared_payloads
+             (xorb_hash, payload_hash, bytes) VALUES (?1, ?2, ?3)",
+            )
+            .map_err(|e| {
+                StagingError::Internal(format!("failed to prepare prepared payload insert: {e}"))
+            })?;
+        let mut payload_verify = tx
+            .prepare_cached(
+                "SELECT payload_hash = ?2 AND bytes = ?3
+             FROM prepared_payloads WHERE xorb_hash = ?1",
+            )
+            .map_err(|e| {
+                StagingError::Internal(format!(
+                    "failed to prepare prepared payload verification: {e}"
+                ))
+            })?;
+        let mut chunk_insert = tx
+            .prepare_cached(
+                "INSERT OR IGNORE INTO prepared_payload_chunks
+             (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
+             VALUES (?1, ?2, ?3, ?4)",
+            )
+            .map_err(|e| {
+                StagingError::Internal(format!(
+                    "failed to prepare prepared payload chunk insert: {e}"
+                ))
+            })?;
+        let mut chunk_verify = tx
+            .prepare_cached(
+                "SELECT xorb_hash, chunk_index, uncompressed_size
+             FROM prepared_payload_chunks WHERE chunk_hash = ?1",
+            )
+            .map_err(|e| {
+                StagingError::Internal(format!(
+                    "failed to prepare prepared payload chunk verification: {e}"
+                ))
+            })?;
         for write in writes {
             let FilePushPlanWrite {
                 file_hash,
@@ -6053,47 +6092,6 @@ impl Index {
                 })?;
             }
 
-            let mut payload_insert = tx
-                .prepare_cached(
-                    "INSERT OR IGNORE INTO prepared_payloads
-                 (xorb_hash, payload_hash, bytes) VALUES (?1, ?2, ?3)",
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!(
-                        "failed to prepare prepared payload insert: {e}"
-                    ))
-                })?;
-            let mut payload_verify = tx
-                .prepare_cached(
-                    "SELECT payload_hash = ?2 AND bytes = ?3
-                 FROM prepared_payloads WHERE xorb_hash = ?1",
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!(
-                        "failed to prepare prepared payload verification: {e}"
-                    ))
-                })?;
-            let mut chunk_insert = tx
-                .prepare_cached(
-                    "INSERT OR IGNORE INTO prepared_payload_chunks
-                 (xorb_hash, chunk_index, chunk_hash, uncompressed_size)
-                 VALUES (?1, ?2, ?3, ?4)",
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!(
-                        "failed to prepare prepared payload chunk insert: {e}"
-                    ))
-                })?;
-            let mut chunk_verify = tx
-                .prepare_cached(
-                    "SELECT xorb_hash, chunk_index, uncompressed_size
-                 FROM prepared_payload_chunks WHERE chunk_hash = ?1",
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!(
-                        "failed to prepare prepared payload chunk verification: {e}"
-                    ))
-                })?;
             for prepared in prepared_xorbs {
                 let xorb_hash: &[u8] = &prepared.xorb_hash;
                 let payload_hash: &[u8] = &prepared.payload_hash;
@@ -6215,11 +6213,11 @@ impl Index {
                     })?;
                 }
             }
-            drop(payload_insert);
-            drop(payload_verify);
-            drop(chunk_insert);
-            drop(chunk_verify);
         }
+        drop(payload_insert);
+        drop(payload_verify);
+        drop(chunk_insert);
+        drop(chunk_verify);
         let removed_payloads = if cleanup_needed {
             // A single sweep avoids repeatedly scanning the global payload
             // table and cannot retire a body that another plan in this batch

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -3933,6 +3933,22 @@ impl StagingAreaReadOnly {
         lock_index(&self.index)?.published_recipe_for_file(&file_hash)
     }
 
+    /// Return published immutable recipes for several file hashes in one index read.
+    pub fn published_recipes_for_files(
+        &self,
+        file_hashes: &[MerkleHash],
+    ) -> Result<HashMap<MerkleHash, Option<crate::recipe::FileRecipe>>> {
+        let raw_hashes = file_hashes
+            .iter()
+            .map(|file_hash| (*file_hash).into())
+            .collect::<Vec<[u8; 32]>>();
+        Ok(lock_index(&self.index)?
+            .published_recipes_for_files(&raw_hashes)?
+            .into_iter()
+            .map(|(file_hash, recipe)| (MerkleHash::from(file_hash), recipe))
+            .collect())
+    }
+
     /// Read one bounded page from an indexed immutable recipe.
     pub fn recipe_page(
         &self,

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -3032,15 +3032,6 @@ impl StagingArea {
             .prepared_payload_exclusive_to_recipe(&<[u8; 32]>::from(*xorb_hash), recipe_hash)
     }
 
-    pub(crate) fn chunks_for_file_with_locators(
-        &self,
-        file_hash: &MerkleHash,
-    ) -> Result<Vec<StagedChunkLocator>> {
-        let fh: [u8; 32] = (*file_hash).into();
-        let chunks = lock_index(&self.index)?.chunks_for_file_with_locators(&fh)?;
-        Ok(chunks.into_iter().map(StagedChunkLocator::from).collect())
-    }
-
     pub(crate) fn file_chunks_match(
         &self,
         file_hash: &MerkleHash,

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -2553,6 +2553,34 @@ impl StagingArea {
         lock_index(&self.index)?.append_recording_remote_chunks(batch_id.as_str(), &writes)
     }
 
+    pub(crate) fn append_recording_batch(
+        &self,
+        batch_id: &StagingBatchId,
+        start_occurrence: u64,
+        start_offset: u64,
+        recipe_chunks: &[(MerkleHash, u64)],
+        remote_chunks: &[(MerkleHash, push_plan::ExistingChunkCandidate)],
+    ) -> Result<()> {
+        let writes = remote_chunks
+            .iter()
+            .map(|(chunk_hash, candidate)| ExistingChunkWrite {
+                chunk_hash: (*chunk_hash).into(),
+                xorb_hash: candidate.xorb_ref.xorb_hash.into(),
+                chunk_index: candidate.xorb_ref.chunk_index,
+                uncompressed_size: candidate.xorb_ref.uncompressed_size,
+                placement_id: candidate.placement_id,
+                origin_proof_id: candidate.origin_proof_id,
+            })
+            .collect::<Vec<_>>();
+        lock_index(&self.index)?.append_recording_batch(
+            batch_id.as_str(),
+            start_occurrence,
+            start_offset,
+            recipe_chunks,
+            &writes,
+        )
+    }
+
     /// Persist an unverified immutable recipe and lease it to one native-byte path.
     ///
     /// The recipe remains invisible to push until the next staging open

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -1040,8 +1040,22 @@ fn indexed_recipe_remote_chunk_page(
     recipe: &crate::recipe::FileRecipe,
     start_occurrence: u64,
 ) -> Result<Vec<(MerkleHash, push_plan::ExistingChunkCandidate)>> {
+    let end_occurrence = start_occurrence
+        .checked_add(crate::recipe::RECIPE_PAGE_ENTRIES as u64)
+        .ok_or_else(|| {
+            StagingError::StagingCorrupt("remote authority page range overflow".to_owned())
+        })?;
+    indexed_recipe_remote_chunk_range(index, recipe, start_occurrence, end_occurrence)
+}
+
+fn indexed_recipe_remote_chunk_range(
+    index: &Mutex<Index>,
+    recipe: &crate::recipe::FileRecipe,
+    start_occurrence: u64,
+    end_occurrence: u64,
+) -> Result<Vec<(MerkleHash, push_plan::ExistingChunkCandidate)>> {
     lock_index(index)?
-        .recipe_remote_chunk_page(&recipe.hash(), start_occurrence)?
+        .recipe_remote_chunk_range(&recipe.hash(), start_occurrence, end_occurrence)?
         .into_iter()
         .map(|existing| {
             Ok((
@@ -3965,6 +3979,16 @@ impl StagingAreaReadOnly {
         start_occurrence: u64,
     ) -> Result<Vec<(MerkleHash, push_plan::ExistingChunkCandidate)>> {
         indexed_recipe_remote_chunk_page(&self.index, recipe, start_occurrence)
+    }
+
+    /// Load a bounded range of proof-bearing remote authority for an immutable recipe.
+    pub fn recipe_remote_chunk_range(
+        &self,
+        recipe: &crate::recipe::FileRecipe,
+        start_occurrence: u64,
+        end_occurrence: u64,
+    ) -> Result<Vec<(MerkleHash, push_plan::ExistingChunkCandidate)>> {
+        indexed_recipe_remote_chunk_range(&self.index, recipe, start_occurrence, end_occurrence)
     }
 
     /// Load the indexed add-time push plan for a file.

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -2931,27 +2931,44 @@ impl StagingArea {
         plan: &push_plan::FilePushPlan,
         recipe: &crate::recipe::FileRecipe,
     ) -> Result<()> {
-        self.write_file_push_plan_bound_to_recipe(plan, recipe, None)
+        let pair = (plan, recipe);
+        self.write_file_push_plans_for_recipes(std::slice::from_ref(&pair))
             .await
     }
 
-    async fn write_file_push_plan_bound_to_recipe(
+    /// Persist several verified push plans in one SQLite transaction.
+    #[expect(
+        clippy::unused_async,
+        reason = "async signature matches the writable staging API"
+    )]
+    pub async fn write_file_push_plans_for_recipes(
         &self,
-        plan: &push_plan::FilePushPlan,
-        recipe: &crate::recipe::FileRecipe,
-        recording_batch_id: Option<&StagingBatchId>,
+        plans: &[(&push_plan::FilePushPlan, &crate::recipe::FileRecipe)],
     ) -> Result<()> {
-        let file_hash = validate_file_push_plan_matches_recipe(plan, recipe)?;
-        let existing_chunks = existing_chunk_index_records(plan)?;
-        let prepared_xorbs = prepared_xorb_index_records(plan)?;
-        let fh: [u8; 32] = file_hash.into();
-        let removed = lock_index(&self.index)?.insert_file_push_plan(index::FilePushPlanWrite {
-            file_hash: &fh,
-            recipe_hash: &recipe.hash(),
-            recording_batch_id: recording_batch_id.map(StagingBatchId::as_str),
-            existing_chunks: &existing_chunks,
-            prepared_xorbs: &prepared_xorbs,
-        })?;
+        if plans.is_empty() {
+            return Ok(());
+        }
+        let mut file_hashes = Vec::with_capacity(plans.len());
+        let mut recipe_hashes = Vec::with_capacity(plans.len());
+        let mut existing_chunks = Vec::with_capacity(plans.len());
+        let mut prepared_xorbs = Vec::with_capacity(plans.len());
+        for (plan, recipe) in plans {
+            let file_hash = validate_file_push_plan_matches_recipe(plan, recipe)?;
+            file_hashes.push(<[u8; 32]>::from(file_hash));
+            recipe_hashes.push(recipe.hash());
+            existing_chunks.push(existing_chunk_index_records(plan)?);
+            prepared_xorbs.push(prepared_xorb_index_records(plan)?);
+        }
+        let writes = (0..plans.len())
+            .map(|index| index::FilePushPlanWrite {
+                file_hash: &file_hashes[index],
+                recipe_hash: &recipe_hashes[index],
+                recording_batch_id: None,
+                existing_chunks: &existing_chunks[index],
+                prepared_xorbs: &prepared_xorbs[index],
+            })
+            .collect::<Vec<_>>();
+        let removed = lock_index(&self.index)?.insert_file_push_plans(&writes)?;
         remove_prepared_payload_files(&self.root, &removed)?;
         Ok(())
     }

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -2534,25 +2534,6 @@ impl StagingArea {
         )
     }
 
-    pub(crate) fn append_recording_remote_chunks(
-        &self,
-        batch_id: &StagingBatchId,
-        chunks: &[(MerkleHash, push_plan::ExistingChunkCandidate)],
-    ) -> Result<()> {
-        let writes = chunks
-            .iter()
-            .map(|(chunk_hash, candidate)| ExistingChunkWrite {
-                chunk_hash: (*chunk_hash).into(),
-                xorb_hash: candidate.xorb_ref.xorb_hash.into(),
-                chunk_index: candidate.xorb_ref.chunk_index,
-                uncompressed_size: candidate.xorb_ref.uncompressed_size,
-                placement_id: candidate.placement_id,
-                origin_proof_id: candidate.origin_proof_id,
-            })
-            .collect::<Vec<_>>();
-        lock_index(&self.index)?.append_recording_remote_chunks(batch_id.as_str(), &writes)
-    }
-
     pub(crate) fn append_recording_batch(
         &self,
         batch_id: &StagingBatchId,

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -2540,25 +2540,14 @@ impl StagingArea {
         start_occurrence: u64,
         start_offset: u64,
         recipe_chunks: &[(MerkleHash, u64)],
-        remote_chunks: &[(MerkleHash, push_plan::ExistingChunkCandidate)],
+        remote_chunks: &[ExistingChunkWrite],
     ) -> Result<()> {
-        let writes = remote_chunks
-            .iter()
-            .map(|(chunk_hash, candidate)| ExistingChunkWrite {
-                chunk_hash: (*chunk_hash).into(),
-                xorb_hash: candidate.xorb_ref.xorb_hash.into(),
-                chunk_index: candidate.xorb_ref.chunk_index,
-                uncompressed_size: candidate.xorb_ref.uncompressed_size,
-                placement_id: candidate.placement_id,
-                origin_proof_id: candidate.origin_proof_id,
-            })
-            .collect::<Vec<_>>();
         lock_index(&self.index)?.append_recording_batch(
             batch_id.as_str(),
             start_occurrence,
             start_offset,
             recipe_chunks,
-            &writes,
+            remote_chunks,
         )
     }
 

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -3979,6 +3979,43 @@ impl StagingAreaReadOnly {
         authoritative_file_push_plan(&self.root, &self.index, file_hash)
     }
 
+    /// Load prepared xorb authority for several published recipes in one index read.
+    pub fn prepared_xorbs_for_recipes(
+        &self,
+        recipe_hashes: &[MerkleHash],
+    ) -> Result<HashMap<MerkleHash, Vec<push_plan::PlannedXorb>>> {
+        let raw_hashes = recipe_hashes
+            .iter()
+            .map(|recipe_hash| (*recipe_hash).into())
+            .collect::<Vec<[u8; 32]>>();
+        let stored = lock_index(&self.index)?.prepared_xorbs_for_recipes(&raw_hashes)?;
+        stored
+            .into_iter()
+            .map(|(recipe_hash, xorbs)| {
+                let xorbs = xorbs
+                    .into_iter()
+                    .map(|stored| push_plan::PlannedXorb {
+                        hash: MerkleHash::from(stored.xorb_hash).hex(),
+                        payload_hash: blake3::Hash::from(stored.payload_hash).to_hex().to_string(),
+                        bytes: stored.bytes,
+                        upload: true,
+                        placements: stored
+                            .placements
+                            .into_iter()
+                            .map(|placement| push_plan::PlannedPlacement {
+                                chunk_hash: MerkleHash::from(placement.chunk_hash).hex(),
+                                xorb_hash: MerkleHash::from(stored.xorb_hash).hex(),
+                                chunk_index: placement.chunk_index,
+                                uncompressed_size: placement.uncompressed_size,
+                            })
+                            .collect(),
+                    })
+                    .collect();
+                Ok((MerkleHash::from(recipe_hash), xorbs))
+            })
+            .collect()
+    }
+
     /// Retire the staged chunks for a successfully-pushed file.
     ///
     /// Removes every `chunks` row with this `file_hash` and decrements

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -3038,6 +3038,16 @@ impl StagingArea {
         Ok(chunks.into_iter().map(StagedChunkLocator::from).collect())
     }
 
+    pub(crate) fn file_chunks_match(
+        &self,
+        file_hash: &MerkleHash,
+        expected: &[(MerkleHash, u64)],
+        expected_size: u64,
+    ) -> Result<bool> {
+        let fh: [u8; 32] = (*file_hash).into();
+        lock_index(&self.index)?.file_chunks_match(&fh, expected, expected_size)
+    }
+
     /// Register a file and its chunks in the index.
     ///
     /// For each chunk in the list, verifies it exists in `chunks` or

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -2867,6 +2867,22 @@ impl StagingArea {
         lock_index(&self.index)?.chunk_payload_exists(&chunk_hash, size)
     }
 
+    /// Return requested chunk hashes whose exact raw segment payload remains locally readable.
+    pub fn segment_payloads_exist(
+        &self,
+        chunks: &[(MerkleHash, u64)],
+    ) -> Result<HashSet<MerkleHash>> {
+        let raw_chunks = chunks
+            .iter()
+            .map(|(hash, size)| ((*hash).into(), *size))
+            .collect::<Vec<_>>();
+        Ok(lock_index(&self.index)?
+            .chunk_payloads_exist(&raw_chunks)?
+            .into_iter()
+            .map(MerkleHash::from)
+            .collect())
+    }
+
     /// Return the immutable recipe owned by a published staging batch.
     pub fn published_recipe_for_file(
         &self,
@@ -3892,6 +3908,22 @@ impl StagingAreaReadOnly {
     pub fn has_segment_payload(&self, chunk_hash: &MerkleHash, size: u64) -> Result<bool> {
         let chunk_hash: [u8; 32] = (*chunk_hash).into();
         lock_index(&self.index)?.chunk_payload_exists(&chunk_hash, size)
+    }
+
+    /// Return requested chunk hashes whose exact raw segment payload remains locally readable.
+    pub fn segment_payloads_exist(
+        &self,
+        chunks: &[(MerkleHash, u64)],
+    ) -> Result<HashSet<MerkleHash>> {
+        let raw_chunks = chunks
+            .iter()
+            .map(|(hash, size)| ((*hash).into(), *size))
+            .collect::<Vec<_>>();
+        Ok(lock_index(&self.index)?
+            .chunk_payloads_exist(&raw_chunks)?
+            .into_iter()
+            .map(MerkleHash::from)
+            .collect())
     }
 
     /// Return the immutable recipe owned by a published staging batch.

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -1207,12 +1207,15 @@ fn existing_chunk_index_records(plan: &push_plan::FilePushPlan) -> Result<Vec<Ex
 fn indexed_prepared_xorb_cache_for_chunks(
     root: &Path,
     index: &Mutex<Index>,
-    wanted_chunks: &HashSet<MerkleHash>,
+    wanted_chunks: &[(MerkleHash, u64)],
 ) -> Result<push_plan::PreparedXorbCache> {
     if wanted_chunks.is_empty() {
         return Ok(push_plan::PreparedXorbCache::default());
     }
-    let wanted: Vec<[u8; 32]> = wanted_chunks.iter().map(|chunk| (*chunk).into()).collect();
+    let wanted: Vec<[u8; 32]> = wanted_chunks
+        .iter()
+        .map(|(chunk, _)| (*chunk).into())
+        .collect();
     let stored = lock_index(index)?.prepared_xorbs_for_chunks(&wanted)?;
     let mut cache = push_plan::PreparedXorbCache::default();
 
@@ -3015,7 +3018,7 @@ impl StagingArea {
 
     pub(crate) fn load_prepared_xorb_cache_for_chunks(
         &self,
-        wanted_chunks: &HashSet<MerkleHash>,
+        wanted_chunks: &[(MerkleHash, u64)],
     ) -> Result<push_plan::PreparedXorbCache> {
         indexed_prepared_xorb_cache_for_chunks(&self.root, &self.index, wanted_chunks)
     }
@@ -5618,11 +5621,6 @@ mod tests {
             .iter()
             .map(|(hash, data)| (*hash, data.len() as u64))
             .collect();
-        let wanted_chunks = chunk_pairs
-            .iter()
-            .map(|(hash, _)| *hash)
-            .collect::<HashSet<_>>();
-
         let file_hash;
         {
             let staging = StagingArea::open(tmp.path().to_path_buf())
@@ -5647,7 +5645,7 @@ mod tests {
                 .expect("write file push plan");
             assert!(
                 !staging
-                    .load_prepared_xorb_cache_for_chunks(&wanted_chunks)
+                    .load_prepared_xorb_cache_for_chunks(&chunk_pairs)
                     .expect("load prepared cache")
                     .is_empty()
             );
@@ -5661,7 +5659,7 @@ mod tests {
             .expect("reopen staging");
         assert!(
             !staging
-                .load_prepared_xorb_cache_for_chunks(&wanted_chunks)
+                .load_prepared_xorb_cache_for_chunks(&chunk_pairs)
                 .expect("load recipe-bound prepared cache")
                 .is_empty(),
             "prepared xorb authority is independent of mutable segment rows"

--- a/crates/crab-staging/src/push_plan.rs
+++ b/crates/crab-staging/src/push_plan.rs
@@ -650,13 +650,22 @@ pub(crate) fn new_push_plan_stats(options: PushPlanSummaryOptions) -> PushPlanSt
 }
 
 pub async fn write_prepared_xorb(root: &Path, xorb_hash: &MerkleHash, bytes: Bytes) -> Result<u64> {
+    let payload_hash = *blake3::hash(&bytes).as_bytes();
+    write_prepared_xorb_with_payload_hash(root, xorb_hash, bytes, payload_hash).await
+}
+
+pub(crate) async fn write_prepared_xorb_with_payload_hash(
+    root: &Path,
+    xorb_hash: &MerkleHash,
+    bytes: Bytes,
+    payload_hash: [u8; 32],
+) -> Result<u64> {
     let path = prepared_xorb_path(root, xorb_hash);
     let parent = path
         .parent()
         .ok_or_else(|| StagingError::Internal("prepared xorb path has no parent".to_owned()))?;
     tokio::fs::create_dir_all(parent).await?;
     validate_prepared_xorb_bytes_identity(&bytes, xorb_hash)?;
-    let payload_hash = *blake3::hash(&bytes).as_bytes();
     let byte_count = bytes.len() as u64;
     if prepared_xorb_file_matches_identity(&path, xorb_hash, &payload_hash, byte_count).await? {
         return Ok(byte_count);

--- a/crates/crab-staging/src/push_plan.rs
+++ b/crates/crab-staging/src/push_plan.rs
@@ -137,7 +137,7 @@ impl PreparedXorbCandidate {
 
 #[derive(Debug, Default)]
 pub struct PreparedXorbCache {
-    chunks: HashMap<MerkleHash, Vec<Arc<PreparedXorbCandidate>>>,
+    chunks: HashMap<MerkleHash, Vec<(Arc<PreparedXorbCandidate>, u32)>>,
     xorbs: HashMap<MerkleHash, Vec<Arc<PreparedXorbCandidate>>>,
 }
 
@@ -153,7 +153,26 @@ impl PreparedXorbCache {
         self.chunks
             .get(chunk_hash)
             .into_iter()
-            .flat_map(|candidates| candidates.iter().map(Arc::as_ref))
+            .flat_map(|candidates| candidates.iter().map(|(candidate, _)| candidate.as_ref()))
+    }
+
+    pub(crate) fn candidate_placements_for_chunk(
+        &self,
+        chunk_hash: &MerkleHash,
+    ) -> impl Iterator<Item = (&PreparedXorbCandidate, &ChunkPlacement)> + '_ {
+        self.chunks
+            .get(chunk_hash)
+            .into_iter()
+            .flat_map(|candidates| {
+                candidates
+                    .iter()
+                    .filter_map(|(candidate, placement_index)| {
+                        candidate
+                            .placements
+                            .get(usize::try_from(*placement_index).ok()?)
+                            .map(|placement| (candidate.as_ref(), placement))
+                    })
+            })
     }
 
     pub fn insert_prepared_xorb(&mut self, planned: &PlannedXorb) -> Result<()> {
@@ -209,12 +228,18 @@ impl PreparedXorbCache {
                     placements,
                 });
                 let mut indexed_chunks = HashSet::new();
-                for placement in &candidate.placements {
+                for (placement_index, placement) in candidate.placements.iter().enumerate() {
                     if indexed_chunks.insert(placement.chunk_hash) {
+                        let placement_index = u32::try_from(placement_index).map_err(|_| {
+                            StagingError::StagingCorrupt(format!(
+                                "prepared xorb {} has too many placements",
+                                xorb_hash.hex()
+                            ))
+                        })?;
                         self.chunks
                             .entry(placement.chunk_hash)
                             .or_default()
-                            .push(Arc::clone(&candidate));
+                            .push((Arc::clone(&candidate), placement_index));
                     }
                 }
                 let candidates = self.xorbs.get_mut(&xorb_hash).ok_or_else(|| {
@@ -239,12 +264,18 @@ impl PreparedXorbCache {
             placements,
         });
         let mut indexed_chunks = HashSet::new();
-        for placement in &candidate.placements {
+        for (placement_index, placement) in candidate.placements.iter().enumerate() {
             if indexed_chunks.insert(placement.chunk_hash) {
+                let placement_index = u32::try_from(placement_index).map_err(|_| {
+                    StagingError::StagingCorrupt(format!(
+                        "prepared xorb {} has too many placements",
+                        xorb_hash.hex()
+                    ))
+                })?;
                 self.chunks
                     .entry(placement.chunk_hash)
                     .or_default()
-                    .push(Arc::clone(&candidate));
+                    .push((Arc::clone(&candidate), placement_index));
             }
         }
         self.xorbs.insert(xorb_hash, vec![candidate]);

--- a/crates/crab-staging/src/push_plan.rs
+++ b/crates/crab-staging/src/push_plan.rs
@@ -149,11 +149,11 @@ impl PreparedXorbCache {
     pub fn candidates_for_chunk(
         &self,
         chunk_hash: &MerkleHash,
-    ) -> impl Iterator<Item = Arc<PreparedXorbCandidate>> + '_ {
+    ) -> impl Iterator<Item = &PreparedXorbCandidate> + '_ {
         self.chunks
             .get(chunk_hash)
             .into_iter()
-            .flat_map(|candidates| candidates.iter().cloned())
+            .flat_map(|candidates| candidates.iter().map(Arc::as_ref))
     }
 
     pub fn insert_prepared_xorb(&mut self, planned: &PlannedXorb) -> Result<()> {

--- a/crates/crab-staging/src/push_plan.rs
+++ b/crates/crab-staging/src/push_plan.rs
@@ -550,7 +550,8 @@ async fn copy_prepared_xorb(
             return Ok(false);
         }
         let payload_hash = planned.payload_hash_bytes()?;
-        install_prepared_xorb_temp(&tmp, target, xorb_hash, &payload_hash, planned.bytes).await?;
+        install_prepared_xorb_temp(&tmp, target, xorb_hash, &payload_hash, planned.bytes, false)
+            .await?;
         tmp_guard.disarm();
         Ok(true)
     }
@@ -713,7 +714,7 @@ pub(crate) async fn write_prepared_xorb_with_payload_hash(
     file.write_all(&bytes).await?;
     file.sync_all().await?;
     drop(file);
-    install_prepared_xorb_temp(&tmp, &path, xorb_hash, &payload_hash, byte_count).await?;
+    install_prepared_xorb_temp(&tmp, &path, xorb_hash, &payload_hash, byte_count, false).await?;
     tmp_guard.disarm();
     Ok(byte_count)
 }
@@ -722,6 +723,7 @@ pub async fn move_prepared_xorb(
     root: &Path,
     xorb_hash: &MerkleHash,
     source_path: &Path,
+    expected_payload_hash: &[u8; 32],
 ) -> Result<u64> {
     let path = prepared_xorb_path(root, xorb_hash);
     let parent = path
@@ -733,6 +735,12 @@ pub async fn move_prepared_xorb(
     tokio::fs::rename(source_path, &tmp).await?;
     let bytes = tokio::fs::metadata(&tmp).await?.len();
     let payload_hash = hash_prepared_xorb_file_async(&tmp).await?;
+    if &payload_hash != expected_payload_hash {
+        return Err(StagingError::StagingCorrupt(format!(
+            "prepared xorb {} payload digest does not match its stream result",
+            xorb_hash.hex()
+        )));
+    }
     validate_prepared_xorb_file_identity(&tmp, xorb_hash, bytes).await?;
     if prepared_xorb_file_matches_identity(&path, xorb_hash, &payload_hash, bytes).await? {
         tokio::fs::remove_file(&tmp).await?;
@@ -741,7 +749,7 @@ pub async fn move_prepared_xorb(
     }
     fail_if_existing_prepared_xorb_is_corrupt(&path, xorb_hash).await?;
     tokio::fs::File::open(&tmp).await?.sync_all().await?;
-    install_prepared_xorb_temp(&tmp, &path, xorb_hash, &payload_hash, bytes).await?;
+    install_prepared_xorb_temp(&tmp, &path, xorb_hash, &payload_hash, bytes, true).await?;
     tmp_guard.disarm();
     Ok(bytes)
 }
@@ -763,14 +771,19 @@ async fn install_prepared_xorb_temp(
     xorb_hash: &MerkleHash,
     payload_hash: &[u8; 32],
     bytes: u64,
+    payload_hash_verified: bool,
 ) -> Result<()> {
     validate_prepared_xorb_file_identity(temp, xorb_hash, bytes).await?;
-    let actual_payload_hash = hash_prepared_xorb_file_async(temp).await?;
-    if &actual_payload_hash != payload_hash {
-        return Err(StagingError::StagingCorrupt(format!(
-            "prepared xorb {} temporary payload digest changed before sealing",
-            xorb_hash.hex()
-        )));
+    // Stream promotion hashes its private temp before this call; rehashing it
+    // here would reread every large xorb without adding a new validation step.
+    if !payload_hash_verified {
+        let actual_payload_hash = hash_prepared_xorb_file_async(temp).await?;
+        if &actual_payload_hash != payload_hash {
+            return Err(StagingError::StagingCorrupt(format!(
+                "prepared xorb {} temporary payload digest changed before sealing",
+                xorb_hash.hex()
+            )));
+        }
     }
 
     match tokio::fs::hard_link(temp, target).await {
@@ -1511,6 +1524,26 @@ mod tests {
 
         assert!(matches!(error, StagingError::StagingCorrupt(_)));
         assert_eq!(std::fs::read(path).expect("read collision"), b"corrupt");
+    }
+
+    #[tokio::test]
+    async fn move_prepared_xorb_rejects_stream_digest_mismatch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let chunks = [(
+            compute_data_hash(b"stream payload"),
+            b"stream payload".to_vec(),
+        )];
+        let (bytes, xorb_hash, _) = xorb_with_chunks(&chunks);
+        let source = tmp.path().join("stream-prepared.xorb");
+        std::fs::write(&source, &bytes).expect("write source");
+
+        let error = move_prepared_xorb(tmp.path(), &xorb_hash, &source, &[0; 32])
+            .await
+            .expect_err("digest mismatch must fail closed");
+
+        assert!(matches!(error, StagingError::StagingCorrupt(_)));
+        assert!(!prepared_xorb_path(tmp.path(), &xorb_hash).exists());
+        assert!(!source.exists());
     }
 
     #[test]

--- a/crates/crab-staging/src/recipe.rs
+++ b/crates/crab-staging/src/recipe.rs
@@ -442,21 +442,29 @@ pub(crate) fn page_hash(
     start_offset: u64,
     chunks: &[(MerkleHash, u64)],
 ) -> Result<[u8; 32]> {
-    if chunks.is_empty() || chunks.len() > RECIPE_PAGE_ENTRIES {
+    let mut hasher = page_hasher(start_occurrence, start_offset, chunks.len())?;
+    for (chunk_hash, size) in chunks {
+        update_sequence_hasher(&mut hasher, *chunk_hash, *size);
+    }
+    Ok(*hasher.finalize().as_bytes())
+}
+
+pub(crate) fn page_hasher(
+    start_occurrence: u64,
+    start_offset: u64,
+    term_count: usize,
+) -> Result<blake3::Hasher> {
+    if term_count == 0 || term_count > RECIPE_PAGE_ENTRIES {
         return Err(StagingError::StagingCorrupt(format!(
-            "recipe page has invalid term count {}",
-            chunks.len()
+            "recipe page has invalid term count {term_count}"
         )));
     }
     let mut hasher = blake3::Hasher::new();
     hasher.update(PAGE_DOMAIN);
     hasher.update(&start_occurrence.to_le_bytes());
     hasher.update(&start_offset.to_le_bytes());
-    hasher.update(&(chunks.len() as u64).to_le_bytes());
-    for (chunk_hash, size) in chunks {
-        update_sequence_hasher(&mut hasher, *chunk_hash, *size);
-    }
-    Ok(*hasher.finalize().as_bytes())
+    hasher.update(&(term_count as u64).to_le_bytes());
+    Ok(hasher)
 }
 
 pub(crate) fn new_page_root_hasher() -> blake3::Hasher {

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use crate::StagingArea;
-use crate::index::{PreparedChunkClaim, RecordingAuthorityState};
+use crate::index::{ExistingChunkWrite, PreparedChunkClaim, RecordingAuthorityState};
 use crate::push_plan::{ExistingChunkCandidate, ExistingChunkLookup, move_prepared_xorb};
 use crate::{Result, StagingError as CrabError};
 use crab_xet::chunker::GearChunker;
@@ -1161,7 +1161,7 @@ struct ChunkStageStats {
 #[derive(Default)]
 struct FlushBatchScratch {
     terms: Vec<(MerkleHash, u64)>,
-    remote_authority: Vec<(MerkleHash, ExistingChunkCandidate)>,
+    remote_authority: Vec<ExistingChunkWrite>,
     existing: Vec<Option<ExistingChunkCandidate>>,
 }
 
@@ -1333,7 +1333,14 @@ async fn flush_batch(
                 .iter()
                 .zip(existing.iter())
                 .filter_map(|((chunk_hash, _), candidate)| {
-                    candidate.map(|candidate| (*chunk_hash, candidate))
+                    candidate.map(|candidate| ExistingChunkWrite {
+                        chunk_hash: (*chunk_hash).into(),
+                        xorb_hash: candidate.xorb_ref.xorb_hash.into(),
+                        chunk_index: candidate.xorb_ref.chunk_index,
+                        uncompressed_size: candidate.xorb_ref.uncompressed_size,
+                        placement_id: candidate.placement_id,
+                        origin_proof_id: candidate.origin_proof_id,
+                    })
                 }),
         );
     if xorb_builder.is_none() {

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -1162,6 +1162,7 @@ struct ChunkStageStats {
 struct FlushBatchScratch {
     terms: Vec<(MerkleHash, u64)>,
     remote_authority: Vec<(MerkleHash, ExistingChunkCandidate)>,
+    existing: Vec<Option<ExistingChunkCandidate>>,
 }
 
 fn append_emitted_chunks(
@@ -1305,8 +1306,15 @@ async fn flush_batch(
 
     let batch_start = *chunk_index_offset;
     let lookup_start = Instant::now();
-    let mut existing =
-        classify_existing_batch(batch, existing_lookup, cancel, &mut scratch.terms).await?;
+    classify_existing_batch(
+        batch,
+        existing_lookup,
+        cancel,
+        &mut scratch.terms,
+        &mut scratch.existing,
+    )
+    .await?;
+    let existing = &mut scratch.existing;
     timings.remote_lookup = timings.remote_lookup.saturating_add(lookup_start.elapsed());
     for (candidate, (_, data)) in existing.iter_mut().zip(batch.iter()) {
         if candidate.as_ref().is_some_and(|candidate| {
@@ -1500,9 +1508,12 @@ async fn classify_existing_batch(
     lookup: Option<&dyn ExistingChunkLookup>,
     cancel: &CancellationToken,
     terms: &mut Vec<(MerkleHash, u64)>,
-) -> Result<Vec<Option<ExistingChunkCandidate>>> {
+    existing: &mut Vec<Option<ExistingChunkCandidate>>,
+) -> Result<()> {
+    existing.clear();
     let Some(lookup) = lookup else {
-        return Ok(vec![None; batch.len()]);
+        existing.resize(batch.len(), None);
+        return Ok(());
     };
     terms.clear();
     terms.extend(batch.iter().map(|(hash, data)| (*hash, data.len() as u64)));
@@ -1512,25 +1523,28 @@ async fn classify_existing_batch(
         result = lookup.lookup_existing_candidates(terms) => result,
     };
     match result {
-        Ok(candidates) if candidates.len() == batch.len() => Ok(candidates),
+        Ok(candidates) if candidates.len() == batch.len() => {
+            existing.extend(candidates);
+        }
         Ok(candidates) => {
             warn!(
                 returned = candidates.len(),
                 requested = batch.len(),
                 "remote chunk classifier returned malformed cardinality; packing batch locally"
             );
-            Ok(vec![None; batch.len()])
+            existing.resize(batch.len(), None);
         }
-        Err(CrabError::Cancelled) => Err(CrabError::Cancelled),
+        Err(CrabError::Cancelled) => return Err(CrabError::Cancelled),
         Err(error) => {
             warn!(
                 error = %error,
                 chunks = batch.len(),
                 "remote chunk classifier unavailable; packing batch locally"
             );
-            Ok(vec![None; batch.len()])
+            existing.resize(batch.len(), None);
         }
     }
+    Ok(())
 }
 
 async fn persist_stream_prepared_authority(

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -1311,13 +1311,6 @@ async fn flush_batch(
             candidate.map(|candidate| (*chunk_hash, candidate))
         })
         .collect::<Vec<_>>();
-    staging.append_recording_remote_chunks(batch_id, &remote_authority)?;
-    *remote_existing_chunks = remote_existing_chunks
-        .checked_add(remote_authority.len() as u64)
-        .ok_or_else(|| {
-            CrabError::StagingCorrupt("remote existing chunk count overflow".to_owned())
-        })?;
-
     if xorb_builder.is_none() {
         let mut start = 0usize;
         while start < batch.len() {
@@ -1349,12 +1342,18 @@ async fn flush_batch(
         .iter()
         .map(|(hash, data)| (*hash, data.len() as u64))
         .collect::<Vec<_>>();
-    staging.append_recipe_recording_terms(
+    staging.append_recording_batch(
         batch_id,
         *chunk_index_offset,
         *recipe_byte_offset,
         &recipe_terms,
+        &remote_authority,
     )?;
+    *remote_existing_chunks = remote_existing_chunks
+        .checked_add(remote_authority.len() as u64)
+        .ok_or_else(|| {
+            CrabError::StagingCorrupt("remote existing chunk count overflow".to_owned())
+        })?;
     *recipe_byte_offset =
         recipe_terms
             .iter()

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -1592,8 +1592,20 @@ async fn persist_stream_prepared_authority(
         if let Some(before_promote) = &hooks.before_prepared_xorb_promote {
             before_promote(&prepared.payload_path)?;
         }
-        let written =
-            move_prepared_xorb(staging.root(), &prepared.hash, &prepared.payload_path).await?;
+        let expected_payload_hash =
+            blake3::Hash::from_hex(&prepared.payload_hash).map_err(|error| {
+                CrabError::StagingCorrupt(format!(
+                    "stream-prepared xorb {} has an invalid payload digest: {error}",
+                    prepared.hash.hex()
+                ))
+            })?;
+        let written = move_prepared_xorb(
+            staging.root(),
+            &prepared.hash,
+            &prepared.payload_path,
+            expected_payload_hash.as_bytes(),
+        )
+        .await?;
         if written != prepared.bytes {
             return Err(CrabError::StagingCorrupt(format!(
                 "stream-prepared xorb {} changed size while becoming authoritative: expected {} bytes, found {written}",

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -1163,6 +1163,8 @@ struct FlushBatchScratch {
     terms: Vec<(MerkleHash, u64)>,
     remote_authority: Vec<ExistingChunkWrite>,
     existing: Vec<Option<ExistingChunkCandidate>>,
+    misses: Vec<(MerkleHash, u64)>,
+    to_pack: Vec<(Chunk, RunId)>,
 }
 
 fn append_emitted_chunks(
@@ -1411,18 +1413,23 @@ async fn flush_batch(
         let coordination = xorb_writer
             .as_ref()
             .and_then(|writer| writer.factory.coordination.as_ref());
+        let mut to_pack = std::mem::take(&mut scratch.to_pack);
+        to_pack.clear();
         let to_pack = if let Some(coordination) = coordination {
-            let misses = batch
-                .iter()
-                .zip(existing.iter())
-                .filter_map(|((hash, data), candidate)| {
-                    candidate.is_none().then_some((*hash, data.len() as u64))
-                })
-                .collect::<Vec<_>>();
-            let claims =
-                staging.claim_prepared_chunks(&coordination.preparation_id, batch_id, &misses)?;
+            scratch.misses.clear();
+            scratch
+                .misses
+                .extend(batch.iter().zip(existing.iter()).filter_map(
+                    |((hash, data), candidate)| {
+                        candidate.is_none().then_some((*hash, data.len() as u64))
+                    },
+                ));
+            let claims = staging.claim_prepared_chunks(
+                &coordination.preparation_id,
+                batch_id,
+                &scratch.misses,
+            )?;
             let mut claims = claims.into_iter();
-            let mut to_pack = Vec::with_capacity(misses.len());
             for ((hash, data), candidate) in batch.iter().zip(existing.iter()) {
                 if candidate.is_some() {
                     continue;
@@ -1449,20 +1456,22 @@ async fn flush_batch(
             }
             to_pack
         } else {
-            batch
-                .iter()
-                .zip(existing.iter())
-                .filter(|(_, candidate)| candidate.is_none())
-                .map(|((hash, data), _)| {
-                    (
-                        Chunk {
-                            hash: *hash,
-                            data: data.clone(),
-                        },
-                        RunId(0),
-                    )
-                })
-                .collect()
+            to_pack.extend(
+                batch
+                    .iter()
+                    .zip(existing.iter())
+                    .filter(|(_, candidate)| candidate.is_none())
+                    .map(|((hash, data), _)| {
+                        (
+                            Chunk {
+                                hash: *hash,
+                                data: data.clone(),
+                            },
+                            RunId(0),
+                        )
+                    }),
+            );
+            to_pack
         };
         let mut builder = xorb_builder.take().ok_or_else(|| {
             CrabError::Internal("direct xorb builder disappeared before pack".to_owned())
@@ -1478,29 +1487,34 @@ async fn flush_batch(
         let runtime = tokio::runtime::Handle::current();
         let pack_cancel = cancel.clone();
         let compression_start = Instant::now();
-        let (returned_builder, returned_sequence) = tokio::task::spawn_blocking(move || {
-            builder.push_batch_with_rollover_admission(
-                &to_pack,
-                || runtime.block_on(writer_factory.acquire_materialization(&pack_cancel)),
-                |result, permit| {
-                    StreamPreparedXorbWriter::submit_reserved_blocking(
-                        &sender,
-                        &mut next_sequence,
-                        result,
-                        permit,
-                    )
-                },
-            )?;
-            Ok::<_, CrabError>((builder, next_sequence))
-        })
-        .await
-        .map_err(|error| CrabError::Internal(format!("direct xorb pack task failed: {error}")))??;
+        let (returned_builder, returned_sequence, returned_to_pack) =
+            tokio::task::spawn_blocking(move || {
+                builder.push_batch_with_rollover_admission(
+                    &to_pack,
+                    || runtime.block_on(writer_factory.acquire_materialization(&pack_cancel)),
+                    |result, permit| {
+                        StreamPreparedXorbWriter::submit_reserved_blocking(
+                            &sender,
+                            &mut next_sequence,
+                            result,
+                            permit,
+                        )
+                    },
+                )?;
+                Ok::<_, CrabError>((builder, next_sequence, to_pack))
+            })
+            .await
+            .map_err(|error| {
+                CrabError::Internal(format!("direct xorb pack task failed: {error}"))
+            })??;
         timings.compression = timings
             .compression
             .saturating_add(compression_start.elapsed());
         *xorb_builder = Some(returned_builder);
         writer.next_sequence = returned_sequence;
         *xorb_writer = Some(writer);
+        scratch.to_pack = returned_to_pack;
+        scratch.to_pack.clear();
     }
     batch.clear();
     *batch_payload_bytes = 0;

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -1376,11 +1376,10 @@ async fn flush_batch(
         ))
     })?;
     if xorb_builder.is_some() {
-        let mut pack = vec![false; batch.len()];
         let coordination = xorb_writer
             .as_ref()
             .and_then(|writer| writer.factory.coordination.as_ref());
-        if let Some(coordination) = coordination {
+        let to_pack = if let Some(coordination) = coordination {
             let misses = batch
                 .iter()
                 .zip(existing.iter())
@@ -1391,7 +1390,8 @@ async fn flush_batch(
             let claims =
                 staging.claim_prepared_chunks(&coordination.preparation_id, batch_id, &misses)?;
             let mut claims = claims.into_iter();
-            for (index, candidate) in existing.iter().enumerate() {
+            let mut to_pack = Vec::with_capacity(misses.len());
+            for ((hash, data), candidate) in batch.iter().zip(existing.iter()) {
                 if candidate.is_some() {
                     continue;
                 }
@@ -1400,32 +1400,38 @@ async fn flush_batch(
                         "prepared ownership claim cardinality was truncated".to_owned(),
                     )
                 })?;
-                pack[index] = matches!(claim, PreparedChunkClaim::Claimed);
+                if matches!(claim, PreparedChunkClaim::Claimed) {
+                    to_pack.push((
+                        Chunk {
+                            hash: *hash,
+                            data: data.clone(),
+                        },
+                        RunId(0),
+                    ));
+                }
             }
             if claims.next().is_some() {
                 return Err(CrabError::Internal(
                     "prepared ownership claim cardinality exceeded input".to_owned(),
                 ));
             }
+            to_pack
         } else {
-            for (index, candidate) in existing.iter().enumerate() {
-                pack[index] = candidate.is_none();
-            }
-        }
-        let to_pack: Vec<_> = batch
-            .iter()
-            .zip(pack)
-            .filter(|(_, should_pack)| *should_pack)
-            .map(|((hash, data), _)| {
-                (
-                    Chunk {
-                        hash: *hash,
-                        data: data.clone(),
-                    },
-                    RunId(0),
-                )
-            })
-            .collect();
+            batch
+                .iter()
+                .zip(existing.iter())
+                .filter(|(_, candidate)| candidate.is_none())
+                .map(|((hash, data), _)| {
+                    (
+                        Chunk {
+                            hash: *hash,
+                            data: data.clone(),
+                        },
+                        RunId(0),
+                    )
+                })
+                .collect()
+        };
         let mut builder = xorb_builder.take().ok_or_else(|| {
             CrabError::Internal("direct xorb builder disappeared before pack".to_owned())
         })?;

--- a/crates/crab-staging/src/stream.rs
+++ b/crates/crab-staging/src/stream.rs
@@ -1019,6 +1019,7 @@ async fn stream_chunk_and_stage_producer(
     let mut remote_existing_chunks = 0u64;
     let mut total = 0u64;
     let mut timings = StreamStageTimingAccumulator::default();
+    let mut flush_scratch = FlushBatchScratch::default();
 
     loop {
         check_cancelled(cancel)?;
@@ -1058,6 +1059,7 @@ async fn stream_chunk_and_stage_producer(
             &mut xorb_writer,
             existing_lookup,
             &mut remote_existing_chunks,
+            &mut flush_scratch,
             &mut timings,
             cancel,
             hooks,
@@ -1090,6 +1092,7 @@ async fn stream_chunk_and_stage_producer(
         &mut xorb_writer,
         existing_lookup,
         &mut remote_existing_chunks,
+        &mut flush_scratch,
         &mut timings,
         cancel,
         hooks,
@@ -1155,6 +1158,12 @@ struct ChunkStageStats {
     timings: StreamStageTimingAccumulator,
 }
 
+#[derive(Default)]
+struct FlushBatchScratch {
+    terms: Vec<(MerkleHash, u64)>,
+    remote_authority: Vec<(MerkleHash, ExistingChunkCandidate)>,
+}
+
 fn append_emitted_chunks(
     chunks: Vec<crab_xet::chunker::Chunk>,
     batch: &mut Vec<(MerkleHash, Bytes)>,
@@ -1198,6 +1207,7 @@ async fn flush_full_batches(
     xorb_writer: &mut Option<&mut StreamPreparedXorbWriter>,
     existing_lookup: Option<&dyn ExistingChunkLookup>,
     remote_existing_chunks: &mut u64,
+    scratch: &mut FlushBatchScratch,
     timings: &mut StreamStageTimingAccumulator,
     cancel: &CancellationToken,
     hooks: &StreamStageHooks,
@@ -1221,6 +1231,7 @@ async fn flush_full_batches(
             xorb_writer,
             existing_lookup,
             remote_existing_chunks,
+            scratch,
             timings,
             cancel,
             hooks,
@@ -1283,6 +1294,7 @@ async fn flush_batch(
     xorb_writer: &mut Option<&mut StreamPreparedXorbWriter>,
     existing_lookup: Option<&dyn ExistingChunkLookup>,
     remote_existing_chunks: &mut u64,
+    scratch: &mut FlushBatchScratch,
     timings: &mut StreamStageTimingAccumulator,
     cancel: &CancellationToken,
     hooks: &StreamStageHooks,
@@ -1293,7 +1305,8 @@ async fn flush_batch(
 
     let batch_start = *chunk_index_offset;
     let lookup_start = Instant::now();
-    let mut existing = classify_existing_batch(batch, existing_lookup, cancel).await?;
+    let mut existing =
+        classify_existing_batch(batch, existing_lookup, cancel, &mut scratch.terms).await?;
     timings.remote_lookup = timings.remote_lookup.saturating_add(lookup_start.elapsed());
     for (candidate, (_, data)) in existing.iter_mut().zip(batch.iter()) {
         if candidate.as_ref().is_some_and(|candidate| {
@@ -1304,13 +1317,17 @@ async fn flush_batch(
             *candidate = None;
         }
     }
-    let remote_authority = batch
-        .iter()
-        .zip(existing.iter())
-        .filter_map(|((chunk_hash, _), candidate)| {
-            candidate.map(|candidate| (*chunk_hash, candidate))
-        })
-        .collect::<Vec<_>>();
+    scratch.remote_authority.clear();
+    scratch
+        .remote_authority
+        .extend(
+            batch
+                .iter()
+                .zip(existing.iter())
+                .filter_map(|((chunk_hash, _), candidate)| {
+                    candidate.map(|candidate| (*chunk_hash, candidate))
+                }),
+        );
     if xorb_builder.is_none() {
         let mut start = 0usize;
         while start < batch.len() {
@@ -1338,24 +1355,25 @@ async fn flush_batch(
             start = end;
         }
     }
-    let recipe_terms = batch
-        .iter()
-        .map(|(hash, data)| (*hash, data.len() as u64))
-        .collect::<Vec<_>>();
+    scratch.terms.clear();
+    scratch
+        .terms
+        .extend(batch.iter().map(|(hash, data)| (*hash, data.len() as u64)));
     staging.append_recording_batch(
         batch_id,
         *chunk_index_offset,
         *recipe_byte_offset,
-        &recipe_terms,
-        &remote_authority,
+        &scratch.terms,
+        &scratch.remote_authority,
     )?;
     *remote_existing_chunks = remote_existing_chunks
-        .checked_add(remote_authority.len() as u64)
+        .checked_add(scratch.remote_authority.len() as u64)
         .ok_or_else(|| {
             CrabError::StagingCorrupt("remote existing chunk count overflow".to_owned())
         })?;
     *recipe_byte_offset =
-        recipe_terms
+        scratch
+            .terms
             .iter()
             .try_fold(*recipe_byte_offset, |offset, (_, size)| {
                 offset.checked_add(*size).ok_or_else(|| {
@@ -1481,18 +1499,17 @@ async fn classify_existing_batch(
     batch: &[(MerkleHash, Bytes)],
     lookup: Option<&dyn ExistingChunkLookup>,
     cancel: &CancellationToken,
+    terms: &mut Vec<(MerkleHash, u64)>,
 ) -> Result<Vec<Option<ExistingChunkCandidate>>> {
     let Some(lookup) = lookup else {
         return Ok(vec![None; batch.len()]);
     };
-    let terms = batch
-        .iter()
-        .map(|(hash, data)| (*hash, data.len() as u64))
-        .collect::<Vec<_>>();
+    terms.clear();
+    terms.extend(batch.iter().map(|(hash, data)| (*hash, data.len() as u64)));
     let result = tokio::select! {
         biased;
         () = cancel.cancelled() => return Err(CrabError::Cancelled),
-        result = lookup.lookup_existing_candidates(&terms) => result,
+        result = lookup.lookup_existing_candidates(terms) => result,
     };
     match result {
         Ok(candidates) if candidates.len() == batch.len() => Ok(candidates),

--- a/crates/crab-xet/src/reconstruction.rs
+++ b/crates/crab-xet/src/reconstruction.rs
@@ -66,13 +66,22 @@ impl FileTermBuilder {
 
     /// Consume one ordered recipe occurrence.
     pub fn push(&mut self, chunk_hash: MerkleHash, placement: &ChunkPlacementMap) -> Result<()> {
+        self.push_with_placement(chunk_hash, placement.get(&chunk_hash))
+    }
+
+    /// Consume one occurrence using a placement lookup performed by the caller.
+    pub fn push_with_placement(
+        &mut self,
+        chunk_hash: MerkleHash,
+        placement: Option<&ChunkPlacement>,
+    ) -> Result<()> {
         let file_index = u32::try_from(self.chunk_count)
             .map_err(|_| shard_format_overflow("file chunk index", self.chunk_count))?;
         self.chunk_count = self
             .chunk_count
             .checked_add(1)
             .ok_or_else(|| shard_format_overflow("file chunk count", u64::MAX))?;
-        let Some(p) = placement.get(&chunk_hash) else {
+        let Some(p) = placement else {
             self.uncovered = self.uncovered.saturating_add(1);
             self.first_miss.get_or_insert((file_index, chunk_hash));
             return Ok(());


### PR DESCRIPTION
## Summary

- Bound the advisory remote-candidate cache across restarts and concurrent writers; preserve negative expiry and invalidate matching misses only after committed publication.
- Preserve local hits and completed remote-proof pages during bounded lookups. Remove the 4,096-candidate push dedup cliff.
- Preserve literal-path symlink boundaries and consolidate batched validation.
- Isolate each concurrent add lookup's receipt snapshot/result. The pre-fix live probe lost 280 remote chunk hits with four workers; after the fix, one and four workers both retain all 1,057 remote hits and prepare only four boundary chunks.
- Add reproducible fresh-bucket RustFS scale qualification with structured phase telemetry, deferred/concurrent add, cold cross-repository dedup, and byte-checked hydration cycles.

## Verification

- Corrected runtime `6e23f81ee16c`: 4,145 library tests passed serially, three ignored; Crab clippy passed; fresh RustFS lifecycle passed 132 checks.
- Earlier boundary changes: 215 staging tests and 96 integration/property/schema tests passed; strict staging clippy and formatting passed.
- Current PR head `ce3fdecfc03`: all 29 executed CI checks passed, eight policy-skipped. Earlier unrelated browser-tooltip contrast retries and parallel Git/LFS fixture-lock failures are documented; no assertions or baselines were weakened.
- Full scale result: **1,223 checks passed, zero failures**. Fresh bucket, 50 × 2 GiB non-zero files, 500 code files, three committed/pushed versions. All 1,100 SHA-256 comparisons passed across cold hydration and rehydration; both dehydration cycles verified all 50 pointers; strict Git fsck passed. This is 100 GiB logical and 20 GiB initial unique entropy, not 100 GiB unique entropy.
- Cold consumer staged 8,274 chunks (> one lookup page), uploaded one new xorb, and cloned/hydrated byte-identically.
- Code-only branch push in the large repository: 1.001 s, no new xorbs, cloned code bytes identical.
- One-worker versus four-worker proof coverage passed again inside the fresh scale run.

| Scale operation | Elapsed |
|---|---:|
| Initial 100 GiB add | 559.033 s |
| Initial push | 593.262 s |
| Edited-version add, v1 / v2 | 620.299 / 642.509 s |
| Edited-version push, v1 / v2 | 245.025 / 277.197 s |
| Deferred 2 GiB prepare / later Git add | 18.800 / 20.120 s |
| Concurrent independent 2 GiB adds | 10.247 / 19.735 s |
| Pointer clone | 1.195 s |
| Cold hydrate / rehydrate | 2165.352 / 1830.921 s |
| First / final dehydrate | 257.228 / 217.152 s |

Each edited version changed 1 MiB in every large file and changed all 500 code files. The pushes uploaded only 57,579,824 and 57,285,483 bytes (54.9 / 54.6 MiB), respectively. Dedup effectiveness is established, but low latency is not universal: post-success cleanup/cache work alone took 108.758 / 131.536 s. That phase needs narrower profiling; it includes staging retirement, not merely cache warming. Edited add also still incurs substantial full-file/recipe/lookup work. These remain optimization opportunities, not claimed fixes.

## Runtime provenance and limitations

Local macOS arm64, 12 logical CPUs, 32 GiB memory; APFS USB SSD shared with source/build/RustFS and other host activity. These are observed wall times, not isolated performance benchmarks. During cold hydration, the verification executable and some top-level build/test logs disappeared externally; the actor is unknown. The running hydrate completed successfully using its loaded executable. The test driver was paused during subsequent hashing, the same locked source/features were rebuilt, and the driver resumed without skipping assertions. Cold hydration overlapped this rebuild.

- Original release SHA-256: `e2ad0e0212c150168c8aa9b2a4ff4087148d4cfdc2dfe8b37c8984d7b2cd63a2`.
- Recovered release SHA-256: `3a825e4b1f4364414107fc8a6d7f2946619f7ac45bb3809164d4c9bc7b737557`.
- Both identify runtime source `6e23f81ee16c`; later PR commits only change the qualification report.
- RustFS command logs, reports, expected hashes and recovery provenance are retained. Some original top-level build/test logs are unavailable; GitHub CI evidence remains available.
- The first pre-fix 100 GiB run was intentionally interrupted after its initial add/push exposed the concurrency issue; it is not counted as a passed run.
- Cleanup completed: generated scale, canary and probe repositories/caches were removed; both final fresh RustFS buckets were deleted. Earlier failed/interrupted-run data and buckets were also removed. Only about 38 MiB of qualification reports/logs remain; the release build artifacts are retained separately. No existing qualification repositories or unrelated bucket data were deleted.

## Audit and scope

Formats remain v1. Cached candidates remain advisory; push revalidates origin/placement proofs. No compatibility reader or dependency override was added. Rebased on `ebd0e40d14c`; main subsequently added documentation only. This PR remains mergeable.

Is this the best bounded fix, rather than merely plausible? Yes: proof ownership now belongs to each lookup, avoiding cross-worker state interference without serializing network I/O or disabling dedup. Cache lifetime, committed publication and paged lookup policies likewise reside at their owner boundaries.

The evidence covers the exercised local RustFS lifecycle, not every CLI command, every historical large-file version, 100 GiB of unique entropy, or production S3/GCS/Azure behavior. See `crab/docs/benchmarks/add-push-hardening-rustfs.md` for the evidence map and dependency contracts.
