### PR TITLE
fix(cli): guide pushes to initialize missing remotes

### DIFF
--- a/crab/docs/architecture/git-integration.md
+++ b/crab/docs/architecture/git-integration.md
@@ -75,7 +75,7 @@ and ETag evidence before Crab claims provider parity.
 
 | Git operation or capability | Direct S3-compatible remote | Automated evidence | RustFS evidence |
 |---|---|---|---|
-| Ref list / `git ls-remote` | Supported; missing layout or manifest fails closed until `crab init` creates generation 0 | `git::remote_helper` manifest and resolved-session tests | missing, valid, and malformed manifest cases |
+| Ref list / `git ls-remote` | Supported; an uninitialized remote reports `CRAB-E0032` with the `crab init <REMOTE>` recovery step, while malformed layout or manifest data fails as corruption | `git::remote_helper` manifest and resolved-session tests | missing, valid, and malformed manifest cases |
 | Clone | Supported | `remote_helper_transcript`, `e2e_fetch_fsck` | fresh ordinary-Git and `crab clone` cases |
 | Fetch into an existing clone | Supported | resolved helper session and `e2e_fetch_fsck` | second-clone branch update case |
 | Push / branch update | Supported | `e2e_add_commit_push`, helper transcript tests | ordinary Git and Crab CLI cases |

--- a/crab/docs/guides/init.md
+++ b/crab/docs/guides/init.md
@@ -110,11 +110,12 @@ Azure credentials, user config, or environment variables.
    canonical manifest after validating the descriptor.
 9. Prints the next `crab setup` and `crab ship` steps.
 
-There is no local-only initialization mode. If the remote prefix contains
-objects but lacks a canonical descriptor, or contains a non-v1 descriptor,
-init fails closed and directs development repositories through the explicit
-reset procedure. Push, clone, and `git ls-remote` never synthesize missing
-repository state.
+Push, clone, and `git ls-remote` never create repositories. If the configured
+remote points to an empty, uninitialized prefix, Crab reports `CRAB-E0032` and
+directs the user to `crab init <REMOTE>`. If that prefix already contains data
+but lacks a valid descriptor, init leaves it unchanged and asks the user to
+verify the URL before deleting disposable data. Malformed or unsupported
+descriptors remain corruption errors and are never replaced automatically.
 
 ## Auto-Tracking
 

--- a/crab/scripts/e2e/run_add_commit_push_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_add_commit_push_rustfs_smoke.py
@@ -1477,7 +1477,7 @@ class AddCommitPushSmoke:
             "non-v1-layout-fails-closed",
             refused.exit_code != 0
             and "canonical v1" in refusal_text
