### PR TITLE
perf(staging): batch push retirement and reduce edited-push latency

### DIFF
--- a/crab/docs/architecture/git-protocol-v2.md
+++ b/crab/docs/architecture/git-protocol-v2.md
@@ -179,6 +179,14 @@ The RustFS concurrency qualification follows each independent-ref and hot-ref
 write swarm with fresh protocol-v2 clones, strict Git fsck, and byte checks so
 ref visibility alone cannot satisfy the gate.
 
+Generation-owner contention does not suppress protocol-v2 capability discovery
+when the compacted manifest has visibility evidence, a bounded pending handoff
+bound to that manifest, or is empty. Discovery does not repair or compact
+metadata. Fetch admission waits for owner work when needed, completes and
+validates pending handoffs, then verifies the advertised refs and immutable pack
+inventory against the admitted snapshot. A pending handoff is not itself object
+authorization; absent evidence still withholds v2.
+
 Upload-pack admission is repository-scoped and distributed: each helper
 process must hold one of the fixed object-store read leases for the duration
 of its session. A rotated, jittered retry probes one slot at a time, leases

--- a/crab/docs/benchmarks/add-push-hardening-rustfs.md
+++ b/crab/docs/benchmarks/add-push-hardening-rustfs.md
@@ -115,3 +115,104 @@ scale/probe data and completed canary data/buckets were removed; reports and
 logs were retained. Qualification covers the exercised local RustFS lifecycle,
 not 100 GiB of unique entropy, all historical large-file versions, all CLI
 commands, or production S3/GCS/Azure behavior.
+
+## Edited-push retirement follow-up
+
+The completed 100-GiB qualification reported edited pushes of 245.025 and
+277.197 seconds for 57,579,824 and 57,285,483 uploaded bytes. The aggregate
+`post_success_cache_warm` phase included staging retirement and took 108.758
+and 131.536 seconds; that label did not isolate cache work.
+
+Additional timers now separate lock release, index preparation, negative
+invalidation, index installation, xorb caching and staging retirement, plus
+manifest preparation. No serialized format, version or durability setting
+changes. A smaller reproduction uses the same 50-file/500-code-file shape,
+256 MiB per large file, ten content families and 1-MiB independent edits.
+
+| Local 12.5-GiB reproduction | Uploaded bytes | Push seconds | Retirement seconds | Manifest preparation seconds |
+|---|---:|---:|---:|---:|
+| Original per-file retirement | 57,853,538 | 38.574 | 21.176 | 10.439 |
+| Batched retirement only | 57,796,320 | 25.174 | 3.676 | 11.013 |
+| Batched retirement and valid private cache | 57,494,049 | 16.764 | 1.621 | 3.728 |
+
+The first comparison isolates batching from the cache fixture correction.
+Replaying the same prepared SQLite snapshot with identical deletion SQL took
+16.705 seconds with per-file commits versus 1.686 seconds with one commit.
+The bundled SQLite source documents the default 1,000-page WAL checkpoint
+threshold after commits; repeated commits amplified local index write costs.
+The production fix also runs unowned payload inventory cleanup once per batch.
+
+The smoke harness previously created its cache root with mode 0755 under umask
+022. Crab correctly rejected that root for private proof-cache access. Fresh
+fixture roots now use 0700; existing roots are not chmodded and the product's
+security checks are unchanged. This qualification error must not be attributed
+solely to product retirement performance. Timings use consecutive edits on a
+shared workstation/USB SSD, not an isolated or universally reproducible bound.
+
+| Changed boundary | Entry/caller → owner → callee | Siblings and proof |
+|---|---|---|
+| Batch retirement | `post_success_cleanup` → `StagingAreaReadOnly::retire_push_snapshot` → `Index::remove_files` | Writer/read-only publication, rollback and recovery use the same path; whole-batch rollback and shared prepared payload regression tests |
+| File/chunk deletion | `remove_files` / `delete_chunks_for_file` → transaction-local deletion | Pending rows do not decrement committed live counts; standalone retirement retains file metadata |
+| Body reclamation | Staging batch removal → committed inventory → filesystem unlink | Active recipe/preparation leases retain bodies; failed unlink remains recoverable orphan state |
+| Private test cache | Smoke preflight → fresh directory creation → production private-root validation | POSIX umask regression; existing directories and production permissions unchanged |
+
+Is batching the best fix rather than merely plausible? It removes repeated
+durable commits and global inventory scans at their owning boundary, instead of
+weakening fsync/checkpoint behavior or deferring correctness-critical cleanup.
+The tradeoff is a longer individual write transaction, held for the complete
+retirement set, and potentially more WAL retained until commit, while measured
+total cleanup time falls. Database failures
+now roll back the whole file-removal batch. Ownership publication is still a
+separate transaction; existing retry/recovery handles an interrupted cleanup.
+
+The follow-up staging suite passed 217 tests with one ignored; strict
+all-target staging clippy and the 11 smoke-harness source tests passed. A new
+RustFS bucket passed all 132 lifecycle checks with the batched implementation
+and corrected private cache root. The exercised binary SHA-256 is
+`e03a72a7646e89a9ea08886076f736570ec1a255198e814ca2dfb57c436a31a9`.
+Its runtime source is merged PR #156 plus this retirement/timing patch; the
+build embeds the pre-squash revision `ce3fdecfc033`, whose runtime source is
+identical to the merged `a371fb7d0024`. Reports record the latter checkout as
+dirty. The fresh 100-GiB follow-up passed all 1,223 checks: 50 large files
+(2 GiB each, ten shared content families), 500 small code files, three versions,
+commit/push, cold clone/hydration, dehydration and rehydration. All 1,100
+SHA-256 comparisons passed. Final Git fsck passed and the harness removed its
+isolated repository/cache data and fresh RustFS bucket, retaining reports.
+
+The full default-feature Crab library replay passed 4,145 tests with three
+ignored. Earlier runs exposed unchanged timing-sensitive cache-lock and
+50-ms cancellation tests under competing disk activity; a long external
+temporary-directory override also exceeded a Unix-socket path limit. The
+final run used normal temporary paths after the large live workload finished;
+no assertions were weakened. The Crab CI lint-category gate passed with its
+existing allowed warnings, as did workspace formatting and diff checks.
+
+Its first edited push completed in 113.972 seconds versus the previous
+245.025 seconds, uploading exactly the same 57,579,824 bytes. Aggregate
+post-success work fell from 108.758 to 29.793 seconds; the new retirement
+subphase measured 28.510 seconds. Manifest preparation took 22.873 seconds,
+candidate metadata publication 13.819 seconds, and xorb upload 2.262 seconds.
+This is a substantial reduction, not a claim that a 55-MiB delta costs only
+its network transfer time: validation and metadata still scale with the file
+recipes being published.
+
+The first edited add took 867.690 seconds versus 620.299 previously. Its
+chunking worker time was essentially unchanged and remote lookup worker time
+was lower, so the wall-time difference is not isolated to a code regression.
+Initial add/push also slowed from 559.033/593.262 to 682.618/706.740 seconds on
+the shared SSD. These separate runs do not establish improved add latency.
+Initial-push miss invalidation (29.323 seconds) and proof-cache work (27.308
+seconds) remain additional opportunities; on the first edited push those
+subphases took only 0.320 and 0.942 seconds, respectively.
+
+The second edited push completed in 108.308 seconds versus 277.197 previously,
+again with identical uploaded bytes (57,285,483). Aggregate post-success work
+fell from 131.536 to 30.215 seconds, including 29.892 seconds of retirement.
+Manifest preparation took 16.788 seconds and candidate metadata publication
+11.088 seconds. The second edited add took 737.900 seconds versus 642.509
+previously. After this push, an immutable read of the closed staging database
+found zero files, chunks, pending chunks, recipes, chunk/prepared payloads,
+push snapshots and path leases; `PRAGMA quick_check` returned `ok`, and no
+prepared plan/payload files remained. Cold hydration took 2,336.695 seconds,
+dehydration 214.653 seconds and rehydration 993.962 seconds. These results prove
+the exercised lifecycle, not universal low latency or 100 GiB of unique data.

