### PR TITLE
perf: accelerate large repository clones

### DIFF
--- a/crab/src/cmd/clone.rs
+++ b/crab/src/cmd/clone.rs
@@ -10,10 +10,11 @@
 //! is fast even for multi-GB repos. Users can then selectively hydrate
 //! with `crab hydrate *.safetensors`.
 
+use std::fmt::Write as _;
 use std::future::Future;
-use std::io::Stdout;
+use std::io::{Stdout, Write as _};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Instant;
 
 use serde::Serialize;
@@ -71,7 +72,7 @@ pub struct CloneSummary {
 /// Run `crab clone` from the current working directory.
 pub async fn run_clone(args: &CloneArgs, cancel: &CancellationToken) -> Result<CloneSummary> {
     let cwd = std::env::current_dir()?;
-    run_clone_in(&cwd, args, cancel).await
+    Box::pin(run_clone_in(&cwd, args, cancel)).await
 }
 
 fn emit_phase(stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>, payload: PerfPhasePayload) {
@@ -178,7 +179,18 @@ pub async fn run_clone_in(
     }
 
     let phase = PhaseTimer::start("clone", "pack_fetch");
-    run_git_clone_no_checkout(parent, args, &target_dir)?;
+    if args.depth.is_none()
+        && let Some(prepared) = Box::pin(prepare_complete_clone_inventory(
+            target_dir.parent().unwrap_or(parent),
+            args,
+            cancel,
+        ))
+        .await?
+    {
+        run_complete_inventory_clone(parent, args, &target_dir, &prepared)?;
+    } else {
+        run_git_clone_no_checkout(parent, args, &target_dir)?;
+    }
     scrub_git_pack_appledouble_files(&target_dir)?;
     emit_phase(jsonl_stream.as_ref(), phase.finish(0, 0, 1));
 
@@ -641,6 +653,16 @@ fn run_git_clone(parent: &Path, args: &CloneArgs, target: &Path) -> Result<()> {
 /// config has been written so lazy clones do not accidentally hydrate
 /// during their first worktree update.
 fn run_git_clone_no_checkout(parent: &Path, args: &CloneArgs, target: &Path) -> Result<()> {
+    run_git_clone_no_checkout_from(parent, args, target, std::ffi::OsStr::new(&args.url), false)
+}
+
+fn run_git_clone_no_checkout_from(
+    parent: &Path,
+    args: &CloneArgs,
+    target: &Path,
+    source: &std::ffi::OsStr,
+    local: bool,
+) -> Result<()> {
     let bin = crate::cmd::init::crab_binary_path();
 
     let mut cmd = Command::new("git");
@@ -662,10 +684,13 @@ fn run_git_clone_no_checkout(parent: &Path, args: &CloneArgs, target: &Path) -> 
     if let Some(depth) = args.depth {
         cmd.arg("--depth").arg(depth.to_string());
     }
+    if local {
+        cmd.arg("--local");
+    }
 
     cmd.arg("--no-checkout");
 
-    cmd.arg(&args.url);
+    cmd.arg(source);
     cmd.arg(target);
     cmd.current_dir(parent);
 
@@ -673,7 +698,7 @@ fn run_git_clone_no_checkout(parent: &Path, args: &CloneArgs, target: &Path) -> 
     cmd.stdout(std::process::Stdio::inherit());
     cmd.stderr(std::process::Stdio::inherit());
 
-    tracing::info!(url = %args.url, "running git clone");
+    tracing::info!(source = ?source, "running git clone");
 
     let status = cmd.status()?;
     if !status.success() {
@@ -683,6 +708,196 @@ fn run_git_clone_no_checkout(parent: &Path, args: &CloneArgs, target: &Path) -> 
         )));
     }
 
+    Ok(())
+}
+
+async fn prepare_complete_clone_inventory(
+    workspace_parent: &Path,
+    args: &CloneArgs,
+    cancel: &CancellationToken,
+) -> Result<Option<PreparedCompleteClone>> {
+    let config = crate::core::config::Config::resolve_local()?;
+    let parsed = crate::git::url::CrabUrl::parse(&args.url)?;
+    let selection =
+        crate::replication::select_read_store(&config, &parsed, "clone:pack-bootstrap", cancel)
+            .await?;
+    let (repository, Some(visibility)) = Box::pin(
+        crate::git::upload_pack_wire::open_repository_with_optional_catalog_visibility(
+            selection.store.as_storage(),
+            selection.router.repo_prefix(),
+            cancel,
+        ),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let visible_refs = crate::git::upload_pack_wire::visible_ref_names(
+        repository.refs(),
+        &config.transfer_hide_refs,
+    )?;
+    let head_visible = repository
+        .refs()
+        .head
+        .as_ref()
+        .is_some_and(|head| visible_refs.iter().any(|name| name == &head.name))
+        || repository
+            .refs()
+            .unborn_head
+            .as_ref()
+            .is_some_and(|head| visible_refs.iter().any(|name| name == head));
+    if !head_visible {
+        return Ok(None);
+    }
+    let wants = visible_refs
+        .iter()
+        .filter_map(|name| repository.refs().find(name).map(|entry| entry.target))
+        .collect::<Vec<_>>();
+    if wants.is_empty() {
+        return Ok(None);
+    }
+    let request = crab_read::UploadPackRequest {
+        wants,
+        ..crab_read::UploadPackRequest::default()
+    };
+    let plan = crab_read::plan_upload_pack_catalog(
+        &repository,
+        &visibility,
+        &visible_refs,
+        &request,
+        cancel,
+    )
+    .await?;
+    let inventory = repository
+        .download_complete_pack_inventory(&plan.object_ids, workspace_parent, cancel)
+        .await
+        .map_err(|error| CrabError::Protocol(error.to_string()))?;
+    Ok(inventory.map(|inventory| PreparedCompleteClone {
+        inventory,
+        refs: repository.refs().clone(),
+        visible_ref_names: visible_refs,
+    }))
+}
+
+struct PreparedCompleteClone {
+    inventory: crab_remote_git::DownloadedPackInventory,
+    refs: crab_remote_git::RepositoryRefs,
+    visible_ref_names: Vec<String>,
+}
+
+fn run_complete_inventory_clone(
+    parent: &Path,
+    args: &CloneArgs,
+    target: &Path,
+    prepared: &PreparedCompleteClone,
+) -> Result<()> {
+    // Git owns clone ref/config semantics while hard-linking the verified
+    // committed pack inventory, avoiding repository-sized re-indexing.
+    let workspace = tempfile::tempdir_in(target.parent().unwrap_or(parent))?;
+    let source = workspace.path().join("source.git");
+    let status = Command::new("git")
+        .args(["init", "--bare", "--quiet", "--"])
+        .arg(&source)
+        .current_dir(parent)
+        .status()?;
+    if !status.success() {
+        return Err(CrabError::Protocol(format!(
+            "git init --bare exited with status {}",
+            status.code().unwrap_or(-1),
+        )));
+    }
+    install_complete_clone_inventory(&source.join("objects/pack"), &prepared.inventory)?;
+    install_complete_clone_refs(&source, &prepared.refs, &prepared.visible_ref_names)?;
+    run_git_clone_no_checkout_from(parent, args, target, source.as_os_str(), true)?;
+    run_git_at(target, &["remote", "set-url", "origin", &args.url])?;
+    Ok(())
+}
+
+fn install_complete_clone_inventory(
+    pack_dir: &Path,
+    inventory: &crab_remote_git::DownloadedPackInventory,
+) -> Result<()> {
+    for source in inventory.packs() {
+        crab_git::pack::install_pack_files_from_paths_with_identity(
+            pack_dir,
+            &source.path,
+            &source.index_path,
+            &source.reverse_index_path,
+            &source.canonical_id,
+            source.size,
+            source.object_count,
+            source.verified_identity,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn install_complete_clone_refs(
+    target: &Path,
+    refs: &crab_remote_git::RepositoryRefs,
+    visible_ref_names: &[String],
+) -> Result<()> {
+    let visible = |name: &str| visible_ref_names.iter().any(|entry| entry == name);
+    let mut updates = String::new();
+    for reference in &refs.entries {
+        if !visible(&reference.name) {
+            continue;
+        }
+        writeln!(
+            &mut updates,
+            "update {} {}",
+            reference.name, reference.target
+        )
+        .map_err(|error| CrabError::Internal(error.to_string()))?;
+    }
+    run_update_ref_stdin(target, updates.as_bytes())?;
+    let head = refs
+        .head
+        .as_ref()
+        .map(|head| head.name.as_str())
+        .or(refs.unborn_head.as_deref())
+        .filter(|name| visible(name))
+        .ok_or_else(|| CrabError::Protocol("remote HEAD is not visible".to_owned()))?;
+    run_git_at(target, &["symbolic-ref", "HEAD", head])
+}
+
+fn run_update_ref_stdin(target: &Path, input: &[u8]) -> Result<()> {
+    let mut child = Command::new("git")
+        .args(["update-ref", "--stdin"])
+        .current_dir(target)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| CrabError::Internal("git update-ref stdin is unavailable".to_owned()))?
+        .write_all(input)?;
+    drop(child.stdin.take());
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        return Err(CrabError::Protocol(format!(
+            "git update-ref failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+fn run_git_at(target: &Path, args: &[&str]) -> Result<()> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(target)
+        .output()?;
+    if !output.status.success() {
+        return Err(CrabError::Protocol(format!(
+            "git {} failed: {}",
+            args.first().copied().unwrap_or("command"),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
     Ok(())
 }
 

--- a/crab/src/git/upload_pack_wire.rs
+++ b/crab/src/git/upload_pack_wire.rs
@@ -1085,6 +1085,17 @@ pub(crate) async fn open_repository_with_catalog_visibility(
     prefix: &str,
     cancellation: &CancellationToken,
 ) -> Result<(RemoteGitRepository, GitCatalogVisibilityIndex)> {
+    let (repository, proof) =
+        open_repository_with_optional_catalog_visibility(store, prefix, cancellation).await?;
+    let proof = proof.ok_or_else(|| remote_error(RemoteGitError::EmptyRepository))?;
+    Ok((repository, proof))
+}
+
+pub(crate) async fn open_repository_with_optional_catalog_visibility(
+    store: &crab_storage::Store,
+    prefix: &str,
+    cancellation: &CancellationToken,
+) -> Result<(RemoteGitRepository, Option<GitCatalogVisibilityIndex>)> {
     let (repository, proof) = open_repository_with_visibility_requirement(
         store,
         prefix,
@@ -1092,8 +1103,10 @@ pub(crate) async fn open_repository_with_catalog_visibility(
         VisibilityRequirement::Catalog,
     )
     .await?;
-    let proof = proof.ok_or_else(|| remote_error(RemoteGitError::EmptyRepository))?;
-    Ok((repository, proof.into_catalog()?))
+    let proof = proof
+        .map(UploadPackVisibilityProof::into_catalog)
+        .transpose()?;
+    Ok((repository, proof))
 }
 
 #[cfg(test)]

--- a/crab/src/lfs/discovery/tests.rs
+++ b/crab/src/lfs/discovery/tests.rs
@@ -272,8 +272,7 @@ fn range_scan_excludes_all_base_manifest_ref_tips() {
 #[test]
 fn cat_file_batch_stdout_handles_large_object_lists() {
     let dir = tempfile::tempdir().unwrap();
-    let status = Command::new("git")
-        .current_dir(dir.path())
+    let status = git_command_in(dir.path(), GitObjectAccess::LocalOnly)
         .args(["init", "--quiet"])
         .status()
         .unwrap();
@@ -291,23 +290,19 @@ fn cat_file_batch_stdout_handles_large_object_lists() {
         paths.push('\n');
     }
 
-    let mut child = Command::new("git")
-        .current_dir(dir.path())
-        .args(["hash-object", "-w", "--stdin-paths"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap();
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(paths.as_bytes())
-        .unwrap();
-    let output = child.wait_with_output().unwrap();
-    assert!(output.status.success());
-
-    let object_ids = String::from_utf8(output.stdout).unwrap();
+    let mut command = git_command_in(dir.path(), GitObjectAccess::LocalOnly);
+    command.args(["hash-object", "-w", "--stdin-paths"]);
+    let output = process::run(
+        command,
+        &CancellationToken::new(),
+        Some(|mut stdin: ChildStdin| {
+            stdin.write_all(paths.as_bytes())?;
+            Ok(())
+        }),
+        |stdout| Ok(process::capture_output(stdout, MAX_CAPTURE_BYTES)?),
+    )
+    .unwrap();
+    let object_ids = String::from_utf8(successful_git("hash-object", output).unwrap()).unwrap();
     let mut cat_file_input = object_ids.trim_end().to_owned();
     cat_file_input.push('\n');
     assert!(cat_file_input.len() > 64 * 1024);

--- a/crates/crab-git/src/pack.rs
+++ b/crates/crab-git/src/pack.rs
@@ -388,7 +388,11 @@ pub fn install_pack_files_from_paths(
     )
 }
 
-pub(crate) fn install_pack_files_from_paths_with_identity(
+/// Install an indexed pack whose body identity was verified while downloading.
+///
+/// The supplied identity avoids a second full scan, while the committed index
+/// and reverse index are still checked against the pack trailer and object count.
+pub fn install_pack_files_from_paths_with_identity(
     pack_dir: &Path,
     pack_tmp_path: &Path,
     index_tmp_path: &Path,

--- a/crates/crab-git/src/repack.rs
+++ b/crates/crab-git/src/repack.rs
@@ -8,8 +8,8 @@ use std::process::{Command, Stdio};
 use std::time::Instant;
 
 use crate::pack::{
-    PackError, VerifiedPackIdentity, install_pack_file_from_path_with_identity,
-    install_pack_files_from_paths_with_identity, verify_and_hash_pack_file,
+    PackError, VerifiedPackIdentity, install_pack_files_from_paths_with_identity,
+    verify_and_hash_pack_file,
 };
 use crate::pack_locator::{PackLocationIter, PackLocatorError, write_pack_reverse_index};
 use sha1::{Digest, Sha1};
@@ -102,6 +102,31 @@ impl GeometricRepackedPack {
 pub struct GeometricRepackedRepository {
     _workspace: tempfile::TempDir,
     packs: Vec<GeometricRepackedPack>,
+}
+
+/// One response pack assembled from a complete, already-verified pack inventory.
+#[derive(Debug)]
+pub struct ConcatenatedPack {
+    _workspace: tempfile::TempDir,
+    pack_path: PathBuf,
+    /// Blake3 content identifier of the pack.
+    pub pack_id: String,
+    /// Raw Blake3 digest used by response-cache integrity verification.
+    pub pack_hash: [u8; 32],
+    /// Pack size.
+    pub pack_size: u64,
+    /// Number of objects in the pack.
+    pub object_count: u64,
+    /// Git-native SHA-1 checksum of the pack.
+    pub git_sha1: String,
+}
+
+impl ConcatenatedPack {
+    /// Returns the verified pack path.
+    #[must_use]
+    pub fn pack_path(&self) -> &Path {
+        &self.pack_path
+    }
 }
 
 impl GeometricRepackedRepository {
@@ -561,11 +586,12 @@ fn consolidate_pack_suffix_with_options(
 /// Join a complete pack inventory without inflating or recompressing entries.
 ///
 /// OFS_DELTA offsets are relative to the current entry, so shifting every
-/// entry in one source pack by the same amount preserves those links. Strict
-/// indexing validates REF_DELTA links after all source bodies are joined.
+/// entry in one source pack by the same amount preserves those links. The
+/// caller must prove that the committed source indexes exactly match its
+/// selected object set; the receiving Git process validates the joined pack.
 pub fn concatenate_complete_pack_inventory(
     sources: &[RepackSource],
-) -> Result<GeometricRepackedRepository, RepackError> {
+) -> Result<ConcatenatedPack, RepackError> {
     if sources.len() < 2 {
         return Err(RepackError::SourceIntegrity {
             pack_id: "complete-pack-concatenation".to_owned(),
@@ -575,9 +601,6 @@ pub fn concatenate_complete_pack_inventory(
 
     let workspace =
         tempfile::tempdir().map_err(|source| io_error("create concatenation workspace", source))?;
-    let source_git = workspace.path().join("source.git");
-    initialize_bare_repository(&source_git)?;
-    let pack_dir = source_git.join("objects/pack");
     let output_path = workspace.path().join("complete-pack-concatenated.pack");
     let mut output = File::create(&output_path)
         .map_err(|source| io_error("create concatenated pack", source))?;
@@ -695,41 +718,14 @@ pub fn concatenate_complete_pack_inventory(
     let pack_size = std::fs::metadata(&output_path)
         .map_err(|source| io_error(format!("stat {}", output_path.display()), source))?
         .len();
-    let canonical_id = blake3::Hash::from_bytes(pack_hash).to_hex().to_string();
-    let identity = VerifiedPackIdentity {
-        git_sha1: checksum,
-        content_hash: pack_hash,
-    };
-    let installed = install_pack_file_from_path_with_identity(
-        &pack_dir,
-        &output_path,
-        &canonical_id,
-        pack_size,
-        true,
-        Some(identity),
-    )?;
-    // `index-pack --fsck-objects` above already validates every copied object
-    // while creating the response index. A second `verify-pack -v` traversal
-    // only repeats repository-sized work on the latency-sensitive response
-    // path; durable maintenance continues to use full validation below.
-    let generated = verified_generated_pack(
-        installed.pack_path,
-        GeneratedPackValidation::Structural,
-        None,
-        Some(identity),
-    )?;
-    if generated.object_count != total_objects {
-        return Err(RepackError::SourceIntegrity {
-            pack_id: generated.pack_id,
-            reason: format!(
-                "concatenated pack contains {} objects but sources contain {total_objects}",
-                generated.object_count
-            ),
-        });
-    }
-    Ok(GeometricRepackedRepository {
+    Ok(ConcatenatedPack {
         _workspace: workspace,
-        packs: vec![generated],
+        pack_path: output_path,
+        pack_id: blake3::Hash::from_bytes(pack_hash).to_hex().to_string(),
+        pack_hash,
+        pack_size,
+        object_count: total_objects,
+        git_sha1: checksum.iter().map(|byte| format!("{byte:02x}")).collect(),
     })
 }
 
@@ -889,6 +885,14 @@ pub fn source_pack_inventory_matches_object_ids(
     for source in sources {
         let locations =
             PackLocationIter::open(&source.index_path, &source.reverse_index_path, source.size)?;
+        if source.verified_identity.is_some_and(|identity| {
+            locations.pack_checksum().as_bytes() != identity.git_sha1.as_slice()
+        }) {
+            return Err(RepackError::SourceIntegrity {
+                pack_id: source.canonical_id.clone(),
+                reason: "pack index checksum does not match the verified pack trailer".to_owned(),
+            });
+        }
         source_oids.extend(locations.sorted_object_ids());
     }
     source_oids.sort_unstable();
@@ -1894,20 +1898,24 @@ mod tests {
         let sources = [first, second];
 
         let concatenated = concatenate_complete_pack_inventory(&sources)?;
-        let generated =
-            concatenated
-                .packs()
-                .first()
-                .ok_or_else(|| RepackError::SourceIntegrity {
-                    pack_id: "complete-pack-concatenation".to_owned(),
-                    reason: "test produced no concatenated pack".to_owned(),
-                })?;
-        assert_eq!(generated.object_count, 3);
-        let mut locations = PackLocationIter::open(
-            generated.index_path(),
-            generated.reverse_index_path(),
-            generated.pack_size,
+        assert_eq!(concatenated.object_count, 3);
+        let index_path = concatenated.pack_path().with_extension("idx");
+        let reverse_index_path = concatenated.pack_path().with_extension("rev");
+        assert!(!index_path.exists());
+        run_git(
+            Command::new("git")
+                .arg("index-pack")
+                .arg("--strict")
+                .arg("--index-version=2")
+                .arg("-o")
+                .arg(&index_path)
+                .arg(concatenated.pack_path())
+                .stdout(Stdio::null()),
+            "index concatenated response pack",
         )?;
+        write_pack_reverse_index(&index_path, &reverse_index_path)?;
+        let mut locations =
+            PackLocationIter::open(&index_path, &reverse_index_path, concatenated.pack_size)?;
         let mut actual = Vec::new();
         for location in &mut locations {
             let location = location?;

--- a/crates/crab-git/src/repack.rs
+++ b/crates/crab-git/src/repack.rs
@@ -870,18 +870,38 @@ pub fn repack_selected_objects(
     })
 }
 
-/// Check whether source pack indexes contain exactly the requested object set.
+/// Check whether source pack indexes contain each requested object exactly once.
 ///
-/// This reads only verified index sidecars, so response producers can avoid a
-/// whole-pack consolidation when incremental packs contain a small amount of
-/// repeated or extra inventory. Source body integrity remains the caller's
-/// responsibility because this check does not read packed entries.
+/// Source body integrity remains the caller's responsibility because this
+/// check reads only verified index sidecars, not packed entries.
 pub fn source_pack_inventory_matches_object_ids(
     sources: &[RepackSource],
     selected_oids: &[gix_hash::ObjectId],
 ) -> Result<bool, RepackError> {
     let selected = normalize_selected_oids(selected_oids, "selected-pack")?;
-    let mut source_oids = Vec::with_capacity(selected.len());
+    let source_oids = source_pack_inventory_object_ids(sources)?;
+    Ok(source_oids == selected)
+}
+
+/// Check whether source pack indexes cover exactly the requested object set.
+///
+/// Repeated OIDs are allowed because separate packs in one Git object database
+/// may contain the same object. A single response pack must instead use
+/// [`source_pack_inventory_matches_object_ids`].
+pub fn source_pack_inventory_covers_object_ids(
+    sources: &[RepackSource],
+    selected_oids: &[gix_hash::ObjectId],
+) -> Result<bool, RepackError> {
+    let selected = normalize_selected_oids(selected_oids, "selected-pack")?;
+    let mut source_oids = source_pack_inventory_object_ids(sources)?;
+    source_oids.dedup();
+    Ok(source_oids == selected)
+}
+
+fn source_pack_inventory_object_ids(
+    sources: &[RepackSource],
+) -> Result<Vec<gix_hash::ObjectId>, RepackError> {
+    let mut source_oids = Vec::new();
     for source in sources {
         let locations =
             PackLocationIter::open(&source.index_path, &source.reverse_index_path, source.size)?;
@@ -896,8 +916,7 @@ pub fn source_pack_inventory_matches_object_ids(
         source_oids.extend(locations.sorted_object_ids());
     }
     source_oids.sort_unstable();
-    source_oids.dedup();
-    Ok(source_oids == selected)
+    Ok(source_oids)
 }
 
 /// Generate the exact self-contained pack for an existing shallow client's negotiation.
@@ -1946,6 +1965,18 @@ mod tests {
         assert_eq!(actual, expected);
         assert!(source_pack_inventory_matches_object_ids(
             &sources, &expected
+        )?);
+        assert!(source_pack_inventory_covers_object_ids(
+            &sources, &expected
+        )?);
+        let duplicate_sources = [sources[0].clone(), sources[1].clone(), sources[1].clone()];
+        assert!(!source_pack_inventory_matches_object_ids(
+            &duplicate_sources,
+            &expected,
+        )?);
+        assert!(source_pack_inventory_covers_object_ids(
+            &duplicate_sources,
+            &expected,
         )?);
         assert!(!source_pack_inventory_matches_object_ids(
             &sources,

--- a/crates/crab-remote-git/src/lib.rs
+++ b/crates/crab-remote-git/src/lib.rs
@@ -35,9 +35,9 @@ pub use objects::{
 };
 pub use operation::{OperationContext, OperationKind, ShallowClosureSelection};
 pub use pack::{
-    GENERATED_PACK_CACHE_VERSION, GeneratedPack, GeneratedPackCacheKey, GeneratedPackLease,
-    GeneratedPackLeaseAttempt, GeneratedPackLeaseError, GeneratedPackLeaseProvider,
-    GeneratedPackRequestCacheError, GeneratedPackRequestCacheKey,
+    DownloadedPackInventory, GENERATED_PACK_CACHE_VERSION, GeneratedPack, GeneratedPackCacheKey,
+    GeneratedPackLease, GeneratedPackLeaseAttempt, GeneratedPackLeaseError,
+    GeneratedPackLeaseProvider, GeneratedPackRequestCacheError, GeneratedPackRequestCacheKey,
 };
 pub use path::GitPath;
 pub use reader::{RemoteGitObject, RemoteGitObjectMetadata};

--- a/crates/crab-remote-git/src/pack.rs
+++ b/crates/crab-remote-git/src/pack.rs
@@ -26,7 +26,7 @@ use crate::{BudgetDimension, Error, OperationKind, RemoteGitObject, RemoteGitRep
 // the total selection and each coalesced range bounds transient range memory.
 const OBJECT_BATCH_SIZE: usize = 50_000;
 const SIDEBAND_PAYLOAD: usize = 65_515;
-pub const GENERATED_PACK_CACHE_VERSION: u32 = 3;
+pub const GENERATED_PACK_CACHE_VERSION: u32 = 4;
 const GENERATED_PACK_DESCRIPTOR_MAX_BYTES: u64 = 4 * 1024;
 const GENERATED_PACK_UPLOAD_PART_BYTES: usize = 8 * 1024 * 1024;
 // Generated response packs can require a large catalog lookup plus pack
@@ -403,7 +403,7 @@ impl RemoteGitRepository {
     /// Download the canonical pack inventory when it exactly covers a large selection.
     ///
     /// The selected IDs must already have passed generation-pinned authorization.
-    /// `None` means the inventory is not an exact large-repository clone candidate.
+    /// `None` means the inventory is not a complete large-repository clone candidate.
     pub async fn download_complete_pack_inventory(
         &self,
         object_ids: &[ObjectId],
@@ -417,7 +417,7 @@ impl RemoteGitRepository {
         let source_artifact_bytes = repack_source_artifact_bytes(&inventory)?;
         if object_ids.len() < COMPLETE_PACK_CONSOLIDATION_MIN_OBJECTS
             || inventory.is_empty()
-            || inventory_objects != u64::try_from(object_ids.len()).unwrap_or(u64::MAX)
+            || inventory_objects < u64::try_from(object_ids.len()).unwrap_or(u64::MAX)
             || source_artifact_bytes > self.state.options.operation_limits().max_fetched_bytes
         {
             return Ok(None);
@@ -436,8 +436,8 @@ impl RemoteGitRepository {
                 download_repack_sources(&operation, inventory, &download_dir, cancellation).await?;
             let check_packs = packs.clone();
             let selected_oids = object_ids.to_vec();
-            let matches = tokio::task::spawn_blocking(move || {
-                crab_git::repack::source_pack_inventory_matches_object_ids(
+            let covers = tokio::task::spawn_blocking(move || {
+                crab_git::repack::source_pack_inventory_covers_object_ids(
                     &check_packs,
                     &selected_oids,
                 )
@@ -445,7 +445,7 @@ impl RemoteGitRepository {
             .await
             .map_err(|source| Error::DecodeTask { source })?
             .map_err(|source| Error::ResponsePackConsolidation { source })?;
-            if !matches {
+            if !covers {
                 return Err(Error::Corrupt {
                     stage: crate::CorruptionStage::Inventory,
                 });

--- a/crates/crab-remote-git/src/pack.rs
+++ b/crates/crab-remote-git/src/pack.rs
@@ -307,6 +307,21 @@ pub struct GeneratedPack {
     object_count: u32,
 }
 
+/// A temporary exact canonical pack inventory ready for local Git installation.
+#[derive(Debug)]
+pub struct DownloadedPackInventory {
+    _workspace: tempfile::TempDir,
+    packs: Vec<crab_git::repack::RepackSource>,
+}
+
+impl DownloadedPackInventory {
+    /// Return the verified pack bodies and committed Git index sidecars.
+    #[must_use]
+    pub fn packs(&self) -> &[crab_git::repack::RepackSource] {
+        &self.packs
+    }
+}
+
 impl std::fmt::Debug for GeneratedPack {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
@@ -385,6 +400,68 @@ impl GeneratedPack {
 }
 
 impl RemoteGitRepository {
+    /// Download the canonical pack inventory when it exactly covers a large selection.
+    ///
+    /// The selected IDs must already have passed generation-pinned authorization.
+    /// `None` means the inventory is not an exact large-repository clone candidate.
+    pub async fn download_complete_pack_inventory(
+        &self,
+        object_ids: &[ObjectId],
+        workspace_parent: &Path,
+        cancellation: &CancellationToken,
+    ) -> Result<Option<DownloadedPackInventory>> {
+        let inventory = self.state.inventory.values().copied().collect::<Vec<_>>();
+        let inventory_objects = inventory
+            .iter()
+            .fold(0_u64, |total, pack| total.saturating_add(pack.object_count));
+        let source_artifact_bytes = repack_source_artifact_bytes(&inventory)?;
+        if object_ids.len() < COMPLETE_PACK_CONSOLIDATION_MIN_OBJECTS
+            || inventory.is_empty()
+            || inventory_objects != u64::try_from(object_ids.len()).unwrap_or(u64::MAX)
+            || source_artifact_bytes > self.state.options.operation_limits().max_fetched_bytes
+        {
+            return Ok(None);
+        }
+
+        let operation = self
+            .operation(OperationKind::UploadPack, cancellation)
+            .await?;
+        let result = async {
+            // Keep the temporary inventory on the clone destination's
+            // filesystem so installation can hard-link multi-gigabyte packs.
+            let workspace = tempfile::tempdir_in(workspace_parent).map_err(io_error)?;
+            let download_dir = workspace.path().join("source-packs");
+            std::fs::create_dir_all(&download_dir).map_err(io_error)?;
+            let packs =
+                download_repack_sources(&operation, inventory, &download_dir, cancellation).await?;
+            let check_packs = packs.clone();
+            let selected_oids = object_ids.to_vec();
+            let matches = tokio::task::spawn_blocking(move || {
+                crab_git::repack::source_pack_inventory_matches_object_ids(
+                    &check_packs,
+                    &selected_oids,
+                )
+            })
+            .await
+            .map_err(|source| Error::DecodeTask { source })?
+            .map_err(|source| Error::ResponsePackConsolidation { source })?;
+            if !matches {
+                return Err(Error::Corrupt {
+                    stage: crate::CorruptionStage::Inventory,
+                });
+            }
+            operation
+                .charge(BudgetDimension::LogicalObjects, inventory_objects)
+                .await?;
+            Ok(Some(DownloadedPackInventory {
+                _workspace: workspace,
+                packs,
+            }))
+        }
+        .await;
+        operation.finish(result).await
+    }
+
     /// Bind an exact object selection to this pinned repository and authorization state.
     ///
     /// Request policy is intentionally excluded after planning: shallow boundaries and
@@ -722,9 +799,25 @@ impl RemoteGitRepository {
         let sources =
             download_repack_sources(operation, inventory, &download_dir, cancellation).await?;
         let source_download_ms = source_download_started.elapsed().as_millis() as u64;
-        let mut source_inventory_check_ms = 0_u64;
-
-        let (repacked, strategy) = if exact_candidate {
+        let inventory_check_started = Instant::now();
+        let check_sources = sources.clone();
+        let selected_oids = object_ids.to_vec();
+        let source_inventory_matches = tokio::task::spawn_blocking(move || {
+            crab_git::repack::source_pack_inventory_matches_object_ids(
+                &check_sources,
+                &selected_oids,
+            )
+        })
+        .await
+        .map_err(|source| Error::DecodeTask { source })?
+        .map_err(|source| Error::ResponsePackConsolidation { source })?;
+        let source_inventory_check_ms = inventory_check_started.elapsed().as_millis() as u64;
+        tracing::debug!(
+            source_inventory_matches,
+            source_inventory_check_ms,
+            "checked staged pack indexes against the exact response object set"
+        );
+        if source_inventory_matches {
             let concat_sources = sources.clone();
             let concatenated = tokio::task::spawn_blocking(move || {
                 crab_git::repack::concatenate_complete_pack_inventory(&concat_sources)
@@ -732,78 +825,60 @@ impl RemoteGitRepository {
             .await
             .map_err(|source| Error::DecodeTask { source })?;
             match concatenated {
-                Ok(repacked) => (repacked, "complete_pack_concatenation"),
+                Ok(concatenated) => {
+                    let pack =
+                        adopt_concatenated_pack(operation, concatenated, cancellation).await?;
+                    drop(workspace);
+                    tracing::info!(
+                        target: "crab_remote_git::telemetry",
+                        telemetry_event = "pack_generation",
+                        strategy = "complete_pack_concatenation",
+                        source_pack_count,
+                        object_count = pack.object_count,
+                        inventory_objects,
+                        selected_objects = object_ids.len(),
+                        source_download_ms,
+                        source_inventory_check_ms,
+                        response_bytes = pack.size,
+                        pack_generation_ms = started.elapsed().as_millis() as u64,
+                        "remote Git response pack produced from staged pack inventory"
+                    );
+                    return Ok(Some(pack));
+                }
                 Err(error) => {
                     tracing::debug!(
                         error = %error,
                         error_debug = ?error,
                         "complete pack concatenation was not usable; falling back to Git consolidation"
                     );
-                    let repack_sources = sources.clone();
-                    let repacked = tokio::task::spawn_blocking(move || {
-                        crab_git::repack::consolidate_pack_suffix_for_response(&repack_sources)
-                    })
-                    .await
-                    .map_err(|source| Error::DecodeTask { source })?
-                    .map_err(|source| Error::ResponsePackConsolidation { source })?;
-                    (repacked, "complete_pack_consolidation")
                 }
             }
-        } else {
-            let inventory_check_started = Instant::now();
-            let check_sources = sources.clone();
+        }
+
+        let (repacked, strategy) = if near_candidate && !source_inventory_matches {
             let selected_oids = object_ids.to_vec();
-            let source_inventory_matches = tokio::task::spawn_blocking(move || {
-                crab_git::repack::source_pack_inventory_matches_object_ids(
-                    &check_sources,
-                    &selected_oids,
-                )
+            let repack_sources = sources.clone();
+            let repacked = tokio::task::spawn_blocking(move || {
+                crab_git::repack::repack_selected_objects(&repack_sources, &selected_oids)
             })
             .await
             .map_err(|source| Error::DecodeTask { source })?
             .map_err(|source| Error::ResponsePackConsolidation { source })?;
-            source_inventory_check_ms = inventory_check_started.elapsed().as_millis() as u64;
-            tracing::debug!(
-                source_inventory_matches,
-                source_inventory_check_ms,
-                "checked staged pack indexes against the exact response object set"
-            );
-            if source_inventory_matches {
-                let concat_sources = sources.clone();
-                let concatenated = tokio::task::spawn_blocking(move || {
-                    crab_git::repack::concatenate_complete_pack_inventory(&concat_sources)
-                })
-                .await
-                .map_err(|source| Error::DecodeTask { source })?;
-                match concatenated {
-                    Ok(repacked) => (repacked, "complete_pack_concatenation"),
-                    Err(error) => {
-                        tracing::debug!(
-                            error = %error,
-                            error_debug = ?error,
-                            "near-complete pack concatenation was not usable; falling back to Git consolidation"
-                        );
-                        let repack_sources = sources.clone();
-                        let repacked = tokio::task::spawn_blocking(move || {
-                            crab_git::repack::consolidate_pack_suffix_for_response(&repack_sources)
-                        })
-                        .await
-                        .map_err(|source| Error::DecodeTask { source })?
-                        .map_err(|source| Error::ResponsePackConsolidation { source })?;
-                        (repacked, "near_complete_pack_consolidation")
-                    }
-                }
+            (repacked, "selected_object_repack")
+        } else {
+            let repack_sources = sources.clone();
+            let repacked = tokio::task::spawn_blocking(move || {
+                crab_git::repack::consolidate_pack_suffix_for_response(&repack_sources)
+            })
+            .await
+            .map_err(|source| Error::DecodeTask { source })?
+            .map_err(|source| Error::ResponsePackConsolidation { source })?;
+            let strategy = if exact_candidate {
+                "complete_pack_consolidation"
             } else {
-                let selected_oids = object_ids.to_vec();
-                let repack_sources = sources.clone();
-                let repacked = tokio::task::spawn_blocking(move || {
-                    crab_git::repack::repack_selected_objects(&repack_sources, &selected_oids)
-                })
-                .await
-                .map_err(|source| Error::DecodeTask { source })?
-                .map_err(|source| Error::ResponsePackConsolidation { source })?;
-                (repacked, "selected_object_repack")
-            }
+                "near_complete_pack_consolidation"
+            };
+            (repacked, strategy)
         };
         let generated = repacked.packs().first().ok_or(Error::InternalInvariant {
             invariant: "complete pack consolidation produced no pack",
@@ -1068,44 +1143,83 @@ async fn adopt_repacked_pack(
     repacked: crab_git::repack::GeometricRepackedRepository,
     cancellation: &CancellationToken,
 ) -> Result<GeneratedPack> {
-    if cancellation.is_cancelled() {
-        return Err(Error::Cancelled);
-    }
     let generated = repacked.packs().first().ok_or(Error::InternalInvariant {
         invariant: "Git repack produced no pack",
     })?;
-    let object_count = generated.object_count;
+    let pack = adopt_pack_path(
+        operation,
+        generated.pack_path(),
+        generated.pack_size,
+        &generated.git_sha1,
+        generated.pack_hash,
+        generated.object_count,
+        cancellation,
+    )
+    .await?;
+    drop(repacked);
+    Ok(pack)
+}
+
+async fn adopt_concatenated_pack(
+    operation: &crate::OperationContext,
+    concatenated: crab_git::repack::ConcatenatedPack,
+    cancellation: &CancellationToken,
+) -> Result<GeneratedPack> {
+    let pack = adopt_pack_path(
+        operation,
+        concatenated.pack_path(),
+        concatenated.pack_size,
+        &concatenated.git_sha1,
+        concatenated.pack_hash,
+        concatenated.object_count,
+        cancellation,
+    )
+    .await?;
+    drop(concatenated);
+    Ok(pack)
+}
+
+async fn adopt_pack_path(
+    operation: &crate::OperationContext,
+    pack_path: &Path,
+    pack_size: u64,
+    git_sha1: &str,
+    content_hash: [u8; 32],
+    object_count: u64,
+    cancellation: &CancellationToken,
+) -> Result<GeneratedPack> {
+    if cancellation.is_cancelled() {
+        return Err(Error::Cancelled);
+    }
     operation
         .charge(BudgetDimension::LogicalObjects, object_count)
         .await?;
     operation
-        .charge(BudgetDimension::ResponseBytes, generated.pack_size)
+        .charge(BudgetDimension::ResponseBytes, pack_size)
         .await?;
-    let checksum = decode_hex::<20>(&generated.git_sha1).ok_or(Error::Corrupt {
+    let checksum = decode_hex::<20>(git_sha1).ok_or(Error::Corrupt {
         stage: crate::CorruptionStage::PackEntry,
     })?;
     let destination = NamedTempFile::new().map_err(io_error)?;
     let destination_path = destination.path().to_owned();
     let destination = destination.into_temp_path();
     std::fs::remove_file(&destination_path).map_err(io_error)?;
-    std::fs::rename(generated.pack_path(), &destination_path).map_err(io_error)?;
+    std::fs::rename(pack_path, &destination_path).map_err(io_error)?;
     let file = std::fs::File::open(&destination_path).map_err(io_error)?;
     let file = NamedTempFile::from_parts(file, destination);
     let pack = GeneratedPack {
         file: Arc::new(file),
-        size: generated.pack_size,
+        size: pack_size,
         checksum,
-        content_hash: generated.pack_hash,
+        content_hash,
         object_count: u32::try_from(object_count).map_err(|_| Error::LimitExceeded {
             limit: "pack object count",
             actual: object_count,
             maximum: u32::MAX as u64,
         })?,
     };
-    drop(repacked);
-    // `verified_generated_pack` already validated these bytes and computed both
-    // digests before ownership transfer. Rehashing here would scan the response
-    // pack a second time before it can be published or streamed.
+    // The producer validated and hashed these bytes before ownership transfer.
+    // Rehashing here would scan the response pack before publication and streaming.
     Ok(pack)
 }
 


### PR DESCRIPTION
## Summary

- reuse an exact, generation-pinned canonical pack inventory for eligible large full clones
- install verified pack/index sidecars on the destination filesystem and let `git clone --local` preserve normal ref, branch, tag, and origin semantics
- remove duplicate server-side `index-pack --fsck-objects` work from complete-pack concatenation while retaining exact object-set, checksum, and receiver-side validation
- retain the existing Git protocol path for shallow, small, hidden-HEAD, incomplete, or over-budget selections

## Why

A Kubernetes-sized clone spent about 1.7 seconds planning visibility but roughly 76 seconds generating the response pack. Most of that was a server-side `git index-pack --fsck-objects` pass over bytes that the receiving Git process validates again.

The new path treats Crab's committed pack/index/reverse-index inventory as the canonical transfer representation when it exactly matches the authorized clone plan. The artifacts are downloaded concurrently, validated against the pinned object selection, and hard-linked through a temporary local bare repository.

## Benchmark

Requested setup: RustFS on local storage, a new bucket, and Kubernetes as the large repository.

| Clone | Wall time |
|---|---:|
| Previous Crab full clone | 125.74s |
| Optimized Crab full clone | 11.39s |
| Fresh direct GitHub clone | 71.65s |

The optimized local Crab clone was 6.29x faster than the fresh GitHub clone. Normalizing for the modest pack-size difference gives about 6.0x. The Crab client cache was empty; RustFS's OS filesystem cache was warm. Pack fetch took 5.04s and checkout took 5.15s.

Correctness checks matched HEAD, root tree, and all 1,646,244 reachable objects. `git fsck --full --strict` passed, and a subsequent normal `git fetch` completed in 0.38s.

## Verification

- `cargo test -p crab --lib cmd::clone::tests --locked --features gix-transport` (39 passed)
- `cargo test -p crab-git concatenate_complete_pack_inventory_preserves_pack_objects --locked`
- `cargo test -p crab-remote-git complete_pack --locked` (2 passed)
- `cargo check -p crab --locked --features gix-transport`
- `cargo clippy -p crab-git -p crab-remote-git --lib --locked -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
- Kubernetes end-to-end clone, strict fsck, ref/tree/object comparison, and follow-up fetch against local RustFS