-            and "reset this isolated development repository" in refusal_text,
+            and "not supported" in refusal_text,
             {"exit_code": refused.exit_code},
         )
         missing_manifest = self.run_aws(

--- a/crab/src/auth/managed.rs
+++ b/crab/src/auth/managed.rs
@@ -37,12 +37,13 @@ pub async fn build_repository_store(
             })
         }
         crab_git::RepositoryLocator::Managed(repository) => {
+            let canonical_url = repository.canonical_url();
             let cache_dir = expand_token_cache_path(&config.auth.token_cache_path);
             let managed = ManagedRepositoryResolver::new(cache_dir)
                 .resolve(&repository, operation, cancel)
                 .await?;
             let store = Store::from_storage(managed.store);
-            validate_repository_store(&store, &managed.repository_prefix).await?;
+            validate_repository_store(&store, &managed.repository_prefix, &canonical_url).await?;
             Ok(RepositoryStore {
                 store,
                 repository_prefix: managed.repository_prefix,

--- a/crab/src/auth/mod.rs
+++ b/crab/src/auth/mod.rs
@@ -440,18 +440,26 @@ pub async fn build_repository_url_store(
 ) -> Result<Store> {
     let url = url.into();
     let repository_prefix = url.repo_path.clone();
+    let remote_url = format!("crab://{}/{}", url.bucket, url.repo_path);
     let store = build_store(config, url, operation, cancel).await?;
-    validate_repository_store(&store, &repository_prefix).await?;
+    validate_repository_store(&store, &repository_prefix, &remote_url).await?;
     Ok(store)
 }
 
 pub(crate) async fn validate_repository_store(
     store: &Store,
     repository_prefix: &str,
+    remote_url: &str,
 ) -> Result<()> {
     let router = crate::storage::StoreLayout::new(store.clone(), repository_prefix.to_owned());
-    crate::core::remote_layout::open(store, &router).await?;
-    Ok(())
+    match crate::core::remote_layout::open(store, &router).await {
+        Err(CrabError::NotFound { path }) if path == router.layout_descriptor_path().as_ref() => {
+            Err(CrabError::RepositoryNotInitialized {
+                url: remote_url.to_owned(),
+            })
+        }
+        result => result.map(|_| ()),
+    }
 }
 
 pub fn build_store_from_credentials(bucket: &str, creds: CloudCredentials) -> Result<Store> {
@@ -519,11 +527,15 @@ mod tests {
         let store = Store::new(Arc::new(InMemory::new()));
         let router = StoreLayout::new(store.clone(), "org/repo".to_owned());
 
-        let error = validate_repository_store(&store, "org/repo")
+        let error = validate_repository_store(&store, "org/repo", "crab://bucket/org/repo")
             .await
             .expect_err("descriptor-less repository must fail closed");
 
-        assert!(error.to_string().contains("layout descriptor is missing"));
+        assert!(matches!(
+            error,
+            CrabError::RepositoryNotInitialized { ref url }
+                if url == "crab://bucket/org/repo"
+        ));
         assert!(store.head(&router.manifest_path()).await.is_err());
         assert!(store.head(&router.layout_descriptor_path()).await.is_err());
     }
@@ -536,7 +548,7 @@ mod tests {
             .await
             .expect("initialize canonical descriptor");
 
-        validate_repository_store(&store, "org/repo")
+        validate_repository_store(&store, "org/repo", "crab://bucket/org/repo")
             .await
             .expect("canonical descriptor should open");
     }

--- a/crab/src/cmd/errors.rs
+++ b/crab/src/cmd/errors.rs
@@ -49,8 +49,8 @@ fn category_for_code(code: &str) -> &'static str {
         "CRAB-E0020" | "CRAB-E0021" | "CRAB-E0082" | "CRAB-E0083" | "CRAB-E0084" | "CRAB-E0101" => {
             "integrity"
         }
-        "CRAB-E0030" | "CRAB-E0031" | "CRAB-E0040" | "CRAB-E0041" | "CRAB-E0042" | "CRAB-E0043"
-        | "CRAB-E0091" => "permanent",
+        "CRAB-E0030" | "CRAB-E0031" | "CRAB-E0032" | "CRAB-E0040" | "CRAB-E0041" | "CRAB-E0042"
+        | "CRAB-E0043" | "CRAB-E0091" => "permanent",
         "CRAB-E0050" | "CRAB-E0051" | "CRAB-E0052" => "config",
         "CRAB-E0060" | "CRAB-E0070" | "CRAB-E0071" | "CRAB-E0110" => "transport",
         "CRAB-E0080" | "CRAB-E0081" => "staging",
@@ -70,6 +70,14 @@ mod tests {
         let entry = doc_entry_for_code("CRAB-E0097").expect("catalog entry");
 
         assert_eq!(entry.category, "conflict");
+        assert!(!entry.retryable);
+    }
+
+    #[test]
+    fn uninitialized_repository_catalog_entry_is_non_retryable_permanent() {
+        let entry = doc_entry_for_code("CRAB-E0032").expect("catalog entry");
+
+        assert_eq!(entry.category, "permanent");
         assert!(!entry.retryable);
     }
 }

--- a/crab/src/cmd/gc/bucket.rs
+++ b/crab/src/cmd/gc/bucket.rs
@@ -3096,11 +3096,11 @@ mod tests {
             .await
             .expect_err("bucket root repair must reject a repository without its v1 descriptor");
 
-        assert!(
-            error
-                .to_string()
-                .contains("canonical v1 layout descriptor is missing")
-        );
+        assert!(matches!(
+            error,
+            CrabError::NotFound { ref path }
+                if path == router.layout_descriptor_path().as_ref()
+        ));
     }
 
     #[tokio::test]

--- a/crab/src/cmd/init.rs
+++ b/crab/src/cmd/init.rs
@@ -160,7 +160,7 @@ pub async fn run_init_with_storage_provider(
     storage_provider: Option<StorageProvider>,
     gc_list_profile: Option<GcListProfile>,
 ) -> Result<()> {
-    run_init_inner(
+    let payload = run_init_inner(
         url,
         root,
         cancel,
@@ -168,9 +168,44 @@ pub async fn run_init_with_storage_provider(
         storage_provider,
         gc_list_profile,
         None,
-        true,
     )
-    .await
+    .await?;
+    emit_init_success(&payload, mode, true)
+}
+
+/// Apply local initialization, create the remote repository, then report success.
+///
+/// This is the standalone CLI boundary. It withholds terminal success output
+/// until the canonical remote roots exist.
+///
+/// # Errors
+///
+/// Returns a local configuration, authentication, storage, or output error.
+pub async fn run_init_command_with_storage_provider(
+    url: &str,
+    root: &Path,
+    cancel: &CancellationToken,
+    mode: OutputMode,
+    storage_provider: Option<StorageProvider>,
+    gc_list_profile: Option<GcListProfile>,
+) -> Result<()> {
+    let payload = run_init_inner(
+        url,
+        root,
+        cancel,
+        mode,
+        storage_provider,
+        gc_list_profile,
+        None,
+    )
+    .await?;
+    if let Err(error) = initialize_remote_repository(url, root, cancel).await {
+        if !mode.is_machine() {
+            eprintln!("Local configuration was saved, but the remote repository is not ready.");
+        }
+        return Err(error);
+    }
+    emit_init_success(&payload, mode, true)
 }
 
 /// Initialize a repository as the first phase of guided configuration.
@@ -190,9 +225,9 @@ pub(crate) async fn run_init_for_configure(
         storage_provider,
         gc_list_profile,
         aws_profile,
-        false,
     )
     .await
+    .map(|_| ())
 }
 
 async fn run_init_inner(
@@ -203,8 +238,7 @@ async fn run_init_inner(
     storage_provider: Option<StorageProvider>,
     gc_list_profile: Option<GcListProfile>,
     aws_profile: Option<&str>,
-    show_next_steps: bool,
-) -> Result<()> {
+) -> Result<InitPayload> {
     check_cancelled(cancel)?;
 
     // Parse and normalize the URL before doing any work. Provider-prefixed
@@ -392,18 +426,14 @@ async fn run_init_inner(
         }
     };
 
-    // Emit JSON payload when in machine mode.
-    if mode == OutputMode::Json {
-        let payload = InitPayload {
-            url: remote_url.clone(),
-            storage_provider: selected_storage_provider
-                .as_ref()
-                .map(|provider| provider.toml_value().to_owned()),
-            gc_list_profile: gc_list_profile.map(|profile| profile.as_str().to_owned()),
-            credential_status,
-        };
-        emit_json(INIT_SCHEMA, INIT_VERSION, payload)?;
-    }
+    let payload = InitPayload {
+        url: remote_url.clone(),
+        storage_provider: selected_storage_provider
+            .as_ref()
+            .map(|provider| provider.toml_value().to_owned()),
+        gc_list_profile: gc_list_profile.map(|profile| profile.as_str().to_owned()),
+        credential_status,
+    };
 
     // Remote publication runs after local setup has written the provider and
     // credential configuration needed to build the Store.
@@ -424,15 +454,22 @@ async fn run_init_inner(
         );
     }
 
-    tracing::info!("crab init complete — local config written and git drivers registered");
+    tracing::info!("local Crab configuration ready");
+    Ok(payload)
+}
 
+fn emit_init_success(payload: &InitPayload, mode: OutputMode, show_next_steps: bool) -> Result<()> {
+    if mode == OutputMode::Json {
+        emit_json(INIT_SCHEMA, INIT_VERSION, payload)?;
+    }
+    tracing::info!(url = %payload.url, "crab init complete");
     if !mode.is_machine() && show_next_steps {
+        eprintln!("Remote repository ready → {}", payload.url);
         eprintln!("\nNext:");
         eprintln!("  1. crab setup            # detect large files and write .gitattributes");
         eprintln!("  2. git status            # review crab.toml and tracking rules");
         eprintln!("  3. crab ship -m 'init'   # commit and push to Crab");
     }
-
     Ok(())
 }
 
@@ -1942,7 +1979,7 @@ storage_provider = "azure"
             .await
             .expect_err("non-empty repository without a descriptor must fail closed");
 
-        assert!(error.to_string().contains("reset"));
+        assert!(error.to_string().contains("Crab left it unchanged"));
         assert!(store.head(&router.layout_descriptor_path()).await.is_err());
         assert!(store.head(&router.manifest_path()).await.is_err());
     }

--- a/crab/src/core/error.rs
+++ b/crab/src/core/error.rs
@@ -95,6 +95,9 @@ pub enum CrabError {
     #[error("forbidden: {path} [CRAB-E0031]")]
     Forbidden { path: String },
 
+    #[error("remote repository is not initialized at {url} [CRAB-E0032]")]
+    RepositoryNotInitialized { url: String },
+
     #[error("no credentials available [CRAB-E0040]")]
     NoCredentials,
 
@@ -2347,6 +2350,7 @@ impl CrabError {
             // General user/operational errors.
             Self::Protocol(_)
             | Self::NotFound { .. }
+            | Self::RepositoryNotInitialized { .. }
             | Self::InsufficientSpace { .. }
             | Self::Throttled { .. }
             | Self::NetworkTransient(_)
@@ -2448,6 +2452,7 @@ impl CrabError {
             Self::ChunkNotFound { .. } => "CRAB-E0021",
             Self::NotFound { .. } => "CRAB-E0030",
             Self::Forbidden { .. } => "CRAB-E0031",
+            Self::RepositoryNotInitialized { .. } => "CRAB-E0032",
             Self::NoCredentials => "CRAB-E0040",
             Self::InsufficientSpace { .. } => "CRAB-E0041",
             Self::AuthFailed { .. } => "CRAB-E0042",
@@ -2664,6 +2669,7 @@ impl CrabError {
             | Self::LfsObjectCorrupt { .. } => ErrorCategory::Integrity,
 
             Self::NotFound { .. }
+            | Self::RepositoryNotInitialized { .. }
             | Self::Forbidden { .. }
             | Self::NoCredentials
             | Self::AuthFailed { .. }
@@ -2868,6 +2874,7 @@ impl CrabError {
             | Self::OriginIntegrity { .. }
             | Self::ChunkNotFound { .. }
             | Self::NotFound { .. }
+            | Self::RepositoryNotInitialized { .. }
             | Self::Forbidden { .. }
             | Self::NoCredentials
             | Self::AuthFailed { .. }
@@ -3076,6 +3083,10 @@ impl CrabError {
             | Self::Forbidden { path }
             | Self::AuthFailed { path }
             | Self::AuthExpired { path } => serde_json::json!({ "path": path }),
+            Self::RepositoryNotInitialized { url } => serde_json::json!({
+                "remote_url": url,
+                "command": format!("crab init {url}"),
+            }),
             Self::ManagedRepository { diagnostic } => serde_json::json!({
                 "kind": diagnostic.kind(),
                 "message": diagnostic.to_string(),
@@ -3809,6 +3820,9 @@ impl CrabError {
             Self::NotFound { .. } => Some(
                 "Check the requested path and remote. For a new repository, run `crab configure <REMOTE>`; otherwise run `crab doctor`.",
             ),
+            Self::RepositoryNotInitialized { .. } => {
+                Some("Run `crab init <REMOTE>` with the remote URL above, then retry the command.")
+            }
             Self::Forbidden { .. } => Some(
                 "Grant the active cloud identity access to this bucket and repository prefix, then run `crab doctor` to verify it.",
             ),
@@ -3835,6 +3849,7 @@ impl CrabError {
             Self::Read(error) => error.docs_anchor(),
             Self::HydrationFailed { source, .. } => source.docs_anchor(),
             Self::NotFound { .. } => Some("cli/diagnostics/error-codes"),
+            Self::RepositoryNotInitialized { .. } => Some("cli/getting-started/first-repository"),
             Self::Forbidden { .. }
             | Self::NoCredentials
             | Self::AuthFailed { .. }
@@ -4055,6 +4070,29 @@ mod tests {
             crate::storage::retry::retry_class(&error),
             crate::storage::retry::RetryClass::Fatal
         );
+    }
+
+    #[test]
+    fn uninitialized_repository_has_actionable_terminal_and_machine_output() {
+        let error = CrabError::RepositoryNotInitialized {
+            url: "crab://team-data/models".to_owned(),
+        };
+
+        assert_eq!(error.code(), "CRAB-E0032");
+        assert_eq!(error.exit_code(), 1);
+        assert_eq!(error.category(), ErrorCategory::Permanent);
+        assert!(!error.is_retryable());
+        assert_eq!(
+            error.details_json(),
+            serde_json::json!({
+                "remote_url": "crab://team-data/models",
+                "command": "crab init crab://team-data/models",
+            })
+        );
+        let rendered = crate::core::error_catalog::render(&error).text;
+        assert!(rendered.contains("remote repository is not initialized"));
+        assert!(rendered.contains("crab init crab://team-data/models"));
+        assert!(rendered.contains("cli/getting-started/first-repository"));
     }
 
     #[test]

--- a/crab/src/core/error_catalog.rs
+++ b/crab/src/core/error_catalog.rs
@@ -41,6 +41,7 @@ pub const ALL_CODES: &[&str] = &[
     "CRAB-E0021",
     "CRAB-E0030",
     "CRAB-E0031",
+    "CRAB-E0032",
     "CRAB-E0040",
     "CRAB-E0041",
     "CRAB-E0042",
@@ -247,6 +248,17 @@ pub fn lookup(code: &str) -> Option<ErrorExplanation> {
             remediation: "\
   Check your IAM policies and bucket permissions. Ensure your\n\
   credentials have read/write access to the repository prefix.",
+        }),
+        "CRAB-E0032" => Some(ErrorExplanation {
+            code: "CRAB-E0032",
+            summary: "Remote repository is not initialized",
+            causes: "\
+  - The remote URL points to a new repository prefix\n\
+  - The configured bucket or repository path is incorrect\n\
+  - Local setup completed before remote initialization succeeded",
+            remediation: "\
+  Verify the remote URL, then run `crab init <REMOTE>` to create the\n\
+  repository. Retry the original command after initialization completes.",
         }),
         "CRAB-E0040" => Some(ErrorExplanation {
             code: "CRAB-E0040",
@@ -1398,6 +1410,7 @@ pub fn error_code(err: &CrabError) -> &'static str {
         CrabError::ChunkNotFound { .. } => "CRAB-E0021",
         CrabError::NotFound { .. } => "CRAB-E0030",
         CrabError::Forbidden { .. } => "CRAB-E0031",
+        CrabError::RepositoryNotInitialized { .. } => "CRAB-E0032",
         CrabError::NoCredentials => "CRAB-E0040",
         CrabError::InsufficientSpace { .. } => "CRAB-E0041",
         CrabError::AuthFailed { .. } => "CRAB-E0042",
@@ -1560,7 +1573,13 @@ pub fn render(err: &CrabError) -> UserMessage {
     let code = error_code(err);
     let mut text = format!("error: {err}");
 
-    if let Some(hint) = err.hint() {
+    if let CrabError::RepositoryNotInitialized { url } = err {
+        use std::fmt::Write as _;
+        let _ = write!(
+            text,
+            "\nhelp: Run `crab init {url}`, then retry the command."
+        );
+    } else if let Some(hint) = err.hint() {
         text.push_str("\nhelp: ");
         text.push_str(hint);
     } else {
@@ -1638,6 +1657,9 @@ mod tests {
             CrabError::Internal("test".into()),
             CrabError::Protocol("test".into()),
             CrabError::NoCredentials,
+            CrabError::RepositoryNotInitialized {
+                url: "crab://bucket/repo".into(),
+            },
             CrabError::StagingLocked { holder_pid: None },
         ];
         for err in &samples {

--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -3333,7 +3333,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                         Some(config) => {
                             let u = config.remote.url.clone();
                             let _span = tracing::info_span!("init", %u).entered();
-                            crab::cmd::init::run_init_with_storage_provider(
+                            crab::cmd::init::run_init_command_with_storage_provider(
                                 &u,
                                 &cwd,
                                 &cancel,
@@ -3342,8 +3342,6 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                                 gc_list_profile,
                             )
                             .await?;
-                            crab::cmd::init::initialize_remote_repository(&u, &cwd, &cancel)
-                                .await?;
                             // Sync .gitattributes with [track] patterns from crab.toml
                             if let Some(ref track) = config.track {
                                 sync_gitattributes_from_track(&cwd, &track.patterns);
@@ -3404,7 +3402,7 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                 }
             };
             let _span = tracing::info_span!("init", url = %resolved_url).entered();
-            crab::cmd::init::run_init_with_storage_provider(
+            crab::cmd::init::run_init_command_with_storage_provider(
                 &resolved_url,
                 &cwd,
                 &cancel,
@@ -3413,8 +3411,6 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
                 gc_list_profile,
             )
             .await?;
-
-            crab::cmd::init::initialize_remote_repository(&resolved_url, &cwd, &cancel).await?;
 
             // Mirror mode: validate remote, add crab remote, install hooks, write config.
             if let Some(ref mirror_remote) = mirror {

--- a/crab/src/storage/retry.rs
+++ b/crab/src/storage/retry.rs
@@ -100,6 +100,7 @@ pub fn retry_class(err: &CrabError) -> RetryClass {
         | CrabError::FileChangedDuringStaging { .. }
         | CrabError::ChunkNotFound { .. }
         | CrabError::NotFound { .. }
+        | CrabError::RepositoryNotInitialized { .. }
         | CrabError::Forbidden { .. }
         | CrabError::NoCredentials
         | CrabError::AuthFailed { .. }
@@ -564,6 +565,15 @@ mod tests {
             hash: "deadbeef".into(),
         };
         assert_eq!(retry_class(&err), RetryClass::Fatal);
+    }
+
+    #[test]
+    fn classifies_uninitialized_repository_as_fatal() {
+        let error = CrabError::RepositoryNotInitialized {
+            url: "crab://bucket/repo".into(),
+        };
+
+        assert_eq!(retry_class(&error), RetryClass::Fatal);
     }
 
     #[test]

--- a/crab/tests/golden/error_codes.txt
+++ b/crab/tests/golden/error_codes.txt
@@ -8,6 +8,7 @@ CRAB-E0020: Corrupt object detected
 CRAB-E0021: Chunk not found in storage
 CRAB-E0030: Object not found in storage
 CRAB-E0031: Access forbidden
+CRAB-E0032: Remote repository is not initialized
 CRAB-E0040: No credentials available
 CRAB-E0041: Insufficient local disk space
 CRAB-E0042: Authentication failed

--- a/crab/tests/prepopulated_walk.rs
+++ b/crab/tests/prepopulated_walk.rs
@@ -125,20 +125,25 @@ fn capture_dispatch(buf: BufferMaker) -> Dispatch {
 /// parallel integration tests in this file don't clobber each other.
 static GIT_DIR_MUTEX: Mutex<()> = Mutex::new(());
 
-/// RAII guard that points `GIT_DIR` at the given directory for the
-/// lifetime of the guard, restoring any previous value on drop.
+/// RAII guard that clears `GIT_DIR` while the fixture is initialized, then
+/// points it at the new repository for the test body.
 struct ScopedGitDir {
     _lock: MutexGuard<'static, ()>,
     prev: Option<String>,
 }
 
 impl ScopedGitDir {
-    fn new(git_dir: &Path) -> Self {
+    fn acquire() -> Self {
         let lock = GIT_DIR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("GIT_DIR").ok();
         // SAFETY: access is serialised by GIT_DIR_MUTEX.
-        unsafe { std::env::set_var("GIT_DIR", git_dir) };
+        unsafe { std::env::remove_var("GIT_DIR") };
         Self { _lock: lock, prev }
+    }
+
+    fn set_git_dir(&self, git_dir: &Path) {
+        // SAFETY: access is serialised by GIT_DIR_MUTEX (held by self).
+        unsafe { std::env::set_var("GIT_DIR", git_dir) };
     }
 }
 
@@ -265,8 +270,9 @@ fn make_specs() -> Vec<PushSpec> {
 /// set to the delegated pipeline.
 #[tokio::test]
 async fn second_native_push_reuses_prepopulated_walk() {
+    let git = ScopedGitDir::acquire();
     let fixture = GitFixture::new();
-    let _git = ScopedGitDir::new(&fixture.git_dir());
+    git.set_git_dir(&fixture.git_dir());
 
     // First commit seeds the baseline for `PushState`.
     let first_sha = fixture.commit_pointer("a.bin", 0x10, "first pointer");
@@ -361,8 +367,9 @@ async fn second_native_push_reuses_prepopulated_walk() {
 /// `reason = "unresolvable_old_sha"`.
 #[tokio::test]
 async fn stale_push_state_falls_back_to_full_walk() {
+    let git = ScopedGitDir::acquire();
     let fixture = GitFixture::new();
-    let _git = ScopedGitDir::new(&fixture.git_dir());
+    git.set_git_dir(&fixture.git_dir());
 
     let _commit_sha = fixture.commit_pointer("a.bin", 0x30, "only pointer");
 
@@ -425,8 +432,9 @@ async fn stale_push_state_falls_back_to_full_walk() {
 /// record `incremental = false, source = "walk_reachable"`.
 #[tokio::test]
 async fn non_native_push_batch_walks_full_graph() {
+    let git = ScopedGitDir::acquire();
     let fixture = GitFixture::new();
-    let _git = ScopedGitDir::new(&fixture.git_dir());
+    git.set_git_dir(&fixture.git_dir());
 
     let _commit_sha = fixture.commit_pointer("a.bin", 0x40, "first pointer");
 

--- a/crates/crab-metadata/src/layout_descriptor.rs
+++ b/crates/crab-metadata/src/layout_descriptor.rs
@@ -57,7 +57,7 @@ impl LayoutDescriptor {
             return Err(corrupt(
                 path,
                 format!(
-                    "layout schema {} is not canonical v1; reset this isolated development repository",
+                    "layout schema {} is not supported; expected canonical v1",
                     self.schema_version
                 ),
             ));
@@ -84,7 +84,7 @@ impl LayoutDescriptor {
         {
             return Err(corrupt(
                 path,
-                "layout parameters are not the canonical v1 contract; reset this isolated development repository",
+                "layout parameters do not match the supported canonical v1 contract",
             ));
         }
         let expected = self.expected_digest();
@@ -113,9 +113,7 @@ impl LayoutDescriptor {
         let descriptor: Self = serde_json::from_slice(bytes).map_err(|error| {
             corrupt(
                 path,
-                format!(
-                    "invalid canonical v1 layout descriptor: {error}; reset this isolated development repository"
-                ),
+                format!("invalid canonical v1 layout descriptor: {error}"),
             )
         })?;
         descriptor.validate(path)?;
@@ -152,22 +150,10 @@ pub async fn read_canonical_layout(
     store: &crab_storage::Store,
     router: &crab_storage::StoreLayout<crab_storage::Store>,
 ) -> Result<LayoutDescriptor> {
-    use crab_storage::StorageError;
-
     let path = router.layout_descriptor_path();
-    let bytes = match store
+    let (bytes, _) = store
         .get_with_etag_bounded(&path, MAX_LAYOUT_DESCRIPTOR_BYTES)
-        .await
-    {
-        Ok((bytes, _)) => bytes,
-        Err(StorageError::NotFound { .. }) => {
-            return Err(corrupt(
-                path.as_ref(),
-                "canonical v1 layout descriptor is missing; reset this isolated development repository",
-            ));
-        }
-        Err(error) => return Err(error.into()),
-    };
+        .await?;
     LayoutDescriptor::parse(path.as_ref(), &bytes)
 }
 
@@ -262,7 +248,15 @@ mod tests {
         let store = crab_storage::Store::new(inner);
         let router = crab_storage::StoreLayout::new(store.clone(), "repo".to_owned());
 
-        assert!(read_canonical_layout(&store, &router).await.is_err());
+        let error = read_canonical_layout(&store, &router)
+            .await
+            .expect_err("missing layout must retain its not-found classification");
+        assert!(matches!(
+            error,
+            MetadataError::Storage {
+                source: crab_storage::StorageError::NotFound { ref path }
+            } if path == router.layout_descriptor_path().as_ref()
+        ));
         assert!(
             store
                 .list_prefix(&router.repo_path(""))

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -903,8 +903,12 @@ mod tests {
         let manifest = Manifest::default_for_repo("refs/heads/main");
         create_manifest(&store, &router, &manifest).await.unwrap();
         let missing = read_repository_snapshot(&store, &router).await.unwrap_err();
-        assert!(matches!(missing, MetadataError::CorruptObject { path, .. }
-            if path == router.layout_descriptor_path().as_ref()));
+        assert!(matches!(
+            missing,
+            MetadataError::Storage {
+                source: crab_storage::StorageError::NotFound { ref path }
+            } if path == router.layout_descriptor_path().as_ref()
+        ));
         assert!(store.head(&router.layout_descriptor_path()).await.is_err());
 
         crate::layout_descriptor::ensure_canonical_layout(&store, &router)

--- a/crates/crab-write/src/initialize.rs
+++ b/crates/crab-write/src/initialize.rs
@@ -30,7 +30,7 @@ pub async fn initialize_repository(
             if store.list_prefix_bounded(&prefix, 0).await?.is_none() {
                 return Err(WriteError::CorruptObject {
                     path: layout.layout_descriptor_path().to_string(),
-                    reason: "canonical v1 layout descriptor is missing but repository objects already exist; reset this isolated development repository instead of converting it in place".to_owned(),
+                    reason: "the remote prefix contains data but is not an initialized Crab repository; Crab left it unchanged. Verify the remote URL before deleting disposable data".to_owned(),
                 });
             }
             ensure_canonical_layout(store, layout).await?;

--- a/packages/web/content/docs/cli/reference/crab-init.mdx
+++ b/packages/web/content/docs/cli/reference/crab-init.mdx
@@ -60,10 +60,12 @@ For conceptual background, see [Creating a Repository](/docs/cli/getting-started
 6. **Creates the generation-0 manifest atomically**, or adopts the existing
    canonical manifest on repeat or concurrent initialization
 
-There is no local-only selector. A non-empty prefix without a descriptor, a
-non-v1 descriptor, or a missing manifest during normal repository use fails
-closed. Reset isolated development data explicitly; push and clone do not
-convert or synthesize repository state.
+Push and clone do not create repositories. If a remote points to an empty,
+uninitialized prefix, Crab reports `CRAB-E0032` and tells you to run
+`crab init <REMOTE>`. If the prefix already contains data but has no valid
+layout, init leaves it unchanged so you can verify the URL before deciding how
+to handle that data. Malformed or unsupported descriptors remain corruption
+errors and are never replaced automatically.
 
 ## Examples
 
@@ -75,6 +77,7 @@ crab init crab://my-bucket/ml-models
 # ✓ Initialized git repository
 # ✓ Created .crab/local.toml
 # ✓ Registered filter.crab driver
+# Remote repository ready → crab://my-bucket/ml-models
 # Next: crab setup
 ```
 


### PR DESCRIPTION
## Summary

- classify a missing canonical layout as an uninitialized remote instead of corruption
- add `CRAB-E0032` with exact `crab init crab://...` recovery in text and structured output
- withhold `crab init` success until the remote layout and generation-0 manifest exist
- leave occupied or malformed prefixes unchanged and remove destructive reset guidance
- update CLI docs, architecture notes, and RustFS expectations

## UX

Before, `crab push` and `git push` reported that the canonical v1 descriptor was missing and suggested resetting isolated development data.

Now they report the configured remote, provide a copy-paste initialization command, and preserve the original command for retry. If remote initialization fails after local setup, `crab init` reports that partial state instead of emitting false success.

## Validation

- `cargo check -p crab --locked`
- focused `crab-metadata` missing-layout test
- `crab-write` initialization test suite
- focused Crab authorization, error rendering, retry, GC, and occupied-prefix tests
- error-code golden test
- `npm run build`
- `npm run check:links` (398 pages, 4305 fragments)

Not run locally: the full RustFS smoke suite, which requires its dedicated object-store environment.