--- a/crab/scripts/e2e/run_add_commit_push_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_add_commit_push_rustfs_smoke.py
@@ -548,7 +548,7 @@ class AddCommitPushSmoke:
         self.run_root.mkdir(parents=True, exist_ok=True)
         self.logs.mkdir(parents=True, exist_ok=True)
         self.artifacts.mkdir(parents=True, exist_ok=True)
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         self.write_report()
 
         for binary in ("git", "aws", self.crab_bin):

--- a/crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_protocol_v2_partial_clone_rustfs_smoke.py
@@ -844,7 +844,8 @@ class ProtocolV2PartialCloneSmoke:
                     event = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                fields = event.get("fields")
+                # Git stderr can contain JSON scalars; only objects are tracing events.
+                fields = event.get("fields") if isinstance(event, dict) else None
                 if not isinstance(fields, dict):
                     continue
                 if "storage_request" in fields:
@@ -874,7 +875,7 @@ class ProtocolV2PartialCloneSmoke:
                     event = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                fields = event.get("fields")
+                fields = event.get("fields") if isinstance(event, dict) else None
                 if not isinstance(fields, dict) or fields.get("protocol_version") != 2:
                     continue
                 if "planned_objects" not in fields and "transferred_bytes" not in fields:
@@ -1209,7 +1210,7 @@ class ProtocolV2PartialCloneSmoke:
                     event = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                fields = event.get("fields")
+                fields = event.get("fields") if isinstance(event, dict) else None
                 if (
                     isinstance(fields, dict)
                     and fields.get("message") == "protocol-v2 upload-pack plan selected"

--- a/crab/scripts/e2e/test_add_commit_push_source.py
+++ b/crab/scripts/e2e/test_add_commit_push_source.py
@@ -66,6 +66,17 @@ class SourceWorkflowTests(unittest.TestCase):
             Path(self.smoke.crab_bin)
         )
 
+    @unittest.skipUnless(os.name == "posix", "POSIX cache permission contract")
+    def test_preflight_creates_a_private_cache_under_permissive_umask(self) -> None:
+        previous = os.umask(0o022)
+        try:
+            with patch.object(self.smoke, "write_report", side_effect=RuntimeError("stop before tools")):
+                with self.assertRaisesRegex(RuntimeError, "stop before tools"):
+                    self.smoke.preflight()
+        finally:
+            os.umask(previous)
+        self.assertEqual(self.smoke.cache_dir.stat().st_mode & 0o777, 0o700)
+
     def test_source_clone_uses_pinned_commit_without_copying_dirty_worktree(self) -> None:
         (self.source / "tracked.txt").write_text("later commit\n", encoding="utf-8")
         self.git("commit", "-am", "later")

--- a/crab/scripts/tests/test_protocol_qualification_logs.py
+++ b/crab/scripts/tests/test_protocol_qualification_logs.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -24,6 +25,18 @@ class EvidenceLogsTest(unittest.TestCase):
         self.runner = RUNNER.ProtocolV2PartialCloneSmoke.__new__(RUNNER.ProtocolV2PartialCloneSmoke)
         self.runner.command_index = 0
         self.runner.logs = Path(self.directory.name) / "logs"
