### PR TITLE
docs(crates): add agent guides for all 21 shared crates

### DIFF
--- a/advisor-plans/001-per-crate-agent-guides.md
+++ b/advisor-plans/001-per-crate-agent-guides.md
@@ -1,0 +1,387 @@
+# Plan 001: Add agent guides to all 21 shared crates
+
+> Executor: read this plan and the inherited repository instructions before work.
+> Implement all six batches. This plan needs no prior conversation context.
+> Update `advisor-plans/README.md` when implementation is complete; do not mark
+> it done merely because the plan exists.
+
+## Status
+
+- Priority: P1
+- Effort: M–L; documentation research across 21 crates
+- Risk: low runtime risk; inaccurate or stale instructions are the main risk
+- Category: docs / developer experience
+- Depends on: none
+- Planned at: `ebd0e40d14c`, 2026-09-06
+- Delivery: 21 `AGENTS.md` files and 21 relative `CLAUDE.md` symlinks
+
+## Why this matters
+
+Agents currently have a workspace-level subsystem map but no individual crate
+reading guides. Each task rediscovers local entry points, consumers, feature
+requirements and lifecycle constraints. Add concise, source-backed navigation
+so agents can reach the right code and verification without duplicating global
+rules or turning these files into design histories.
+
+## Current state and evidence
+
+- `Cargo.toml` declares 21 `crates/crab-*` members plus the `crab` product crate.
+  Only the 21 shared/server crates are in this plan; `crab/` is excluded.
+- All 21 have a README. None has a crate-local AGENTS.md or CLAUDE.md at the
+  planned commit. Check again before writing; do not overwrite new guidance.
+- `crates/AGENTS.md` provides the subsystem and dependency ownership map.
+  Its opening explicitly says: `Root AGENTS.md also applies.`
+- Root `AGENTS.md` requires: `New AGENTS.md: add sibling CLAUDE.md symlink;
+  edit AGENTS.md only.` Use `CLAUDE.md -> AGENTS.md`, not a second text file.
+- `crates/crab-write/src/lib.rs:1` says:
+  `//! Shared publication mechanics; authentication and product policy stay with callers.`
+  Its `journal.rs` API documents leases, publication and cancellation. This is
+  a useful ownership example: guide readers to the contract rather than copying it.
+- `crates/crab-staging/src/lib.rs:17` starts concurrency documentation;
+  `tests/unit/` contains property tests. Test discovery must include inline
+  tests and path-mounted unit modules, not only top-level integration tests.
+- `CONTEXT.md` distinguishes a worktree (Git checkout and its metadata) from
+  a working tree (checked-out files). Preserve the distinction in guides.
+- Existing CI already includes split-crate interface, behavior, Clippy and
+  test checks in `.github/workflows/architecture.yml`. Do not propose or add
+  duplicate gates as part of this documentation work.
+
+## Scope and exclusions
+
+Only create `crates/<name>/AGENTS.md` and `crates/<name>/CLAUDE.md` for the
+21 names listed below. Update this plan's status in `advisor-plans/README.md`.
+No source, README, Cargo manifest/lockfile, CI, root/scoped guide, baseline,
+example or test changes. Do not introduce new policy, compatibility shims or
+runtime behavior. If a source defect is noticed, report it separately.
+
+Use the existing worktree. If a branch is needed, use `codex/crate-agent-guides`.
+Do not commit, push or create a PR unless requested. Preserve unrelated changes.
+
+## Guide shape
+
+Use these headings consistently. Aim for roughly 80–140 lines; this is an
+editing target, not a quota. Small crates should be shorter. Avoid nested lists
+and long paragraphs. Use repository-root-relative file references inside guides.
+
+```markdown
+# <crate-name>
+
+Root AGENTS.md and crates/AGENTS.md apply. Read README.md for crate usage.
+
+## Purpose and ownership
+<One short paragraph; owned responsibilities and neighboring owners.>
+
+## Read first
+<Ordered route of 3–6 source files, each with a reason to read it.>
+
+## Common changes
+| Task | Start here | Also inspect |
+| ... | real source path | caller, callee or sibling path |
+
+## Invariants
+<3–6 local constraints with source references; link detailed contracts.>
+
+## Features and platform
+<Exact feature names from Cargo.toml; defaults, optional paths and OS needs.>
+
+## Verification
+<Focused, copyable commands; distinguish local tests from dedicated/live CI.>
+
+## Related documentation
+<Existing README, relevant docs/tests and when to update this guide.>
+```
+
+For crates without explicit Cargo features, say so rather than inventing
+`default` or `all` features. Distinguish dependency-enabled capabilities from
+crate features. Server entry points may be binaries; their caller map should
+start at that binary and router rather than inventing a library consumer.
+
+A reading guide is not an API inventory. Every path and rule must help a future
+agent make a concrete decision. Do not paste root style rules, entire READMEs,
+feature dependency trees, transient line counts, benchmark numbers or plan IDs.
+Use a small diagram only when a lifecycle is clearer than an ordered route.
+
+## Crate-specific investigation routes
+
+Paths below are relative to `crates/<crate>/`. Every listed route existed at
+planning time. These are research starting points, not a claim that every
+function or dependency contract has already been audited. Read the relevant
+whole functions, callers, callees, sibling paths and tests before writing
+behavioral instructions. Verify focus statements against current source.
+
+| Crate | Read in order | Guide emphasis |
+|---|---|---|
+| crab-types | `src/lib.rs` → `src/pointer.rs` → `src/storage.rs` → `src/error.rs` | Serialized shapes and validation; distinguish worktree from working tree; inspect consumers before changing wire contracts. |
+| crab-git | `src/lib.rs` → `src/discover.rs` → `src/receive_plan.rs` → `src/pack.rs` → `src/refname.rs` | Git mechanics versus command policy; protocol parsing, ref namespaces and pack integrity; facade is optional. |
+| crab-diff | `src/lib.rs` → `src/types.rs` → `src/chunk_sequence.rs` → `src/chunk_comparator.rs` → `src/pointer_pairs.rs` | Pure comparisons and chunk ordering; no storage or hydration orchestration. |
+| crab-xet | `src/lib.rs` → `src/hash.rs` → `src/xorb/builder.rs` → `src/reconstruction.rs` → `src/shard.rs` | Hashes, serialized Xorbs and complete term coverage; trace upstream Xet contracts before changing formats. |
+| crab-storage | `src/lib.rs` → `src/layout.rs` → `src/store.rs` → `src/cas.rs` → `src/error_map.rs` | Storage keys, conditional writes and retry classification; inspect object_store contract and distinguish transport from caller policy. |
+| crab-metadata | `src/lib.rs` → `src/manifests.rs` → `src/manifest_store.rs` → `src/ref_journal.rs` → `src/git_visibility.rs` | Payload-only versus persistence features; publication visibility, codecs and explicit writer close; follow git_object_locator/ for catalog tasks. |
+| crab-staging | `src/lib.rs` → `src/index.rs` → `src/segment.rs` → `src/recovery.rs` → `src/push_plan.rs` | Durability, complete file-version chunks, locking and recovery; read recipe.rs and multipart_resume.rs for those tasks. |
+| crab-coordination | `src/lib.rs` → `src/push_lock.rs` → `src/lease_operation.rs` → `src/gc_fence.rs` → `src/write_coordinator.rs` | Per-ref serialization, lease renewal/release and GC fencing; distinguish object-store and active-active backends. |
+| crab-write | `src/lib.rs` → `src/journal.rs` → `src/namespace.rs` → `src/generation.rs` → `src/catalog.rs` | Caller-held leases and snapshots; commit uncertainty, publication versus read readiness, cancellation draining and cleanup. |
+| crab-cache | `src/lib.rs` → `src/key.rs` → `src/path_class.rs` → `src/local_cache.rs` → `src/lifecycle.rs` | Cache identity, admission and lifecycle ownership; remote contracts in cache_client.rs; keep routing policy boundaries explicit. |
+| crab-cache-store | `src/lib.rs` → `src/xorb_read.rs` | Canonical cache/origin composition; verified reads, error-source preservation and sibling caller behavior. |
+| crab-read | `src/lib.rs` → `src/selection.rs` → `src/hydrator.rs` → `src/term_resolver.rs` → `src/store_client.rs` | Selection and verified hydration; branch to upload_pack.rs and fetch_admission.rs for Git transport tasks. |
+| crab-remote-git | `src/lib.rs` → `src/repository.rs` → `src/snapshot.rs` → `src/operation.rs` → `src/reader.rs` | Bounded filesystem-free reads, snapshot/operation lifecycle and immutable pack evidence; inspect pack.rs for range reads. |
+| crab-lfs | `src/lib.rs` → `src/object_store.rs` → `src/lock.rs` | LFS object identity, integrity and locks; pointer parsing belongs to crab-git. |
+| crab-auth | `src/lib.rs` → `src/credentials.rs` → `src/credential_provider.rs` → `src/token_cache.rs` → `src/protected_push.rs` | Credential and scope contracts, secret handling and optional clients; use managed/ for managed-service API tasks. |
+| crab-auth-store | `src/lib.rs` → `src/refreshing_store.rs` → `src/gateway_store.rs` → `src/managed_repository.rs` | Resolved credentials to storage; refresh and gateway lifecycles; separate credential policy from storage mechanics. |
+| crab-auth-server | `src/lib.rs` → `src/receive.rs` → `src/receive/git_workspace.rs` → `src/view.rs` → `src/doctor.rs` | Protected receive and view composition; authorization boundary, workspace cleanup and binary entry points from Cargo.toml. |
+| crab-cache-server | `src/lib.rs` → `src/server.rs` → `src/state.rs` → `src/handlers.rs` → `src/cache_store.rs` | Request/auth/origin flow, persistence and eviction; config.rs and preflight.rs for operations; service lifecycle ownership. |
+| crab-http-server | `src/main.rs` → `src/server.rs` → `src/app.rs` → `src/auth.rs` → `src/receive.rs` | HTTP routing, auth and native Git receive; branch to contents.rs, git.rs, lfs.rs and maintenance.rs; embedded frontend build prerequisites. |
+| crab-vfs | `src/lib.rs` → `src/pipeline.rs` → `src/engine.rs` → `src/hydration.rs` → `src/mount_runtime.rs` | Mount admission and teardown, leases, IPC and worker shutdown; separate FUSE/NFS adapters from canonical read orchestration. |
+| crab-workflow | `src/lib.rs` → `src/yaml.rs` → `src/graph.rs` → `src/scheduler.rs` → `src/executor.rs` | Strict parse, deterministic plan and execution; lockfile.rs, journal.rs and resume.rs for persisted state; CLI owns product invocation. |
+
+## Feature inventory at the planned commit
+
+Use this to detect drift; regenerate from Cargo.toml before documenting.
+An omitted `default` key does not imply the absence of optional features.
+
+| Crate | Declared features |
+|---|---|
+| crab-types | None declared |
+| crab-git | `facade` |
+| crab-diff | None declared |
+| crab-xet | `default`, `chunker`, `upload-concurrency` |
+| crab-storage | `default`, `test-support` |
+| crab-metadata | `default`, `file-index-reader`, `local-index`, `remote-index`, `storage` |
+| crab-staging | None declared |
+| crab-coordination | `default`, `object-store-lock`, `coordinator-dynamodb`, `coordinator-spanner`, `coordinator-cosmosdb` |
+| crab-write | None declared |
+| crab-cache | `default`, `active-probe`, `local-cache`, `remote-client`, `xet-chunk-cache` |
+| crab-cache-store | `default`, `remote-client` |
+| crab-read | None declared |
+| crab-remote-git | None declared |
+| crab-lfs | None declared |
+| crab-auth | `default`, `aws-oidc-client`, `azure-entra-client`, `crab-auth-client`, `gcp-workload-identity-client`, `oidc-client` |
+| crab-auth-store | `default`, `refreshing-store`, `managed-service` |
+| crab-auth-server | None declared |
+| crab-cache-server | None declared |
+| crab-http-server | None declared |
+| crab-vfs | `default`, `fuse`, `nfs`, `gix-facade` |
+| crab-workflow | `default`, `crash-injection`, `gix-facade`, `testing`, `watch` |
+
+## Implementation steps
+
+### 1. Establish baseline and inspect inherited guidance
+
+Run from repository root:
+
+```sh
+git status --short
+git diff --stat ebd0e40d14c..HEAD -- AGENTS.md CONTEXT.md crates Cargo.toml
+cat AGENTS.md crates/AGENTS.md CONTEXT.md
+```
+
+Record pre-existing changes. Read each crate's README, Cargo.toml and lib.rs
+before its batch. Inspect binary declarations and build scripts for servers.
+If source moved, refresh the route from current source; if an ownership rule
+conflicts with code, report the conflict instead of publishing it as fact.
+
+Verify the matrix contains exactly the current `crates/` workspace members:
+
+```sh
+python3 - <<'PYVERIFY'
+import tomllib
+from pathlib import Path
+workspace = tomllib.loads(Path('Cargo.toml').read_text())['workspace']['members']
+crates = sorted(p for p in workspace if p.startswith('crates/'))
+assert len(crates) == 21, crates
+assert all((Path(p) / 'README.md').is_file() for p in crates)
+print('21 crate members; all README entry points exist')
+PYVERIFY
+```
+
+Expected: the printed success line and exit 0. A changed membership requires
+reconciling scope before claiming all-crate coverage.
+
+### 2. Write and verify six batches
+
+1. Contracts/mechanics: types, git, diff, xet.
+2. Persistence/publication: storage, metadata, staging, coordination, write.
+3. Read/cache: cache, cache-store, read, remote-git, lfs.
+4. Credentials: auth, auth-store.
+5. Services/mounts: auth-server, cache-server, http-server, vfs.
+6. Workflow: workflow.
+
+All names have the `crab-` prefix. Within each batch, for each crate:
+
+1. Read the route and the whole relevant functions. Search direct consumers
+   using the Cargo package name and Rust crate identifier, including aliases
+   and re-exports. Follow at least one real entry-point → owner → callee path.
+2. Build a temporary evidence table: local responsibility, source symbol,
+   caller/entry point, callee, sibling, test and feature gate. Cover each
+   invariant proposed for the guide. Missing evidence means narrow the claim;
+   do not fill a cell with a guess. Trace dependency-backed behavior to the
+   locked dependency's types/source/docs when making a claim about it.
+3. Write the guide with the shape above. Include at least two common-change
+   routes, one caller/entry-point reference and one callee/neighbor reference.
+   Name actual test modules/files and a narrow test command for the important
+   contract. Do not claim the tests passed merely because their source exists.
+4. Create the relative symlink only if no file/symlink already occupies it:
+   `ln -s AGENTS.md crates/<crate>/CLAUDE.md`. Substitute the actual crate name.
+   Never force-overwrite a pre-existing file.
+5. Check both local paths and paths into sibling crates. Read the generated
+   guide from top to bottom and remove duplication or unsupported guarantees.
+
+Useful searches (substitute a real crate or symbol):
+
+```sh
+rg -n 'crab_staging::|crab-staging' crab/src crates Cargo.toml
+rg -n '#\[test\]|#\[tokio::test|proptest!|#\[path' crates/crab-staging
+rg -n 'StagingArea|flush_pending' crates/crab-staging crab/src
+```
+
+Expected: actual callers and test source for the selected route. Search results
+are navigation, not proof; inspect their enclosing functions. Use equivalent
+queries for every crate, not just staging.
+
+After each batch run `git diff --check` (expected exit 0) and the structural
+verification below with `GUIDE_CHECK_PARTIAL=1`. Newly created untracked files
+must also pass the Python check; Git diff alone does not inspect them.
+
+### 3. Verify commands without unnecessary builds
+
+This task changes documentation only. Do not run all crate suites or cloud
+qualification just to add guides. Validate command package names, test target
+names and feature flags against manifests, test declarations and existing CI.
+If a command cannot be established statically, label its validation limitation
+in the handoff; do not invent a passing result.
+
+Source command recipes from:
+
+- `crab/scripts/check-crate-behavior.py` — focused test filters.
+- `crab/scripts/check-crate-interface-builds.py` — interface/feature slices.
+- `crab/Makefile` — split-crate Clippy/test targets.
+- `.github/workflows/architecture.yml` — dedicated runner prerequisites.
+- Relevant live/platform workflows (NFS, cache-service, HTTP, Git protocol).
+
+A complete example for future storage changes, backed by the existing behavior
+check script:
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c"   cargo test -p crab-storage --locked provider_store
+```
+
+On another worktree choose a unique target directory for that worktree. Before
+any compilation, verify `$HOME/Workspace` resolves to the mounted workspace
+volume and the chosen target is writable. Never silently use local `target/`
+or share another worktree's build directory. Respect the inherited install
+policy if a dependency is missing. Do not run installation for this docs task.
+
+Commands included in final guides should be runnable from repository root and
+carry their CARGO_TARGET_DIR assignment on every compilation invocation.
+Distinguish platform-only or live-service tests, prerequisites and side effects.
+Do not put real credentials, cloud resource identifiers or destructive GC
+commands into guides. Do not prescribe broad `--all-features` where exact
+feature slices are required.
+
+### 4. Check coverage, references, headings and symlinks
+
+Run the following from repository root after all batches. For intermediate
+batches prefix the command with `GUIDE_CHECK_PARTIAL=1`.
+
+```sh
+python3 - <<'PYVERIFY'
+import os
+import re
+import tomllib
+from pathlib import Path
+
+root = Path.cwd()
+members = tomllib.loads((root / 'Cargo.toml').read_text())['workspace']['members']
+crates = sorted(p for p in members if p.startswith('crates/'))
+assert len(crates) == 21, crates
+partial = os.environ.get('GUIDE_CHECK_PARTIAL') == '1'
+headings = [
+    'Purpose and ownership', 'Read first', 'Common changes', 'Invariants',
+    'Features and platform', 'Verification', 'Related documentation',
+]
+count = 0
+for member in crates:
+    directory = root / member
+    guide = directory / 'AGENTS.md'
+    alias = directory / 'CLAUDE.md'
+    if partial and not guide.exists():
+        assert not alias.exists() and not alias.is_symlink(), str(alias)
+        continue
+    assert guide.is_file() and not guide.is_symlink(), str(guide)
+    assert alias.is_symlink(), str(alias)
+    assert os.readlink(alias) == 'AGENTS.md', str(alias)
+    assert alias.resolve() == guide.resolve(), str(alias)
+    body = guide.read_text()
+    assert body.startswith('# ' + directory.name + '\n'), str(guide)
+    for heading in headings:
+        assert f'## {heading}' in body, (member, heading)
+    assert 'crates/AGENTS.md' in body, member
+    assert 'CARGO_TARGET_DIR=' in body, member
+    assert not any(line.rstrip() != line for line in body.splitlines()), member
+    assert body.endswith('\n'), member
+    # Root-relative references only; strip an optional source line suffix.
+    refs = re.findall(r'`((?:crates|crab|packages|\.github)/[^`\s]+)`', body)
+    assert len(set(refs)) >= 3, (member, 'too few concrete source references')
+    for ref in refs:
+        target = re.sub(r':\d+(?:-\d+)?$', '', ref)
+        assert (root / target).exists(), (member, ref)
+    count += 1
+assert count > 0
+assert partial or count == 21
+print(f'{count}/21 guides checked; headings, source paths and symlinks valid')
+PYVERIFY
+git diff --check
+git status --short
+```
+
+Expected final result: `21/21 guides checked; headings, source paths and
+symlinks valid`; Git diff check exits 0. The checker validates structure,
+not factual accuracy, test execution, arbitrary Markdown links or test filters.
+Review those manually against source.
+
+### 5. Review factual quality and hand off
+
+Review every guide against its temporary evidence table. Check feature names
+and defaults against the live manifest, cleanup rules against implementation,
+and test commands against the actual test declarations. Ask: is this the best
+navigation guide for the crate, or merely a plausible module list?
+
+Confirm exactly 42 guide/symlink additions and the permitted status update,
+adjusting only for pre-existing changes recorded at baseline. Use `git status
+--short --untracked-files=all` because new files are not shown by ordinary diff.
+Mark the plan DONE only once all 21 guides exist and checks pass. Report the
+structural checks run and any command validation gaps; no runtime change or
+runtime qualification is implied.
+
+## Done criteria
+
+- [ ] All 21 workspace crate members have a substantive AGENTS.md.
+- [ ] All 21 CLAUDE.md files are relative symlinks to their sibling AGENTS.md.
+- [ ] Structural checker prints 21/21 and exits 0; `git diff --check` exits 0.
+- [ ] Every guide has source-backed ownership, reading routes, invariants,
+      feature/platform notes and focused verification commands.
+- [ ] Every stated contract has source/test/consumer evidence; no invented APIs,
+      feature names, passing-test claims or blanket copied instructions.
+- [ ] No source, READMEs, manifests, CI, baselines or existing root guides changed.
+- [ ] Plan status updated in advisor-plans/README.md; final handoff states limits.
+
+## Stop conditions
+
+- A pre-existing guide or alias would be overwritten: preserve it and reconcile
+  its instructions first; report a blocking conflict rather than forcing a write.
+- Workspace crate membership differs from 21: report the scope difference.
+- A lifecycle or ownership assertion conflicts with source or inherited rules:
+  omit the unsupported claim, record the gap, and seek resolution if it prevents
+  a useful guide. Continue independent crates.
+- Accurate guidance requires source fixes, new policy or out-of-scope edits:
+  record follow-up work; do not implement it in this task.
+- Workspace volume is unavailable when compilation is actually needed:
+  stop that verification and report the missing prerequisite.
+
+## Maintenance
+
+Update the local guide when public entry points, ownership, feature flags,
+cleanup responsibilities or verification routes change. Keep stable source
+paths and symbol names rather than fragile line-number inventories. Deep API
+contracts remain in rustdoc/source; detailed usage remains in READMEs. README
+rewrites, executable examples, code refactors and permanent CI doc gates are
+separate follow-up work.

--- a/advisor-plans/README.md
+++ b/advisor-plans/README.md
@@ -1,0 +1,48 @@
+# Crate quality implementation plans
+
+Created 2026-09-06 with the improve skill; planned against `ebd0e40d14c`.
+This directory separates the selected crate-guidance work from the existing
+GC/product roadmap in `plans/`.
+
+| Plan | Scope | Priority | Effort | Depends on | Status |
+|---|---|---|---|---|---|
+| [001: Per-crate agent guides](001-per-crate-agent-guides.md) | All 21 shared/server crates; AGENTS.md plus CLAUDE.md symlinks | P1 | M–L | None | DONE |
+
+## Execution order
+
+Execute plan 001 in its six batches. Complete source-backed navigation and
+validation for every crate before marking it DONE. No dependency on GC plans.
+
+## Scope decisions
+
+- Selected by the user: agent guides across all 21 crates.
+- Deferred: README/rustdoc rewrites, executable examples and code decomposition.
+- Rejected: copying root instructions into each crate; this adds duplicated policy.
+- Existing split-crate CI already checks interfaces, behavior, Clippy and tests;
+  new blanket quality gates are not part of this plan.
+
+## Completion evidence — 2026-09-07
+
+Implemented all six batches: 21 crate-local AGENTS.md guides and 21 relative
+CLAUDE.md symlinks. Each guide includes named source entry points, a concrete
+call path, common-change routes, local invariants, feature/platform notes and
+focused verification recipes. Parent review checked the complete guides and
+relevant source paths; revisions corrected close-test selection, staging
+flush ownership, metadata minimal features and LFS sibling implementation scope.
+
+Checks passed against the completed files:
+
+- Plan membership and structural checks: 21/21 crates and valid relative aliases.
+- 210 distinct repository path references exist; 146 navigation symbol tokens
+  occur in their referenced source files.
+- All declared crate feature names appear in the corresponding guides.
+- 47 Cargo test recipes: shell syntax, package names, feature names and
+  integration targets checked; 44 library filters map to source modules/functions.
+- Exactly 42 guide/alias additions. No Rust source, manifests, tests, existing
+  READMEs, inherited guides or CI changes. `git diff --check` passed.
+
+These are static documentation checks and source review, not test execution.
+Cargo recipes were not run: this is documentation-only work, and the required
+workspace build volume is unavailable on this host. No runtime or provider
+qualification is claimed. README rewrites, runnable examples and Rust refactors
+remain separate work; this completion covers plan 001's full guide scope.

--- a/crates/crab-auth-server/AGENTS.md
+++ b/crates/crab-auth-server/AGENTS.md
@@ -1,0 +1,70 @@
+# crab-auth-server
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-auth-server/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns JSON-speaking protected receive and path-scoped view helper binaries. It is a service-side execution boundary, not a persistent HTTP router; managed-service authorization inputs and local workspace lifecycle meet here.
+
+## Read first
+
+1. `crates/crab-auth-server/src/lib.rs` — helper modules and error boundary.
+2. `crates/crab-auth-server/src/receive.rs` — `ProtectedPushPlan / commit_service_metadata`: prepare/verify/commit orchestration.
+3. `crates/crab-auth-server/src/receive/git_workspace.rs` — `materialize_source_push / verify_source_push`: pack installation and Git validation.
+4. `crates/crab-auth-server/src/view.rs` — `materialize_view_with_store`: scoped source materialization.
+5. `crates/crab-auth-server/src/doctor.rs` — `git_version`: native Git capability checks.
+
+Trace one path: `crates/crab-auth-server/src/bin/crab_auth_receive.rs` → receive
+functions in `crates/crab-auth-server/src/receive.rs` → pack/workspace
+operations in `crates/crab-auth-server/src/receive/git_workspace.rs`.
+`crates/crab-auth-server/src/bin/crab_auth_view.rs` is the separate view entry.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Receive command | `crates/crab-auth-server/src/bin/crab_auth_receive.rs` | `crates/crab-auth-server/src/receive.rs` |
+| Scoped view | `crates/crab-auth-server/src/bin/crab_auth_view.rs` | `crates/crab-auth-server/src/view.rs` |
+| Git validation | `crates/crab-auth-server/src/receive/git_workspace.rs` | `crates/crab-git/src/pack.rs` |
+
+## Invariants
+
+- Keep prepare, verify, and commit boundaries explicit; commit must use verified state and expected ref changes rather than trusting uploaded bytes.
+  Source: `crates/crab-auth-server/src/receive.rs`.
+- Read-path authorization and denied paths must remain part of view construction; do not reuse an unscoped view merely because its source generation matches.
+  Source: `crates/crab-auth-server/src/view.rs`.
+- Operation-owned Git workspace cleanup and worker draining are part of error/cancellation handling, not just the success path. Inspect workspace creation and callers together.
+  Source: `crates/crab-auth-server/src/receive/git_workspace.rs`.
+
+## Features and platform
+
+No declared Cargo features. Binaries: `crab-auth-receive` and `crab-auth-view`. Native Git and writable temporary space are required for workspace tests; doctor validates service prerequisites. Cloud-backed prepare/commit/view proof needs a dedicated environment.
+
+## Verification
+
+Receive/git_workspace and view contain inline tests for malformed packs/paths and unavailable workspaces; library test helpers isolate process-global temporary-directory overrides.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-auth-server --locked --lib receive
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-auth-server --locked --lib view
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-auth-server/README.md` — usage and detailed contracts.
+- `crates/crab-auth-server/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-auth-server/CLAUDE.md
+++ b/crates/crab-auth-server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-auth-store/AGENTS.md
+++ b/crates/crab-auth-store/AGENTS.md
@@ -1,0 +1,68 @@
+# crab-auth-store
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-auth-store/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns composition from resolved cloud credentials/managed grants to Store, including scope routing and refresh wrappers. Auth owns credential policy; storage owns provider construction and transport identity.
+
+## Read first
+
+1. `crates/crab-auth-store/src/lib.rs` — `build_store_from_credentials / build_protected_push_store`: credential conversion and store construction.
+2. `crates/crab-auth-store/src/refreshing_store.rs` — `RefreshingObjectStore::refresh_parts`: refresh/retry and target binding.
+3. `crates/crab-auth-store/src/gateway_store.rs` — `GatewayObjectStore`: scoped HTTP object adapter.
+4. `crates/crab-auth-store/src/managed_repository.rs` — `ManagedRepositoryResolver`: managed discovery, grants, and push finalization.
+
+Trace one path: `crab/src/auth/mod.rs` (`build_store_from_credentials`) → same-named
+function in `crates/crab-auth-store/src/lib.rs` → provider construction in
+`crates/crab-storage/src/provider_store.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Credential conversion | `crates/crab-auth-store/src/lib.rs` | `crates/crab-storage/src/provider_store.rs` |
+| Refresh target safety | `crates/crab-auth-store/src/refreshing_store.rs` | `crab/src/auth/mod.rs` |
+| Managed grant/gateway | `crates/crab-auth-store/src/gateway_store.rs` | `crates/crab-auth/src/managed` |
+
+## Invariants
+
+- Keep Azure split read/write credentials on the protected-push constructor path; a write prefix mismatch must not widen the grant.
+  Source: `crates/crab-auth-store/src/lib.rs`.
+- Refresh may replace secrets for the same target; reject a changed target before replacing the active store or retrying requests.
+  Source: `crates/crab-auth-store/src/refreshing_store.rs`.
+- Gateway paths must remain inside the grant repository/staging scope; inspect rejection-before-network tests when changing path mapping.
+  Source: `crates/crab-auth-store/src/gateway_store.rs`.
+
+## Features and platform
+
+Empty default. `refreshing-store` enables object-store/HTTP wrappers; `managed-service` also enables refreshing-store and managed resolution with auth OIDC support. Check that exact slice for managed changes. Live refresh/grant behavior needs dedicated identity-service proof.
+
+## Verification
+
+Inline lib tests cover credential conversion; refreshing_store tests cover destination changes including multipart; gateway_store tests cover out-of-scope paths.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-auth-store --locked --lib --features refreshing-store refreshing_store::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-auth-store --locked --lib --features refreshing-store gateway_store::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-auth-store/README.md` — usage and detailed contracts.
+- `crates/crab-auth-store/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-auth-store/CLAUDE.md
+++ b/crates/crab-auth-store/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-auth/AGENTS.md
+++ b/crates/crab-auth/AGENTS.md
@@ -1,0 +1,74 @@
+# crab-auth
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-auth/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns credential/scope contracts, provider resolution, protected-push validation, and token storage. crab-auth-store translates resolved authority into storage; server callers enforce operation policy.
+
+## Read first
+
+1. `crates/crab-auth/src/lib.rs` — always-available contracts and optional clients.
+2. `crates/crab-auth/src/credentials.rs` — `CloudCredentials / CredentialResolution`: provider secrets and scoped resolution.
+3. `crates/crab-auth/src/credential_provider.rs` — `CredentialProvider`: resolution/refresh interface.
+4. `crates/crab-auth/src/token_cache.rs` — `TokenCache / CachedTokens`: encrypted persistence and locking.
+5. `crates/crab-auth/src/protected_push.rs` — `validate_push_ref_updates`: prepare/finalize validation.
+
+Trace one path: `create_credential_provider` in `crates/crab-auth/src/credential_provider.rs`
+→ `StaticProvider` in `crates/crab-auth/src/static_credentials.rs` for static
+configuration → `CredentialResolution` from `crates/crab-auth/src/credentials.rs`.
+Store consumers compose those results in `crates/crab-auth-store/src/lib.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Credential response | `crates/crab-auth/src/credential_response.rs` | `crates/crab-auth-store/src/lib.rs` |
+| Token persistence | `crates/crab-auth/src/token_cache.rs` | `crab/src/cmd/login.rs` |
+| Managed API contract | `crates/crab-auth/src/managed` | `crates/crab-auth-store/src/managed_repository.rs` |
+
+## Invariants
+
+- Preserve scopes alongside resolved credentials; translating provider variants must not drop path restrictions.
+  Source: `crates/crab-auth/src/credentials.rs`.
+- Keep token-cache encryption and file locking together when changing store/load/delete paths; do not expose token material in diagnostics or fixtures.
+  Source: `crates/crab-auth/src/token_cache.rs`.
+- Validate protected-push response/ref updates at the contract boundary; duplicate destinations and no-op ref updates have explicit rejection tests.
+  Source: `crates/crab-auth/src/protected_push.rs`.
+
+## Features and platform
+
+Empty default. Optional features are `oidc-client`, `aws-oidc-client`, `azure-entra-client`, `crab-auth-client`, and `gcp-workload-identity-client`; provider clients enable oidc-client. Token locking has platform-specific code. `CachedTokens` contains token strings;
+do not log the struct or assume Debug redacts it. TokenCache construction may
+use the OS keychain or a fallback key file; inspect fixture setup before running
+token persistence tests. Mock OIDC tests do not qualify real identity providers; inspect their contract before changing exchanges.
+
+## Verification
+
+Inline credential_response/protected_push tests validate payloads; token_cache tests exercise encrypted round trips. Managed protocol coverage is in `crates/crab-auth/tests/managed_contract.rs`.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-auth --locked --lib credential_response
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-auth --locked --lib protected_push
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-auth --locked --lib --features oidc-client oidc
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-auth/README.md` — usage and detailed contracts.
+- `crates/crab-auth/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-auth/CLAUDE.md
+++ b/crates/crab-auth/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-cache-server/AGENTS.md
+++ b/crates/crab-cache-server/AGENTS.md
@@ -1,0 +1,72 @@
+# crab-cache-server
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-cache-server/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns the cache-service binary, HTTP admission, origin composition, disk persistence, and maintenance tasks. crab-cache defines shared route/client contracts; repository mutation remains outside the cache service.
+
+## Read first
+
+1. `crates/crab-cache-server/src/lib.rs` — service modules.
+2. `crates/crab-cache-server/src/server.rs` — `prepare_server / run_server`: listener/TLS startup and shutdown.
+3. `crates/crab-cache-server/src/state.rs` — `build_router / AppState`: router and shared state.
+4. `crates/crab-cache-server/src/handlers.rs` — `read_object / write_object`: request parsing and cache/origin decisions.
+5. `crates/crab-cache-server/src/cache_store.rs` — `ServerObjectKey`: disk payload and SQLite accounting.
+
+Trace one path: `crates/crab-cache-server/src/bin/crab_cache.rs` → `run_server` in
+`crates/crab-cache-server/src/server.rs` → `build_router` in
+`crates/crab-cache-server/src/state.rs` → handlers in
+`crates/crab-cache-server/src/handlers.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Service startup | `crates/crab-cache-server/src/bin/crab_cache.rs` | `crates/crab-cache-server/src/server.rs` |
+| Route or authorization | `crates/crab-cache-server/src/state.rs` | `crates/crab-cache/src/path_class.rs` |
+| Disk retention | `crates/crab-cache-server/src/cache_store.rs` | `crates/crab-cache-server/src/evictor.rs` |
+
+## Invariants
+
+- Separate public health/metrics routes from authenticated object/admin routes; inspect router composition before moving middleware.
+  Source: `crates/crab-cache-server/src/state.rs`.
+- Path parsing and immutable admission precede cache/origin operations; reject invalid paths rather than normalizing them into a different object.
+  Source: `crates/crab-cache-server/src/handlers.rs`.
+- Payload integrity and persistent accounting must agree after put/eviction; inspect cache-store and evictor paths together.
+  Source: `crates/crab-cache-server/src/cache_store.rs`.
+
+## Features and platform
+
+No declared Cargo features. Binary `crab-cache-server` is declared at src/bin/crab_cache.rs. Disk/SQLite and loopback networking support are needed for relevant tests; TLS/live origin/eviction qualification needs the dedicated workflow.
+
+## Verification
+
+Inline state/handlers tests exercise routes and range errors; cache_store tests cover hash mismatch and persistence. Full service qualification is defined in `.github/workflows/cache-service.yml`.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-cache-server --locked --lib state::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-cache-server --locked --lib cache_store::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-cache-server/README.md` — usage and detailed contracts.
+- `crates/crab-cache-server/Cargo.toml` — dependency and feature authority.
+
+Read `crates/crab-cache-server/src/config.rs` and `crates/crab-cache-server/src/preflight.rs` before changing operational requirements.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-cache-server/CLAUDE.md
+++ b/crates/crab-cache-server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-cache-store/AGENTS.md
+++ b/crates/crab-cache-store/AGENTS.md
@@ -1,0 +1,69 @@
+# crab-cache-store
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-cache-store/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns the canonical local-cache/service/origin composition behind CachingStore. crab-cache owns local storage and client contracts; crab-storage owns authoritative transport and retries.
+
+## Read first
+
+1. `crates/crab-cache-store/src/lib.rs` — `CachingStore / CacheStoreError`: ObjectStore adapter, path routing, and error conversions.
+2. `crates/crab-cache-store/src/xorb_read.rs` — `get_xorb_chunks / xorb_chunk_metadata`: source-specific verified xorb plans and repair.
+
+3. `crates/crab-cache/src/path_class.rs` — `classify_path`: shared mutable/immutable admission consumed by the adapter.
+
+Trace one path: `StoreClient` in `crates/crab-read/src/store_client.rs` →
+`get_xorb_chunks_without_install` in `crates/crab-cache-store/src/xorb_read.rs`
+→ parser/range verification in `crates/crab-xet/src/xorb/parser.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Read routing or ETags | `crates/crab-cache-store/src/lib.rs` | `crates/crab-read/src/store_client.rs` |
+| Xorb repair | `crates/crab-cache-store/src/xorb_read.rs` | `crates/crab-xet/src/xorb/parser.rs` |
+| Remote service behavior | `crates/crab-cache-store/src/lib.rs` | `crates/crab-cache/src/cache_client.rs` |
+
+## Invariants
+
+- Mutable paths and HEAD operations must retain origin authority; inspect bypass tests before extending cache admission.
+  Source: `crates/crab-cache-store/src/lib.rs`.
+- One xorb attempt uses one source; retrying cached corruption must not combine cache metadata with origin payload bytes.
+  Source: `crates/crab-cache-store/src/xorb_read.rs`.
+- Origin corruption is a typed integrity failure with its source retained; optional cache eviction failure must not prevent trying origin.
+  Source: `crates/crab-cache-store/src/xorb_read.rs`.
+
+## Features and platform
+
+Empty default. `remote-client` enables crab-cache remote support; local-cache dependencies remain enabled without it. Remote tests may start loopback service fixtures. Do not equate these fixtures with live cache-service qualification.
+
+## Verification
+
+Tests are inline in `crates/crab-cache-store/src/lib.rs`, including mutable-path bypass, corrupt-origin provenance, and repair when cache eviction fails.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-cache-store --locked --lib --no-default-features xorb
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-cache-store --locked --lib --no-default-features --features remote-client xorb
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-cache-store --locked --lib mutable_path_bypasses_cache_even_when_configured
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-cache-store/README.md` — usage and detailed contracts.
+- `crates/crab-cache-store/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-cache-store/CLAUDE.md
+++ b/crates/crab-cache-store/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-cache/AGENTS.md
+++ b/crates/crab-cache/AGENTS.md
@@ -1,0 +1,70 @@
+# crab-cache
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-cache/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns cache keys, roots, admission, disk lifecycle, and optional remote client contracts. Read routing across local cache, service, and origin belongs to crab-cache-store.
+
+## Read first
+
+1. `crates/crab-cache/src/lib.rs` — feature-gated cache surfaces.
+2. `crates/crab-cache/src/key.rs` — `CacheKey`: content identities versus named manifests.
+3. `crates/crab-cache/src/path_class.rs` — `classify_path / cache_route_contract`: mutable/immutable service route taxonomy.
+4. `crates/crab-cache/src/local_cache.rs` — `LocalCache::get_or_fetch`: verified reads and fallible writes.
+5. `crates/crab-cache/src/lifecycle.rs` — `CacheUseGuard / CacheCleanGuard`: shared cache ownership and cleanup.
+
+Trace one path: `CachingStore::get_with_etag` in `crates/crab-cache-store/src/lib.rs`
+→ `LocalCache::get_or_fetch_with` in `crates/crab-cache/src/local_cache.rs`
+→ its validation/publication helpers. Inspect `CacheKey` and origin closure
+semantics rather than treating every cache object as interchangeable.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Key or path admission | `crates/crab-cache/src/path_class.rs` | `crates/crab-cache-store/src/lib.rs` |
+| Disk fill or cleanup | `crates/crab-cache/src/local_cache.rs` | `crates/crab-cache/src/lifecycle.rs` |
+| Remote client contract | `crates/crab-cache/src/cache_client.rs` | `crates/crab-cache-server/src/state.rs` |
+
+## Invariants
+
+- Manifest keys carry names and optional ETags; do not treat them as content-addressed chunk/shard/xorb identities.
+  Source: `crates/crab-cache/src/key.rs`.
+- Path taxonomy is shared with the service and store adapter; review both consumers before changing immutable admission.
+  Source: `crates/crab-cache/src/path_class.rs`.
+- Read-through cache persistence failure and origin fetch/validation failure have different outcomes. Preserve explicit put errors rather than applying read-through behavior to every API.
+  Source: `crates/crab-cache/src/local_cache.rs`.
+
+## Features and platform
+
+Empty default. `active-probe` adds HTTP probing; `remote-client` includes active-probe and async client support. `local-cache` and `xet-chunk-cache` enable separate disk-backed surfaces and shared lifecycle code. Test both enabled paths when changing common private filesystem/catalog behavior.
+
+## Verification
+
+Inline local_cache tests exercise fills and corrupt entries; path_class tests cover route admission. Inspect lifecycle/private filesystem tests for cache root changes.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-cache --locked --lib --features local-cache local_cache::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-cache --locked --lib path_class::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-cache/README.md` — usage and detailed contracts.
+- `crates/crab-cache/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-cache/CLAUDE.md
+++ b/crates/crab-cache/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-coordination/AGENTS.md
+++ b/crates/crab-coordination/AGENTS.md
@@ -1,0 +1,69 @@
+# crab-coordination
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-coordination/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns lease/admission and active-active write coordination mechanics. Callers choose operation policy and must maintain the required ref/GC authority through publication.
+
+## Read first
+
+1. `crates/crab-coordination/src/lib.rs` — feature-gated exports.
+2. `crates/crab-coordination/src/push_lock.rs` — `PushLock`: holder-checked lease lifecycle.
+3. `crates/crab-coordination/src/lease_operation.rs` — `while_renewing`: renewal while draining an operation.
+4. `crates/crab-coordination/src/gc_fence.rs` — `GcFenceLease`: shared/exclusive GC admission.
+5. `crates/crab-coordination/src/write_coordinator.rs` — `WriteCoordinator / PushTransactionState`: transaction state contract.
+
+Trace one path: `crates/crab-write/src/generation.rs` → `while_renewing` in
+`crates/crab-coordination/src/lease_operation.rs` → `PushLock::renew` in
+`crates/crab-coordination/src/push_lock.rs`. The caller still releases its lease.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Lease cancellation | `crates/crab-coordination/src/lease_operation.rs` | `crates/crab-write/src/generation.rs` |
+| GC fence lifecycle | `crates/crab-coordination/src/gc_fence.rs` | `crab/src/cmd/gc` |
+| Active-active transitions | `crates/crab-coordination/src/write_coordinator.rs` | `crates/crab-coordination/src/active_active_runtime.rs` |
+
+## Invariants
+
+- while_renewing borrows the lease: await it to completion, then explicitly release. Dropping its future does neither cleanup action.
+  Source: `crates/crab-coordination/src/lease_operation.rs`.
+- Renewal failure signals cancellation and drains work; preserve primary operation errors instead of replacing them with renewal failure.
+  Source: `crates/crab-coordination/src/lease_operation.rs`.
+- Do not conflate ref leases, GC fences, and active-active transaction state; inspect the corresponding owner contract before moving authority boundaries.
+  Source: `crates/crab-coordination/src/write_coordinator.rs`.
+
+## Features and platform
+
+Empty default. `object-store-lock` exposes lease/fence/admission code. `coordinator-dynamodb`, `coordinator-spanner`, and `coordinator-cosmosdb` enable their provider adapters. Provider SDK semantics require locked source review and dedicated backend proof; do not assume default tests exercise those services.
+
+## Verification
+
+Inline lease_operation tests cover lost-lease draining and error precedence; `crates/crab-coordination/src/active_active_tests.rs` covers coordinator behavior.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-coordination --locked --lib --features object-store-lock lease_operation::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-coordination --locked --lib active_active_tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-coordination/README.md` — usage and detailed contracts.
+- `crates/crab-coordination/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-coordination/CLAUDE.md
+++ b/crates/crab-coordination/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-diff/AGENTS.md
+++ b/crates/crab-diff/AGENTS.md
@@ -1,0 +1,68 @@
+# crab-diff
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-diff/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns pure file pairing and chunk/term comparison. Callers gather staging or remote inputs and render results; this crate performs no storage fetch or hydration.
+
+## Read first
+
+1. `crates/crab-diff/src/lib.rs` — public comparison entry points.
+2. `crates/crab-diff/src/types.rs` — `ChunkDiffReport / ChunkDiffMetrics`: report fields and byte metrics.
+3. `crates/crab-diff/src/chunk_sequence.rs` — `compare_sequences / ChunkSequence`: ordered hash matching and bounded matching work.
+4. `crates/crab-diff/src/chunk_comparator.rs` — `compare_terms`: term-level comparison.
+5. `crates/crab-diff/src/pointer_pairs.rs` — `pair_files`: sorted file pairing.
+
+Trace one path: `crab/src/cmd/diff.rs` → `compare_sequences` in
+`crates/crab-diff/src/chunk_sequence.rs` → its matching/metric helpers
+(`lcs_matches`, `build_metrics`), then reports from `crates/crab-diff/src/types.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Ordered chunk diff | `crates/crab-diff/src/chunk_sequence.rs` | `crates/crab-read/src/term_resolver.rs` |
+| File pairing or output shape | `crates/crab-diff/src/pointer_pairs.rs` | `crab/src/cmd/diff.rs` |
+
+## Invariants
+
+- Compare ordered content hashes independently of xorb placement; repeated chunks must retain occurrence and range semantics.
+  Source: `crates/crab-diff/src/chunk_sequence.rs`.
+- Keep the bounded large-input path in view when changing exact matching; small examples do not qualify large-input complexity.
+  Source: `crates/crab-diff/src/chunk_sequence.rs`.
+- Pair files deterministically and skip unchanged file hashes; do not add storage reads to resolve missing comparison input.
+  Source: `crates/crab-diff/src/pointer_pairs.rs`.
+
+## Features and platform
+
+No declared Cargo features.
+
+## Verification
+
+Inline `crates/crab-diff/src/chunk_sequence.rs` tests include repeated chunk order and replacement ranges; pairing tests are inline in `crates/crab-diff/src/pointer_pairs.rs`.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-diff --locked --lib chunk_sequence::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-diff --locked --lib pointer_pairs::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-diff/README.md` — usage and detailed contracts.
+- `crates/crab-diff/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-diff/CLAUDE.md
+++ b/crates/crab-diff/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-git/AGENTS.md
+++ b/crates/crab-git/AGENTS.md
@@ -1,0 +1,69 @@
+# crab-git
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-git/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns Git discovery, refs, pointers, packs, and bounded protocol mechanics. Transport authorization and publication policy belong to callers; LFS payload storage belongs to crab-lfs.
+
+## Read first
+
+1. `crates/crab-git/src/lib.rs` — public mechanics and optional facade.
+2. `crates/crab-git/src/discover.rs` — `discover_git_dir_from / resolve_common_dir`: Git directory and common-directory discovery.
+3. `crates/crab-git/src/receive_plan.rs` — `validate / GraphSource`: ref comparisons and graph validation.
+4. `crates/crab-git/src/pack.rs` — `verify_pack_sha1 / install_pack_file_from_path`: pack/index integrity and installation.
+5. `crates/crab-git/src/refname.rs` — `validate_push_refname / validate_ref_namespace`: individual names versus final namespace validation.
+
+Trace one path: `crates/crab-http-server/src/receive/validate.rs` → `validate` in
+`crates/crab-git/src/receive_plan.rs` → `validate_ref_namespace` in
+`crates/crab-git/src/refname.rs`. Publication remains above this chain.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Native receive validation | `crates/crab-git/src/receive_plan.rs` | `crates/crab-http-server/src/receive/validate.rs` |
+| Pack decoding | `crates/crab-git/src/incoming_pack.rs` | `crates/crab-remote-git/src/reader.rs` |
+| Pointer classification | `crates/crab-git/src/pointer_detect.rs` | `crates/crab-types/src/pointer.rs` |
+
+## Invariants
+
+- Validate the final ref namespace after edits; validate individual names separately. A parent ref cannot coexist with its slash-delimited descendants.
+  Source: `crates/crab-git/src/refname.rs`.
+- A receive plan is not publication authority: callers supply policy, verify pointer dependencies, and recheck the captured base under writer leases.
+  Source: `crates/crab-git/src/receive_plan.rs`.
+- Keep common-directory discovery distinct from the current working tree; discovery has an explicit .git result outside repositories.
+  Source: `crates/crab-git/src/discover.rs`.
+
+## Features and platform
+
+Only `facade` is declared; there is no declared default feature. It enables the optional high-level gix dependency. Git-spawning tests need Git on PATH; inspect locked gix source before altering its validation or discovery contract.
+
+## Verification
+
+Read inline discovery/ref tests and `crates/crab-git/src/receive_plan/tests.rs`; pack quarantine regressions live in `crates/crab-git/src/incoming_pack/tests.rs`.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-git --locked --lib receive_plan::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-git --locked --lib discover::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-git/README.md` — usage and detailed contracts.
+- `crates/crab-git/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-git/CLAUDE.md
+++ b/crates/crab-git/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-http-server/AGENTS.md
+++ b/crates/crab-http-server/AGENTS.md
@@ -1,0 +1,75 @@
+# crab-http-server
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-http-server/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns the repository HTTP application, native Git endpoints, authentication, and embedded React assets. It composes remote-git/read/write/storage APIs; shared Git and storage mechanics remain in their owner crates.
+
+## Read first
+
+1. `crates/crab-http-server/src/main.rs` — CLI configuration and lifecycle entry.
+2. `crates/crab-http-server/src/server.rs` — `serve / router / Repository::open_current`: repository catalog, routing, and runtime.
+3. `crates/crab-http-server/src/app.rs` — `admit / repository`: request repository/principal boundary and error mapping.
+4. `crates/crab-http-server/src/auth.rs` — `Principal / Authentication`: session identity and Git-token boundary.
+5. `crates/crab-http-server/src/receive.rs` — `receive / publish_objects`: bounded native receive and publication orchestration.
+
+Trace one path: `crates/crab-http-server/src/main.rs` → `serve` in
+`crates/crab-http-server/src/server.rs` → router/handler composition.
+Receive continues through `crates/crab-http-server/src/receive.rs` to the
+shared publication owner `crates/crab-write/src/journal.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| HTTP receive | `crates/crab-http-server/src/receive.rs` | `crates/crab-write/src/journal.rs` |
+| Content reads | `crates/crab-http-server/src/contents.rs` | `crates/crab-remote-git/src/snapshot.rs` |
+| Auth or routing | `crates/crab-http-server/src/server.rs` | `crates/crab-http-server/src/auth.rs` |
+| Read readiness | `crates/crab-http-server/src/maintenance.rs` | `crates/crab-write/src/generation.rs` |
+
+## Invariants
+
+- Keep transport identity/session checks and repository authorization before storage or Git effects; inspect auth and app boundary together.
+  Source: `crates/crab-http-server/src/app.rs`.
+- Git receive validation, publication outcome, and protocol acknowledgement are distinct steps; trace validate/publish and fault tests before changing error mapping.
+  Source: `crates/crab-http-server/src/receive.rs`.
+- Repository operations and maintenance share long-lived runtime ownership; preserve explicit shutdown/draining when changing listener lifecycle.
+  Source: `crates/crab-http-server/src/server.rs`.
+
+## Features and platform
+
+No declared Cargo features. Both library and auto-discovered main binary exist. `crates/crab-http-server/build.rs` requires packages/repository/dist/index.html and rejects symlink assets. Build the frontend before any Cargo check/test/build for this crate; Node requirements are in its README.
+
+## Verification
+
+Tests are mounted from server.rs, including `crates/crab-http-server/src/receive_tests.rs`, `crates/crab-http-server/src/receive_fault_tests.rs`, and `crates/crab-http-server/src/auth_tests.rs`.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+npm ci --prefix packages/repository
+npm run build --prefix packages/repository
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-http-server --locked --lib server::auth_tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-http-server --locked --lib server::receive_tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-http-server/README.md` — usage and detailed contracts.
+- `crates/crab-http-server/Cargo.toml` — dependency and feature authority.
+
+Read `crates/crab-http-server/build.rs` and `packages/repository/package.json` for embedding changes. Dedicated image/service proof: `.github/workflows/http-server-container.yml`; native fetch proof: `.github/workflows/git-protocol-v2-partial-clone.yml`. Browser UI changes require their own frontend checks.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-http-server/CLAUDE.md
+++ b/crates/crab-http-server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-lfs/AGENTS.md
+++ b/crates/crab-lfs/AGENTS.md
@@ -1,0 +1,75 @@
+# crab-lfs
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-lfs/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns LFS object layout, SHA-256 byte verification, receipts, and file-lock storage. crab-git owns pointer parsing; CLI/server layers own protocol and authorization.
+
+## Read first
+
+1. `crates/crab-lfs/src/lib.rs` — payload and lock entry points.
+2. `crates/crab-lfs/src/object_store.rs` — `LfsObjectStore`: upload/download integrity and receipts.
+3. `crates/crab-lfs/src/object_store/origin.rs` — `inspect`: fresh bounded origin verification.
+4. `crates/crab-lfs/src/lock.rs` — `LfsLockManager::unlock_with_id`: holder identity and CAS tombstones.
+
+Trace one path: `crab/src/lfs/transfer_agent.rs` → `LfsObjectStore::put_stream_with_size`
+in `crates/crab-lfs/src/object_store.rs` → `Store`/multipart transport from
+`crates/crab-storage/src/store.rs`. This transfer chain does not establish
+that the shared lock manager is wired into a product endpoint.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Transfer integrity | `crates/crab-lfs/src/object_store.rs` | `crab/src/lfs/transfer_agent.rs` |
+| Origin proof | `crates/crab-lfs/src/object_store/origin.rs` | `crates/crab-read/src/dependency_proof.rs` |
+| Lock/unlock races | `crates/crab-lfs/src/lock.rs` | `crab/src/lfs/lock.rs` (separate implementation) |
+
+The shared `LfsLockManager` has local tests but no established production caller
+in this checkout. Compare the separate CLI lock implementation in
+`crab/src/lfs/lock.rs`; HTTP `crates/crab-http-server/src/lfs.rs` currently
+reports lock operations unavailable. Do not assume a shared-lock fix reaches
+either product surface.
+
+## Invariants
+
+- Keep declared SHA-256 identity and size verification together; presence or a matching path alone does not prove object bytes.
+  Source: `crates/crab-lfs/src/object_store.rs`.
+- Fresh origin verification differs from receipt-aware reads and replica fallback; callers needing publication proof must retain the origin-only boundary.
+  Source: `crates/crab-lfs/src/object_store/origin.rs`.
+- Release locks with holder/ID checks and CAS tombstones; a stale unlock must not remove a replacement lock.
+  Source: `crates/crab-lfs/src/lock.rs`.
+
+## Features and platform
+
+No declared Cargo features. Local object-store tests do not prove provider multipart/conditional-write behavior; inspect crab-storage and the locked object_store contract before changing those calls.
+
+## Verification
+
+Inline object_store tests cover hash rejection and streamed round trips. Inline lock tests include force_unlock_id_mismatch_preserves_replacement_lock.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-lfs --locked --lib object_store::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-lfs --locked --lib lock::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-lfs/README.md` — usage and detailed contracts.
+- `crates/crab-lfs/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-lfs/CLAUDE.md
+++ b/crates/crab-lfs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-metadata/AGENTS.md
+++ b/crates/crab-metadata/AGENTS.md
@@ -1,0 +1,71 @@
+# crab-metadata
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-metadata/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns metadata schemas, codecs, manifests, visibility evidence, and feature-gated indexes. Storage owns transport; crab-write composes publication and caller-held authority.
+
+## Read first
+
+1. `crates/crab-metadata/src/lib.rs` — payload-only versus persistence exports.
+2. `crates/crab-metadata/src/manifests.rs` — `Manifest / validate_manifest_payload`: validation and serialized roots.
+3. `crates/crab-metadata/src/manifest_store.rs` — `read_repository_snapshot / RepositorySnapshot`: stored snapshots and CAS.
+4. `crates/crab-metadata/src/ref_journal.rs` — `commit_ref_transaction / RefJournalSnapshot`: committed transaction overlay.
+5. `crates/crab-metadata/src/git_visibility.rs` — `GitVisibilityIndex / GitCatalogVisibilityIndex`: generation-bound authorization evidence.
+
+Trace one path: `crates/crab-write/src/journal.rs` → `commit_ref_transaction` in
+`crates/crab-metadata/src/ref_journal.rs` → bounded marker write/readback on
+`Store` in `crates/crab-storage/src/store.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Manifest/journal change | `crates/crab-metadata/src/manifest_store.rs` | `crates/crab-write/src/journal.rs` |
+| Catalog coverage | `crates/crab-metadata/src/git_object_locator` | `crates/crab-remote-git/src/repository.rs` |
+| Local dedup index | `crates/crab-metadata/src/persistent_chunk_index.rs` | `crates/crab-staging/src/index.rs` |
+
+## Invariants
+
+- Validate manifest payloads before trusting refs and bulk index pointers; preserve the distinction between compacted manifest and journal-overlay snapshot.
+  Source: `crates/crab-metadata/src/manifest_store.rs`.
+- Pack presence alone does not authorize object visibility; inspect closure evidence and its generation binding together.
+  Source: `crates/crab-metadata/src/git_visibility.rs`.
+- Keep explicit close ownership when adding index readers/writers; inspect error and cancellation paths as well as successful reads.
+  Source: `crates/crab-metadata/src/git_object_locator`.
+
+## Features and platform
+
+Empty default. `storage` adds object-store helpers; `file-index-reader` and `remote-index` also enable storage and SlateDB paths; `local-index` adds SQLite. Inspect locked SlateDB session/writer close contracts before changing lifecycle. Payload-only checks must remain a separate slice.
+
+## Verification
+
+Inline manifest-store/visibility tests cover stale proofs and malformed roots. `crates/crab-metadata/src/file_index_lookup.rs` and `crates/crab-metadata/src/persistent_chunk_index.rs` have feature-gated lookup tests.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-metadata --locked --no-default-features --lib
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-metadata --locked --lib --features storage,remote-index git_visibility
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-metadata --locked --lib --features file-index-reader file_index_lookup
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-metadata --locked --lib --features local-index persistent_chunk_index
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-metadata/README.md` — usage and detailed contracts.
+- `crates/crab-metadata/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-metadata/CLAUDE.md
+++ b/crates/crab-metadata/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-read/AGENTS.md
+++ b/crates/crab-read/AGENTS.md
@@ -1,0 +1,70 @@
+# crab-read
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-read/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns read selection, fetch admission, term resolution, and verified hydration. VFS and product commands compose this path; storage/cache crates retain transport and cache mechanics.
+
+## Read first
+
+1. `crates/crab-read/src/lib.rs` — public admission and reconstruction APIs.
+2. `crates/crab-read/src/selection.rs` — `select_read_replicas / ReadRoutingPolicy`: replica readiness and routing decisions.
+3. `crates/crab-read/src/hydrator.rs` — `ShardHydrator / ReadRuntimeBuilder`: whole-file versus range reconstruction.
+4. `crates/crab-read/src/term_resolver.rs` — `TermResolver::resolve_batch`: file-index/shard lookup and session closure.
+5. `crates/crab-read/src/store_client.rs` — `StoreClient`: cache-aware object reads.
+
+Trace one path: `crates/crab-vfs/src/hydration.rs` →
+`ShardHydrator::reconstruct_range_from_pointer` in
+`crates/crab-read/src/hydrator.rs` → read-side store/metadata resolution.
+For object download changes continue into `crates/crab-read/src/store_client.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Hydration or range integrity | `crates/crab-read/src/hydrator.rs` | `crates/crab-vfs/src/hydration.rs` |
+| Fetch authorization | `crates/crab-read/src/fetch_admission.rs` | `crab/src/git/remote_helper.rs` |
+| Term resolution | `crates/crab-read/src/term_resolver.rs` | `crates/crab-metadata/src/file_index_lookup.rs` |
+
+## Invariants
+
+- Requests naming hidden refs remain rejected even when arbitrary wants are enabled. This does not imply that the same SHA is denied under every other name; inspect policy and advertisement together.
+  Source: `crates/crab-read/src/fetch_admission.rs`.
+- Preserve the difference between full-file hash verification and range/chunk verification; partial output is not proof of the complete file.
+  Source: `crates/crab-read/src/hydrator.rs`.
+- Close file-index lookup sessions after successful, failed, and cancelled resolution; follow the explicit close helper when changing batching.
+  Source: `crates/crab-read/src/term_resolver.rs`.
+
+## Features and platform
+
+No declared Cargo features. The manifest explicitly enables dependency cache/index capabilities. Hydration fixtures cannot prove live replica selection or mounted read behavior; qualify those affected consumers separately.
+
+## Verification
+
+Inline `crates/crab-read/src/fetch_admission.rs` tests cover hidden-ref and non-tip rejection; hydration tests live with `crates/crab-read/src/hydrator.rs` and its adjacent modules.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-read --locked --lib fetch_admission::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-read --locked --lib hydrator
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-read/README.md` — usage and detailed contracts.
+- `crates/crab-read/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-read/CLAUDE.md
+++ b/crates/crab-read/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-remote-git/AGENTS.md
+++ b/crates/crab-remote-git/AGENTS.md
@@ -1,0 +1,70 @@
+# crab-remote-git
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-remote-git/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns bounded filesystem-free Git reads from committed manifests, catalogs, and immutable packs. Caller authorization and resolved placement identity precede repository opening; logical Xet hydration belongs to crab-read.
+
+## Read first
+
+1. `crates/crab-remote-git/src/lib.rs` — supported public API.
+2. `crates/crab-remote-git/src/repository.rs` — `RemoteGitRepository::open / RepositoryIdentity`: identity and opening handshake.
+3. `crates/crab-remote-git/src/snapshot.rs` — `RemoteGitSnapshot`: pinned commit/tree operations.
+4. `crates/crab-remote-git/src/operation.rs` — `OperationContext::finish`: budgets, cancellation, and explicit finish.
+5. `crates/crab-remote-git/src/reader.rs` — `RemoteGitReader::read_with_session`: object lookup and verified decoding.
+
+Trace one path: HTTP repository opening in `crates/crab-http-server/src/server.rs`
+→ `RemoteGitRepository::open` in `crates/crab-remote-git/src/repository.rs`
+→ manifest/catalog acquisition from `crates/crab-metadata/src/manifest_store.rs`
+and `crates/crab-metadata/src/git_object_locator`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Repository consistency | `crates/crab-remote-git/src/repository.rs` | `crates/crab-http-server/src/server.rs` |
+| Object range/decode | `crates/crab-remote-git/src/reader.rs` | `crates/crab-remote-git/src/pack.rs` |
+| Operation lifetime | `crates/crab-remote-git/src/operation.rs` | `crates/crab-remote-git/src/runtime.rs` |
+
+## Invariants
+
+- Keep repository identity and generation/catalog coverage checks in the open path; locator presence alone is not a visibility proof.
+  Source: `crates/crab-remote-git/src/repository.rs`.
+- Finish each OperationContext with its semantic result so the locator session closes and close failures remain observable. Runtime shutdown is a separate process-lifecycle obligation.
+  Source: `crates/crab-remote-git/src/operation.rs`.
+- Preserve operation work budgets and cancellation through object lookup/decode, including cache hits; individual request limits do not bound aggregate work.
+  Source: `crates/crab-remote-git/src/operation.rs`.
+
+## Features and platform
+
+No declared Cargo features. Inspect locked gix-pack/delta and SlateDB session contracts before altering decode or close behavior. Dedicated large-repository/HTTP qualification is separate from local fixture tests.
+
+## Verification
+
+Inline operation tests cover close-error precedence. `crates/crab-remote-git/tests/remote_repository.rs` covers repository behavior with real Git fixtures; inspect fixture requirements before broad execution.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-remote-git --locked --lib operation::close_fault_tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-remote-git --locked --lib repository::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-remote-git/README.md` — usage and detailed contracts.
+- `crates/crab-remote-git/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-remote-git/CLAUDE.md
+++ b/crates/crab-remote-git/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-staging/AGENTS.md
+++ b/crates/crab-staging/AGENTS.md
@@ -1,0 +1,76 @@
+# crab-staging
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-staging/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns local segment bytes, SQLite locators, durable boundaries, recipes, prepared plans, and recovery. Remote publication and retirement decisions remain with push callers.
+
+## Read first
+
+1. `crates/crab-staging/src/lib.rs` — `StagingArea::open / flush_pending / close`: open/read-only admission and lock hierarchy.
+2. `crates/crab-staging/src/index.rs` — `Index::chunks_for_file / chunks_for_file_with_sizes`: file-version membership and transactions.
+3. `crates/crab-staging/src/segment.rs` — `SegmentWriter / decode_record`: record framing and durable writes.
+4. `crates/crab-staging/src/recovery.rs` — `recover`: torn-tail and sealed-segment handling.
+5. `crates/crab-staging/src/push_plan.rs` — `FilePushPlan / PreparedXorbCache`: prepared xorb identity and persistence.
+
+Trace one path: `crab/src/cmd/add.rs` (`close_staging_before_indexing`) →
+`StagingArea::flush_pending` in `crates/crab-staging/src/lib.rs` →
+`Index::flush_pending` in `crates/crab-staging/src/index.rs`, after segment fsync.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| File chunk membership | `crates/crab-staging/src/index.rs` | `crab/src/cmd/add.rs` |
+| Crash recovery or flush | `crates/crab-staging/src/recovery.rs` | `crates/crab-staging/src/segment.rs` |
+| Prepared upload/resume | `crates/crab-staging/src/push_plan.rs` | `crates/crab-staging/src/multipart_resume.rs` |
+
+## Invariants
+
+- Keep process admission and in-process locks separate; synchronous index guards must end before await points.
+  Source: `crates/crab-staging/src/lib.rs`.
+- File-version reads must include all ordered chunk occurrences, even when chunk bytes deduplicate; inspect recipe consumers before changing index membership.
+  Source: `crates/crab-staging/src/index.rs`.
+- Recovery rejects missing/undersized sealed segments; current-segment truncation and index cleanup must agree on the surviving durable data.
+  Source: `crates/crab-staging/src/recovery.rs`.
+
+- Flush staged data before publication. `StagingArea::close` flushes explicitly;
+  Drop releases handles but does not provide the same flush barrier. Inspect
+  success/error/cancellation ownership before relying on cleanup.
+  Sources: `crates/crab-staging/src/lib.rs`,
+  `crab/src/cmd/add.rs` (`close_staging_before_indexing`), and
+  `crab/src/import/coordinator.rs` (flush before exposing import pointers).
+
+## Features and platform
+
+No declared Cargo features. Requires writable local filesystem/SQLite and platform lock semantics. Scale tests under `crates/crab-staging/tests` need dedicated disk/time budgets; do not run them as an incidental unit check.
+
+## Verification
+
+Inline recovery tests cover torn tails and sealed corruption. Property modules under `crates/crab-staging/tests/unit` are path-mounted by lib.rs; they are not standalone integration targets.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-staging --locked --lib recovery::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-staging --locked --lib prop_compaction_preserves_reads
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-staging/README.md` — usage and detailed contracts.
+- `crates/crab-staging/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-staging/CLAUDE.md
+++ b/crates/crab-staging/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-storage/AGENTS.md
+++ b/crates/crab-storage/AGENTS.md
@@ -1,0 +1,70 @@
+# crab-storage
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-storage/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns provider construction, object paths, conditional writes, transport retries, and storage errors. Auth resolves credentials; callers supply mutation and publication policy.
+
+## Read first
+
+1. `crates/crab-storage/src/lib.rs` — Store facade and exports.
+2. `crates/crab-storage/src/layout.rs` — `StoreLayout / canonical_global_content_path`: global versus repository key routing.
+3. `crates/crab-storage/src/store.rs` — `Store`: read/write operations and observers.
+4. `crates/crab-storage/src/cas.rs` — `cas_update_bounded`: bounded load/mutate/conditional-write loop.
+5. `crates/crab-storage/src/error_map.rs` — `classify_auth_error / map_object_store_error`: dependency error classification.
+
+Trace one path: `crates/crab-auth-store/src/lib.rs` (credential conversion) → provider
+builders in `crates/crab-storage/src/provider_store.rs` → object_store builders.
+For protocol changes, resolve their locked version from Cargo.lock and read the
+dependency source before asserting provider behavior.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| CAS behavior | `crates/crab-storage/src/cas.rs` | `crates/crab-metadata/src/manifest_store.rs` |
+| Provider or target identity | `crates/crab-storage/src/provider_store.rs` | `crates/crab-auth-store/src/lib.rs` |
+| Object key layout | `crates/crab-storage/src/layout.rs` | `crates/crab-cache/src/path_class.rs` |
+
+## Invariants
+
+- Keep CAS conditional create/update and conflict handling distinct from transport retry. The mutation callback may be evaluated more than once.
+  Source: `crates/crab-storage/src/cas.rs`.
+- Check both loaded and newly serialized CAS object sizes; a successful write must remain within the same read ceiling.
+  Source: `crates/crab-storage/src/cas.rs`.
+- Logical bucket identity and credential-free transport target identity serve different consumers; do not derive the latter from display text.
+  Source: `crates/crab-storage/src/identity.rs`.
+
+## Features and platform
+
+Empty default; `test-support` exposes shared test helpers. S3/GCS/Azure/fs capabilities are dependency features, not crate flags. Read the locked object_store ObjectStore/PutMode/UpdateVersion contract before changing conditions or error mapping. Live provider behavior needs dedicated credentials and CI, not just in-memory tests.
+
+## Verification
+
+Inline `crates/crab-storage/src/provider_store.rs` tests exercise construction; `crates/crab-storage/src/cas.rs` covers conditional updates and size ceilings.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-storage --locked --lib provider_store
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-storage --locked --lib cas::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-storage/README.md` — usage and detailed contracts.
+- `crates/crab-storage/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-storage/CLAUDE.md
+++ b/crates/crab-storage/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-types/AGENTS.md
+++ b/crates/crab-types/AGENTS.md
@@ -1,0 +1,69 @@
+# crab-types
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-types/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns shared serialized contracts and provider identity; keep runtime, storage transport, and product decisions in their consuming crates.
+
+## Read first
+
+1. `crates/crab-types/src/lib.rs` — exported contract families.
+2. `crates/crab-types/src/pointer.rs` — `Pointer::parse / serialize / is_pointer`: wire serialization, parsing, and the separate detection heuristic.
+3. `crates/crab-types/src/storage.rs` — `BucketIdentity / StorageScope`: provider aliases, bucket identity, and issued scopes.
+4. `crates/crab-types/src/error.rs` — `ErrorCategory`: cross-crate error categories.
+
+Trace one path: `crates/crab-git/src/pointer_detect.rs` (`classify`) →
+`Pointer::parse` in `crates/crab-types/src/pointer.rs` → its `parse_hex32`
+validation. Inspect detection and parse tests together.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Pointer format | `crates/crab-types/src/pointer.rs` | `crates/crab-git/src/pointer_detect.rs` |
+| Storage identity or scope | `crates/crab-types/src/storage.rs` | `crates/crab-storage/src/identity.rs` |
+
+## Invariants
+
+- Keep parsing and heuristic detection distinct; detection is not a substitute for parsing. Preserve canonical serialization and investigate tagged consumers before changing accepted versions.
+  Source: `crates/crab-types/src/pointer.rs`.
+- Bucket normalization and provider distinctions participate in identity; do not replace them with display URL equality.
+  Source: `crates/crab-types/src/storage.rs`.
+- Cloud alias parsing deliberately excludes local/file aliases; callers must opt into local storage.
+  Source: `crates/crab-types/src/storage.rs`.
+
+## Features and platform
+
+No declared Cargo features.
+
+## Verification
+
+Inline tests in `crates/crab-types/src/pointer.rs` cover round trips and detection; `crates/crab-types/src/storage.rs` covers normalization and provider distinctions.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-types --locked --lib pointer::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-types --locked --lib storage::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-types/README.md` — usage and detailed contracts.
+- `crates/crab-types/Cargo.toml` — dependency and feature authority.
+
+Use `CONTEXT.md` terminology: a worktree includes Git metadata; a working tree means checked-out files.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-types/CLAUDE.md
+++ b/crates/crab-types/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-vfs/AGENTS.md
+++ b/crates/crab-vfs/AGENTS.md
@@ -1,0 +1,70 @@
+# crab-vfs
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-vfs/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns mount preparation, snapshots/overlays, filesystem adapters, and mount lifecycle. Canonical reconstruction stays in crab-read; FUSE/NFS translate that behavior into filesystem operations.
+
+## Read first
+
+1. `crates/crab-vfs/src/lib.rs` — mount feature gates and common contracts.
+2. `crates/crab-vfs/src/pipeline.rs` — `MountPipelineBuilder::execute`: source through engine preparation.
+3. `crates/crab-vfs/src/engine.rs` — `VfsEngine`: filesystem operation semantics.
+4. `crates/crab-vfs/src/hydration.rs` — `HydrationService::spawn_workers / read_range`: queued reads and worker lifecycle.
+5. `crates/crab-vfs/src/mount_runtime.rs` — `refresh_mount_runtime / switch_mount_runtime`: refresh/switch/adopt operations.
+
+Trace one path: `MountPipelineBuilder::execute` in `crates/crab-vfs/src/pipeline.rs`
+prepares `HydrationService` from `crates/crab-vfs/src/hydration.rs`; its read
+path calls `ShardHydrator` in `crates/crab-read/src/hydrator.rs`. Backend
+mount/control owners consume the pipeline output separately.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Prepare or refresh mount | `crates/crab-vfs/src/pipeline.rs` | `crates/crab-vfs/src/mount_runtime.rs` |
+| Read windows | `crates/crab-vfs/src/hydration.rs` | `crates/crab-read/src/hydrator.rs` |
+| Backend teardown | `crates/crab-vfs/src/nfs_mount.rs` | `crates/crab-vfs/src/mount.rs` |
+
+## Invariants
+
+- Separate pipeline preparation from backend mount/control lifetime; a built engine does not prove a mounted, usable filesystem.
+  Source: `crates/crab-vfs/src/pipeline.rs`.
+- Cached read windows retain integrity checks; corruption must not be served merely because the byte length matches.
+  Source: `crates/crab-vfs/src/hydration.rs`.
+- Review cancellation, hydration worker shutdown, leases, and control resources in both FUSE and NFS owners before changing teardown.
+  Source: `crates/crab-vfs/src/nfs_mount.rs`.
+
+## Features and platform
+
+Empty default. `fuse` enables fuser; `nfs` enables NFS dependencies; `gix-facade` forwards crab-git/facade. Shared engine/pipeline/hydration modules require fuse or nfs. Run the corresponding fuse slice on a supported host with OS prerequisites; neither backend fixture checks nor default tests prove real mounting.
+
+## Verification
+
+Inline pipeline and hydration tests are feature-gated. Default crate tests do not compile those mount modules. Real mounted user-action proof belongs in `.github/workflows/nfs-mount.yml` or the appropriate FUSE environment.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-vfs --locked --lib --features nfs pipeline::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-vfs --locked --lib --features nfs hydration::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-vfs/README.md` — usage and detailed contracts.
+- `crates/crab-vfs/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-vfs/CLAUDE.md
+++ b/crates/crab-vfs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-workflow/AGENTS.md
+++ b/crates/crab-workflow/AGENTS.md
@@ -1,0 +1,71 @@
+# crab-workflow
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-workflow/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns workflow parsing, DAG planning, stage execution, cache/state persistence, and experiments. Product commands choose invocation and user-facing policy; the executor is one stage attempt, not the whole scheduler.
+
+## Read first
+
+1. `crates/crab-workflow/src/lib.rs` — public workflow and persisted contracts.
+2. `crates/crab-workflow/src/yaml.rs` — `parse / validate_semantics`: strict schema parsing and expansion.
+3. `crates/crab-workflow/src/graph.rs` — `Graph::build / toposort`: dependency inference and deterministic plan.
+4. `crates/crab-workflow/src/scheduler.rs` — `DagScheduler`: concurrency and dependency admission.
+5. `crates/crab-workflow/src/executor.rs` — `run_local`: one attempt and journal transitions.
+
+Trace one path: `crab/src/cmd/run.rs` → `parse_at` in `crates/crab-workflow/src/yaml.rs`
+→ `Graph::build` in `crates/crab-workflow/src/graph.rs` before scheduler
+execution. Parsing and graph construction are sequential caller-owned steps.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Workflow grammar | `crates/crab-workflow/src/yaml.rs` | `crab/src/cmd/run.rs` |
+| Execution ordering | `crates/crab-workflow/src/scheduler.rs` | `crates/crab-workflow/src/executor.rs` |
+| Persisted state/resume | `crates/crab-workflow/src/lockfile.rs` | `crates/crab-workflow/src/resume.rs` |
+
+## Invariants
+
+- Unknown schema keys must fail visibly; parse/expand before planning so typos cannot silently alter execution.
+  Source: `crates/crab-workflow/src/yaml.rs`.
+- Reject duplicate output ownership and cycles before execution; preserve deterministic topological decisions.
+  Source: `crates/crab-workflow/src/graph.rs`.
+- Keep per-attempt journal transitions separate from retry and DAG scheduling; inspect resume and journal consumers before changing durable state.
+  Source: `crates/crab-workflow/src/executor.rs`.
+
+## Features and platform
+
+Empty default. `watch` enables notify; `gix-facade` enables gix; `testing` exposes test helpers; `crash-injection` enables fault-injection paths. Use exact feature slices for changes; do not enable crash injection incidentally.
+
+## Verification
+
+Inline yaml tests cover unknown fields and invalid paths; graph tests include cycle/output conflicts and property checks. Execution tests can spawn real local child processes and mutate temporary fixtures.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-workflow --locked --lib yaml
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-workflow --locked --lib graph::tests
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-workflow/README.md` — usage and detailed contracts.
+- `crates/crab-workflow/Cargo.toml` — dependency and feature authority.
+
+Read `crates/crab-workflow/src/journal.rs`, `crates/crab-workflow/src/resume.rs`, and `crates/crab-workflow/src/lockfile.rs` together for persistence changes.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-workflow/CLAUDE.md
+++ b/crates/crab-workflow/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-write/AGENTS.md
+++ b/crates/crab-write/AGENTS.md
@@ -1,0 +1,72 @@
+# crab-write
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-write/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns shared initialization, journal publication/compaction, and catalog generation mechanics. Authorization, ref leases, dependency proof, GC fencing, and generation-owner election belong to callers.
+
+## Read first
+
+1. `crates/crab-write/src/lib.rs` — shared API and source-preserving errors.
+2. `crates/crab-write/src/journal.rs` — `commit_edits / compact_for_owner`: commit preconditions and uncertain outcomes.
+3. `crates/crab-write/src/namespace.rs` — `with_ref_namespace`: namespace lease around ref-set changes.
+4. `crates/crab-write/src/generation.rs` — `maintain_catalog / make_readable`: catalog lifecycle and make_readable.
+5. `crates/crab-write/src/catalog.rs` — `publish_inventory / LocatorPackEvidence`: immutable pack evidence and locator writes.
+
+Trace one path: `crab/src/git/push.rs` → `commit_edits` in
+`crates/crab-write/src/journal.rs` → namespace protection in
+`crates/crab-write/src/namespace.rs` and journal commit in
+`crates/crab-metadata/src/ref_journal.rs`.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Ref publication | `crates/crab-write/src/journal.rs` | `crab/src/git/push.rs` |
+| Read readiness | `crates/crab-write/src/generation.rs` | `crates/crab-http-server/src/maintenance.rs` |
+| Repository initialization | `crates/crab-write/src/initialize.rs` | `crab/src/cmd/init.rs` |
+
+## Invariants
+
+- commit_edits requires a snapshot captured under every edited ref lease; callers retain authorization, dependency checks, uploads, and lease renewal.
+  Source: `crates/crab-write/src/journal.rs`.
+- A marker storage error can leave an uncertain commit. Await the commit future and resolve outcome rather than treating every error as rejection.
+  Source: `crates/crab-write/src/journal.rs`.
+- Journal publication does not make the catalog readable. Trace maintain_catalog and make_readable, including explicit writer close, before acknowledging broader readiness.
+  Source: `crates/crab-write/src/generation.rs`.
+- Namespace changes need a fresh final-ref-set check under the namespace lease; individual ref locks do not prevent parent/child name conflicts.
+  Source: `crates/crab-write/src/namespace.rs`.
+
+## Features and platform
+
+No declared Cargo features. Dependencies enable storage/index/lease capabilities. Tests use local fixtures; live service publication and restart qualification belong in dedicated CI.
+
+## Verification
+
+Integration tests `crates/crab-write/tests/journal.rs`, `crates/crab-write/tests/generation.rs`, and `crates/crab-write/tests/catalog.rs` exercise publication and maintenance boundaries.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-write --locked --test journal
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-write --locked --test generation
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-write/README.md` — usage and detailed contracts.
+- `crates/crab-write/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-write/CLAUDE.md
+++ b/crates/crab-write/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/crab-xet/AGENTS.md
+++ b/crates/crab-xet/AGENTS.md
@@ -1,0 +1,69 @@
+# crab-xet
+
+Root `AGENTS.md` and `crates/AGENTS.md` apply. Read
+`crates/crab-xet/README.md` for crate usage. Paths below are repository-root-relative.
+
+## Purpose and ownership
+
+Owns chunk/hash, Xorb, shard, and reconstruction mechanics. Staging owns local durability; storage and higher layers own transport and publication.
+
+## Read first
+
+1. `crates/crab-xet/src/lib.rs` — format modules and feature gates.
+2. `crates/crab-xet/src/hash.rs` — `merkle_hex_from_bytes`: data/file hash conversions.
+3. `crates/crab-xet/src/xorb/builder.rs` — `XorbBuilder`: container construction and placements.
+4. `crates/crab-xet/src/reconstruction.rs` — `FileTermBuilder / validate_term_coverage`: ordered recipe occurrences and term coverage.
+5. `crates/crab-xet/src/shard.rs` — `ShardWriter / ShardReader`: file/xorb metadata assembly.
+
+Trace one path: `crab/src/git/push.rs` (`build_file_terms`) → `build_file_terms` in
+`crates/crab-xet/src/reconstruction.rs` → `FileTermBuilder::push` and `finish`.
+Use the ordered recipe tests when changing this chain.
+
+## Common changes
+
+| Task | Start here | Also inspect |
+| --- | --- | --- |
+| Recipe coverage | `crates/crab-xet/src/reconstruction.rs` | `crates/crab-staging/src/recipe.rs` |
+| Xorb verification | `crates/crab-xet/src/xorb/parser.rs` | `crates/crab-cache-store/src/xorb_read.rs` |
+
+## Invariants
+
+- Consume every ordered recipe occurrence, including duplicates; missing placements and count mismatches must remain errors.
+  Source: `crates/crab-xet/src/reconstruction.rs`.
+- Term coverage counts are not complete payload integrity proof; retain parser digest/chunk checks and final read-side file verification.
+  Source: `crates/crab-xet/src/xorb/parser.rs`.
+- Check representable format sizes before changing builder state; do not silently truncate serialized chunk metadata.
+  Source: `crates/crab-xet/src/xorb/builder.rs`.
+
+## Features and platform
+
+Empty default. `chunker` enables xet-data; `upload-concurrency` enables Tokio and Xet client/runtime admission. Inspect the locked xet-core-structures/xet-data source and Cargo.lock before altering hashes or serialized formats; do not infer format guarantees from wrapper names.
+
+## Verification
+
+Inline reconstruction tests cover missing placements and duplicate occurrences; builder/parser tests cover overflow and corrupted payloads.
+
+Run from repository root. The target below is the example for worktree `089c`;
+replace it with a unique directory for your checkout. Before compilation, verify
+`$HOME/Workspace` resolves to the mounted workspace volume and the target is
+writable. Stop if unavailable; never fall back to a local target directory.
+
+```sh
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-xet --locked --lib reconstruction::tests
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-xet --locked --lib --features chunker chunker
+CARGO_TARGET_DIR="$HOME/Workspace/crabbuild-target/crab-089c" cargo test -p crab-xet --locked --lib --features upload-concurrency upload_concurrency
+```
+
+These are focused checks, not full runtime qualification. Use affected-consumer
+checks and dedicated CI for broader behavior; existing interface/behavior slices
+are in `crab/scripts/check-crate-interface-builds.py` and
+`crab/scripts/check-crate-behavior.py`.
+
+## Related documentation
+
+- `crates/crab-xet/README.md` — usage and detailed contracts.
+- `crates/crab-xet/Cargo.toml` — dependency and feature authority.
+
+Update this guide when entry points, ownership, invariants, features, or test
+routes change. Keep detailed API preconditions in rustdoc rather than copying
+them into a second specification.

--- a/crates/crab-xet/CLAUDE.md
+++ b/crates/crab-xet/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Agents currently have workspace-level guidance but must rediscover each crate’s entry points, ownership boundaries and verification routes. Add tailored AGENTS.md guides to all 21 shared/server crates, with relative CLAUDE.md symlinks, concrete call paths, local invariants, feature requirements and focused test recipes.

Include the implementation plan and completion evidence. The guides distinguish staging flush from handle cleanup, catalog publication from read readiness, and the separate CLI/shared LFS lock implementations. No Rust source, dependency, test or runtime changes.

## Validation

- Crate membership, guide structure and relative symlinks: 21/21 passed.
- Checked 210 distinct source paths, navigation symbols, feature names, shell syntax and test target/filter references; 47 Cargo recipes validated statically.
- `cargo fmt --all -- --check` and staged `git diff --check` passed.
- Cargo tests were not executed: documentation-only change; the required external build volume is unavailable locally.