+
+    def test_telemetry_ignores_non_event_stderr_without_losing_events(self) -> None:
+        self.runner.logs.mkdir()
+        fields = {"protocol_version": 2, "planned_objects": 3,
+                  "storage_request": "range_get", "storage_bytes": 7}
+        for value in (5481203632, None, True, "progress", [], {"fields": 7}):
+            with self.subTest(value=value):
+                (self.runner.logs / "mixed.stderr.log").write_text(
+                    "ordinary stderr\n" + json.dumps(value) + "\n"
+                    + json.dumps({"fields": fields}) + "\n", encoding="utf-8")
+                self.assertEqual(len(self.runner.protocol_telemetry()), 1)
+                self.assertEqual(self.runner.storage_telemetry()["bytes"], 7)
 
     def test_long_labels_are_writable_and_remain_unique(self) -> None:
         paths = []

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -23678,13 +23678,13 @@ mod tests {
             Some(&RefPushOutcome::Ok)
         );
         assert!(
-            !crate::git::upload_pack_wire::snapshot_available(
+            crate::git::upload_pack_wire::snapshot_available(
                 store.as_storage(),
                 repo_prefix,
                 &CancellationToken::new(),
             )
             .await,
-            "protocol v2 must remain withheld while the generation owner protects the active journal"
+            "protocol v2 must remain available while fetch admission waits for the active owner"
         );
         let (manifest, _) = read_manifest(&store, &router)
             .await
@@ -24084,6 +24084,72 @@ mod tests {
         assert!(admitted.manifest.generation > initial.generation);
         assert!(admitted.manifest.refs.contains_key("refs/heads/main"));
         assert_eq!(repository.generation(), admitted.manifest.generation);
+        let storage_router =
+            crab_storage::StoreLayout::new(store.as_storage().clone(), repo_prefix.to_owned());
+        assert!(
+            crab_metadata::git_visibility::ensure_catalog_bound(
+                store.as_storage(),
+                &storage_router,
+                &admitted.manifest,
+            )
+            .await
+            .expect("bind the base catalog proof")
+        );
+        let pushed = Box::pin(
+            PushPipeline::new(
+                PushConfig::default(),
+                vec![make_spec("refs/heads/dev")],
+                Some(store.clone()),
+                None,
+                None,
+                repo_prefix.to_owned(),
+                router.clone(),
+                None,
+                CancellationToken::new(),
+                None,
+            )
+            .execute(),
+        )
+        .await;
+        assert_eq!(
+            pushed.outcomes.get("refs/heads/dev"),
+            Some(&RefPushOutcome::Ok)
+        );
+        // Pause at the same boundary as a concurrent reader: the compacted
+        // manifest is visible, but its ordinal handoff is not materialized.
+        let compacted = crab_metadata::manifest_store::compact_ref_journal(
+            store.as_storage(),
+            &storage_router,
+            admitted.manifest.created_at.clone(),
+            None,
+            "pending-admission".to_owned(),
+        )
+        .await
+        .expect("compact the journal")
+        .expect("journal compaction exists");
+        assert!(!compacted.git_visibility_published);
+        assert!(
+            crate::git::upload_pack_wire::snapshot_available(
+                store.as_storage(),
+                repo_prefix,
+                &CancellationToken::new(),
+            )
+            .await,
+            "durable pending visibility evidence must preserve protocol v2"
+        );
+        assert!(
+            !git_visibility_proof_available_for_manifest(&store, &router, &compacted.manifest)
+                .await
+                .expect("capability discovery must leave materialization to admission")
+        );
+        let (repository, _) = crate::git::upload_pack_wire::open_repository_with_visibility(
+            store.as_storage(),
+            repo_prefix,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("admission completes the pending handoff");
+        assert_eq!(repository.generation(), compacted.manifest.generation);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -24279,6 +24345,15 @@ mod tests {
             git_generation_owner_is_active(&store, &router)
                 .await
                 .expect("inspect active generation owner")
+        );
+        assert!(
+            crate::git::upload_pack_wire::snapshot_available(
+                store.as_storage(),
+                repo_prefix,
+                &CancellationToken::new(),
+            )
+            .await,
+            "an active owner must not disable protocol v2 when visibility evidence exists"
         );
         let cancellation = CancellationToken::new();
         cancellation.cancel();

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -15640,7 +15640,9 @@ impl PushPipeline {
     #[tracing::instrument(level = "info", name = "push.post_commit", skip_all)]
     async fn post_success_cleanup(&self) -> PostSuccessCleanupStats {
         let mut stats = PostSuccessCleanupStats::default();
+        let release_phase = PhaseTimer::start("push", "post_success_lock_release");
         self.stop_heartbeat_and_release_lock().await;
+        self.emit_perf_phase(release_phase.finish(0, 0, 0));
 
         // Build the per-shard chunk→xorb entries outside the ChunkIndex
         // lock to minimize lock contention. The metadata path hands us a
@@ -15651,6 +15653,7 @@ impl PushPipeline {
         // the shard session). We use `file_shard_index` to map each file
         // back to its shard, then group the file's chunk placements under
         // that shard for the session-local ChunkIndex.
+        let entries_phase = PhaseTimer::start("push", "post_success_index_prepare");
         let shard_entries = match self.precomputed_chunk_index_entries.lock().await.take() {
             Some(entries) => entries,
             None => {
@@ -15743,7 +15746,9 @@ impl PushPipeline {
             }
         };
 
+        self.emit_perf_phase(entries_phase.finish(0, 0, shard_entries.len() as u64));
         if !shard_entries.is_empty() {
+            let invalidation_phase = PhaseTimer::start("push", "post_success_miss_invalidation");
             // Only successful visibility publication invalidates cached misses.
             // Reuse the prepared shard membership; do not rescan recipes or
             // promote pre-CAS candidates into add-time remote authority.
@@ -15775,6 +15780,8 @@ impl PushPipeline {
                     Err(error) => warn!(error = %error, "add cache invalidation task failed"),
                 }
             }
+            self.emit_perf_phase(invalidation_phase.finish(0, 0, 0));
+            let install_phase = PhaseTimer::start("push", "post_success_index_install");
             let mut chunk_index = self.chunk_index.lock().await;
             for (shard_hash, entries) in shard_entries.iter() {
                 let already_installed = chunk_index.has_shard(shard_hash);
@@ -15788,6 +15795,7 @@ impl PushPipeline {
                 shards = shard_entries.len(),
                 "step 13: installed shards into ChunkIndex"
             );
+            self.emit_perf_phase(install_phase.finish(0, 0, shard_entries.len() as u64));
         }
 
         // Warm advisory xorb caches with small xorbs just uploaded. Streamed
@@ -15796,6 +15804,7 @@ impl PushPipeline {
         // Very large initial pushes already made the origin durable; copying
         // those bytes again before returning would make cache warming dominate
         // the user-visible push path.
+        let warm_phase = PhaseTimer::start("push", "post_success_xorb_cache");
         let uploaded = std::mem::take(&mut *self.uploaded_xorbs.lock().await)
             .into_iter()
             .filter(|uploaded_xorb| uploaded_xorb.cache_warm)
@@ -15906,6 +15915,12 @@ impl PushPipeline {
             }
         }
 
+        self.emit_perf_phase(warm_phase.finish(
+            stats.xorb_cache_warm_bytes,
+            0,
+            stats.xorb_cache_warm_items,
+        ));
+        let retirement_phase = PhaseTimer::start("push", "post_success_staging_retirement");
         let has_staging_snapshot = *self.staging_push_marked.lock().await;
         if has_staging_snapshot {
             self.commit_staging_push_snapshot().await;
@@ -15924,6 +15939,7 @@ impl PushPipeline {
             }
         }
 
+        self.emit_perf_phase(retirement_phase.finish(0, 0, 0));
         debug!("step 13: post-success cleanup complete");
         stats
     }
@@ -16569,10 +16585,12 @@ impl PushPipeline {
                 CrabError::Internal("push ref preflight result is missing".to_owned())
             });
             let (sha_map, decisions) = self.at_stage(PushFailureStage::RefCommit, preflight)?;
+            let manifest_prepare_phase = PhaseTimer::start("push", "manifest_prepare");
             let apply_result = self
                 .apply_decisions_with_sha_map(&decisions, self.config.atomic, &sha_map)
                 .await;
             let (manifest, bulk) = self.at_stage(PushFailureStage::RefCommit, apply_result)?;
+            self.emit_perf_phase(manifest_prepare_phase.finish(0, 0, 0));
             let metadata_phase = PhaseTimer::start("push", "candidate_metadb");
             let metadata_result = self.publish_candidate_metadb(&manifest).await;
             self.at_stage(PushFailureStage::RefCommit, metadata_result)?;

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -311,25 +311,9 @@ async fn capability_snapshot_is_stable(
     };
     let repair_store = crate::storage::Store::from_storage(store.clone());
     let repair_layout = crate::storage::StoreLayout::new(repair_store.clone(), prefix.to_owned());
-    let active_marker_present = store
-        .list_prefix_bounded(&layout.ref_journal_active_prefix(), 1)
-        .await?
-        .is_none_or(|objects| !objects.is_empty());
-    let owner_active =
-        match super::push::git_generation_owner_is_active(&repair_store, &repair_layout).await {
-            Ok(active) => active,
-            Err(error) => {
-                tracing::warn!(%error, "generation owner probe failed during capability discovery");
-                return Ok(false);
-            }
-        };
-    if owner_active {
-        tracing::debug!(
-            active_marker_present,
-            "protocol-v2 capability withheld while generation-owner admission is active"
-        );
-        return Ok(false);
-    }
+    // Owner contention is transient, not missing protocol support. Fetch
+    // admission waits for repair and validates the discovered refs/inventory;
+    // gating here would randomly downgrade concurrent clones to legacy fetch.
     if manifest.refs.is_empty() {
         return Ok(true);
     }
@@ -340,7 +324,15 @@ async fn capability_snapshot_is_stable(
     )
     .await
     {
-        Ok(available) => Ok(available),
+        Ok(true) => Ok(true),
+        // Compaction publishes its immutable handoff before the manifest CAS.
+        // Requiring its materialized result here races the first reader that
+        // completes it; fetch admission remains the only repair/validation path.
+        Ok(false) => {
+            crab_metadata::git_visibility::pending_bound_available(store, &layout, &manifest)
+                .await
+                .map_err(RemoteGitError::from)
+        }
         Err(error) => {
             tracing::warn!(%error, "visibility proof probe failed during capability discovery");
             Ok(false)

--- a/crates/crab-metadata/src/git_visibility.rs
+++ b/crates/crab-metadata/src/git_visibility.rs
@@ -3278,11 +3278,12 @@ mod storage {
     }
 
     #[cfg(feature = "remote-index")]
-    async fn apply_catalog_journal_edits(
+    async fn read_catalog_pending(
         store: &Store,
         router: &StoreLayout<Store>,
         manifest: &Manifest,
-    ) -> Result<Option<GitCatalogVisibilityIndex>> {
+    ) -> Result<Option<GitVisibilityPending>> {
+        validate_hash(&manifest.git_validation_digest, "Git validation digest")?;
         let pending_path = router.git_visibility_pending_path(&manifest.git_validation_digest);
         let body = match read_bounded(store, &pending_path).await {
             Ok(body) => body,
@@ -3312,6 +3313,33 @@ mod storage {
             "base Git validation digest",
         )?;
         validate_hash(&pending.base_catalog_digest, "base catalog digest")?;
+        Ok(Some(pending))
+    }
+
+    /// Check for a bounded pending visibility handoff bound to this manifest.
+    ///
+    /// This is admission evidence, not a materialized proof. Fetch must still
+    /// validate the base catalog and edits while completing the handoff.
+    #[cfg(feature = "remote-index")]
+    pub async fn pending_bound_available(
+        store: &Store,
+        router: &StoreLayout<Store>,
+        manifest: &Manifest,
+    ) -> Result<bool> {
+        Ok(read_catalog_pending(store, router, manifest)
+            .await?
+            .is_some())
+    }
+
+    #[cfg(feature = "remote-index")]
+    async fn apply_catalog_journal_edits(
+        store: &Store,
+        router: &StoreLayout<Store>,
+        manifest: &Manifest,
+    ) -> Result<Option<GitCatalogVisibilityIndex>> {
+        let Some(pending) = read_catalog_pending(store, router, manifest).await? else {
+            return Ok(None);
+        };
         let base_path = router.git_visibility_catalog_path(&pending.base_git_validation_digest);
         let base_body = match read_bounded(store, &base_path).await {
             Ok(body) => body,
@@ -3776,7 +3804,10 @@ pub use storage::{
 };
 
 #[cfg(all(feature = "remote-index", feature = "storage"))]
-pub use storage::{GitCatalogVisibilityRead, catalog_bound_available, read_catalog_with_format};
+pub use storage::{
+    GitCatalogVisibilityRead, catalog_bound_available, pending_bound_available,
+    read_catalog_with_format,
+};
 
 #[cfg(test)]
 mod tests {
@@ -5095,6 +5126,28 @@ mod tests {
             .await
             .expect("prepare catalog visibility handoff")
         );
+        assert!(
+            pending_bound_available(&store, &router, &target)
+                .await
+                .expect("pending handoff is admission evidence")
+        );
+        for mismatch in [
+            Manifest {
+                generation: target.generation + 1,
+                ..target.clone()
+            },
+            Manifest {
+                pack_index_hash: "f".repeat(64),
+                ..target.clone()
+            },
+        ] {
+            assert!(
+                pending_bound_available(&store, &router, &mismatch)
+                    .await
+                    .is_err(),
+                "pending admission must reject a mismatched target binding"
+            );
+        }
         assert!(
             ensure_catalog_bound(&store, &router, &target)
                 .await

--- a/crates/crab-staging/README.md
+++ b/crates/crab-staging/README.md
@@ -41,6 +41,13 @@ fsyncs the segment and records the durable boundary. Reads verify both the
 record checksum and the requested BLAKE3 hash. Recipes, push plans, streaming
 helpers, compaction, verification, and retirement build on these primitives.
 
+Ownership retirement removes each unowned file batch in one SQLite transaction,
+including chunk rows, segment live counts and unreferenced payload inventory.
+Prepared bodies are unlinked only after that transaction commits. A database
+failure rolls back the batch; an unlink failure leaves an orphan for recovery,
+not a missing live payload. This shares one cleanup path across publication,
+rollback and push, avoiding repeated per-file commits and inventory scans.
+
 ## Usage
 
 The smallest complete staging cycle is:

--- a/crates/crab-staging/src/index.rs
+++ b/crates/crab-staging/src/index.rs
@@ -3054,10 +3054,9 @@ impl Index {
         for batch_id in batches {
             unleased_files.extend(self.rollback_batch(&batch_id)?);
         }
-        for file_hash in unleased_files {
-            let (_, payloads) = self.remove_file(&file_hash)?;
-            removed.extend(payloads);
-        }
+        let unleased_files = unleased_files.into_iter().collect::<Vec<_>>();
+        let (_, payloads) = self.remove_files(&unleased_files)?;
+        removed.extend(payloads);
         removed.sort_unstable();
         removed.dedup();
         Ok(removed)
@@ -5925,102 +5924,56 @@ impl Index {
         })
     }
 
-    /// Remove a file and all its chunk/pending rows from the index.
+    /// Atomically remove files and their chunk rows, then reclaim unowned payload inventory.
     ///
-    /// Returns the segment IDs that had chunks removed (caller should
-    /// decrement `live_chunk_count` on those segments). Returns an empty
-    /// vec if the file was not found.
+    /// Returns per-file retirement stats and prepared bodies eligible for unlinking.
+    /// Segment live counts are decremented only for committed chunk rows.
     ///
     /// # Errors
     ///
     /// Returns [`StagingError::Internal`] on SQLite failure.
-    pub fn remove_file(&self, file_hash: &[u8; 32]) -> Result<(Vec<u64>, Vec<[u8; 32]>)> {
-        let fh: &[u8] = file_hash;
+    pub fn remove_files(
+        &self,
+        file_hashes: &[[u8; 32]],
+    ) -> Result<(Vec<crate::RetireStats>, Vec<[u8; 32]>)> {
+        if file_hashes.is_empty() {
+            return Ok((Vec::new(), Vec::new()));
+        }
+        // Retire one ownership set in one transaction. Per-file commits
+        // repeatedly checkpoint the same recipe indexes and expose partial
+        // retirement if a later file fails.
         let tx = self
             .conn
             .unchecked_transaction()
-            .map_err(|e| StagingError::Internal(format!("failed to begin remove_file tx: {e}")))?;
-
-        // Collect affected segment IDs from committed chunks.
-        let affected: Vec<u64> = {
-            let mut stmt = tx
-                .prepare_cached("SELECT DISTINCT segment_id FROM chunks WHERE file_hash = ?1")
-                .map_err(|e| {
-                    StagingError::Internal(format!("prepare affected segments query: {e}"))
-                })?;
-            stmt.query_map(params![fh], |row| row.get(0))
-                .map_err(|e| StagingError::Internal(format!("query affected segments: {e}")))?
-                .collect::<std::result::Result<Vec<u64>, _>>()
-                .map_err(|e| StagingError::Internal(format!("collect affected segments: {e}")))?
-        };
-
-        // Count committed chunks per segment for live_chunk_count adjustment.
-        let segment_counts: Vec<(u64, u64)>;
-        {
-            let mut stmt = tx
-                .prepare_cached(
-                    "SELECT segment_id, COUNT(*) FROM chunks WHERE file_hash = ?1 GROUP BY segment_id",
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!("prepare chunk count query: {e}"))
-                })?;
-            segment_counts = stmt
-                .query_map(params![fh], |row| {
-                    Ok((row.get(0)?, row.get::<_, i64>(1)? as u64))
-                })
-                .map_err(|e| StagingError::Internal(format!("query chunk counts: {e}")))?
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|e| StagingError::Internal(format!("collect chunk counts: {e}")))?;
-        }
-
-        // Delete pending chunks for this file.
-        tx.execute(
-            "DELETE FROM pending_chunks WHERE file_hash = ?1",
-            params![fh],
-        )
-        .map_err(|e| {
-            StagingError::Internal(format!("failed to delete pending chunks for file: {e}"))
-        })?;
-
-        // Delete committed chunks for this file.
-        tx.execute("DELETE FROM chunks WHERE file_hash = ?1", params![fh])
+            .map_err(|e| StagingError::Internal(format!("failed to begin file removal: {e}")))?;
+        let mut retired = Vec::with_capacity(file_hashes.len());
+        for file_hash in file_hashes {
+            let fh: &[u8] = file_hash;
+            retired.push(Self::delete_chunks_for_file_in(&tx, file_hash)?);
+            tx.execute(
+                "DELETE FROM file_recipes
+                 WHERE file_hash = ?1
+                   AND NOT EXISTS (
+                       SELECT 1 FROM path_leases WHERE path_leases.file_hash = ?1
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM push_snapshot_recipes
+                       WHERE push_snapshot_recipes.recipe_hash = file_recipes.recipe_hash
+                   )",
+                params![fh],
+            )
             .map_err(|e| {
-                StagingError::Internal(format!("failed to delete chunks for file: {e}"))
+                StagingError::Internal(format!("failed to delete unleased recipes: {e}"))
             })?;
+            // Delete the file row.
+            tx.execute("DELETE FROM files WHERE file_hash = ?1", params![fh])
+                .map_err(|e| StagingError::Internal(format!("failed to delete file: {e}")))?;
 
-        // Decrement live_chunk_count on affected segments.
-        {
-            let mut stmt = tx
-                .prepare_cached(
-                    "UPDATE segments SET live_chunk_count = MAX(0, live_chunk_count - ?1) WHERE segment_id = ?2",
-                )
-                .map_err(|e| {
-                    StagingError::Internal(format!("prepare live_chunk_count update: {e}"))
-                })?;
-            #[expect(clippy::cast_possible_wrap, reason = "count fits in i64")]
-            for (seg_id, count) in &segment_counts {
-                stmt.execute(params![*count as i64, seg_id]).map_err(|e| {
-                    StagingError::Internal(format!(
-                        "failed to decrement live_chunk_count for segment {seg_id}: {e}"
-                    ))
-                })?;
-            }
+            // Clean up the file_paths side table.
+            tx.execute("DELETE FROM file_paths WHERE file_hash = ?1", params![fh])
+                .map_err(|e| StagingError::Internal(format!("failed to delete file_path: {e}")))?;
         }
-
-        tx.execute(
-            "DELETE FROM file_recipes
-             WHERE file_hash = ?1
-               AND NOT EXISTS (
-                   SELECT 1 FROM path_leases WHERE path_leases.file_hash = ?1
-               )
-               AND NOT EXISTS (
-                   SELECT 1
-                   FROM push_snapshot_recipes
-                   WHERE push_snapshot_recipes.recipe_hash = file_recipes.recipe_hash
-               )",
-            params![fh],
-        )
-        .map_err(|e| StagingError::Internal(format!("failed to delete unleased recipes: {e}")))?;
 
         tx.execute(
             "DELETE FROM chunk_payloads
@@ -6096,25 +6049,16 @@ impl Index {
             StagingError::Internal(format!("failed to delete unleased prepared payloads: {e}"))
         })?;
 
-        // Delete the file row.
-        tx.execute("DELETE FROM files WHERE file_hash = ?1", params![fh])
-            .map_err(|e| StagingError::Internal(format!("failed to delete file: {e}")))?;
-
-        // Clean up the file_paths side table.
-        tx.execute("DELETE FROM file_paths WHERE file_hash = ?1", params![fh])
-            .map_err(|e| StagingError::Internal(format!("failed to delete file_path: {e}")))?;
-
         tx.commit()
-            .map_err(|e| StagingError::Internal(format!("failed to commit remove_file tx: {e}")))?;
-
-        Ok((affected, reclaimable_payloads))
+            .map_err(|e| StagingError::Internal(format!("failed to commit file removal: {e}")))?;
+        Ok((retired, reclaimable_payloads))
     }
 
     /// Delete every `chunks` and `pending_chunks` row for `file_hash`.
     ///
     /// Executes as a single SQLite transaction so a partial failure
     /// cannot leave `live_chunk_count` out of sync with the surviving
-    /// `chunks` rows. Unlike [`Self::remove_file`], this helper leaves
+    /// `chunks` rows. Unlike [`Self::remove_files`], this helper leaves
     /// the `files` row untouched. Pending rows are removed so a failed
     /// or retried add cannot collide on `(file_hash, chunk_index)`, but
     /// only committed `chunks` rows decrement `live_chunk_count`.
@@ -6129,11 +6073,21 @@ impl Index {
     ///
     /// Returns [`StagingError::Internal`] on SQLite failure.
     pub fn delete_chunks_for_file(&self, file_hash: &[u8; 32]) -> Result<(u64, Vec<u64>)> {
-        let fh: &[u8] = file_hash;
         let tx = self.conn.unchecked_transaction().map_err(|e| {
-            StagingError::Internal(format!("failed to begin delete_chunks_for_file tx: {e}"))
+            StagingError::Internal(format!("failed to begin chunk retirement: {e}"))
         })?;
+        let stats = Self::delete_chunks_for_file_in(&tx, file_hash)?;
+        tx.commit().map_err(|e| {
+            StagingError::Internal(format!("failed to commit chunk retirement: {e}"))
+        })?;
+        Ok((stats.rows_deleted, stats.segments_touched))
+    }
 
+    fn delete_chunks_for_file_in(
+        tx: &rusqlite::Transaction<'_>,
+        file_hash: &[u8; 32],
+    ) -> Result<crate::RetireStats> {
+        let fh: &[u8] = file_hash;
         // Capture touched segments from both tables for tracing and
         // cleanup decisions, but decrement live counts only for rows
         // already promoted into `chunks`. Pending rows never increment
@@ -6220,11 +6174,10 @@ impl Index {
             }
         }
 
-        tx.commit().map_err(|e| {
-            StagingError::Internal(format!("failed to commit delete_chunks_for_file tx: {e}"))
-        })?;
-
-        Ok((rows_deleted, touched_segments))
+        Ok(crate::RetireStats {
+            rows_deleted,
+            segments_touched: touched_segments,
+        })
     }
 
     /// List all files in the staging index with their chunk counts and sizes.
@@ -9916,6 +9869,69 @@ mod tests {
     }
 
     #[test]
+    fn removing_multiple_files_preserves_shared_prepared_payload() {
+        let idx = open_in_memory();
+        let first = insert_test_recipe_lease(&idx, "first", b"first.bin", 0x61, 0x51);
+        let second = insert_test_recipe_lease(&idx, "second", b"second.bin", 0x62, 0x52);
+        let survivor = insert_test_recipe_lease(&idx, "survivor", b"survivor.bin", 0x63, 0x53);
+        let xorb = test_hash(0x64);
+        idx.conn.execute(
+            "INSERT INTO prepared_payloads (xorb_hash, payload_hash, bytes) VALUES (?1, ?1, 24)",
+            params![xorb.as_slice()],
+        ).unwrap();
+        for recipe in [&first, &second, &survivor] {
+            idx.conn
+                .execute(
+                    "INSERT INTO prepared_leases (recipe_hash, xorb_hash) VALUES (?1, ?2)",
+                    params![recipe.hash().as_slice(), xorb.as_slice()],
+                )
+                .unwrap();
+        }
+        idx.rollback_batch("first").unwrap();
+        idx.rollback_batch("second").unwrap();
+        let (retired, payloads) = idx
+            .remove_files(&[first.file_hash().into(), second.file_hash().into()])
+            .unwrap();
+        let surviving_rows: (i64, i64, i64) = idx
+            .conn
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM files),
+                    (SELECT COUNT(*) FROM prepared_payloads),
+                    (SELECT COUNT(*) FROM prepared_leases)",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (
+                retired.iter().map(|stats| stats.rows_deleted).sum::<u64>(),
+                payloads,
+                surviving_rows
+            ),
+            (2, Vec::new(), (1, 1, 1)),
+        );
+    }
+
+    #[test]
+    fn remove_files_rolls_back_the_whole_batch_on_failure() {
+        let idx = open_in_memory();
+        let first = test_hash(0x71);
+        let second = test_hash(0x72);
+        insert_test_file(&idx, &first, 8);
+        insert_test_file(&idx, &second, 8);
+        idx.conn.execute_batch(
+            "CREATE TRIGGER fail_second_removal BEFORE DELETE ON files
+             WHEN OLD.file_hash = X'7272727272727272727272727272727272727272727272727272727272727272'
+             BEGIN SELECT RAISE(ABORT, 'injected retirement failure'); END;"
+        ).unwrap();
+        assert!(idx.remove_files(&[first, second]).is_err());
+        assert!(
+            idx.file_exists(&first).unwrap(),
+            "failed retirement must retain every file"
+        );
+    }
+
+    #[test]
     fn retiring_last_recipe_reclaims_payload_inventory() {
         let idx = open_in_memory();
         let segment_id = idx.allocate_segment_id().expect("allocate segment");
@@ -9970,7 +9986,7 @@ mod tests {
                 .expect("retire exact snapshot"),
             vec![file_hash]
         );
-        idx.remove_file(&file_hash).expect("remove file");
+        idx.remove_files(&[file_hash]).expect("remove file");
         idx.remove_push_snapshot("push-retire")
             .expect("remove snapshot");
 

--- a/crates/crab-staging/src/lib.rs
+++ b/crates/crab-staging/src/lib.rs
@@ -953,14 +953,16 @@ fn remove_prepared_payload_files(root: &Path, hashes: &[[u8; 32]]) -> Result<()>
     Ok(())
 }
 
-fn remove_indexed_file(
+fn remove_indexed_files(
     root: &Path,
     index: &Mutex<Index>,
-    file_hash: &[u8; 32],
-) -> Result<Vec<u64>> {
-    let (segments, payloads) = lock_index(index)?.remove_file(file_hash)?;
+    file_hashes: &[[u8; 32]],
+) -> Result<Vec<RetireStats>> {
+    let (retired, payloads) = lock_index(index)?.remove_files(file_hashes)?;
+    // SQL ownership commits before filesystem reclamation. A failed unlink
+    // leaves only an orphan for the existing sweep, never a missing live body.
     remove_prepared_payload_files(root, &payloads)?;
-    Ok(segments)
+    Ok(retired)
 }
 
 fn sweep_abandoned_prepared_payload_files(root: &Path, index: &Index) -> Result<()> {
@@ -2615,11 +2617,7 @@ impl StagingArea {
     /// Mark a batch as published after its Git index replacement commits.
     pub fn mark_batch_published(&self, batch_id: &StagingBatchId) -> Result<()> {
         let unleased = lock_index(&self.index)?.mark_batch_published(batch_id.as_str())?;
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            self.retire_file(&file_hash)?;
-            self.unregister_file(&file_hash)?;
-        }
+        remove_indexed_files(&self.root, &self.index, &unleased)?;
         Ok(())
     }
 
@@ -2635,11 +2633,7 @@ impl StagingArea {
         else {
             return Ok(false);
         };
-        for file_hash in unowned {
-            let file_hash = MerkleHash::from(file_hash);
-            self.retire_file(&file_hash)?;
-            self.unregister_file(&file_hash)?;
-        }
+        remove_indexed_files(&self.root, &self.index, &unowned)?;
         Ok(true)
     }
 
@@ -2667,11 +2661,7 @@ impl StagingArea {
     /// Atomically publish every batch recorded by an add publication intent.
     pub fn publish_publication_intent(&self, intent_id: &PublicationIntentId) -> Result<()> {
         let unleased = lock_index(&self.index)?.publish_publication_intent(intent_id.as_str())?;
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            self.retire_file(&file_hash)?;
-            self.unregister_file(&file_hash)?;
-        }
+        remove_indexed_files(&self.root, &self.index, &unleased)?;
         Ok(())
     }
 
@@ -2686,13 +2676,7 @@ impl StagingArea {
         intent_id: &PublicationIntentId,
     ) -> Result<Vec<RetireStats>> {
         let unleased = lock_index(&self.index)?.rollback_publication_intent(intent_id.as_str())?;
-        let mut retired = Vec::with_capacity(unleased.len());
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            retired.push(self.retire_file(&file_hash)?);
-            self.unregister_file(&file_hash)?;
-        }
-        Ok(retired)
+        remove_indexed_files(&self.root, &self.index, &unleased)
     }
 
     /// Publish one complete recipe outside the multi-path `crab add` index transaction.
@@ -2769,12 +2753,7 @@ impl StagingArea {
     /// Remove one batch's leases and reclaim only recipes with no other owner.
     pub fn rollback_batch(&self, batch_id: &StagingBatchId) -> Result<Vec<RetireStats>> {
         let unleased = lock_index(&self.index)?.rollback_batch(batch_id.as_str())?;
-        let mut retired = Vec::with_capacity(unleased.len());
-        for file_hash in unleased {
-            retired.push(self.retire_file(&MerkleHash::from(file_hash))?);
-            self.unregister_file(&MerkleHash::from(file_hash))?;
-        }
-        Ok(retired)
+        remove_indexed_files(&self.root, &self.index, &unleased)
     }
 
     /// Reclaim a recipe only when no path head/lease or push snapshot owns it.
@@ -3112,10 +3091,13 @@ impl StagingArea {
             if !idx.file_exists(&fh)? {
                 return Ok(false);
             }
-            let (segments, payloads) = idx.remove_file(&fh)?;
+            let (retired, payloads) = idx.remove_files(&[fh])?;
             drop(idx);
             remove_prepared_payload_files(&self.root, &payloads)?;
-            segments
+            retired
+                .into_iter()
+                .flat_map(|stats| stats.segments_touched)
+                .collect::<Vec<_>>()
         };
         debug!(
             file_hash = %file_hash.hex(),
@@ -3141,12 +3123,7 @@ impl StagingArea {
 
     fn discard_open_push_snapshot(&self, push_id: &str) -> Result<()> {
         let unleased = lock_index(&self.index)?.discard_open_push_snapshot(push_id)?;
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            self.retire_file(&file_hash)?;
-            let bytes: [u8; 32] = file_hash.into();
-            remove_indexed_file(&self.root, &self.index, &bytes)?;
-        }
+        remove_indexed_files(&self.root, &self.index, &unleased)?;
         Ok(())
     }
 
@@ -3246,19 +3223,11 @@ impl StagingArea {
                 continue;
             }
             let unleased = lock_index(&self.index)?.retire_push_snapshot(&snapshot_id)?;
-            for file_hash in unleased {
-                let file_hash = MerkleHash::from(file_hash);
-                self.retire_file(&file_hash)?;
-                self.unregister_file(&file_hash)?;
-            }
+            remove_indexed_files(&self.root, &self.index, &unleased)?;
             lock_index(&self.index)?.remove_push_snapshot(&snapshot_id)?;
         }
         let unowned = lock_index(&self.index)?.reclaim_superseded_ownership()?;
-        for file_hash in unowned {
-            let file_hash = MerkleHash::from(file_hash);
-            self.retire_file(&file_hash)?;
-            self.unregister_file(&file_hash)?;
-        }
+        remove_indexed_files(&self.root, &self.index, &unowned)?;
 
         // 2. Sweep orphan segments.
         let (segments_removed, bytes_reclaimed, chunks_reclaimed) = self.sweep_orphans()?;
@@ -4082,12 +4051,7 @@ impl StagingAreaReadOnly {
     /// Mark a staged batch published after the Git index commit.
     pub fn mark_batch_published(&self, batch_id: &StagingBatchId) -> Result<()> {
         let unleased = lock_index(&self.index)?.mark_batch_published(batch_id.as_str())?;
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            self.retire_file_now(&file_hash)?;
-            let file_hash_bytes: [u8; 32] = file_hash.into();
-            remove_indexed_file(&self.root, &self.index, &file_hash_bytes)?;
-        }
+        remove_indexed_files(&self.root, &self.index, &unleased)?;
         Ok(())
     }
 
@@ -4120,12 +4084,7 @@ impl StagingAreaReadOnly {
     /// Atomically publish every batch recorded by an add publication intent.
     pub fn publish_publication_intent(&self, intent_id: &PublicationIntentId) -> Result<()> {
         let unleased = lock_index(&self.index)?.publish_publication_intent(intent_id.as_str())?;
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            self.retire_file_now(&file_hash)?;
-            let file_hash_bytes: [u8; 32] = file_hash.into();
-            remove_indexed_file(&self.root, &self.index, &file_hash_bytes)?;
-        }
+        remove_indexed_files(&self.root, &self.index, &unleased)?;
         Ok(())
     }
 
@@ -4135,28 +4094,13 @@ impl StagingAreaReadOnly {
         intent_id: &PublicationIntentId,
     ) -> Result<Vec<RetireStats>> {
         let unleased = lock_index(&self.index)?.rollback_publication_intent(intent_id.as_str())?;
-        let mut retired = Vec::with_capacity(unleased.len());
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            retired.push(self.retire_file(&file_hash).await?);
-            let file_hash_bytes: [u8; 32] = file_hash.into();
-            remove_indexed_file(&self.root, &self.index, &file_hash_bytes)?;
-        }
-        Ok(retired)
+        remove_indexed_files(&self.root, &self.index, &unleased)
     }
 
     /// Roll back one batch while preserving recipes leased by another path.
     pub async fn rollback_batch(&self, batch_id: &StagingBatchId) -> Result<Vec<RetireStats>> {
         let unleased = lock_index(&self.index)?.rollback_batch(batch_id.as_str())?;
-        let mut retired = Vec::with_capacity(unleased.len());
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            let stats = self.retire_file(&file_hash).await?;
-            let file_hash_bytes: [u8; 32] = file_hash.into();
-            remove_indexed_file(&self.root, &self.index, &file_hash_bytes)?;
-            retired.push(stats);
-        }
-        Ok(retired)
+        remove_indexed_files(&self.root, &self.index, &unleased)
     }
 
     /// Pin the exact published recipes read by one push.
@@ -4176,15 +4120,7 @@ impl StagingAreaReadOnly {
     /// Retire the exact recipe ownership pinned by one committed push snapshot.
     pub async fn retire_push_snapshot(&self, push_id: &str) -> Result<Vec<RetireStats>> {
         let unleased = lock_index(&self.index)?.retire_push_snapshot(push_id)?;
-        let mut retired = Vec::with_capacity(unleased.len());
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            let stats = self.retire_file(&file_hash).await?;
-            let file_hash_bytes: [u8; 32] = file_hash.into();
-            remove_indexed_file(&self.root, &self.index, &file_hash_bytes)?;
-            retired.push(stats);
-        }
-        Ok(retired)
+        remove_indexed_files(&self.root, &self.index, &unleased)
     }
 
     /// Remove a push recipe snapshot on success or failure.
@@ -4203,15 +4139,7 @@ impl StagingAreaReadOnly {
 
     fn discard_open_push_snapshot_now(&self, push_id: &str) -> Result<Vec<RetireStats>> {
         let unleased = lock_index(&self.index)?.discard_open_push_snapshot(push_id)?;
-        let mut retired = Vec::with_capacity(unleased.len());
-        for file_hash in unleased {
-            let file_hash = MerkleHash::from(file_hash);
-            let stats = self.retire_file_now(&file_hash)?;
-            let bytes: [u8; 32] = file_hash.into();
-            remove_indexed_file(&self.root, &self.index, &bytes)?;
-            retired.push(stats);
-        }
-        Ok(retired)
+        remove_indexed_files(&self.root, &self.index, &unleased)
     }
 
     /// Create a push-inflight marker file from a shared push handle.

--- a/crates/crab-workflow/src/signals.rs
+++ b/crates/crab-workflow/src/signals.rs
@@ -151,6 +151,24 @@ pub struct SupervisorOutcome {
 /// typically forwards these straight into the journal.
 pub type EventSink = Arc<dyn Fn(SupervisorEvent) + Send + Sync>;
 
+#[cfg(unix)]
+struct ParentSignals {
+    sigint: tokio::signal::unix::Signal,
+    sigterm: tokio::signal::unix::Signal,
+}
+
+#[cfg(unix)]
+impl ParentSignals {
+    fn register() -> Result<Self> {
+        Ok(Self {
+            sigint: tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+                .map_err(CrabError::Io)?,
+            sigterm: tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .map_err(CrabError::Io)?,
+        })
+    }
+}
+
 /// Configuration for a single supervised run.
 pub struct ChildSupervisor {
     command: Command,
@@ -274,6 +292,12 @@ impl ChildSupervisor {
             .map_err(CrabError::Io)?;
         let log_file = Arc::new(Mutex::new(log_file));
 
+        // Install listeners immediately before spawning. A signal can arrive
+        // as soon as the child exists; registering afterward loses that event
+        // on hosts where the inherited disposition ignores SIGINT/SIGTERM.
+        #[cfg(unix)]
+        let parent_signals = ParentSignals::register()?;
+
         let mut child = self.command.spawn().map_err(CrabError::Io)?;
         let pid = child.id().ok_or_else(|| {
             // `Child::id` returns None only after the child has been
@@ -324,6 +348,9 @@ impl ChildSupervisor {
         ));
         self.emit(SupervisorEvent::Started { pid });
 
+        #[cfg(unix)]
+        let outcome = self.supervise(&mut child, pid, parent_signals).await;
+        #[cfg(not(unix))]
         let outcome = self.supervise(&mut child, pid).await;
 
         // Drain I/O tasks before returning: the child is gone, its
@@ -363,17 +390,8 @@ impl ChildSupervisor {
         &self,
         child: &mut Child,
         pid: u32,
+        mut parent_signals: ParentSignals,
     ) -> Result<(ExitStatus, Option<i32>, bool)> {
-        // Listen for parent SIGINT/SIGTERM so we can relay them.
-        // Registering fails only if the signal handler slot is
-        // already full (shouldn't happen in normal binaries; bail
-        // loud if it does — silently swallowing Ctrl-C handling is
-        // worse than surfacing the error).
-        let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
-            .map_err(CrabError::Io)?;
-        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .map_err(CrabError::Io)?;
-
         let start = Instant::now();
         let timeout_deadline = self.timeout.map(|t| start + t);
 
@@ -423,7 +441,7 @@ impl ChildSupervisor {
                 }
 
                 // Parent SIGINT → forward SIGINT to child.
-                Some(()) = sigint.recv(), if !sent_term => {
+                Some(()) = parent_signals.sigint.recv(), if !sent_term => {
                     debug!(pid, "workflow supervisor: parent SIGINT; forwarding");
                     request_child_signal(child, pid, Signal::Int).await;
                     self.emit(SupervisorEvent::SignalSent {
@@ -434,7 +452,7 @@ impl ChildSupervisor {
                 }
 
                 // Parent SIGTERM → forward SIGTERM to child.
-                Some(()) = sigterm.recv(), if !sent_term => {
+                Some(()) = parent_signals.sigterm.recv(), if !sent_term => {
                     debug!(pid, "workflow supervisor: parent SIGTERM; forwarding");
                     request_child_signal(child, pid, Signal::Term).await;
                     self.emit(SupervisorEvent::SignalSent {

--- a/packages/repository/tests/browser/accessibility.ts
+++ b/packages/repository/tests/browser/accessibility.ts
@@ -2,6 +2,12 @@ import AxeBuilder from "@axe-core/playwright";
 import { expect, type Page } from "@playwright/test";
 
 export async function expectNoAccessibilityViolations(page: Page) {
+  // TooltipV2 opens on hover and fades in. Move the pointer away and wait
+  // for the popover to close so axe never samples a half-transparent overlay.
+  await page.mouse.move(0, 0);
+  await expect(
+    page.locator('[data-component="Tooltip"][popover]:popover-open'),
+  ).toHaveCount(0);
   const result = await new AxeBuilder({ page })
     .withTags([
       "wcag2a",


### PR DESCRIPTION
## Summary

- Batch staging file retirement into one SQLite transaction and run unowned payload inventory cleanup once per batch. Writer/shared-push publication, rollback and recovery share the canonical path.
- Preserve committed segment counts, prepared-payload leases, whole-batch rollback and commit-before-unlink ordering. No format/version, dependency or durability-setting changes.
- Split push timing into retirement, cache/index and manifest subphases.
- Create fresh smoke-test private cache roots with mode 0700; existing directories and production security checks remain unchanged.

## Measured performance

Fresh local RustFS qualification: 50 × 2-GiB large files, ten shared content families, 500 small code files, three versions. Approximately 20 GiB unique base content, not 100 GiB unique entropy.

| Phase | Before | After |
|---|---:|---:|
| First edited push | 245.025 s | 113.972 s |
| Second edited push | 277.197 s | 108.308 s |
| First post-success cleanup/cache | 108.758 s | 29.793 s |
| Second post-success cleanup/cache | 131.536 s | 30.215 s |

Uploaded bytes are identical across the before/after scale runs: 57,579,824 and 57,285,483 bytes. The old aggregate timer included staging retirement, not just cache work. Same-snapshot SQL replay isolated per-file commits versus batching: 16.705 s → 1.686 s. The harness permission correction contributes separately to end-to-end improvements.

## Verification

- Fresh-bucket 100-GiB RustFS lifecycle: **1,223 checks passed**, including **1,100 SHA-256 comparisons**, commit/push, cold clone/hydration, dehydration/rehydration and final Git fsck.
- Separate fresh-bucket lifecycle canary: **132 checks passed**.
- Crab default-feature library: **4,145 passed, 3 ignored**.
- Staging library: **217 passed, 1 ignored**; new whole-batch failure rollback and shared prepared-payload retention regressions.
- Smoke-harness Python suite: **11 passed**.
- Release CLI build, strict staging all-target clippy, Crab CI lint-category gate, workspace format and diff checks passed. Crab lint retains existing CI-allowed warnings.
- Earlier broad runs exposed unchanged timing-sensitive cache-lock/cancellation tests and an overly long temporary-path setup; final normal-temp run after live I/O completed passed without weakening assertions.
- Disposable qualification repositories/caches and all three task-created RustFS buckets removed; reports/logs retained locally.

Detailed evidence, ownership map, binary provenance and limitations: `crab/docs/benchmarks/add-push-hardening-rustfs.md`, section “Edited-push retirement follow-up”. Runtime source tested is this patch atop merged PR #156; the binary embeds its runtime-identical pre-squash revision, documented with SHA-256.

## Design and remaining gaps

Is this the best fix rather than merely plausible? Batching removes repeated durable commits/global scans at the staging owner boundary, instead of weakening durability or deferring cleanup. It also removes duplicated writer/read-only retirement loops. The tradeoff is a longer individual write transaction and potentially more WAL retained until commit. Ownership publication remains a separate transaction with existing retry/recovery.

Retirement still takes approximately 29 seconds at scale; metadata work remains material. Initial pushes and add wall times were slower on the shared workstation/USB SSD, so this does **not** establish improved add latency, universal low latency, all historical-version reconstruction, or production S3/GCS/Azure performance. All formats remain v1; no compatibility path is added.
