### PR TITLE
feat(s3): complete object-store compatibility and performance paths

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,3 +51,7 @@ _Avoid_: Empty clone, broken worktree
 **Per-worktree state**:
 Crab-local metadata scoped to one worktree identity rather than the whole repository.
 _Avoid_: Shared state
+
+**Repository read view**:
+An immutable repository generation plus its validated committed-journal overlay, used to resolve refs, trees, objects, and version-bound attributes consistently for one request.
+_Avoid_: Mutable repository handle, when referring to a pinned view

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "url",
 ]
 
 [[package]]

--- a/crab/docs/architecture/crab-s3-gateway.md
+++ b/crab/docs/architecture/crab-s3-gateway.md
@@ -1,6 +1,8 @@
 # Crab S3 gateway: executable design and phased implementation plan
 
-Status: initial gateway implemented in `crates/crab-s3-gateway`; broader
+Status: gateway implemented in `crates/crab-s3-gateway`, including object
+attributes/tagging, conditional writes, persisted checksums, and optional
+virtual-host routing; broader
 cross-client, cross-provider, failure-injection, and deployment qualification
 remains a release gate. The frozen delivered surface and deliberate limits are
 recorded in `s3-gateway-contract.md`.

--- a/crab/docs/architecture/crab-s3-gateway.md
+++ b/crab/docs/architecture/crab-s3-gateway.md
@@ -565,6 +565,16 @@ is not a substitute. Read symlinks/submodules only according to phase 0; never
 follow paths into the gateway host filesystem. Version-specific AWS parameters
 remain unsupported unless full S3 versioning was selected and qualified.
 
+For Crab/Xet pointers, a partial GET or copy-source range uses the shared Xet
+range reconstructor and prunes the reconstruction recipe to chunks overlapping
+the selected logical byte interval. Cold, low-coverage reads fetch bounded xorb
+ranges; the cache may fetch and retain a complete verified xorb when the
+selected chunks cover most of it. The selected bytes are streamed from bounded
+temporary storage, so the gateway does not hydrate the complete logical file or
+retain the requested range in memory. A complete GET continues through
+whole-file reconstruction so the pointer hash and declared size are both
+verified.
+
 ### 3.2 Headers, conditions and ranges
 
 | Concern | Required implementation rule |

--- a/crab/docs/architecture/crab-s3-gateway.md
+++ b/crab/docs/architecture/crab-s3-gateway.md
@@ -551,6 +551,15 @@ verified data; authorization and mutable ref resolution are not permanently
 cached along with it. Missing path visibility follows the selected permission
 contract, including distinctions between access denial and absence.
 
+The implemented repository read view is keyed by both compacted generation and
+the validated committed-journal digest. Concurrent refreshes and branch-tip
+snapshot resolution use singleflight cells; Git trees reuse the generation-bound
+remote-read cache, and attributes are cached per immutable commit. The gateway
+invalidates its mutable-ref view after publication. HEAD and attributed LIST
+resolve size and ETag from committed attributes without opening blob payloads.
+Committed journal packs remain readable through this path before locator/catalog
+publication completes.
+
 GET uses logical content opening for Git, Crab and LFS content. Raw `read_blob`
 is not a substitute. Read symlinks/submodules only according to phase 0; never
 follow paths into the gateway host filesystem. Version-specific AWS parameters
@@ -689,6 +698,18 @@ Shared admission must retire an old token before any replacement can execute.
 Re-preparation is bounded and allowed only for a proven pre-publication conflict;
 recheck object conditions on the new destination view. Never resolve contention
 with a blind forced branch update or replacement of an entire stale tree.
+
+The implemented mutation owner admits same-ref requests through a bounded FIFO
+queue. It resolves only the target's ancestor trees, writes one path-local
+attribute delta, prepares the pack, and uploads the pack sidecars, visibility
+evidence, and attribute delta concurrently before acquiring the ref lease. Under
+the lease it captures a new repository snapshot, revalidates the parent, and
+either publishes the journal edit or releases and reprepares. Journal success is
+the acknowledgement point; catalog compaction and commit-graph maintenance run
+asynchronously because the repository read view consumes committed journal
+transactions directly. The gateway coalesces that maintenance until its local
+repository write burst is idle, preventing overlapping compaction waves from
+advancing ahead of visibility proof publication.
 
 ### 4.2 PUT and DELETE execution rules
 

--- a/crab/docs/architecture/crab-s3-gateway.md
+++ b/crab/docs/architecture/crab-s3-gateway.md
@@ -707,9 +707,11 @@ the lease it captures a new repository snapshot, revalidates the parent, and
 either publishes the journal edit or releases and reprepares. Journal success is
 the acknowledgement point; catalog compaction and commit-graph maintenance run
 asynchronously because the repository read view consumes committed journal
-transactions directly. The gateway coalesces that maintenance until its local
-repository write burst is idle, preventing overlapping compaction waves from
-advancing ahead of visibility proof publication.
+transactions directly. A new foreground write cancels an in-flight maintenance
+pass so derived catalog work releases its fences and yields to S3 mutation
+traffic. The gateway schedules maintenance again after the local write burst is
+idle and prevents overlapping compaction waves from advancing ahead of visibility
+proof publication.
 
 ### 4.2 PUT and DELETE execution rules
 

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -18,8 +18,9 @@ branch names a mutable view; a tag or full commit ID names an immutable read-onl
 view. Every request resolves and pins one commit before reading. Writes recheck
 authorization, branch protection, and the branch tip under the canonical per-ref
 publication lock. A conflicting branch update returns `OperationAborted` and is
-safe for the S3 client to retry. Conditional PUT and DELETE headers are not part
-of the initial surface and return `NotImplemented` before reading the body.
+safe for the S3 client to retry. `PutObject` supports `If-None-Match: *` for
+atomic creation. Other conditional PUT and DELETE headers are not part of the
+initial surface and return `NotImplemented` before reading the body.
 
 ## Bucket and key namespace
 
@@ -144,7 +145,7 @@ Supported operations:
 | `ListBuckets`, `HeadBucket` | Authorized logical repositories only; deterministic order |
 | `GetObject`, `HeadObject` | metadata, response overrides, RFC dates, ETag/date conditions, one byte range including open and suffix forms |
 | `ListObjects`, `ListObjectsV2` | prefix, delimiter `/`, marker/start-after, max keys, reusable keys, common prefixes |
-| `PutObject` | body up to 5 GiB, `Content-MD5`, SigV4 payload hash, CRC32/CRC32C/CRC64NVME/SHA1/SHA256 checksums, metadata and standard content headers |
+| `PutObject` | body up to 5 GiB, atomic create with `If-None-Match: *`, `Content-MD5`, SigV4 payload hash, CRC32/CRC32C/CRC64NVME/SHA1/SHA256 checksums, metadata and standard content headers |
 | `DeleteObject`, `DeleteObjects` | S3 missing-key success, per-key authorization/results, quiet mode, and at most 1000 XML entries |
 | `CopyObject` | pinned source, source conditions/range where defined, `COPY`/`REPLACE`, separately authorized destination |
 | Multipart create/upload/copy/list/abort/complete | durable opaque sessions, part replacement, ordered selection, 10,000 parts, 5 GiB per part, 50 TB completed objects, restart and multi-instance retry |
@@ -158,8 +159,8 @@ the matching checksum mode.
 Conditional reads use S3 precedence: match conditions are evaluated before
 unmodified conditions, then modified conditions; a failed read condition returns
 `NotModified` or `PreconditionFailed` as defined by that header. Conditional
-PUT, DELETE, multipart completion, and destination COPY are not in the initial
-surface.
+DELETE, multipart completion, and destination COPY are not in the initial
+surface. PUT conditions other than `If-None-Match: *` are unsupported.
 
 ## Listings and continuation
 

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -12,15 +12,17 @@ upload publishes one commit immediately to the addressed branch. `DeleteObjects`
 performs ordered, individually reported mutations and is not atomic across keys.
 A delete of a missing key succeeds without advancing the branch.
 
-Repository history is the only version model. The initial release does not
+Repository history is the only version model. The gateway does not
 implement AWS bucket versioning, delete markers, or version-ID parameters. A
 branch names a mutable view; a tag or full commit ID names an immutable read-only
 view. Every request resolves and pins one commit before reading. Writes recheck
 authorization, branch protection, and the branch tip under the canonical per-ref
 publication lock. A conflicting branch update returns `OperationAborted` and is
-safe for the S3 client to retry. `PutObject` supports `If-None-Match: *` for
-atomic creation. Other conditional PUT and DELETE headers are not part of the
-initial surface and return `NotImplemented` before reading the body.
+safe for the S3 client to retry. `PutObject` and `CompleteMultipartUpload`
+support `If-None-Match: *` and strong `If-Match` atomically. The ETag is checked
+before receiving or assembling content, and the observed blob identity is
+checked again under the publication lock. Conditional DELETE headers are not
+part of the surface and return `NotImplemented` before mutation.
 
 ## Bucket and key namespace
 
@@ -130,10 +132,11 @@ Content and attributes are never read from different commits.
 
 ## Protocol surface
 
-The initial release supports path-style addressing. Virtual-hosted addressing
-is not configured by the gateway. HTTPS is mandatory beyond loopback and is
+Path-style addressing is always supported. Setting `endpoint_domain` enables
+virtual-hosted addressing under that base domain; DNS and TLS wildcard coverage
+remain deployment responsibilities. HTTPS is mandatory beyond loopback and is
 terminated by the deployment ingress. Browser POST, bucket create/delete, ACLs, policies, IAM,
-versioning, tagging, Select, object lock, retention, torrent, website, inventory,
+version mutation/listing, Select, object lock, retention, torrent, website, inventory,
 replication, acceleration, notification, storage-class selection, and all SSE
 request headers return `NotImplemented` or the operation-specific documented S3
 error before mutation.
@@ -142,25 +145,32 @@ Supported operations:
 
 | Operation | Supported contract |
 | --- | --- |
-| `ListBuckets`, `HeadBucket` | Authorized logical repositories only; deterministic order |
-| `GetObject`, `HeadObject` | metadata, response overrides, RFC dates, ETag/date conditions, one byte range including open and suffix forms |
+| `ListBuckets`, `HeadBucket`, `GetBucketLocation`, `GetBucketVersioning` | Authorized logical repositories only; deterministic order; configured region; honest unversioned response |
+| `GetObject`, `HeadObject`, `GetObjectAttributes` | metadata, response overrides, RFC dates, ETag/date conditions, checksum mode, object size, ETag, part-number reads, and paginated multipart-part attributes; one byte range including open and suffix forms |
 | `ListObjects`, `ListObjectsV2` | prefix, delimiter `/`, marker/start-after, max keys, reusable keys, common prefixes |
-| `PutObject` | body up to 5 GiB, atomic create with `If-None-Match: *`, `Content-MD5`, SigV4 payload hash, CRC32/CRC32C/CRC64NVME/SHA1/SHA256 checksums, metadata and standard content headers |
+| `PutObject` | body up to 5 GiB, atomic `If-Match` and `If-None-Match: *`, `Content-MD5`, SigV4 payload hash, CRC32/CRC32C/CRC64NVME/SHA1/SHA256 checksums, tags, metadata and standard content headers |
+| `GetObjectTagging`, `PutObjectTagging`, `DeleteObjectTagging` | Up to ten current-object tags; tag changes publish metadata-only commits without changing object bytes or ETag |
 | `DeleteObject`, `DeleteObjects` | S3 missing-key success, per-key authorization/results, quiet mode, and at most 1000 XML entries |
-| `CopyObject` | pinned source, source conditions/range where defined, `COPY`/`REPLACE`, separately authorized destination |
-| Multipart create/upload/copy/list/abort/complete | durable opaque sessions, part replacement, ordered selection, 10,000 parts, 5 GiB per part, 50 TB completed objects, restart and multi-instance retry |
+| `CopyObject` | pinned source, source conditions/range where defined, metadata/tag `COPY`/`REPLACE`, checksum selection, separately authorized destination |
+| Multipart create/upload/copy/list/abort/complete | durable opaque sessions, conditional completion, validated full-object CRC and composite CRC/SHA checksums, part replacement, ordered selection, 10,000 parts, 5 GiB per part, 50 TB completed objects, restart and multi-instance retry |
 
 Modeled unsupported request headers and query parameters are rejected rather
 than ignored. Multi-range GET returns `InvalidRange`. `versionId` returns
-`NotImplemented`. Checksums are validated before publication. A response never
-attaches a full-object checksum to a partial range unless the protocol defines
-the matching checksum mode.
+`NotImplemented`; `GetBucketVersioning` returns the S3 empty/unversioned state.
+Checksums are validated before publication and stored in the commit attribute
+manifest. Objects uploaded without a checksum receive S3's default full-object
+CRC64NVME checksum. A response never attaches a full-object checksum to a
+partial range. A part-number request or a byte range exactly aligned to one
+persisted multipart part returns that part's checksum.
+Composite object checksum responses carry S3's `-PART_COUNT` suffix; individual
+part checksums and a precomputed completion checksum use the raw Base64 digest.
 
 Conditional reads use S3 precedence: match conditions are evaluated before
 unmodified conditions, then modified conditions; a failed read condition returns
 `NotModified` or `PreconditionFailed` as defined by that header. Conditional
-DELETE, multipart completion, and destination COPY are not in the initial
-surface. PUT conditions other than `If-None-Match: *` are unsupported.
+DELETE and destination COPY conditions are outside this surface. `PutObject`
+and `CompleteMultipartUpload` support atomic strong `If-Match` and
+`If-None-Match: *`; weak or multi-value write validators are rejected.
 
 ## Listings and continuation
 

--- a/crates/crab-read/Cargo.toml
+++ b/crates/crab-read/Cargo.toml
@@ -41,7 +41,6 @@ xet-data = { workspace = true }
 xet-runtime = { workspace = true }
 
 [dev-dependencies]
-crab-storage = { workspace = true, features = ["test-support"] }
 slatedb = { version = "=0.15.0", features = ["wal_disable", "zstd"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/crab-read/Cargo.toml
+++ b/crates/crab-read/Cargo.toml
@@ -41,6 +41,7 @@ xet-data = { workspace = true }
 xet-runtime = { workspace = true }
 
 [dev-dependencies]
+crab-storage = { workspace = true, features = ["test-support"] }
 slatedb = { version = "=0.15.0", features = ["wal_disable", "zstd"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/crab-read/README.md
+++ b/crates/crab-read/README.md
@@ -108,8 +108,10 @@ async fn example(pointer_bytes: &[u8]) -> Result<(), Box<dyn std::error::Error>>
 Use `reconstruct_range_from_pointer` for bounded in-memory partial reads,
 `reconstruct_range_to_path` for large partial reads, and `reconstruct_to_path`
 for complete large files. Range reconstruction limits the recipe to the Xet
-chunks overlapping the selected byte interval. Cold, low-coverage reads fetch
-bounded xorb ranges; high-coverage reads may cache a complete verified xorb.
+chunks overlapping the selected byte interval. The path API makes cold,
+low-coverage reads with bounded xorb requests; high-coverage reads may cache a
+complete verified xorb. The in-memory API retains its non-installing whole-xorb
+source read so VFS windows preserve one-request fetch and decoded-range reuse.
 The pointer and metadata remain the source of truth; caches only change where
 immutable bytes are fetched from.
 Use `reconstruct_to_writer` with a sink for verification or cache warming that

--- a/crates/crab-read/README.md
+++ b/crates/crab-read/README.md
@@ -105,9 +105,13 @@ async fn example(pointer_bytes: &[u8]) -> Result<(), Box<dyn std::error::Error>>
 }
 ```
 
-Use `reconstruct_range_from_pointer` for partial reads and
-`reconstruct_to_path` for large files. The pointer and metadata remain the
-source of truth; caches only change where immutable bytes are fetched from.
+Use `reconstruct_range_from_pointer` for bounded in-memory partial reads,
+`reconstruct_range_to_path` for large partial reads, and `reconstruct_to_path`
+for complete large files. Range reconstruction limits the recipe to the Xet
+chunks overlapping the selected byte interval. Cold, low-coverage reads fetch
+bounded xorb ranges; high-coverage reads may cache a complete verified xorb.
+The pointer and metadata remain the source of truth; caches only change where
+immutable bytes are fetched from.
 Use `reconstruct_to_writer` with a sink for verification or cache warming that
 does not need to retain the file. Success verifies actual whole-file hash and
 size, but a writer can receive bytes before final verification; consumers must

--- a/crates/crab-read/src/hydrator.rs
+++ b/crates/crab-read/src/hydrator.rs
@@ -604,6 +604,88 @@ mod tests {
 
     use super::{GenericHasherTap, GenericHasherTapState};
 
+    #[derive(Debug)]
+    struct RejectFullXorbReads {
+        inner: Arc<dyn object_store::ObjectStore>,
+    }
+
+    impl std::fmt::Display for RejectFullXorbReads {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("RejectFullXorbReads")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl object_store::ObjectStore for RejectFullXorbReads {
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            options: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, options).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            if !options.head && options.range.is_none() && location.as_ref().contains("/xorbs/") {
+                return Err(object_store::Error::Generic {
+                    store: "RejectFullXorbReads",
+                    source: Box::new(std::io::Error::other(
+                        "test forbids complete xorb body reads",
+                    )),
+                });
+            }
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures_util::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures_util::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures_util::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
     pub(super) async fn reconstruction_fixture(
         root: &std::path::Path,
         corrupt_origin: bool,
@@ -1006,17 +1088,14 @@ mod tests {
 
     #[tokio::test]
     async fn range_to_path_returns_exact_bytes_without_full_xorb_reads() {
-        use crab_storage::test_support::{CountingObjectStore, ObjectReadKind};
-
         let directory = tempfile::tempdir().unwrap();
-        let counted = Arc::new(CountingObjectStore::new(Arc::new(
-            object_store::memory::InMemory::new(),
-        )));
-        let origin = crab_storage::Store::new(counted.clone());
+        let guarded = Arc::new(RejectFullXorbReads {
+            inner: Arc::new(object_store::memory::InMemory::new()),
+        });
+        let origin = crab_storage::Store::new(guarded);
         let (hydrator, pointer, original) =
             reconstruction_fixture_with_origin(&directory.path().join("cache"), false, origin)
                 .await;
-        counted.reset();
         let dest = directory.path().join("selected");
 
         let written = hydrator
@@ -1026,21 +1105,6 @@ mod tests {
 
         assert_eq!(written, 8192 - 1024);
         assert_eq!(std::fs::read(dest).unwrap(), original[1024..8192]);
-        let xorb_reads = counted
-            .requests()
-            .into_iter()
-            .filter(|request| request.location.contains("/xorbs/"))
-            .collect::<Vec<_>>();
-        assert!(
-            xorb_reads
-                .iter()
-                .any(|request| request.kind == ObjectReadKind::Range)
-        );
-        assert!(
-            xorb_reads
-                .iter()
-                .all(|request| request.kind != ObjectReadKind::Full)
-        );
     }
 
     #[tokio::test]

--- a/crates/crab-read/src/hydrator.rs
+++ b/crates/crab-read/src/hydrator.rs
@@ -156,6 +156,57 @@ impl ShardHydrator {
         self.reconstruct_to_writer(ptr, file).await
     }
 
+    /// Reconstruct `[start, end)` into `dest` without buffering the selected range.
+    ///
+    /// The range is clamped to the pointer's declared size. Partial reconstruction
+    /// verifies the selected Xet chunks and exact output length, but cannot verify
+    /// the pointer's whole-file hash because unread bytes are not reconstructed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed ranges, unavailable or corrupt Xet data,
+    /// output-length mismatches, or destination I/O failures.
+    pub async fn reconstruct_range_to_path(
+        &self,
+        ptr: &Pointer,
+        start: u64,
+        end: u64,
+        dest: &std::path::Path,
+    ) -> Result<u64> {
+        let (start, end) = checked_range(ptr.size, start, end, "reconstruct_range_to_path")?;
+        let file = std::fs::File::create(dest)?;
+        if start >= end {
+            return Ok(0);
+        }
+
+        let file_hash = MerkleHash::from(ptr.file_hash);
+        let client = self
+            .store_client_for_pointer(ptr, None)
+            .with_selective_xorb_reads();
+        let cancel = CancellationToken::new();
+        let _cancel_on_drop = cancel.clone().drop_guard();
+        let (_, bytes_written) = self
+            .reconstruct_bounded_to_writer(
+                client,
+                file_hash,
+                file,
+                Some(FileRange::new(start, end)),
+                end - start,
+                &cancel,
+            )
+            .await?;
+        if bytes_written != end - start {
+            return Err(ReadError::CorruptObject {
+                path: file_hash.hex(),
+                reason: format!(
+                    "reconstruction size mismatch: expected {}, got {bytes_written}",
+                    end - start
+                ),
+            });
+        }
+        Ok(bytes_written)
+    }
+
     /// Reconstruct a pointer into a blocking writer and verify its hash.
     pub async fn reconstruct_to_writer<W>(&self, ptr: &Pointer, writer: W) -> Result<u64>
     where
@@ -183,53 +234,9 @@ impl ShardHydrator {
         let client = self.store_client_for_pointer(ptr, file_index_lookup);
         self.preflight_shard_coverage(&client, ptr).await?;
 
-        let tap_state = Arc::new(std::sync::Mutex::new(GenericHasherTapState {
-            writer: Some(writer),
-            hasher: blake3::Hasher::new(),
-            bytes_written: 0,
-            expected_size: ptr.size,
-            exceeded: false,
-        }));
-        let _writer_owner = GenericHasherTapOwner(Arc::clone(&tap_state));
-        let writer = GenericHasherTap {
-            shared: Arc::clone(&tap_state),
-        };
-
-        let operation_cancel = cancel.child_token();
-        let _cancel_on_drop = operation_cancel.clone().drop_guard();
-        let outcome = self
-            .reconstruct_to_writer_unverified(client, file_hash, writer, None, &operation_cancel)
-            .await;
-
-        let (actual_hash, bytes_written) = {
-            let mut guard = tap_state
-                .lock()
-                .map_err(|_| ReadError::internal("hasher tap poisoned"))?;
-            let mut writer = guard.writer.take();
-            if guard.exceeded {
-                return Err(ReadError::CorruptObject {
-                    path: file_hash.hex(),
-                    reason: format!(
-                        "reconstruction exceeds declared output size of {} bytes",
-                        ptr.size
-                    ),
-                });
-            }
-            outcome?;
-            if let Some(writer) = writer.as_mut() {
-                // A final-flush failure follows written output, just like an
-                // Xet writer failure; retain the same source and replay policy.
-                writer.flush().map_err(|error| ReadError::Reconstruction {
-                    file_hash: file_hash.hex(),
-                    source: crate::error::ReconstructionError::from(
-                        xet_data::file_reconstruction::FileReconstructionError::from(error),
-                    ),
-                })?;
-            }
-            drop(writer);
-            let hash: [u8; 32] = guard.hasher.finalize().into();
-            (hash, guard.bytes_written)
-        };
+        let (actual_hash, bytes_written) = self
+            .reconstruct_bounded_to_writer(client, file_hash, writer, None, ptr.size, cancel)
+            .await?;
 
         if actual_hash != ptr.file_hash {
             return Err(ReadError::HashMismatch {
@@ -241,12 +248,11 @@ impl ShardHydrator {
             return Err(ReadError::CorruptObject {
                 path: file_hash.hex(),
                 reason: format!(
-                    "reconstruction size mismatch: expected {}, got {}",
-                    ptr.size, bytes_written
+                    "reconstruction size mismatch: expected {}, got {bytes_written}",
+                    ptr.size
                 ),
             });
         }
-
         Ok(bytes_written)
     }
 
@@ -258,16 +264,11 @@ impl ShardHydrator {
         end: u64,
     ) -> Result<Vec<u8>> {
         let ptr = Pointer::parse(pointer_bytes)?;
-        let client = self.store_client_for_pointer(&ptr, None);
+        let client = self
+            .store_client_for_pointer(&ptr, None)
+            .with_selective_xorb_reads();
 
-        if end < start {
-            return Err(ReadError::internal(format!(
-                "reconstruct_range_from_pointer: end ({end}) < start ({start})"
-            )));
-        }
-
-        let end = end.min(ptr.size);
-        let start = start.min(ptr.size);
+        let (start, end) = checked_range(ptr.size, start, end, "reconstruct_range_from_pointer")?;
         if start >= end {
             return Ok(Vec::new());
         }
@@ -382,6 +383,64 @@ impl ShardHydrator {
         Ok(())
     }
 
+    async fn reconstruct_bounded_to_writer<W>(
+        &self,
+        client: StoreClient,
+        file_hash: MerkleHash,
+        writer: W,
+        range: Option<FileRange>,
+        expected_size: u64,
+        cancel: &CancellationToken,
+    ) -> Result<([u8; 32], u64)>
+    where
+        W: Write + Send + 'static,
+    {
+        let tap_state = Arc::new(std::sync::Mutex::new(GenericHasherTapState {
+            writer: Some(writer),
+            hasher: blake3::Hasher::new(),
+            bytes_written: 0,
+            expected_size,
+            exceeded: false,
+        }));
+        let _writer_owner = GenericHasherTapOwner(Arc::clone(&tap_state));
+        let writer = GenericHasherTap {
+            shared: Arc::clone(&tap_state),
+        };
+
+        let operation_cancel = cancel.child_token();
+        let _cancel_on_drop = operation_cancel.clone().drop_guard();
+        let outcome = self
+            .reconstruct_to_writer_unverified(client, file_hash, writer, range, &operation_cancel)
+            .await;
+
+        let mut guard = tap_state
+            .lock()
+            .map_err(|_| ReadError::internal("hasher tap poisoned"))?;
+        let mut writer = guard.writer.take();
+        if guard.exceeded {
+            return Err(ReadError::CorruptObject {
+                path: file_hash.hex(),
+                reason: format!(
+                    "reconstruction exceeds declared output size of {expected_size} bytes"
+                ),
+            });
+        }
+        outcome?;
+        if let Some(writer) = writer.as_mut() {
+            // A final-flush failure follows written output, just like an
+            // Xet writer failure; retain the same source and replay policy.
+            writer.flush().map_err(|error| ReadError::Reconstruction {
+                file_hash: file_hash.hex(),
+                source: crate::error::ReconstructionError::from(
+                    xet_data::file_reconstruction::FileReconstructionError::from(error),
+                ),
+            })?;
+        }
+        drop(writer);
+        let hash: [u8; 32] = guard.hasher.finalize().into();
+        Ok((hash, guard.bytes_written))
+    }
+
     async fn preflight_shard_coverage(&self, client: &StoreClient, ptr: &Pointer) -> Result<()> {
         use xet_client::cas_client::Client;
         let file_hash = MerkleHash::from(ptr.file_hash);
@@ -415,6 +474,15 @@ impl ShardHydrator {
             example_chunk_index: example.0,
         })
     }
+}
+
+fn checked_range(size: u64, start: u64, end: u64, operation: &str) -> Result<(u64, u64)> {
+    if end < start {
+        return Err(ReadError::internal(format!(
+            "{operation}: end ({end}) < start ({start})"
+        )));
+    }
+    Ok((start.min(size), end.min(size)))
 }
 
 fn fixed_hydrate_concurrency(concurrency: usize) -> Result<Arc<AdaptiveConcurrencyController>> {
@@ -540,27 +608,51 @@ mod tests {
         root: &std::path::Path,
         corrupt_origin: bool,
     ) -> (super::ShardHydrator, crab_types::pointer::Pointer, Vec<u8>) {
+        let origin = crab_storage::Store::new(Arc::new(object_store::memory::InMemory::new()));
+        reconstruction_fixture_with_origin(root, corrupt_origin, origin).await
+    }
+
+    async fn reconstruction_fixture_with_origin(
+        root: &std::path::Path,
+        corrupt_origin: bool,
+        origin: crab_storage::Store,
+    ) -> (super::ShardHydrator, crab_types::pointer::Pointer, Vec<u8>) {
         use crab_xet::shard::{
             FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo, MDBXorbInfo, ShardWriter,
             XorbChunkSequenceEntry, XorbChunkSequenceHeader,
         };
         use crab_xet::xorb::builder::{RunId, XorbBuilder};
 
-        let data = vec![42; 128 * 1024];
-        let chunk = crab_xet::xorb::format::Chunk::new(bytes::Bytes::from(data.clone()));
+        let payloads = (0_u8..4)
+            .map(|value| vec![42 + value; 32 * 1024])
+            .collect::<Vec<_>>();
+        let data = payloads.concat();
+        let chunks = payloads
+            .into_iter()
+            .map(|payload| crab_xet::xorb::format::Chunk::new(bytes::Bytes::from(payload)))
+            .collect::<Vec<_>>();
         let mut builder = XorbBuilder::new();
-        builder.push(&chunk, RunId(0)).unwrap();
+        for chunk in &chunks {
+            builder.push(chunk, RunId(0)).unwrap();
+        }
         let xorb = builder.finalize().unwrap().remove(0);
         let file_hash = *blake3::hash(&data).as_bytes();
         let mut shard = ShardWriter::new();
         shard
             .add_xorb(Arc::new(MDBXorbInfo {
-                metadata: XorbChunkSequenceHeader::new(xorb.hash, 1, data.len()),
-                chunks: vec![XorbChunkSequenceEntry::new(
-                    chunk.hash,
-                    data.len() as u32,
-                    0,
-                )],
+                metadata: XorbChunkSequenceHeader::new(xorb.hash, chunks.len() as u32, data.len()),
+                chunks: chunks
+                    .iter()
+                    .scan(0_u32, |offset, chunk| {
+                        let entry = XorbChunkSequenceEntry::new(
+                            chunk.hash,
+                            chunk.data.len() as u32,
+                            *offset,
+                        );
+                        *offset += chunk.data.len() as u32;
+                        Some(entry)
+                    })
+                    .collect(),
             }))
             .unwrap();
         shard
@@ -570,14 +662,14 @@ mod tests {
                     xorb.hash,
                     data.len() as u32,
                     0,
-                    1,
+                    chunks.len() as u32,
                 )],
                 verification: vec![],
                 metadata_ext: None,
             })
             .unwrap();
         let (shard_bytes, shard_hash) = shard.finalize().unwrap();
-        let hydrator = runtime(root, 1024 * 1024);
+        let hydrator = runtime_with_origin(root, 1024 * 1024, origin);
         hydrator
             .store
             .origin()
@@ -913,6 +1005,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn range_to_path_returns_exact_bytes_without_full_xorb_reads() {
+        use crab_storage::test_support::{CountingObjectStore, ObjectReadKind};
+
+        let directory = tempfile::tempdir().unwrap();
+        let counted = Arc::new(CountingObjectStore::new(Arc::new(
+            object_store::memory::InMemory::new(),
+        )));
+        let origin = crab_storage::Store::new(counted.clone());
+        let (hydrator, pointer, original) =
+            reconstruction_fixture_with_origin(&directory.path().join("cache"), false, origin)
+                .await;
+        counted.reset();
+        let dest = directory.path().join("selected");
+
+        let written = hydrator
+            .reconstruct_range_to_path(&pointer, 1024, 8192, &dest)
+            .await
+            .unwrap();
+
+        assert_eq!(written, 8192 - 1024);
+        assert_eq!(std::fs::read(dest).unwrap(), original[1024..8192]);
+        let xorb_reads = counted
+            .requests()
+            .into_iter()
+            .filter(|request| request.location.contains("/xorbs/"))
+            .collect::<Vec<_>>();
+        assert!(
+            xorb_reads
+                .iter()
+                .any(|request| request.kind == ObjectReadKind::Range)
+        );
+        assert!(
+            xorb_reads
+                .iter()
+                .all(|request| request.kind != ObjectReadKind::Full)
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_range_does_not_truncate_destination() {
+        let directory = tempfile::tempdir().unwrap();
+        let (hydrator, pointer, _) =
+            reconstruction_fixture(&directory.path().join("cache"), false).await;
+        let dest = directory.path().join("selected");
+        std::fs::write(&dest, b"keep").unwrap();
+
+        assert!(
+            hydrator
+                .reconstruct_range_to_path(&pointer, 9, 8, &dest)
+                .await
+                .is_err()
+        );
+        assert_eq!(std::fs::read(dest).unwrap(), b"keep");
+    }
+
+    #[tokio::test]
     async fn incomplete_range_output_is_not_success() {
         let directory = tempfile::tempdir().unwrap();
         let (hydrator, mut pointer, _) =
@@ -977,6 +1125,14 @@ mod tests {
 
     fn runtime(root: &std::path::Path, max_bytes: u64) -> super::ShardHydrator {
         let origin = crab_storage::Store::new(Arc::new(object_store::memory::InMemory::new()));
+        runtime_with_origin(root, max_bytes, origin)
+    }
+
+    fn runtime_with_origin(
+        root: &std::path::Path,
+        max_bytes: u64,
+        origin: crab_storage::Store,
+    ) -> super::ShardHydrator {
         let local = Arc::new(crab_cache::LocalCache::with_limits(
             root.to_owned(),
             max_bytes,

--- a/crates/crab-read/src/hydrator.rs
+++ b/crates/crab-read/src/hydrator.rs
@@ -264,9 +264,9 @@ impl ShardHydrator {
         end: u64,
     ) -> Result<Vec<u8>> {
         let ptr = Pointer::parse(pointer_bytes)?;
-        let client = self
-            .store_client_for_pointer(&ptr, None)
-            .with_selective_xorb_reads();
+        // VFS windows retain decoded Xet ranges and expect one non-installing
+        // whole-xorb source read. The path API opts into selective origin reads.
+        let client = self.store_client_for_pointer(&ptr, None);
 
         let (start, end) = checked_range(ptr.size, start, end, "reconstruct_range_from_pointer")?;
         if start >= end {

--- a/crates/crab-read/src/store_client.rs
+++ b/crates/crab-read/src/store_client.rs
@@ -54,6 +54,7 @@ pub struct StoreClient {
     metrics: Option<Arc<dyn ReadMetrics>>,
     availability: Option<Arc<dyn XorbAvailability>>,
     failures: Option<Arc<crate::error::OperationFailures>>,
+    selective_xorb_reads: bool,
 }
 
 impl StoreClient {
@@ -72,6 +73,7 @@ impl StoreClient {
             metrics: None,
             availability: None,
             failures: None,
+            selective_xorb_reads: false,
         }
     }
 
@@ -110,6 +112,13 @@ impl StoreClient {
 
     pub(crate) fn with_failures(mut self, failures: Arc<crate::error::OperationFailures>) -> Self {
         self.failures = Some(failures);
+        self
+    }
+
+    pub(crate) fn with_selective_xorb_reads(mut self) -> Self {
+        // Whole-file hydration avoids storing a second complete xorb beside its
+        // output. Range hydration opts in so cold reads fetch only needed payload.
+        self.selective_xorb_reads = true;
         self
     }
 
@@ -324,55 +333,11 @@ fn parse_xorb_url(url: &str) -> ClientResult<(MerkleHash, Vec<ChunkRange>)> {
     Ok((hash, ranges))
 }
 
-fn build_response_v2(
-    file_info: &MDBFileInfo,
-    byte_range: Option<FileRange>,
-) -> Option<QueryReconstructionResponseV2> {
-    let mut cumulative: u64 = 0;
-    let mut spans: Vec<(u64, u64)> = Vec::with_capacity(file_info.segments.len());
-    for seg in &file_info.segments {
-        let size = u64::from(seg.unpacked_segment_bytes);
-        spans.push((cumulative, cumulative + size));
-        cumulative += size;
-    }
-    let file_size = cumulative;
-
-    let (first_idx, last_idx, offset_into_first_range) = match byte_range {
-        Some(range) => {
-            if range.start >= file_size {
-                return None;
-            }
-
-            let first = spans.iter().position(|(_, end)| *end > range.start)?;
-            let last = spans
-                .iter()
-                .rposition(|(start, _)| *start < range.end.min(file_size))
-                .unwrap_or(first);
-            let offset = range.start.saturating_sub(spans[first].0);
-            (first, last, offset)
-        }
-        None => {
-            if file_info.segments.is_empty() {
-                (0, 0, 0)
-            } else {
-                (0, file_info.segments.len() - 1, 0)
-            }
-        }
-    };
-
-    if file_info.segments.is_empty() {
-        return Some(QueryReconstructionResponseV2 {
-            offset_into_first_range: 0,
-            terms: Vec::new(),
-            xorbs: HashMap::new(),
-        });
-    }
-
-    let selected = &file_info.segments[first_idx..=last_idx];
-    let mut terms = Vec::with_capacity(selected.len());
+fn build_response_v2(file_info: &MDBFileInfo) -> QueryReconstructionResponseV2 {
+    let mut terms = Vec::with_capacity(file_info.segments.len());
     let mut xorbs: HashMap<HexMerkleHash, Vec<XorbMultiRangeFetch>> = HashMap::new();
 
-    for seg in selected {
+    for seg in &file_info.segments {
         let chunks = ChunkRange::new(seg.chunk_index_start, seg.chunk_index_end);
         terms.push(XorbReconstructionTerm {
             hash: HexMerkleHash::from(seg.xorb_hash),
@@ -393,11 +358,158 @@ fn build_response_v2(
             .push(fetch);
     }
 
-    Some(QueryReconstructionResponseV2 {
-        offset_into_first_range,
+    QueryReconstructionResponseV2 {
+        offset_into_first_range: 0,
         terms,
         xorbs,
-    })
+    }
+}
+
+fn build_range_response_v2(
+    file_info: &MDBFileInfo,
+    shard: &ShardReader,
+    requested: FileRange,
+) -> ClientResult<Option<QueryReconstructionResponseV2>> {
+    if requested.end < requested.start {
+        return Err(ClientError::InvalidRange);
+    }
+    let file_size = file_info
+        .segments
+        .iter()
+        .try_fold(0_u64, |total, segment| {
+            total.checked_add(u64::from(segment.unpacked_segment_bytes))
+        })
+        .ok_or_else(|| ClientError::Other("reconstruction file size overflow".to_owned()))?;
+    if requested.start >= file_size {
+        return Ok(None);
+    }
+    let requested = FileRange::new(requested.start, requested.end.min(file_size));
+    let mut terms = Vec::new();
+    let mut xorbs: HashMap<HexMerkleHash, Vec<XorbMultiRangeFetch>> = HashMap::new();
+    let mut segment_start = 0_u64;
+    let mut offset_into_first_range = None;
+
+    for segment in &file_info.segments {
+        let segment_end = segment_start
+            .checked_add(u64::from(segment.unpacked_segment_bytes))
+            .ok_or_else(|| ClientError::Other("reconstruction segment overflow".to_owned()))?;
+        if segment_end <= requested.start {
+            segment_start = segment_end;
+            continue;
+        }
+        if segment_start >= requested.end {
+            break;
+        }
+
+        let xorb = shard
+            .get_xorb_info(&segment.xorb_hash)
+            .map_err(ClientError::internal)?
+            .ok_or_else(|| {
+                ClientError::Other(format!(
+                    "reconstruction shard lacks xorb metadata for {}",
+                    segment.xorb_hash.hex()
+                ))
+            })?;
+        let chunk_start = usize::try_from(segment.chunk_index_start)
+            .map_err(|_| ClientError::Other("xorb chunk index overflow".to_owned()))?;
+        let chunk_end = usize::try_from(segment.chunk_index_end)
+            .map_err(|_| ClientError::Other("xorb chunk index overflow".to_owned()))?;
+        let chunks = xorb.chunks.get(chunk_start..chunk_end).ok_or_else(|| {
+            ClientError::Other(format!(
+                "reconstruction chunk range {}..{} exceeds xorb {} metadata",
+                segment.chunk_index_start,
+                segment.chunk_index_end,
+                segment.xorb_hash.hex()
+            ))
+        })?;
+        let declared_size = chunks.iter().try_fold(0_u64, |total, chunk| {
+            total.checked_add(u64::from(chunk.unpacked_segment_bytes))
+        });
+        if declared_size != Some(u64::from(segment.unpacked_segment_bytes)) {
+            return Err(ClientError::Other(format!(
+                "reconstruction segment size does not match xorb {} chunk metadata",
+                segment.xorb_hash.hex()
+            )));
+        }
+
+        let mut selected_start = 0_usize;
+        let mut selected_chunk_file_start = segment_start;
+        while selected_start < chunks.len() {
+            let next = selected_chunk_file_start
+                .checked_add(u64::from(chunks[selected_start].unpacked_segment_bytes))
+                .ok_or_else(|| ClientError::Other("reconstruction chunk overflow".to_owned()))?;
+            if next > requested.start {
+                break;
+            }
+            selected_chunk_file_start = next;
+            selected_start += 1;
+        }
+
+        let mut selected_end = selected_start;
+        let mut selected_size = 0_u64;
+        let mut selected_chunk_file_end = selected_chunk_file_start;
+        while selected_end < chunks.len() && selected_chunk_file_end < requested.end {
+            let size = u64::from(chunks[selected_end].unpacked_segment_bytes);
+            selected_size = selected_size
+                .checked_add(size)
+                .ok_or_else(|| ClientError::Other("reconstruction chunk overflow".to_owned()))?;
+            selected_chunk_file_end = selected_chunk_file_end
+                .checked_add(size)
+                .ok_or_else(|| ClientError::Other("reconstruction chunk overflow".to_owned()))?;
+            selected_end += 1;
+        }
+        if selected_start == selected_end {
+            segment_start = segment_end;
+            continue;
+        }
+
+        if offset_into_first_range.is_none() {
+            offset_into_first_range = Some(requested.start - selected_chunk_file_start);
+        }
+        let selected_start = segment
+            .chunk_index_start
+            .checked_add(
+                u32::try_from(selected_start).map_err(|_| {
+                    ClientError::Other("selected xorb chunk index overflow".to_owned())
+                })?,
+            )
+            .ok_or_else(|| ClientError::Other("selected xorb chunk index overflow".to_owned()))?;
+        let selected_end = segment
+            .chunk_index_start
+            .checked_add(
+                u32::try_from(selected_end).map_err(|_| {
+                    ClientError::Other("selected xorb chunk index overflow".to_owned())
+                })?,
+            )
+            .ok_or_else(|| ClientError::Other("selected xorb chunk index overflow".to_owned()))?;
+        let chunks = ChunkRange::new(selected_start, selected_end);
+        let unpacked_length = u32::try_from(selected_size)
+            .map_err(|_| ClientError::Other("selected xorb range exceeds u32".to_owned()))?;
+        terms.push(XorbReconstructionTerm {
+            hash: HexMerkleHash::from(segment.xorb_hash),
+            unpacked_length,
+            range: chunks,
+        });
+        xorbs
+            .entry(HexMerkleHash::from(segment.xorb_hash))
+            .or_default()
+            .push(XorbMultiRangeFetch {
+                url: xorb_url(&segment.xorb_hash, std::slice::from_ref(&chunks)),
+                ranges: vec![XorbRangeDescriptor {
+                    chunks,
+                    // This adapter encodes chunk addressing in its private URL;
+                    // Xet still requires a well-formed inclusive HTTP range.
+                    bytes: HttpRange::new(0, selected_size - 1),
+                }],
+            });
+        segment_start = segment_end;
+    }
+
+    Ok(Some(QueryReconstructionResponseV2 {
+        offset_into_first_range: offset_into_first_range.unwrap_or(0),
+        terms,
+        xorbs,
+    }))
 }
 
 #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
@@ -448,7 +560,10 @@ impl Client for StoreClient {
             ))));
         };
 
-        Ok(build_response_v2(&file_info, bytes_range))
+        match bytes_range {
+            Some(range) => build_range_response_v2(&file_info, &shard, range),
+            None => Ok(Some(build_response_v2(&file_info))),
+        }
     }
 
     async fn batch_get_reconstruction(
@@ -492,9 +607,7 @@ impl Client for StoreClient {
                     );
                     continue;
                 };
-                let Some(response) = build_response_v2(&file_info, None) else {
-                    continue;
-                };
+                let response = build_response_v2(&file_info);
                 files.insert(HexMerkleHash::from(file_id), response.terms);
                 for (xorb_hash, fetches) in response.xorbs {
                     let entries = fetch_info.entry(xorb_hash).or_default();
@@ -546,9 +659,16 @@ impl Client for StoreClient {
             .iter()
             .map(|range| (range.start, range.end))
             .collect::<Vec<_>>();
-        self.store
-            .get_xorb_chunks_without_install(&xorb_path, &xorb_hash, &ranges)
-            .await
+        let result = if self.selective_xorb_reads {
+            self.store
+                .get_xorb_chunks(&xorb_path, &xorb_hash, &ranges)
+                .await
+        } else {
+            self.store
+                .get_xorb_chunks_without_install(&xorb_path, &xorb_hash, &ranges)
+                .await
+        };
+        result
             .map_err(ReadError::from)
             .map_err(|error| self.map_read_error(error))
     }

--- a/crates/crab-read/src/store_client/tests.rs
+++ b/crates/crab-read/src/store_client/tests.rs
@@ -205,7 +205,7 @@ fn build_response_v2_covers_every_segment() {
         metadata_ext: None,
     };
 
-    let response = build_response_v2(&info, None).expect("full-file reconstruction should be Some");
+    let response = build_response_v2(&info);
     assert_eq!(response.terms.len(), 2);
     assert_eq!(response.terms[0].range, ChunkRange::new(0, 4));
     assert_eq!(response.terms[0].unpacked_length, 1024);
@@ -230,7 +230,7 @@ fn build_response_v2_represents_zero_byte_file() {
         metadata_ext: None,
     };
 
-    let response = build_response_v2(&info, None).expect("zero-byte file should reconstruct");
+    let response = build_response_v2(&info);
     assert!(response.terms.is_empty());
     assert!(response.xorbs.is_empty());
     assert_eq!(response.offset_into_first_range, 0);
@@ -238,37 +238,66 @@ fn build_response_v2_represents_zero_byte_file() {
 
 #[test]
 fn reconstruction_ranges_preserve_segment_offsets_and_eof() {
+    let xorb_a = hash_from_seed(2);
+    let xorb_b = hash_from_seed(3);
     let info = MDBFileInfo {
         metadata: FileDataSequenceHeader::new(hash_from_seed(1), 2, false, false),
         segments: vec![
-            FileDataSequenceEntry::new(hash_from_seed(2), 1024, 0, 4),
-            FileDataSequenceEntry::new(hash_from_seed(3), 2048, 5, 13),
+            FileDataSequenceEntry::new(xorb_a, 1024, 0, 4),
+            FileDataSequenceEntry::new(xorb_b, 2048, 5, 13),
         ],
         verification: vec![],
         metadata_ext: None,
     };
+    let xorb_info = |hash: MerkleHash, count: u32| {
+        Arc::new(MDBXorbInfo {
+            metadata: XorbChunkSequenceHeader::new(hash, count, count * 256),
+            chunks: (0..count)
+                .map(|index| {
+                    XorbChunkSequenceEntry::new(
+                        hash_from_seed(100 + u64::from(index)),
+                        256,
+                        index * 256,
+                    )
+                })
+                .collect(),
+        })
+    };
+    let mut writer = ShardWriter::new();
+    writer.add_xorb(xorb_info(xorb_a, 4)).unwrap();
+    writer.add_xorb(xorb_info(xorb_b, 13)).unwrap();
+    writer.add_file(info.clone()).unwrap();
+    let (bytes, hash) = writer.finalize().unwrap();
+    let shard = ShardReader::from_bytes(Bytes::from(bytes), hash);
     for (start, end, expected) in [
         (
             512,
             2048,
-            Some((512, vec![ChunkRange::new(0, 4), ChunkRange::new(5, 13)])),
+            Some((0, vec![ChunkRange::new(2, 4), ChunkRange::new(5, 9)])),
         ),
         (1024, 3072, Some((0, vec![ChunkRange::new(5, 13)]))),
-        (1536, 4096, Some((512, vec![ChunkRange::new(5, 13)]))),
+        (1536, 4096, Some((0, vec![ChunkRange::new(7, 13)]))),
+        (600, 700, Some((88, vec![ChunkRange::new(2, 3)]))),
         (3072, 4096, None),
     ] {
-        let actual = build_response_v2(&info, Some(FileRange::new(start, end))).map(|response| {
-            (
-                response.offset_into_first_range,
-                response
-                    .terms
-                    .into_iter()
-                    .map(|term| term.range)
-                    .collect::<Vec<_>>(),
-            )
-        });
+        let actual = build_range_response_v2(&info, &shard, FileRange::new(start, end))
+            .unwrap()
+            .map(|response| {
+                (
+                    response.offset_into_first_range,
+                    response
+                        .terms
+                        .into_iter()
+                        .map(|term| term.range)
+                        .collect::<Vec<_>>(),
+                )
+            });
         assert_eq!(actual, expected, "byte range {start}..{end}");
     }
+    assert!(matches!(
+        build_range_response_v2(&info, &shard, FileRange::new(2, 1)),
+        Err(ClientError::InvalidRange)
+    ));
 }
 
 #[tokio::test]

--- a/crates/crab-remote-git/README.md
+++ b/crates/crab-remote-git/README.md
@@ -11,6 +11,8 @@ Caller: authorize and resolve physical placement
   -> RepositoryIdentity + RemoteGitRuntime
   -> RemoteGitRepository::open
        manifest generation + pack inventory + locator coverage
+     or RemoteGitRepository::from_snapshot
+       validated manifest + committed journal overlay
   -> OperationContext: shared budgets and cancellation
        snapshot -> tree / blob / history / diff
   -> OperationContext::finish: result + locator close
@@ -27,6 +29,7 @@ open, but selecting a snapshot returns `EmptyRepository`.
 | --- | --- | --- |
 | Shared admission and caches | `RemoteGitRuntime` | Process-wide; shut down after active contexts finish or drop |
 | Open a repository | `RemoteGitRepository::open` | Caller supplies authorized physical placement identity |
+| Open a committed journal view | `RemoteGitRepository::from_snapshot` | Caller supplies a validated snapshot, retention, and freshness policy; no catalog required |
 | Reuse a handle | `is_current` | Checks manifest identity; journal freshness can require reopening |
 | Select a revision | `refs`, `resolve`, `snapshot` | Selection stays within pinned visible refs |
 | Browse content | `entry`, `list_directory`, `list_tree_recursive`, `read_blob` | Paths are opaque `GitPath` bytes; blob reads return Git representation |

--- a/crates/crab-remote-git/REFERENCE.md
+++ b/crates/crab-remote-git/REFERENCE.md
@@ -31,6 +31,8 @@ The supported entry points are:
 - `RemoteGitRuntime`: process-wide bounded caches, origin/decode admission, and
   metrics;
 - `RemoteGitRepository::open`: generation-consistent repository open;
+- `RemoteGitRepository::from_snapshot`: immutable committed-journal repository
+  view without locator publication, for callers that own retention and freshness;
 - `RemoteGitRepository::is_current`: metadata-only manifest identity check for
   safely reusing a pinned immutable handle;
 - `RemoteGitRepository::operation`: one typed operation kind,
@@ -120,9 +122,11 @@ Archive traversal produces one entry at a time; its pending tree work is bounded
 by the verified tree-object limit.
 
 Services may keep a bounded cache of cloned immutable repository handles.
-`is_current` detects manifest changes only; observing uncompacted journal commits
-requires reopening after the freshness interval. A changed manifest always
-requires a new complete open handshake; cached state is never refreshed in place.
+`is_current` detects manifest changes only. Services that must observe
+uncompacted commits capture a validated repository snapshot and open it through
+`from_snapshot`; its snapshot digest isolates journal-specific cache entries. A
+changed snapshot requires a new immutable handle; cached state is never refreshed
+in place.
 
 ### Generated response packs
 

--- a/crates/crab-remote-git/src/repository.rs
+++ b/crates/crab-remote-git/src/repository.rs
@@ -292,6 +292,35 @@ impl OperationContext {
     pub async fn from_snapshot(
         layout: StoreLayout<Store>,
         snapshot: &crab_metadata::manifest_store::RepositorySnapshot,
+        identity: RepositoryIdentity,
+        runtime: Arc<RemoteGitRuntime>,
+        options: RepositoryOptions,
+        cancellation: &CancellationToken,
+    ) -> Result<Self> {
+        RemoteGitRepository::from_snapshot(
+            layout,
+            snapshot,
+            identity,
+            runtime,
+            options,
+            cancellation,
+        )
+        .await?
+        .operation(OperationKind::Repository, cancellation)
+        .await
+    }
+}
+
+impl RemoteGitRepository {
+    /// Open an immutable repository view from a validated metadata snapshot.
+    ///
+    /// This path consumes committed ref-journal transactions directly and does
+    /// not require locator publication or journal compaction. The caller must
+    /// retain the referenced immutable objects and revalidate freshness before
+    /// using this view for a write decision.
+    pub async fn from_snapshot(
+        layout: StoreLayout<Store>,
+        snapshot: &crab_metadata::manifest_store::RepositorySnapshot,
         mut identity: RepositoryIdentity,
         runtime: Arc<RemoteGitRuntime>,
         options: RepositoryOptions,
@@ -318,7 +347,7 @@ impl OperationContext {
         let manifest = snapshot.materialized_manifest();
         let refs = RepositoryRefs::try_from(&manifest)?;
         let inventory = parse_inventory(&snapshot.journal.packs)?;
-        let reader = RemoteGitReader::from_pinned(
+        let reader = Arc::new(RemoteGitReader::from_pinned(
             layout.store().clone(),
             layout.repo_prefix(),
             inventory.values().copied(),
@@ -326,28 +355,28 @@ impl OperationContext {
             Arc::clone(&runtime),
             identity.clone(),
             manifest.generation,
-        )?;
-        let state = RepositoryState {
-            store: layout.store().clone(),
-            layout,
-            runtime,
-            identity,
-            options,
-            generation: manifest.generation,
-            git_validation_digest: Arc::from(manifest.git_validation_digest.as_str()),
-            manifest_etag: snapshot.manifest_etag.clone(),
-            coverage: None,
-            inventory,
-            refs,
-            reader: Some(Arc::new(reader)),
-            commit_graph: None,
-            shallow_closure: None,
-        };
-        Self::open(Arc::new(state), OperationKind::Repository, cancellation).await
+        )?);
+        Ok(Self {
+            state: Arc::new(RepositoryState {
+                store: layout.store().clone(),
+                layout,
+                runtime,
+                identity,
+                options,
+                generation: manifest.generation,
+                git_validation_digest: Arc::from(manifest.git_validation_digest.as_str()),
+                manifest_etag: snapshot.manifest_etag.clone(),
+                coverage: None,
+                inventory,
+                refs,
+                reader: Some(reader),
+                commit_graph: None,
+                shallow_closure: None,
+            }),
+            generated_pack_lease_provider: None,
+        })
     }
-}
 
-impl RemoteGitRepository {
     /// Open one consistent repository generation from an authenticated store.
     ///
     /// The supplied cancellation token is checked around metadata I/O. Empty
@@ -1019,10 +1048,22 @@ impl RemoteGitRepository {
     ) -> Result<RemoteGitSnapshot> {
         let resolved = self.resolve(revision, operation).await?;
         let commit = operation.read_commit(resolved.commit).await?;
-        let coverage = self.state.coverage.ok_or(Error::EmptyRepository)?;
+        let pack_index_hash = match self.state.coverage {
+            Some(coverage) => coverage.pack_index_hash,
+            None if self.state.reader.is_some() => self
+                .state
+                .identity
+                .snapshot_digest
+                .as_deref()
+                .ok_or(Error::InternalInvariant {
+                    invariant: "journal-backed repository view has no snapshot identity",
+                })
+                .and_then(parse_merkle_hash)?,
+            None => return Err(Error::EmptyRepository),
+        };
         Ok(RemoteGitSnapshot {
             generation: self.state.generation,
-            pack_index_hash: coverage.pack_index_hash,
+            pack_index_hash,
             commit_oid: commit.oid,
             root_tree_oid: commit.tree,
             repository: Arc::clone(&self.state),

--- a/crates/crab-remote-git/tests/remote_repository.rs
+++ b/crates/crab-remote-git/tests/remote_repository.rs
@@ -1054,7 +1054,7 @@ async fn canonical_snapshot_reads_deltas_without_catalog_or_remote_mutation() {
         }
         let runtime = Arc::new(RemoteGitRuntime::default());
         fixture.backend.mutations.store(0, Ordering::SeqCst);
-        let operation = crab_remote_git::OperationContext::from_snapshot(
+        let repository = RemoteGitRepository::from_snapshot(
             fixture.layout.clone(),
             &snapshot,
             fixture.repository.identity().clone(),
@@ -1064,6 +1064,17 @@ async fn canonical_snapshot_reads_deltas_without_catalog_or_remote_mutation() {
         )
         .await
         .expect("open without catalog");
+        let operation = repository
+            .operation(OperationKind::Repository, &CancellationToken::new())
+            .await
+            .expect("journal-backed operation");
+        repository
+            .snapshot(
+                &Revision::parse("refs/heads/main").expect("main revision"),
+                &operation,
+            )
+            .await
+            .expect("journal-backed branch snapshot");
         let result = operation.read_object(fixture.target).await;
         let object = operation
             .finish(result)

--- a/crates/crab-s3-gateway/Cargo.toml
+++ b/crates/crab-s3-gateway/Cargo.toml
@@ -47,3 +47,4 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = "1"
+url = "2.5"

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -22,6 +22,11 @@ and part inspection APIs. Path-style addressing is always available. Set
 multipart parts support up to 5 GiB, and multipart completion supports S3's
 50 TB object limit.
 Large payloads use bounded-memory spooling and Crab's verified LFS content path.
+Objects already stored as Crab/Xet pointers retain Xet deduplication: partial
+GET and copy-source ranges limit reconstruction to overlapping Xet chunks and
+stream the selected bytes through bounded temporary storage. Low-coverage cold
+reads fetch bounded xorb ranges; the cache may fetch a complete verified xorb
+for high-coverage reads. Complete GETs retain whole-file verification.
 The complete frozen surface and deliberate exclusions are in the protocol
 contract linked below.
 

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -14,8 +14,9 @@ The initial client-compatible surface includes bucket listing/head, object
 GET/HEAD/PUT/DELETE/COPY, V1/V2 object listing, multi-delete, and durable
 multipart create/upload/copy/list/abort/complete. GET/HEAD support conditions
 and a single byte range; PUT validates Content-MD5 and the standard S3 checksum
-headers. Path-style addressing is required. Single PUTs and multipart parts
-support up to 5 GiB, and multipart completion supports S3's 50 TB object limit.
+headers, and supports atomic create with `If-None-Match: *`. Path-style
+addressing is required. Single PUTs and multipart parts support up to 5 GiB,
+and multipart completion supports S3's 50 TB object limit.
 Large payloads use bounded-memory spooling and Crab's verified LFS content path.
 The complete frozen surface and deliberate exclusions are in the protocol
 contract linked below.

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -37,11 +37,12 @@ path-local attribute delta. Immutable pack, index, visibility, and attribute
 artifacts are prepared and uploaded before the destination ref lease; the lease
 contains only branch revalidation and journal publication. Same-ref requests are
 admitted through a bounded FIFO queue, while different refs may prepare in
-parallel. Successful journal publication is immediately readable by the gateway;
-catalog compaction and commit-graph maintenance continue in the background.
-Maintenance is coalesced until the repository's local write burst is idle so a
-later journal wave never advances from a generation whose visibility proof is
-still being finalized.
+parallel. A new write cancels in-flight derived maintenance so foreground traffic
+does not wait behind catalog or commit-graph work. Successful journal publication
+is immediately readable by the gateway; catalog compaction and commit-graph
+maintenance continue after the write burst becomes idle. Maintenance is
+coalesced so a later journal wave never advances from a generation whose
+visibility proof is still being finalized.
 
 ## Build and run
 

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -10,13 +10,17 @@ each access key to a Crab principal and authorizes that principal against the
 logical repository catalog. Gateway credentials are independent of the cloud
 credentials used for the backing object store.
 
-The initial client-compatible surface includes bucket listing/head, object
-GET/HEAD/PUT/DELETE/COPY, V1/V2 object listing, multi-delete, and durable
-multipart create/upload/copy/list/abort/complete. GET/HEAD support conditions
-and a single byte range; PUT validates Content-MD5 and the standard S3 checksum
-headers, and supports atomic create with `If-None-Match: *`. Path-style
-addressing is required. Single PUTs and multipart parts support up to 5 GiB,
-and multipart completion supports S3's 50 TB object limit.
+The client-compatible surface includes bucket listing/head/location/versioning
+discovery, object GET/HEAD/PUT/DELETE/COPY/attributes/tagging, V1/V2 object
+listing, multi-delete, and durable multipart create/upload/copy/list/abort/complete.
+GET/HEAD support conditions, checksum mode, and a single byte range. PUT and
+multipart completion support atomic `If-Match` and `If-None-Match: *` writes.
+Content-MD5 and modeled S3 checksum headers are validated and persisted;
+multipart full-object and composite checksum profiles are returned by object
+and part inspection APIs. Path-style addressing is always available. Set
+`endpoint_domain` to also accept virtual-hosted requests. Single PUTs and
+multipart parts support up to 5 GiB, and multipart completion supports S3's
+50 TB object limit.
 Large payloads use bounded-memory spooling and Crab's verified LFS content path.
 The complete frozen surface and deliberate exclusions are in the protocol
 contract linked below.
@@ -37,6 +41,11 @@ The backing provider uses Crab's existing environment credential chain. Set
 the usual AWS, GCP, or Azure credentials for the selected provider. For an
 S3-compatible endpoint, `AWS_ENDPOINT_URL_S3`, `AWS_ALLOW_HTTP`, and
 `AWS_VIRTUAL_HOSTED_STYLE_REQUEST` are supported by the shared storage layer.
+
+`endpoint_domain` is the gateway's public host name, without a scheme. When it
+is set, both `https://endpoint.example/repository/key` and
+`https://repository.endpoint.example/key` address the same logical bucket.
+The deployment's DNS and TLS certificate must cover the wildcard host.
 
 See `s3-gateway.example.toml` for configuration and
 `crab/docs/architecture/s3-gateway-contract.md` for the protocol contract.

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -25,6 +25,24 @@ Large payloads use bounded-memory spooling and Crab's verified LFS content path.
 The complete frozen surface and deliberate exclusions are in the protocol
 contract linked below.
 
+## Read and write performance model
+
+Requests share immutable repository read views keyed by the compacted generation
+and committed journal state. Ref snapshots, parsed Git trees, and S3 attributes
+are singleflight-cached inside that view. HEAD and attributed LIST requests use
+the committed size and ETag without opening blob payloads.
+
+Each mutation rewrites only the target path's ancestor trees and persists one
+path-local attribute delta. Immutable pack, index, visibility, and attribute
+artifacts are prepared and uploaded before the destination ref lease; the lease
+contains only branch revalidation and journal publication. Same-ref requests are
+admitted through a bounded FIFO queue, while different refs may prepare in
+parallel. Successful journal publication is immediately readable by the gateway;
+catalog compaction and commit-graph maintenance continue in the background.
+Maintenance is coalesced until the repository's local write burst is idle so a
+later journal wave never advances from a generation whose visibility proof is
+still being finalized.
+
 ## Build and run
 
 ```sh

--- a/crates/crab-s3-gateway/s3-gateway.example.toml
+++ b/crates/crab-s3-gateway/s3-gateway.example.toml
@@ -1,5 +1,8 @@
 listen = "127.0.0.1:8080"
 region = "us-east-1"
+# Set to the public host (and port, when non-default) to also accept
+# virtual-hosted requests such as repository.example.s3.crab.build.
+# endpoint_domain = "s3.crab.build"
 
 [[credentials]]
 access_key = "replace-with-issued-access-key"

--- a/crates/crab-s3-gateway/src/attributes.rs
+++ b/crates/crab-s3-gateway/src/attributes.rs
@@ -9,6 +9,32 @@ use crate::gateway::Repository;
 const VERSION: u32 = 1;
 const MAX_MANIFEST_BYTES: u64 = 32 * 1024 * 1024;
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Checksums {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) crc32: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) crc32c: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) crc64nvme: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) sha1: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) checksum_type: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PartAttributes {
+    pub(crate) number: i32,
+    pub(crate) size: u64,
+    #[serde(default, skip_serializing_if = "Checksums::is_empty")]
+    pub(crate) checksums: Checksums,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct PutAttributes {
@@ -18,6 +44,12 @@ pub(crate) struct PutAttributes {
     pub(crate) completion_upload_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) logical_size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Checksums::is_empty")]
+    pub(crate) checksums: Checksums,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) tags: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) parts: Vec<PartAttributes>,
     pub(crate) cache_control: Option<String>,
     pub(crate) content_disposition: Option<String>,
     pub(crate) content_encoding: Option<String>,
@@ -36,6 +68,12 @@ pub(crate) struct ObjectAttributes {
     pub(crate) modified_seconds: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) completion_upload_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Checksums::is_empty")]
+    pub(crate) checksums: Checksums,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) tags: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) parts: Vec<PartAttributes>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) cache_control: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -66,6 +104,9 @@ impl ObjectAttributes {
             size,
             modified_seconds,
             completion_upload_id: pending.completion_upload_id,
+            checksums: pending.checksums,
+            tags: pending.tags,
+            parts: pending.parts,
             cache_control: pending.cache_control,
             content_disposition: pending.content_disposition,
             content_encoding: pending.content_encoding,
@@ -80,6 +121,9 @@ impl ObjectAttributes {
         self.etag == etag
             && self.size == size
             && self.completion_upload_id == pending.completion_upload_id
+            && self.checksums == pending.checksums
+            && self.tags == pending.tags
+            && self.parts == pending.parts
             && self.cache_control == pending.cache_control
             && self.content_disposition == pending.content_disposition
             && self.content_encoding == pending.content_encoding
@@ -87,6 +131,16 @@ impl ObjectAttributes {
             && self.content_type == pending.content_type
             && self.expires == pending.expires
             && self.metadata == pending.metadata
+    }
+}
+
+impl Checksums {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.crc32.is_none()
+            && self.crc32c.is_none()
+            && self.crc64nvme.is_none()
+            && self.sha1.is_none()
+            && self.sha256.is_none()
     }
 }
 

--- a/crates/crab-s3-gateway/src/attributes.rs
+++ b/crates/crab-s3-gateway/src/attributes.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr as _};
 
 use bytes::Bytes;
 use gix_hash::ObjectId;
@@ -6,8 +6,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::gateway::Repository;
 
-const VERSION: u32 = 1;
+const VERSION: u32 = 2;
+const LEGACY_VERSION: u32 = 1;
 const MAX_MANIFEST_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_DELTA_DEPTH: usize = 1_000_000;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -144,20 +146,25 @@ impl Checksums {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct Manifest {
+    objects: BTreeMap<String, ObjectAttributes>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyManifest {
     version: u32,
     objects: BTreeMap<String, ObjectAttributes>,
 }
 
-impl Default for Manifest {
-    fn default() -> Self {
-        Self {
-            version: VERSION,
-            objects: BTreeMap::new(),
-        }
-    }
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Delta {
+    version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    parent: Option<String>,
+    changes: BTreeMap<String, Option<ObjectAttributes>>,
 }
 
 impl Manifest {
@@ -167,16 +174,112 @@ impl Manifest {
             .filter(|attributes| attributes.blob_oid == oid.to_string())
     }
 
-    pub(crate) fn put(&mut self, path: String, attributes: ObjectAttributes) {
-        self.objects.insert(path, attributes);
-    }
-
-    pub(crate) fn remove(&mut self, path: &str) {
-        self.objects.remove(path);
+    fn apply(&mut self, changes: BTreeMap<String, Option<ObjectAttributes>>) {
+        for (path, attributes) in changes {
+            match attributes {
+                Some(attributes) => {
+                    self.objects.insert(path, attributes);
+                }
+                None => {
+                    self.objects.remove(&path);
+                }
+            }
+        }
     }
 }
 
 pub(crate) async fn load(repository: &Repository, commit: ObjectId) -> crate::Result<Manifest> {
+    let mut current = Some(commit);
+    let mut deltas = Vec::new();
+    let mut manifest = Manifest::default();
+    while let Some(commit) = current {
+        if deltas.len() >= MAX_DELTA_DEPTH {
+            return Err(crate::Error::Config("S3 attribute delta chain is too deep"));
+        }
+        match load_stored(repository, commit).await? {
+            None => break,
+            Some(Stored::Legacy(legacy)) => {
+                manifest.objects = legacy.objects;
+                break;
+            }
+            Some(Stored::Delta(delta)) => {
+                current = parse_parent(delta.parent.as_deref())?;
+                deltas.push(delta.changes);
+            }
+        }
+    }
+    for changes in deltas.into_iter().rev() {
+        manifest.apply(changes);
+    }
+    Ok(manifest)
+}
+
+pub(crate) async fn load_object(
+    repository: &Repository,
+    commit: ObjectId,
+    path: &str,
+    oid: ObjectId,
+) -> crate::Result<Option<ObjectAttributes>> {
+    let mut current = Some(commit);
+    for _ in 0..MAX_DELTA_DEPTH {
+        let Some(commit) = current else {
+            return Ok(None);
+        };
+        match load_stored(repository, commit).await? {
+            None => return Ok(None),
+            Some(Stored::Legacy(legacy)) => {
+                return Ok(legacy
+                    .objects
+                    .get(path)
+                    .filter(|attributes| attributes.blob_oid == oid.to_string())
+                    .cloned());
+            }
+            Some(Stored::Delta(delta)) => {
+                if let Some(attributes) = delta.changes.get(path) {
+                    return Ok(attributes
+                        .as_ref()
+                        .filter(|attributes| attributes.blob_oid == oid.to_string())
+                        .cloned());
+                }
+                current = parse_parent(delta.parent.as_deref())?;
+            }
+        }
+    }
+    Err(crate::Error::Config("S3 attribute delta chain is too deep"))
+}
+
+pub(crate) async fn save_delta(
+    repository: &Repository,
+    commit: ObjectId,
+    parent: Option<ObjectId>,
+    path: String,
+    attributes: Option<ObjectAttributes>,
+) -> crate::Result<()> {
+    let target = repository
+        .layout
+        .repo_path(&format!("s3/attributes/{commit}.json"));
+    let bytes = serde_json::to_vec(&Delta {
+        version: VERSION,
+        parent: parent.map(|oid| oid.to_string()),
+        changes: BTreeMap::from([(path, attributes)]),
+    })
+    .map_err(|source| crate::Error::Attributes { source })?;
+    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        return Err(crate::Error::Config("S3 attribute delta exceeds 32 MiB"));
+    }
+    repository
+        .store
+        .put_exact(&target, Bytes::from(bytes))
+        .await?;
+    Ok(())
+}
+
+enum Stored {
+    Legacy(LegacyManifest),
+    Delta(Delta),
+}
+
+async fn load_stored(repository: &Repository, commit: ObjectId) -> crate::Result<Option<Stored>> {
     let path = repository
         .layout
         .repo_path(&format!("s3/attributes/{commit}.json"));
@@ -186,35 +289,40 @@ pub(crate) async fn load(repository: &Repository, commit: ObjectId) -> crate::Re
         .await
     {
         Ok((bytes, _)) => bytes,
-        Err(crab_storage::StorageError::NotFound { .. }) => return Ok(Manifest::default()),
+        Err(crab_storage::StorageError::NotFound { .. }) => return Ok(None),
         Err(error) => return Err(error.into()),
     };
-    let manifest: Manifest =
-        serde_json::from_slice(&bytes).map_err(|source| crate::Error::Attributes { source })?;
-    if manifest.version != VERSION {
-        return Err(crate::Error::Config(
+    let version = serde_json::from_slice::<serde_json::Value>(&bytes)
+        .map_err(|source| crate::Error::Attributes { source })?
+        .get("version")
+        .and_then(serde_json::Value::as_u64);
+    match version {
+        Some(value) if value == u64::from(VERSION) => serde_json::from_slice(&bytes)
+            .map(Stored::Delta)
+            .map_err(|source| crate::Error::Attributes { source }),
+        // Version 1 is a persisted migration seam from the first gateway
+        // release. New commits always write path-local version 2 deltas.
+        Some(value) if value == u64::from(LEGACY_VERSION) => serde_json::from_slice(&bytes)
+            .map(Stored::Legacy)
+            .map_err(|source| crate::Error::Attributes { source }),
+        _ => Err(crate::Error::Config(
             "unsupported S3 attribute manifest version",
-        ));
+        )),
     }
-    Ok(manifest)
+    .and_then(|stored| match &stored {
+        Stored::Legacy(value) if value.version != LEGACY_VERSION => Err(crate::Error::Config(
+            "unsupported S3 attribute manifest version",
+        )),
+        Stored::Delta(value) if value.version != VERSION => Err(crate::Error::Config(
+            "unsupported S3 attribute manifest version",
+        )),
+        Stored::Legacy(_) | Stored::Delta(_) => Ok(Some(stored)),
+    })
 }
 
-pub(crate) async fn save(
-    repository: &Repository,
-    commit: ObjectId,
-    manifest: &Manifest,
-) -> crate::Result<()> {
-    let path = repository
-        .layout
-        .repo_path(&format!("s3/attributes/{commit}.json"));
-    let bytes =
-        serde_json::to_vec(manifest).map_err(|source| crate::Error::Attributes { source })?;
-    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
-        return Err(crate::Error::Config("S3 attribute manifest exceeds 32 MiB"));
-    }
-    repository
-        .store
-        .put_exact(&path, Bytes::from(bytes))
-        .await?;
-    Ok(())
+fn parse_parent(value: Option<&str>) -> crate::Result<Option<ObjectId>> {
+    value
+        .map(ObjectId::from_str)
+        .transpose()
+        .map_err(|_| crate::Error::Config("S3 attribute delta parent is corrupt"))
 }

--- a/crates/crab-s3-gateway/src/config.rs
+++ b/crates/crab-s3-gateway/src/config.rs
@@ -14,6 +14,8 @@ use crate::{Error, Result};
 #[serde(deny_unknown_fields)]
 pub struct Config {
     pub listen: SocketAddr,
+    /// Base domain used to accept both path-style and virtual-hosted requests.
+    pub endpoint_domain: Option<String>,
     #[serde(default = "default_region")]
     pub region: String,
     pub credentials: Vec<CredentialConfig>,
@@ -85,6 +87,9 @@ impl Config {
                 .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
         {
             return Err(Error::Config("region must be a non-empty AWS region name"));
+        }
+        if let Some(domain) = self.endpoint_domain.as_deref() {
+            s3s::host::SingleDomain::new(domain)?;
         }
         let mut access_keys = HashSet::new();
         let mut configured_principals = HashSet::new();

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -10,8 +10,8 @@ use bytes::Bytes;
 use crab_cache_store::{CacheConfig, CachingStore};
 use crab_git::pointer_detect::PointerKind;
 use crab_remote_git::{
-    ContentClassification, EntryKind, OperationKind, RemoteGitRepository, RemoteGitRuntime,
-    RepositoryIdentity, RepositoryOptions, Revision,
+    ContentClassification, EntryKind, OperationKind, RemoteGitRuntime, RepositoryIdentity,
+    RepositoryOptions,
 };
 use crab_storage::{StorageProviderKind, Store, StoreLayout, build_static_env_store};
 use futures_util::StreamExt as _;
@@ -26,6 +26,8 @@ pub(crate) struct Repository {
     pub(crate) store: Store,
     pub(crate) layout: StoreLayout<Store>,
     pub(crate) identity: RepositoryIdentity,
+    pub(crate) read_views: crate::repository::ReadViewCache,
+    pub(crate) maintenance: Arc<crate::repository::WriteMaintenance>,
     hydrator: crab_read::ShardHydrator,
     lfs: crab_lfs::LfsObjectStore,
 }
@@ -47,6 +49,8 @@ impl Repository {
                 config.prefix.clone(),
                 1,
             )?,
+            read_views: crate::repository::ReadViewCache::new(),
+            maintenance: Arc::new(crate::repository::WriteMaintenance::new()),
             config,
             store,
             layout,
@@ -67,6 +71,7 @@ pub(crate) struct Gateway {
     repositories: Arc<BTreeMap<String, Repository>>,
     runtime: Arc<RemoteGitRuntime>,
     options: RepositoryOptions,
+    mutations: Arc<mutation::Coordinator>,
     auth: GatewayAuth,
     region: Arc<str>,
     admission: Arc<Semaphore>,
@@ -74,8 +79,15 @@ pub(crate) struct Gateway {
 }
 
 struct ReadObject {
-    blob_oid: gix_hash::ObjectId,
     content: ReadContent,
+    size: u64,
+    etag: String,
+    modified: Timestamp,
+    attributes: Option<crate::attributes::ObjectAttributes>,
+}
+
+struct ReadObjectMetadata {
+    blob_oid: gix_hash::ObjectId,
     size: u64,
     etag: String,
     modified: Timestamp,
@@ -210,10 +222,13 @@ impl Gateway {
             let repository = Repository::new(entry.clone(), store)?;
             repositories.insert(entry.name.clone(), repository);
         }
+        let runtime = Arc::new(RemoteGitRuntime::default());
+        let options = RepositoryOptions::default();
         Ok(Self {
             repositories: Arc::new(repositories),
-            runtime: Arc::new(RemoteGitRuntime::default()),
-            options: RepositoryOptions::default(),
+            mutations: Arc::new(mutation::Coordinator::new(Arc::clone(&runtime), options)),
+            runtime,
+            options,
             auth,
             region,
             admission: Arc::new(Semaphore::new(32)),
@@ -292,32 +307,32 @@ impl Gateway {
         }
     }
 
-    async fn open(&self, repository: &Repository) -> S3Result<RemoteGitRepository> {
-        crate::repository::open_current(
-            repository,
-            Arc::clone(&self.runtime),
-            self.options,
-            &self.cancellation,
-        )
-        .await
-        .map_err(gateway_error)
+    async fn open(&self, repository: &Repository) -> S3Result<Arc<crate::repository::ReadView>> {
+        repository
+            .read_views
+            .current(
+                repository,
+                Arc::clone(&self.runtime),
+                self.options,
+                &self.cancellation,
+            )
+            .await
+            .map_err(gateway_error)
     }
 
     async fn read_object(&self, repository: &Repository, key: &str) -> S3Result<ReadObject> {
         let address = namespace::object_address(key).map_err(namespace_error)?;
         let repo = self.open(repository).await?;
         let operation = repo
+            .remote()
             .operation(OperationKind::Repository, &self.cancellation)
             .await
             .map_err(remote_error)?;
         let result = async {
             let snapshot = repo
-                .snapshot(
-                    &Revision::parse(&address.reference).map_err(remote_error)?,
-                    &operation,
-                )
+                .snapshot(&address.reference, &operation)
                 .await
-                .map_err(remote_error)?;
+                .map_err(gateway_error)?;
             let commit = snapshot.commit(&operation).await.map_err(remote_error)?;
             let blob = snapshot
                 .read_blob(&address.path, &operation)
@@ -326,7 +341,8 @@ impl Gateway {
             if blob.metadata.kind != EntryKind::Blob {
                 return Err(s3_error!(InvalidObjectState));
             }
-            let manifest = crate::attributes::load(repository, snapshot.commit_oid())
+            let manifest = repo
+                .attributes(repository, snapshot.commit_oid())
                 .await
                 .map_err(gateway_error)?;
             let path = std::str::from_utf8(address.path.as_bytes())
@@ -337,7 +353,6 @@ impl Gateway {
                 .and_then(|value| i64::try_from(value.modified_seconds).ok())
                 .unwrap_or(commit.committer.seconds);
             let modified = timestamp(modified_seconds)?;
-            let blob_oid = blob.metadata.oid;
             let (content, size) = classify_blob(blob)?;
             let etag = match attributes.as_ref() {
                 Some(value) => value.etag.clone(),
@@ -350,12 +365,80 @@ impl Gateway {
                 },
             };
             Ok(ReadObject {
-                blob_oid,
                 content,
                 size,
                 etag,
                 modified,
                 attributes,
+            })
+        }
+        .await;
+        finish(operation, result).await
+    }
+
+    async fn read_object_metadata(
+        &self,
+        repository: &Repository,
+        key: &str,
+    ) -> S3Result<ReadObjectMetadata> {
+        let address = namespace::object_address(key).map_err(namespace_error)?;
+        let view = self.open(repository).await?;
+        let operation = view
+            .remote()
+            .operation(OperationKind::Repository, &self.cancellation)
+            .await
+            .map_err(remote_error)?;
+        let result = async {
+            let snapshot = view
+                .snapshot(&address.reference, &operation)
+                .await
+                .map_err(gateway_error)?;
+            let entry = snapshot
+                .entry(&address.path, &operation)
+                .await
+                .map_err(remote_error)?
+                .ok_or_else(|| s3_error!(NoSuchKey))?;
+            if entry.kind != EntryKind::Blob {
+                return Err(s3_error!(InvalidObjectState));
+            }
+            let path = std::str::from_utf8(address.path.as_bytes())
+                .map_err(|_| s3_error!(InvalidObjectState))?;
+            let attributes = view
+                .object_attributes(repository, snapshot.commit_oid(), path, entry.oid)
+                .await
+                .map_err(gateway_error)?;
+            if let Some(attributes) = attributes {
+                return Ok(ReadObjectMetadata {
+                    blob_oid: entry.oid,
+                    size: attributes.size,
+                    etag: attributes.etag.clone(),
+                    modified: timestamp(
+                        i64::try_from(attributes.modified_seconds)
+                            .map_err(|_| s3_error!(InternalError))?,
+                    )?,
+                    attributes: Some(attributes),
+                });
+            }
+            let commit = snapshot.commit(&operation).await.map_err(remote_error)?;
+            let blob = snapshot
+                .read_blob(&address.path, &operation)
+                .await
+                .map_err(remote_error)?;
+            let blob_oid = blob.metadata.oid;
+            let (content, size) = classify_blob(blob)?;
+            let etag = match &content {
+                ReadContent::Ordinary(bytes) => md5_hex(bytes),
+                ReadContent::CrabPointer(_) | ReadContent::LfsPointer(_) => {
+                    let spool = content.spool(repository, 0..size, u64::MAX).await?;
+                    crate::content::md5_hex(&spool.digests.md5)
+                }
+            };
+            Ok(ReadObjectMetadata {
+                blob_oid,
+                size,
+                etag,
+                modified: timestamp(commit.committer.seconds)?,
+                attributes: None,
             })
         }
         .await;
@@ -416,7 +499,7 @@ impl Gateway {
             return Err(s3_error!(InvalidRequest, "Conflicting write preconditions"));
         }
         if let Some(condition) = if_match {
-            let object = match self.read_object(repository, key).await {
+            let object = match self.read_object_metadata(repository, key).await {
                 Ok(object) => object,
                 Err(error) if error.code().as_str() == "NoSuchKey" => {
                     return Err(s3_error!(PreconditionFailed));
@@ -727,7 +810,9 @@ impl S3 for Gateway {
             .map_err(|_| s3_error!(SlowDown))?;
         reject_head_extensions(&req.input)?;
         let repository = self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
-        let object = self.read_object(repository, &req.input.key).await?;
+        let object = self
+            .read_object_metadata(repository, &req.input.key)
+            .await?;
         let tag_count = tag_count(object.attributes.as_ref())?;
         evaluate_conditions(
             req.input.if_match.as_ref(),
@@ -834,39 +919,39 @@ impl S3 for Gateway {
         let stored_checksums = checksums.stored(&spool.digests);
         let etag = crate::content::md5_hex(&spool.digests.md5);
         let bytes = mutation_bytes(repository, &spool).await?;
-        let outcome = mutation::apply(
-            repository,
-            Arc::clone(&self.runtime),
-            self.options,
-            address
-                .branch
-                .as_deref()
-                .ok_or_else(|| s3_error!(MethodNotAllowed))?,
-            &address.path,
-            mutation::Change::Put {
-                bytes,
-                attributes: Box::new(crate::attributes::PutAttributes {
-                    etag_override: Some(etag),
-                    completion_upload_id: None,
-                    logical_size: Some(spool.size),
-                    checksums: stored_checksums.clone(),
-                    tags: parse_tagging_header(req.input.tagging.as_deref())?,
-                    parts: Vec::new(),
-                    cache_control: req.input.cache_control,
-                    content_disposition: req.input.content_disposition,
-                    content_encoding: req.input.content_encoding,
-                    content_language: req.input.content_language,
-                    content_type: req.input.content_type,
-                    expires: req.input.expires,
-                    metadata: req.input.metadata.unwrap_or_default().into_iter().collect(),
-                }),
-                condition,
-            },
-            &principal,
-            &self.cancellation,
-        )
-        .await
-        .map_err(mutation_error)?;
+        let outcome = self
+            .mutations
+            .apply(
+                repository,
+                address
+                    .branch
+                    .as_deref()
+                    .ok_or_else(|| s3_error!(MethodNotAllowed))?,
+                &address.path,
+                mutation::Change::Put {
+                    bytes,
+                    attributes: Box::new(crate::attributes::PutAttributes {
+                        etag_override: Some(etag),
+                        completion_upload_id: None,
+                        logical_size: Some(spool.size),
+                        checksums: stored_checksums.clone(),
+                        tags: parse_tagging_header(req.input.tagging.as_deref())?,
+                        parts: Vec::new(),
+                        cache_control: req.input.cache_control,
+                        content_disposition: req.input.content_disposition,
+                        content_encoding: req.input.content_encoding,
+                        content_language: req.input.content_language,
+                        content_type: req.input.content_type,
+                        expires: req.input.expires,
+                        metadata: req.input.metadata.unwrap_or_default().into_iter().collect(),
+                    }),
+                    condition,
+                },
+                &principal,
+                &self.cancellation,
+            )
+            .await
+            .map_err(mutation_error)?;
         Ok(S3Response::new(PutObjectOutput {
             e_tag: outcome.etag.map(ETag::Strong),
             checksum_crc32: stored_checksums.crc32,
@@ -905,7 +990,9 @@ impl S3 for Gateway {
             return Err(s3_error!(InvalidArgument));
         }
         let repository = self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
-        let object = self.read_object(repository, &req.input.key).await?;
+        let object = self
+            .read_object_metadata(repository, &req.input.key)
+            .await?;
         let requested = object_attribute_names(&req.input.object_attributes);
         if requested.iter().any(|value| {
             !matches!(
@@ -965,7 +1052,9 @@ impl S3 for Gateway {
             return Err(s3_error!(NotImplemented));
         }
         let repository = self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
-        let object = self.read_object(repository, &req.input.key).await?;
+        let object = self
+            .read_object_metadata(repository, &req.input.key)
+            .await?;
         let tags = object
             .attributes
             .map(|value| value.tags)
@@ -1011,7 +1100,9 @@ impl S3 for Gateway {
                 })
                 .collect::<S3Result<Vec<_>>>()?,
         )?;
-        let object = self.read_object(repository, &req.input.key).await?;
+        let object = self
+            .read_object_metadata(repository, &req.input.key)
+            .await?;
         let mut attributes = object
             .attributes
             .as_ref()
@@ -1020,24 +1111,23 @@ impl S3 for Gateway {
         attributes.etag_override = Some(object.etag);
         attributes.logical_size = Some(object.size);
         attributes.tags = tags;
-        mutation::apply(
-            repository,
-            Arc::clone(&self.runtime),
-            self.options,
-            address
-                .branch
-                .as_deref()
-                .ok_or_else(|| s3_error!(MethodNotAllowed))?,
-            &address.path,
-            mutation::Change::Attributes {
-                expected: object.blob_oid,
-                attributes: Box::new(attributes),
-            },
-            &principal,
-            &self.cancellation,
-        )
-        .await
-        .map_err(mutation_error)?;
+        self.mutations
+            .apply(
+                repository,
+                address
+                    .branch
+                    .as_deref()
+                    .ok_or_else(|| s3_error!(MethodNotAllowed))?,
+                &address.path,
+                mutation::Change::Attributes {
+                    expected: object.blob_oid,
+                    attributes: Box::new(attributes),
+                },
+                &principal,
+                &self.cancellation,
+            )
+            .await
+            .map_err(mutation_error)?;
         Ok(S3Response::new(PutObjectTaggingOutput::default()))
     }
 
@@ -1054,7 +1144,9 @@ impl S3 for Gateway {
         }
         let (repository, address, principal) =
             self.writable_address(&req, &req.input.bucket, &req.input.key)?;
-        let object = self.read_object(repository, &req.input.key).await?;
+        let object = self
+            .read_object_metadata(repository, &req.input.key)
+            .await?;
         let mut attributes = object
             .attributes
             .as_ref()
@@ -1063,24 +1155,23 @@ impl S3 for Gateway {
         attributes.etag_override = Some(object.etag);
         attributes.logical_size = Some(object.size);
         attributes.tags.clear();
-        mutation::apply(
-            repository,
-            Arc::clone(&self.runtime),
-            self.options,
-            address
-                .branch
-                .as_deref()
-                .ok_or_else(|| s3_error!(MethodNotAllowed))?,
-            &address.path,
-            mutation::Change::Attributes {
-                expected: object.blob_oid,
-                attributes: Box::new(attributes),
-            },
-            &principal,
-            &self.cancellation,
-        )
-        .await
-        .map_err(mutation_error)?;
+        self.mutations
+            .apply(
+                repository,
+                address
+                    .branch
+                    .as_deref()
+                    .ok_or_else(|| s3_error!(MethodNotAllowed))?,
+                &address.path,
+                mutation::Change::Attributes {
+                    expected: object.blob_oid,
+                    attributes: Box::new(attributes),
+                },
+                &principal,
+                &self.cancellation,
+            )
+            .await
+            .map_err(mutation_error)?;
         Ok(S3Response::new(DeleteObjectTaggingOutput::default()))
     }
 
@@ -1095,21 +1186,20 @@ impl S3 for Gateway {
         reject_delete_extensions(&req.input)?;
         let (repository, address, principal) =
             self.writable_address(&req, &req.input.bucket, &req.input.key)?;
-        mutation::apply(
-            repository,
-            Arc::clone(&self.runtime),
-            self.options,
-            address
-                .branch
-                .as_deref()
-                .ok_or_else(|| s3_error!(MethodNotAllowed))?,
-            &address.path,
-            mutation::Change::Delete,
-            &principal,
-            &self.cancellation,
-        )
-        .await
-        .map_err(mutation_error)?;
+        self.mutations
+            .apply(
+                repository,
+                address
+                    .branch
+                    .as_deref()
+                    .ok_or_else(|| s3_error!(MethodNotAllowed))?,
+                &address.path,
+                mutation::Change::Delete,
+                &principal,
+                &self.cancellation,
+            )
+            .await
+            .map_err(mutation_error)?;
         Ok(S3Response::new(DeleteObjectOutput::default()))
     }
 
@@ -1159,18 +1249,17 @@ impl S3 for Gateway {
             let result = async {
                 let address = namespace::object_address(&key).map_err(namespace_error)?;
                 let branch = writable_branch(repository, &address)?;
-                mutation::apply(
-                    repository,
-                    Arc::clone(&self.runtime),
-                    self.options,
-                    branch,
-                    &address.path,
-                    mutation::Change::Delete,
-                    &principal,
-                    &self.cancellation,
-                )
-                .await
-                .map_err(mutation_error)
+                self.mutations
+                    .apply(
+                        repository,
+                        branch,
+                        &address.path,
+                        mutation::Change::Delete,
+                        &principal,
+                        &self.cancellation,
+                    )
+                    .await
+                    .map_err(mutation_error)
             }
             .await;
             match result {
@@ -1317,25 +1406,25 @@ impl S3 for Gateway {
         };
         let response_checksums = attributes.checksums.clone();
         let bytes = mutation_bytes(repository, &spool).await?;
-        let outcome = mutation::apply(
-            repository,
-            Arc::clone(&self.runtime),
-            self.options,
-            address
-                .branch
-                .as_deref()
-                .ok_or_else(|| s3_error!(MethodNotAllowed))?,
-            &address.path,
-            mutation::Change::Put {
-                bytes,
-                attributes: Box::new(attributes),
-                condition: mutation::PutCondition::None,
-            },
-            &principal,
-            &self.cancellation,
-        )
-        .await
-        .map_err(mutation_error)?;
+        let outcome = self
+            .mutations
+            .apply(
+                repository,
+                address
+                    .branch
+                    .as_deref()
+                    .ok_or_else(|| s3_error!(MethodNotAllowed))?,
+                &address.path,
+                mutation::Change::Put {
+                    bytes,
+                    attributes: Box::new(attributes),
+                    condition: mutation::PutCondition::None,
+                },
+                &principal,
+                &self.cancellation,
+            )
+            .await
+            .map_err(mutation_error)?;
         Ok(S3Response::new(CopyObjectOutput {
             copy_object_result: Some(CopyObjectResult {
                 e_tag: outcome.etag.map(ETag::Strong),
@@ -1772,22 +1861,21 @@ impl S3 for Gateway {
             .collect();
         let address = namespace::object_address(&session.key).map_err(namespace_error)?;
         let bytes = mutation_bytes(repository, &spool).await?;
-        mutation::apply(
-            repository,
-            Arc::clone(&self.runtime),
-            self.options,
-            &session.branch,
-            &address.path,
-            mutation::Change::Put {
-                bytes,
-                attributes: Box::new(attributes),
-                condition,
-            },
-            &principal,
-            &self.cancellation,
-        )
-        .await
-        .map_err(mutation_error)?;
+        self.mutations
+            .apply(
+                repository,
+                &session.branch,
+                &address.path,
+                mutation::Change::Put {
+                    bytes,
+                    attributes: Box::new(attributes),
+                    condition,
+                },
+                &principal,
+                &self.cancellation,
+            )
+            .await
+            .map_err(mutation_error)?;
         let loaded = crate::multipart::load(repository, &session.id)
             .await
             .map_err(multipart_error)?;
@@ -2111,20 +2199,19 @@ impl S3 for Gateway {
         };
         let repo = self.open(repository).await?;
         let operation = repo
+            .remote()
             .operation(OperationKind::Repository, &self.cancellation)
             .await
             .map_err(remote_error)?;
         let result = async {
             let snapshot = repo
-                .snapshot(
-                    &Revision::parse(&reference).map_err(remote_error)?,
-                    &operation,
-                )
+                .snapshot(&reference, &operation)
                 .await
-                .map_err(remote_error)?;
+                .map_err(gateway_error)?;
             let commit = snapshot.commit(&operation).await.map_err(remote_error)?;
             let commit_modified = timestamp(commit.committer.seconds)?;
-            let attribute_manifest = crate::attributes::load(repository, snapshot.commit_oid())
+            let attribute_manifest = repo
+                .attributes(repository, snapshot.commit_oid())
                 .await
                 .map_err(gateway_error)?;
             let encoded_ref = prefix
@@ -2146,10 +2233,6 @@ impl S3 for Gateway {
                 if !key.starts_with(prefix) {
                     continue;
                 }
-                let blob = snapshot
-                    .read_blob(&entry.path, &operation)
-                    .await
-                    .map_err(remote_error)?;
                 let attributes = attribute_manifest.object(path, entry.oid);
                 let modified = match attributes {
                     Some(attributes) => timestamp(
@@ -2158,12 +2241,16 @@ impl S3 for Gateway {
                     )?,
                     None => commit_modified.clone(),
                 };
-                let (content, logical_size) = classify_blob(blob)?;
-                let etag = match attributes {
-                    Some(attributes) => attributes.etag.clone(),
+                let (etag, logical_size) = match attributes {
+                    Some(attributes) => (attributes.etag.clone(), attributes.size),
                     None => {
+                        let blob = snapshot
+                            .read_blob(&entry.path, &operation)
+                            .await
+                            .map_err(remote_error)?;
+                        let (content, logical_size) = classify_blob(blob)?;
                         let spool = content.spool(repository, 0..logical_size, u64::MAX).await?;
-                        crate::content::md5_hex(&spool.digests.md5)
+                        (crate::content::md5_hex(&spool.digests.md5), logical_size)
                     }
                 };
                 keys.push((key, etag, Some(logical_size), modified));
@@ -3088,6 +3175,7 @@ impl Gateway {
         let url_encode = list_url_encoding(req.input.encoding_type.as_ref())?;
         let repo = self.open(repository).await?;
         let mut keys = repo
+            .remote()
             .refs()
             .entries
             .iter()
@@ -3266,6 +3354,9 @@ fn mutation_error(error: mutation::Error) -> s3s::S3Error {
             s3_error!(InvalidObjectState)
         }
         mutation::Error::Cancelled => s3_error!(RequestTimeout),
+        mutation::Error::Overloaded | mutation::Error::AdmissionTimeout => {
+            s3_error!(SlowDown)
+        }
         mutation::Error::PreconditionFailed => s3_error!(PreconditionFailed),
         mutation::Error::Write(crab_write::WriteError::RefChanged { .. }) => {
             s3_error!(

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -728,6 +728,7 @@ impl S3 for Gateway {
         reject_head_extensions(&req.input)?;
         let repository = self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
         let object = self.read_object(repository, &req.input.key).await?;
+        let tag_count = tag_count(object.attributes.as_ref())?;
         evaluate_conditions(
             req.input.if_match.as_ref(),
             req.input.if_none_match.as_ref(),
@@ -747,7 +748,7 @@ impl S3 for Gateway {
             selection.checksums.as_ref(),
         )?;
         let content_length = selection.range.end - selection.range.start;
-        Ok(S3Response::new(HeadObjectOutput {
+        let mut response = S3Response::new(HeadObjectOutput {
             accept_ranges: Some("bytes".to_owned()),
             content_length: Some(
                 i64::try_from(content_length).map_err(|_| s3_error!(InternalError))?,
@@ -791,7 +792,15 @@ impl S3 for Gateway {
                 .attributes
                 .map(|value| value.metadata.into_iter().collect()),
             ..Default::default()
-        }))
+        });
+        if let Some(tag_count) = tag_count {
+            response.headers.insert(
+                "x-amz-tagging-count",
+                http::HeaderValue::from_str(&tag_count.to_string())
+                    .map_err(|_| s3_error!(InternalError))?,
+            );
+        }
+        Ok(response)
     }
 
     async fn put_object(

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -118,7 +118,7 @@ impl ReadContent {
         range: std::ops::Range<u64>,
     ) -> S3Result<ContentStream> {
         use futures_util::{StreamExt as _, TryStreamExt as _};
-        use tokio::io::{AsyncReadExt as _, AsyncSeekExt as _};
+        use tokio::io::AsyncReadExt as _;
 
         match self {
             Self::Ordinary(bytes) => {
@@ -147,15 +147,19 @@ impl ReadContent {
                 };
                 let directory = tempfile::tempdir().map_err(|error| gateway_error(error.into()))?;
                 let path = directory.path().join("content");
-                repository
-                    .hydrator
-                    .reconstruct_to_path(&pointer, &path)
-                    .await
-                    .map_err(|error| gateway_error(error.into()))?;
-                let mut file = tokio::fs::File::open(path)
-                    .await
-                    .map_err(|error| gateway_error(error.into()))?;
-                file.seek(std::io::SeekFrom::Start(range.start))
+                if range.start == 0 && range.end == pointer.size {
+                    repository
+                        .hydrator
+                        .reconstruct_to_path(&pointer, &path)
+                        .await
+                } else {
+                    repository
+                        .hydrator
+                        .reconstruct_range_to_path(&pointer, range.start, range.end, &path)
+                        .await
+                }
+                .map_err(|error| gateway_error(error.into()))?;
+                let file = tokio::fs::File::open(path)
                     .await
                     .map_err(|error| gateway_error(error.into()))?;
                 let reader = tokio_util::io::ReaderStream::new(file.take(range.end - range.start));

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -701,6 +701,7 @@ impl S3 for Gateway {
             .try_acquire()
             .map_err(|_| s3_error!(SlowDown))?;
         reject_put_extensions(&req.input)?;
+        let condition = put_condition(&req.input)?;
         let (repository, address, principal) =
             self.writable_address(&req, &req.input.bucket, &req.input.key)?;
         let content_length = req.input.content_length;
@@ -742,6 +743,7 @@ impl S3 for Gateway {
                     expires: req.input.expires,
                     metadata: req.input.metadata.unwrap_or_default().into_iter().collect(),
                 }),
+                condition,
             },
             &principal,
             &self.cancellation,
@@ -973,6 +975,7 @@ impl S3 for Gateway {
             mutation::Change::Put {
                 bytes,
                 attributes: Box::new(attributes),
+                condition: mutation::PutCondition::None,
             },
             &principal,
             &self.cancellation,
@@ -1283,6 +1286,7 @@ impl S3 for Gateway {
             mutation::Change::Put {
                 bytes,
                 attributes: Box::new(attributes),
+                condition: mutation::PutCondition::None,
             },
             &principal,
             &self.cancellation,
@@ -1770,7 +1774,6 @@ fn reject_put_extensions(input: &PutObjectInput) -> S3Result<()> {
         || input.grant_read_acp.is_some()
         || input.grant_write_acp.is_some()
         || input.if_match.is_some()
-        || input.if_none_match.is_some()
         || input.object_lock_legal_hold_status.is_some()
         || input.object_lock_mode.is_some()
         || input.object_lock_retain_until_date.is_some()
@@ -1789,6 +1792,14 @@ fn reject_put_extensions(input: &PutObjectInput) -> S3Result<()> {
         return Err(s3_error!(NotImplemented));
     }
     Ok(())
+}
+
+fn put_condition(input: &PutObjectInput) -> S3Result<mutation::PutCondition> {
+    match input.if_none_match.as_ref() {
+        None => Ok(mutation::PutCondition::None),
+        Some(ETagCondition::Any) => Ok(mutation::PutCondition::IfNoneMatchAny),
+        Some(ETagCondition::ETag(_)) => Err(s3_error!(NotImplemented)),
+    }
 }
 
 #[derive(Clone)]
@@ -2255,6 +2266,7 @@ fn mutation_error(error: mutation::Error) -> s3s::S3Error {
             s3_error!(InvalidObjectState)
         }
         mutation::Error::Cancelled => s3_error!(RequestTimeout),
+        mutation::Error::PreconditionFailed => s3_error!(PreconditionFailed),
         mutation::Error::Write(crab_write::WriteError::RefChanged { .. }) => {
             s3_error!(
                 OperationAborted,

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -74,11 +74,19 @@ pub(crate) struct Gateway {
 }
 
 struct ReadObject {
+    blob_oid: gix_hash::ObjectId,
     content: ReadContent,
     size: u64,
     etag: String,
     modified: Timestamp,
     attributes: Option<crate::attributes::ObjectAttributes>,
+}
+
+struct ReadSelection {
+    range: std::ops::Range<u64>,
+    content_range: Option<String>,
+    parts_count: Option<i32>,
+    checksums: Option<crate::attributes::Checksums>,
 }
 
 #[derive(Clone)]
@@ -329,6 +337,7 @@ impl Gateway {
                 .and_then(|value| i64::try_from(value.modified_seconds).ok())
                 .unwrap_or(commit.committer.seconds);
             let modified = timestamp(modified_seconds)?;
+            let blob_oid = blob.metadata.oid;
             let (content, size) = classify_blob(blob)?;
             let etag = match attributes.as_ref() {
                 Some(value) => value.etag.clone(),
@@ -341,6 +350,7 @@ impl Gateway {
                 },
             };
             Ok(ReadObject {
+                blob_oid,
                 content,
                 size,
                 etag,
@@ -378,6 +388,56 @@ impl Gateway {
             ));
         }
         Ok((repository, address, principal))
+    }
+
+    async fn put_condition(
+        &self,
+        repository: &Repository,
+        key: &str,
+        input: &PutObjectInput,
+    ) -> S3Result<mutation::PutCondition> {
+        self.put_condition_values(
+            repository,
+            key,
+            input.if_match.clone(),
+            input.if_none_match.clone(),
+        )
+        .await
+    }
+
+    async fn put_condition_values(
+        &self,
+        repository: &Repository,
+        key: &str,
+        if_match: Option<ETagCondition>,
+        if_none_match: Option<ETagCondition>,
+    ) -> S3Result<mutation::PutCondition> {
+        if if_match.is_some() && if_none_match.is_some() {
+            return Err(s3_error!(InvalidRequest, "Conflicting write preconditions"));
+        }
+        if let Some(condition) = if_match {
+            let object = match self.read_object(repository, key).await {
+                Ok(object) => object,
+                Err(error) if error.code().as_str() == "NoSuchKey" => {
+                    return Err(s3_error!(PreconditionFailed));
+                }
+                Err(error) => return Err(error),
+            };
+            let actual = ETag::Strong(object.etag);
+            let matches = match condition {
+                ETagCondition::Any => true,
+                ETagCondition::ETag(expected) => actual.strong_cmp(&expected),
+            };
+            if !matches {
+                return Err(s3_error!(PreconditionFailed));
+            }
+            return Ok(mutation::PutCondition::IfMatch(object.blob_oid));
+        }
+        match if_none_match {
+            None => Ok(mutation::PutCondition::None),
+            Some(ETagCondition::Any) => Ok(mutation::PutCondition::IfNoneMatchAny),
+            Some(ETagCondition::ETag(_)) => Err(s3_error!(InvalidRequest)),
+        }
     }
 }
 
@@ -523,6 +583,41 @@ impl S3 for Gateway {
         Ok(response)
     }
 
+    async fn get_bucket_location(
+        &self,
+        req: S3Request<GetBucketLocationInput>,
+    ) -> S3Result<S3Response<GetBucketLocationOutput>> {
+        let _permit = self
+            .admission
+            .try_acquire()
+            .map_err(|_| s3_error!(SlowDown))?;
+        if req.input.expected_bucket_owner.is_some() {
+            return Err(s3_error!(NotImplemented));
+        }
+        self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
+        Ok(S3Response::new(GetBucketLocationOutput {
+            location_constraint: (self.region.as_ref() != "us-east-1")
+                .then(|| BucketLocationConstraint::from(self.region.to_string())),
+        }))
+    }
+
+    async fn get_bucket_versioning(
+        &self,
+        req: S3Request<GetBucketVersioningInput>,
+    ) -> S3Result<S3Response<GetBucketVersioningOutput>> {
+        let _permit = self
+            .admission
+            .try_acquire()
+            .map_err(|_| s3_error!(SlowDown))?;
+        if req.input.expected_bucket_owner.is_some() {
+            return Err(s3_error!(NotImplemented));
+        }
+        self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
+        // An empty response is S3's representation for a bucket that has never
+        // enabled versioning. Crab refs remain a separate namespace contract.
+        Ok(S3Response::new(GetBucketVersioningOutput::default()))
+    }
+
     async fn get_object(
         &self,
         req: S3Request<GetObjectInput>,
@@ -534,6 +629,7 @@ impl S3 for Gateway {
         reject_get_extensions(&req.input)?;
         let repository = self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
         let object = self.read_object(repository, &req.input.key).await?;
+        let tag_count = tag_count(object.attributes.as_ref())?;
         evaluate_conditions(
             req.input.if_match.as_ref(),
             req.input.if_none_match.as_ref(),
@@ -542,19 +638,17 @@ impl S3 for Gateway {
             &object.etag,
             &object.modified,
         )?;
-        let checked = req
-            .input
-            .range
-            .as_ref()
-            .map(|range| range.check(object.size))
-            .transpose()?;
-        let (range, content_range) = match checked {
-            Some(range) => {
-                let header = format!("bytes {}-{}/{}", range.start, range.end - 1, object.size);
-                (range.start..range.end, Some(header))
-            }
-            None => (0..object.size, None),
-        };
+        let selection = read_selection(
+            object.size,
+            object.attributes.as_ref(),
+            req.input.range.as_ref(),
+            req.input.part_number,
+        )?;
+        let response_checksums = response_checksums(
+            req.input.checksum_mode.as_ref(),
+            selection.checksums.as_ref(),
+        )?;
+        let range = selection.range;
         let content_length =
             i64::try_from(range.end - range.start).map_err(|_| s3_error!(InternalError))?;
         let body = object.content.stream(repository, range).await?;
@@ -564,7 +658,7 @@ impl S3 for Gateway {
             accept_ranges: Some("bytes".to_owned()),
             body: Some(StreamingBlob::from(s3s::Body::http_body_unsync(body))),
             content_length: Some(content_length),
-            content_range,
+            content_range: selection.content_range,
             content_type: req
                 .input
                 .response_content_type
@@ -606,7 +700,15 @@ impl S3 for Gateway {
                     .and_then(|value| value.expires.clone())
             }),
             e_tag: Some(ETag::Strong(object.etag)),
+            checksum_crc32: response_checksums.crc32,
+            checksum_crc32c: response_checksums.crc32c,
+            checksum_crc64nvme: response_checksums.crc64nvme,
+            checksum_sha1: response_checksums.sha1,
+            checksum_sha256: response_checksums.sha256,
+            checksum_type: response_checksums.checksum_type.map(ChecksumType::from),
             last_modified: Some(object.modified),
+            parts_count: selection.parts_count,
+            tag_count,
             metadata: object
                 .attributes
                 .map(|value| value.metadata.into_iter().collect()),
@@ -634,30 +736,23 @@ impl S3 for Gateway {
             &object.etag,
             &object.modified,
         )?;
-        let checked = req
-            .input
-            .range
-            .as_ref()
-            .map(|range| range.check(object.size))
-            .transpose()?;
-        let (content_length, content_range) = match checked {
-            Some(range) => (
-                range.end - range.start,
-                Some(format!(
-                    "bytes {}-{}/{}",
-                    range.start,
-                    range.end - 1,
-                    object.size
-                )),
-            ),
-            None => (object.size, None),
-        };
+        let selection = read_selection(
+            object.size,
+            object.attributes.as_ref(),
+            req.input.range.as_ref(),
+            req.input.part_number,
+        )?;
+        let response_checksums = response_checksums(
+            req.input.checksum_mode.as_ref(),
+            selection.checksums.as_ref(),
+        )?;
+        let content_length = selection.range.end - selection.range.start;
         Ok(S3Response::new(HeadObjectOutput {
             accept_ranges: Some("bytes".to_owned()),
             content_length: Some(
                 i64::try_from(content_length).map_err(|_| s3_error!(InternalError))?,
             ),
-            content_range,
+            content_range: selection.content_range,
             cache_control: object
                 .attributes
                 .as_ref()
@@ -680,11 +775,18 @@ impl S3 for Gateway {
                 .and_then(|value| value.content_type.clone())
                 .or_else(|| Some("application/octet-stream".to_owned())),
             e_tag: Some(ETag::Strong(object.etag)),
+            checksum_crc32: response_checksums.crc32,
+            checksum_crc32c: response_checksums.crc32c,
+            checksum_crc64nvme: response_checksums.crc64nvme,
+            checksum_sha1: response_checksums.sha1,
+            checksum_sha256: response_checksums.sha256,
+            checksum_type: response_checksums.checksum_type.map(ChecksumType::from),
             expires: object
                 .attributes
                 .as_ref()
                 .and_then(|value| value.expires.clone()),
             last_modified: Some(object.modified),
+            parts_count: selection.parts_count,
             metadata: object
                 .attributes
                 .map(|value| value.metadata.into_iter().collect()),
@@ -701,9 +803,11 @@ impl S3 for Gateway {
             .try_acquire()
             .map_err(|_| s3_error!(SlowDown))?;
         reject_put_extensions(&req.input)?;
-        let condition = put_condition(&req.input)?;
         let (repository, address, principal) =
             self.writable_address(&req, &req.input.bucket, &req.input.key)?;
+        let condition = self
+            .put_condition(repository, &req.input.key, &req.input)
+            .await?;
         let content_length = req.input.content_length;
         let content_md5 = req.input.content_md5.clone();
         let mut checksums = RequestChecksums::from(&req.input);
@@ -718,6 +822,7 @@ impl S3 for Gateway {
         checksums.merge_trailers(trailing_headers.as_ref())?;
         verify_content_md5(&spool.digests.md5, content_md5.as_deref())?;
         checksums.verify(&spool.digests)?;
+        let stored_checksums = checksums.stored(&spool.digests);
         let etag = crate::content::md5_hex(&spool.digests.md5);
         let bytes = mutation_bytes(repository, &spool).await?;
         let outcome = mutation::apply(
@@ -735,6 +840,9 @@ impl S3 for Gateway {
                     etag_override: Some(etag),
                     completion_upload_id: None,
                     logical_size: Some(spool.size),
+                    checksums: stored_checksums.clone(),
+                    tags: parse_tagging_header(req.input.tagging.as_deref())?,
+                    parts: Vec::new(),
                     cache_control: req.input.cache_control,
                     content_disposition: req.input.content_disposition,
                     content_encoding: req.input.content_encoding,
@@ -752,17 +860,219 @@ impl S3 for Gateway {
         .map_err(mutation_error)?;
         Ok(S3Response::new(PutObjectOutput {
             e_tag: outcome.etag.map(ETag::Strong),
-            checksum_crc32: checksums.crc32,
-            checksum_crc32c: checksums.crc32c,
-            checksum_crc64nvme: checksums.crc64nvme,
-            checksum_sha1: checksums.sha1,
-            checksum_sha256: checksums.sha256,
-            checksum_type: checksums
-                .algorithm
-                .as_ref()
-                .map(|_| ChecksumType::from_static(ChecksumType::FULL_OBJECT)),
+            checksum_crc32: stored_checksums.crc32,
+            checksum_crc32c: stored_checksums.crc32c,
+            checksum_crc64nvme: stored_checksums.crc64nvme,
+            checksum_sha1: stored_checksums.sha1,
+            checksum_sha256: stored_checksums.sha256,
+            checksum_type: stored_checksums.checksum_type.map(ChecksumType::from),
             ..Default::default()
         }))
+    }
+
+    async fn get_object_attributes(
+        &self,
+        req: S3Request<GetObjectAttributesInput>,
+    ) -> S3Result<S3Response<GetObjectAttributesOutput>> {
+        let _permit = self
+            .admission
+            .try_acquire()
+            .map_err(|_| s3_error!(SlowDown))?;
+        if req.input.expected_bucket_owner.is_some()
+            || req.input.request_payer.is_some()
+            || req.input.sse_customer_algorithm.is_some()
+            || req.input.sse_customer_key.is_some()
+            || req.input.sse_customer_key_md5.is_some()
+            || req.input.version_id.is_some()
+        {
+            return Err(s3_error!(NotImplemented));
+        }
+        if req
+            .input
+            .max_parts
+            .is_some_and(|value| !(1..=1000).contains(&value))
+            || req.input.part_number_marker.is_some_and(|value| value < 0)
+        {
+            return Err(s3_error!(InvalidArgument));
+        }
+        let repository = self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
+        let object = self.read_object(repository, &req.input.key).await?;
+        let requested = object_attribute_names(&req.input.object_attributes);
+        if requested.iter().any(|value| {
+            !matches!(
+                *value,
+                ObjectAttributes::CHECKSUM
+                    | ObjectAttributes::ETAG
+                    | ObjectAttributes::OBJECT_PARTS
+                    | ObjectAttributes::OBJECT_SIZE
+                    | ObjectAttributes::STORAGE_CLASS
+            )
+        }) {
+            return Err(s3_error!(InvalidArgument));
+        }
+        let checksum = requested
+            .contains(ObjectAttributes::CHECKSUM)
+            .then(|| {
+                object
+                    .attributes
+                    .as_ref()
+                    .map(|value| checksum_dto(&value.checksums))
+            })
+            .flatten();
+        let object_parts = requested
+            .contains(ObjectAttributes::OBJECT_PARTS)
+            .then(|| object.attributes.as_ref().map(|value| &value.parts))
+            .flatten()
+            .filter(|parts| !parts.is_empty())
+            .map(|parts| object_parts(parts, req.input.part_number_marker, req.input.max_parts))
+            .transpose()?;
+        Ok(S3Response::new(GetObjectAttributesOutput {
+            checksum,
+            e_tag: requested
+                .contains(ObjectAttributes::ETAG)
+                .then_some(ETag::Strong(object.etag)),
+            last_modified: Some(object.modified),
+            object_parts,
+            object_size: requested
+                .contains(ObjectAttributes::OBJECT_SIZE)
+                .then(|| i64::try_from(object.size).map_err(|_| s3_error!(InternalError)))
+                .transpose()?,
+            ..Default::default()
+        }))
+    }
+
+    async fn get_object_tagging(
+        &self,
+        req: S3Request<GetObjectTaggingInput>,
+    ) -> S3Result<S3Response<GetObjectTaggingOutput>> {
+        let _permit = self
+            .admission
+            .try_acquire()
+            .map_err(|_| s3_error!(SlowDown))?;
+        if req.input.expected_bucket_owner.is_some()
+            || req.input.request_payer.is_some()
+            || req.input.version_id.is_some()
+        {
+            return Err(s3_error!(NotImplemented));
+        }
+        let repository = self.repository(&req, &req.input.bucket, RepositoryAccess::Read)?;
+        let object = self.read_object(repository, &req.input.key).await?;
+        let tags = object
+            .attributes
+            .map(|value| value.tags)
+            .unwrap_or_default();
+        Ok(S3Response::new(GetObjectTaggingOutput {
+            tag_set: tags
+                .into_iter()
+                .map(|(key, value)| Tag {
+                    key: Some(key),
+                    value: Some(value),
+                })
+                .collect(),
+            ..Default::default()
+        }))
+    }
+
+    async fn put_object_tagging(
+        &self,
+        req: S3Request<PutObjectTaggingInput>,
+    ) -> S3Result<S3Response<PutObjectTaggingOutput>> {
+        let _permit = self
+            .admission
+            .try_acquire()
+            .map_err(|_| s3_error!(SlowDown))?;
+        if req.input.expected_bucket_owner.is_some()
+            || req.input.request_payer.is_some()
+            || req.input.version_id.is_some()
+        {
+            return Err(s3_error!(NotImplemented));
+        }
+        let (repository, address, principal) =
+            self.writable_address(&req, &req.input.bucket, &req.input.key)?;
+        let tags = validate_tags(
+            req.input
+                .tagging
+                .tag_set
+                .into_iter()
+                .map(|tag| {
+                    Ok((
+                        tag.key.ok_or_else(|| s3_error!(InvalidTag))?,
+                        tag.value.ok_or_else(|| s3_error!(InvalidTag))?,
+                    ))
+                })
+                .collect::<S3Result<Vec<_>>>()?,
+        )?;
+        let object = self.read_object(repository, &req.input.key).await?;
+        let mut attributes = object
+            .attributes
+            .as_ref()
+            .map(stored_to_pending)
+            .unwrap_or_default();
+        attributes.etag_override = Some(object.etag);
+        attributes.logical_size = Some(object.size);
+        attributes.tags = tags;
+        mutation::apply(
+            repository,
+            Arc::clone(&self.runtime),
+            self.options,
+            address
+                .branch
+                .as_deref()
+                .ok_or_else(|| s3_error!(MethodNotAllowed))?,
+            &address.path,
+            mutation::Change::Attributes {
+                expected: object.blob_oid,
+                attributes: Box::new(attributes),
+            },
+            &principal,
+            &self.cancellation,
+        )
+        .await
+        .map_err(mutation_error)?;
+        Ok(S3Response::new(PutObjectTaggingOutput::default()))
+    }
+
+    async fn delete_object_tagging(
+        &self,
+        req: S3Request<DeleteObjectTaggingInput>,
+    ) -> S3Result<S3Response<DeleteObjectTaggingOutput>> {
+        let _permit = self
+            .admission
+            .try_acquire()
+            .map_err(|_| s3_error!(SlowDown))?;
+        if req.input.expected_bucket_owner.is_some() || req.input.version_id.is_some() {
+            return Err(s3_error!(NotImplemented));
+        }
+        let (repository, address, principal) =
+            self.writable_address(&req, &req.input.bucket, &req.input.key)?;
+        let object = self.read_object(repository, &req.input.key).await?;
+        let mut attributes = object
+            .attributes
+            .as_ref()
+            .map(stored_to_pending)
+            .unwrap_or_default();
+        attributes.etag_override = Some(object.etag);
+        attributes.logical_size = Some(object.size);
+        attributes.tags.clear();
+        mutation::apply(
+            repository,
+            Arc::clone(&self.runtime),
+            self.options,
+            address
+                .branch
+                .as_deref()
+                .ok_or_else(|| s3_error!(MethodNotAllowed))?,
+            &address.path,
+            mutation::Change::Attributes {
+                expected: object.blob_oid,
+                attributes: Box::new(attributes),
+            },
+            &principal,
+            &self.cancellation,
+        )
+        .await
+        .map_err(mutation_error)?;
+        Ok(S3Response::new(DeleteObjectTaggingOutput::default()))
     }
 
     async fn delete_object(
@@ -945,6 +1255,9 @@ impl S3 for Gateway {
                 etag_override: None,
                 completion_upload_id: None,
                 logical_size: None,
+                checksums: crate::attributes::Checksums::default(),
+                tags: BTreeMap::new(),
+                parts: Vec::new(),
                 cache_control: req.input.cache_control,
                 content_disposition: req.input.content_disposition,
                 content_encoding: req.input.content_encoding,
@@ -960,8 +1273,40 @@ impl S3 for Gateway {
                 .map(stored_to_pending)
                 .unwrap_or_default()
         };
+        // A copy creates a new S3 object version even when the source came
+        // from multipart upload; completion identity and part layout remain
+        // properties of the source object only.
+        attributes.completion_upload_id = None;
+        attributes.parts.clear();
+        let replace_tags = req
+            .input
+            .tagging_directive
+            .as_ref()
+            .is_some_and(|value| value.as_str() == TaggingDirective::REPLACE);
+        if req.input.tagging.is_some() && !replace_tags {
+            return Err(s3_error!(InvalidRequest));
+        }
+        attributes.tags = if replace_tags {
+            parse_tagging_header(req.input.tagging.as_deref())?
+        } else {
+            source_object
+                .attributes
+                .as_ref()
+                .map(|value| value.tags.clone())
+                .unwrap_or_default()
+        };
         attributes.etag_override = Some(crate::content::md5_hex(&spool.digests.md5));
         attributes.logical_size = Some(spool.size);
+        attributes.checksums = match req.input.checksum_algorithm.as_ref() {
+            Some(algorithm) => calculated_checksums(&spool.digests, algorithm.as_str())?,
+            None => source_object
+                .attributes
+                .as_ref()
+                .map(|value| value.checksums.clone())
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| default_checksums(&spool.digests)),
+        };
+        let response_checksums = attributes.checksums.clone();
         let bytes = mutation_bytes(repository, &spool).await?;
         let outcome = mutation::apply(
             repository,
@@ -985,6 +1330,12 @@ impl S3 for Gateway {
         Ok(S3Response::new(CopyObjectOutput {
             copy_object_result: Some(CopyObjectResult {
                 e_tag: outcome.etag.map(ETag::Strong),
+                checksum_crc32: response_checksums.crc32,
+                checksum_crc32c: response_checksums.crc32c,
+                checksum_crc64nvme: response_checksums.crc64nvme,
+                checksum_sha1: response_checksums.sha1,
+                checksum_sha256: response_checksums.sha256,
+                checksum_type: response_checksums.checksum_type.map(ChecksumType::from),
                 last_modified: Some(timestamp(
                     i64::try_from(
                         std::time::SystemTime::now()
@@ -994,7 +1345,6 @@ impl S3 for Gateway {
                     )
                     .map_err(|_| s3_error!(InternalError))?,
                 )?),
-                ..Default::default()
             }),
             ..Default::default()
         }))
@@ -1009,6 +1359,10 @@ impl S3 for Gateway {
             .try_acquire()
             .map_err(|_| s3_error!(SlowDown))?;
         reject_create_multipart_extensions(&req.input)?;
+        let (checksum_algorithm, checksum_type) = multipart_checksum_profile(
+            req.input.checksum_algorithm.as_ref(),
+            req.input.checksum_type.as_ref(),
+        )?;
         let (repository, address, principal) =
             self.writable_address(&req, &req.input.bucket, &req.input.key)?;
         let branch = address
@@ -1019,30 +1373,42 @@ impl S3 for Gateway {
             std::str::from_utf8(address.path.as_bytes()).map_err(|_| s3_error!(InvalidArgument))?;
         let session = crate::multipart::create(
             repository,
-            &req.input.bucket,
-            &req.input.key,
-            branch,
-            path,
-            &principal,
-            crate::attributes::PutAttributes {
-                etag_override: None,
-                completion_upload_id: None,
-                logical_size: None,
-                cache_control: req.input.cache_control,
-                content_disposition: req.input.content_disposition,
-                content_encoding: req.input.content_encoding,
-                content_language: req.input.content_language,
-                content_type: req.input.content_type,
-                expires: req.input.expires,
-                metadata: req.input.metadata.unwrap_or_default().into_iter().collect(),
+            crate::multipart::Initiation {
+                bucket: &req.input.bucket,
+                key: &req.input.key,
+                branch,
+                path,
+                principal: &principal,
+                attributes: crate::attributes::PutAttributes {
+                    etag_override: None,
+                    completion_upload_id: None,
+                    logical_size: None,
+                    checksums: crate::attributes::Checksums::default(),
+                    tags: parse_tagging_header(req.input.tagging.as_deref())?,
+                    parts: Vec::new(),
+                    cache_control: req.input.cache_control,
+                    content_disposition: req.input.content_disposition,
+                    content_encoding: req.input.content_encoding,
+                    content_language: req.input.content_language,
+                    content_type: req.input.content_type,
+                    expires: req.input.expires,
+                    metadata: req.input.metadata.unwrap_or_default().into_iter().collect(),
+                },
+                checksum_algorithm,
+                checksum_type,
+                now: now_seconds()?,
             },
-            now_seconds()?,
         )
         .await
         .map_err(multipart_error)?;
         Ok(S3Response::new(CreateMultipartUploadOutput {
             bucket: Some(req.input.bucket),
             key: Some(req.input.key),
+            checksum_algorithm: session
+                .checksum_algorithm
+                .clone()
+                .map(ChecksumAlgorithm::from),
+            checksum_type: session.checksum_type.clone().map(ChecksumType::from),
             upload_id: Some(session.id),
             ..Default::default()
         }))
@@ -1071,6 +1437,8 @@ impl S3 for Gateway {
         .map_err(multipart_error)?;
         let content_length = req.input.content_length;
         let content_md5 = req.input.content_md5.clone();
+        let mut checksums = RequestChecksums::from_upload_part(&req.input);
+        let trailing_headers = req.trailing_headers.clone();
         let spool = crate::content::spool_body(
             req.input.body,
             content_length,
@@ -1078,7 +1446,26 @@ impl S3 for Gateway {
         )
         .await
         .map_err(content_error)?;
+        checksums.merge_trailers(trailing_headers.as_ref())?;
+        checksums.ensure_single_value()?;
+        if let Some(algorithm) = loaded.session.checksum_algorithm.as_deref()
+            && (checksums
+                .algorithm
+                .as_ref()
+                .is_some_and(|requested| requested.as_str() != algorithm)
+                || (!checksums.values_empty() && !checksums.has_algorithm(algorithm))
+                || (loaded.session.checksum_type.as_deref() == Some(ChecksumType::COMPOSITE)
+                    && checksums.values_empty()))
+        {
+            return Err(s3_error!(
+                InvalidRequest,
+                "Multipart checksum algorithm mismatch"
+            ));
+        }
         verify_content_md5(&spool.digests.md5, content_md5.as_deref())?;
+        checksums.verify_values(&spool.digests)?;
+        let stored_checksums = checksums
+            .stored_for_algorithm(&spool.digests, loaded.session.checksum_algorithm.as_deref())?;
         let etag = crate::content::md5_hex(&spool.digests.md5);
         crate::multipart::register_part(
             repository,
@@ -1086,6 +1473,7 @@ impl S3 for Gateway {
             req.input.part_number,
             &spool,
             etag.clone(),
+            stored_checksums.clone(),
             now_seconds()?,
             &self.cancellation,
         )
@@ -1093,6 +1481,11 @@ impl S3 for Gateway {
         .map_err(multipart_error)?;
         Ok(S3Response::new(UploadPartOutput {
             e_tag: Some(ETag::Strong(etag)),
+            checksum_crc32: stored_checksums.crc32,
+            checksum_crc32c: stored_checksums.crc32c,
+            checksum_crc64nvme: stored_checksums.crc64nvme,
+            checksum_sha1: stored_checksums.sha1,
+            checksum_sha256: stored_checksums.sha256,
             ..Default::default()
         }))
     }
@@ -1159,6 +1552,13 @@ impl S3 for Gateway {
             &principal,
         )
         .map_err(multipart_error)?;
+        let part_checksums = loaded
+            .session
+            .checksum_algorithm
+            .as_deref()
+            .map(|algorithm| calculated_checksums(&spool.digests, algorithm))
+            .transpose()?
+            .unwrap_or_else(|| default_checksums(&spool.digests));
         let etag = crate::content::md5_hex(&spool.digests.md5);
         crate::multipart::register_part(
             repository,
@@ -1166,6 +1566,7 @@ impl S3 for Gateway {
             req.input.part_number,
             &spool,
             etag.clone(),
+            part_checksums.clone(),
             now_seconds()?,
             &self.cancellation,
         )
@@ -1174,10 +1575,14 @@ impl S3 for Gateway {
         Ok(S3Response::new(UploadPartCopyOutput {
             copy_part_result: Some(CopyPartResult {
                 e_tag: Some(ETag::Strong(etag)),
+                checksum_crc32: part_checksums.crc32,
+                checksum_crc32c: part_checksums.crc32c,
+                checksum_crc64nvme: part_checksums.crc64nvme,
+                checksum_sha1: part_checksums.sha1,
+                checksum_sha256: part_checksums.sha256,
                 last_modified: Some(timestamp(
                     i64::try_from(now_seconds()?).map_err(|_| s3_error!(InternalError))?,
                 )?),
-                ..Default::default()
             }),
             ..Default::default()
         }))
@@ -1192,6 +1597,12 @@ impl S3 for Gateway {
             .try_acquire()
             .map_err(|_| s3_error!(SlowDown))?;
         reject_complete_multipart_extensions(&req.input)?;
+        let if_match = req.input.if_match.clone();
+        let if_none_match = req.input.if_none_match.clone();
+        let completion_checksums = RequestChecksums::from_complete(&req.input);
+        completion_checksums.ensure_single_value()?;
+        let requested_checksum_type = req.input.checksum_type.clone();
+        let expected_size = req.input.mpu_object_size;
         let repository = self.repository(&req, &req.input.bucket, RepositoryAccess::Write)?;
         let principal = self.principal(&req)?.to_owned();
         let loaded = crate::multipart::load(repository, &req.input.upload_id)
@@ -1204,6 +1615,22 @@ impl S3 for Gateway {
             &principal,
         )
         .map_err(multipart_error)?;
+        if requested_checksum_type.as_ref().map(ChecksumType::as_str)
+            != loaded.session.checksum_type.as_deref()
+            && requested_checksum_type.is_some()
+        {
+            return Err(s3_error!(BadDigest));
+        }
+        if let Some(algorithm) = loaded.session.checksum_algorithm.as_deref()
+            && !completion_checksums.values_empty()
+            && !completion_checksums.has_algorithm(algorithm)
+        {
+            return Err(s3_error!(BadDigest));
+        }
+        let composite_algorithm = (loaded.session.checksum_type.as_deref()
+            == Some(ChecksumType::COMPOSITE))
+        .then(|| loaded.session.checksum_algorithm.clone())
+        .flatten();
         let selected = req
             .input
             .multipart_upload
@@ -1212,23 +1639,57 @@ impl S3 for Gateway {
             .into_iter()
             .map(|part| {
                 let number = part.part_number.ok_or_else(|| s3_error!(InvalidPart))?;
-                let etag = match part.e_tag.ok_or_else(|| s3_error!(InvalidPart))? {
-                    ETag::Strong(value) => value,
+                let etag = match part.e_tag.as_ref().ok_or_else(|| s3_error!(InvalidPart))? {
+                    ETag::Strong(value) => value.clone(),
                     ETag::Weak(_) => return Err(s3_error!(InvalidPart)),
                 };
+                let stored = loaded
+                    .session
+                    .parts
+                    .get(&number)
+                    .ok_or_else(|| s3_error!(InvalidPart))?;
+                completed_part_checksums_match(&part, &stored.checksums)?;
+                if let Some(algorithm) = composite_algorithm.as_deref()
+                    && completed_part_checksum_value(&part, algorithm)
+                        != checksum_value(&stored.checksums, algorithm)
+                {
+                    return Err(s3_error!(InvalidPart));
+                }
                 Ok((number, etag))
             })
             .collect::<S3Result<Vec<_>>>()?;
+        if composite_algorithm.is_some()
+            && selected
+                .iter()
+                .zip(1_i32..)
+                .any(|((number, _), expected)| *number != expected)
+        {
+            return Err(s3_error!(InvalidPartOrder));
+        }
         if let Some(etag) =
             crate::multipart::completed_etag(&loaded.session, &selected).map_err(multipart_error)?
         {
+            let checksums = loaded
+                .session
+                .completion_checksums
+                .clone()
+                .unwrap_or_default();
             return Ok(S3Response::new(CompleteMultipartUploadOutput {
                 bucket: Some(req.input.bucket),
                 key: Some(req.input.key),
                 e_tag: Some(ETag::Strong(etag.to_owned())),
+                checksum_crc32: checksums.crc32,
+                checksum_crc32c: checksums.crc32c,
+                checksum_crc64nvme: checksums.crc64nvme,
+                checksum_sha1: checksums.sha1,
+                checksum_sha256: checksums.sha256,
+                checksum_type: checksums.checksum_type.map(ChecksumType::from),
                 ..Default::default()
             }));
         }
+        let condition = self
+            .put_condition_values(repository, &req.input.key, if_match, if_none_match)
+            .await?;
         let (session, parts) = crate::multipart::freeze(
             repository,
             loaded,
@@ -1270,11 +1731,36 @@ impl S3 for Gateway {
             }
         }
         let spool = writer.finish().await.map_err(content_error)?;
+        let actual_size = i64::try_from(spool.size).map_err(|_| s3_error!(EntityTooLarge))?;
+        if expected_size.is_some_and(|expected| expected != actual_size) {
+            return Err(s3_error!(InvalidRequest, "Multipart object size mismatch"));
+        }
+        let stored_checksums = if let Some(algorithm) = composite_algorithm.as_deref() {
+            let calculated =
+                composite_checksums(parts.iter().map(|part| &part.checksums), algorithm)?;
+            if !request_checksums_match(&completion_checksums, &calculated) {
+                return Err(s3_error!(BadDigest));
+            }
+            calculated
+        } else {
+            completion_checksums.verify_values(&spool.digests)?;
+            completion_checksums
+                .stored_for_algorithm(&spool.digests, session.checksum_algorithm.as_deref())?
+        };
         let etag = multipart_etag(&parts)?;
         let mut attributes = session.attributes.clone();
         attributes.etag_override = Some(etag.clone());
         attributes.completion_upload_id = Some(session.id.clone());
         attributes.logical_size = Some(spool.size);
+        attributes.checksums = stored_checksums.clone();
+        attributes.parts = parts
+            .iter()
+            .map(|part| crate::attributes::PartAttributes {
+                number: part.number,
+                size: part.size,
+                checksums: part.checksums.clone(),
+            })
+            .collect();
         let address = namespace::object_address(&session.key).map_err(namespace_error)?;
         let bytes = mutation_bytes(repository, &spool).await?;
         mutation::apply(
@@ -1286,7 +1772,7 @@ impl S3 for Gateway {
             mutation::Change::Put {
                 bytes,
                 attributes: Box::new(attributes),
-                condition: mutation::PutCondition::None,
+                condition,
             },
             &principal,
             &self.cancellation,
@@ -1296,13 +1782,19 @@ impl S3 for Gateway {
         let loaded = crate::multipart::load(repository, &session.id)
             .await
             .map_err(multipart_error)?;
-        crate::multipart::complete(repository, loaded, etag.clone())
+        crate::multipart::complete(repository, loaded, etag.clone(), stored_checksums.clone())
             .await
             .map_err(multipart_error)?;
         Ok(S3Response::new(CompleteMultipartUploadOutput {
             bucket: Some(req.input.bucket),
             key: Some(req.input.key),
             e_tag: Some(ETag::Strong(etag)),
+            checksum_crc32: stored_checksums.crc32,
+            checksum_crc32c: stored_checksums.crc32c,
+            checksum_crc64nvme: stored_checksums.crc64nvme,
+            checksum_sha1: stored_checksums.sha1,
+            checksum_sha256: stored_checksums.sha256,
+            checksum_type: stored_checksums.checksum_type.map(ChecksumType::from),
             ..Default::default()
         }))
     }
@@ -1384,6 +1876,12 @@ impl S3 for Gateway {
         let next = truncated
             .then(|| parts.last().map(|part| part.number))
             .flatten();
+        let checksum_algorithm = loaded
+            .session
+            .checksum_algorithm
+            .clone()
+            .map(ChecksumAlgorithm::from);
+        let checksum_type = loaded.session.checksum_type.clone().map(ChecksumType::from);
         Ok(S3Response::new(ListPartsOutput {
             bucket: Some(req.input.bucket),
             key: Some(req.input.key),
@@ -1392,12 +1890,19 @@ impl S3 for Gateway {
             part_number_marker: Some(marker),
             next_part_number_marker: next,
             is_truncated: Some(truncated),
+            checksum_algorithm,
+            checksum_type,
             parts: Some(
                 parts
                     .into_iter()
                     .map(|part| {
                         Ok(Part {
                             e_tag: Some(ETag::Strong(part.etag)),
+                            checksum_crc32: part.checksums.crc32,
+                            checksum_crc32c: part.checksums.crc32c,
+                            checksum_crc64nvme: part.checksums.crc64nvme,
+                            checksum_sha1: part.checksums.sha1,
+                            checksum_sha256: part.checksums.sha256,
                             last_modified: Some(timestamp(
                                 i64::try_from(part.modified_seconds)
                                     .map_err(|_| s3_error!(InternalError))?,
@@ -1406,7 +1911,6 @@ impl S3 for Gateway {
                             size: Some(
                                 i64::try_from(part.size).map_err(|_| s3_error!(InternalError))?,
                             ),
-                            ..Default::default()
                         })
                     })
                     .collect::<S3Result<Vec<_>>>()?,
@@ -1528,6 +2032,10 @@ impl S3 for Gateway {
                         Ok(MultipartUpload {
                             key: Some(session.key),
                             upload_id: Some(session.id),
+                            checksum_algorithm: session
+                                .checksum_algorithm
+                                .map(ChecksumAlgorithm::from),
+                            checksum_type: session.checksum_type.map(ChecksumType::from),
                             initiated: Some(timestamp(
                                 i64::try_from(session.created_seconds)
                                     .map_err(|_| s3_error!(InternalError))?,
@@ -1773,7 +2281,6 @@ fn reject_put_extensions(input: &PutObjectInput) -> S3Result<()> {
         || input.grant_read.is_some()
         || input.grant_read_acp.is_some()
         || input.grant_write_acp.is_some()
-        || input.if_match.is_some()
         || input.object_lock_legal_hold_status.is_some()
         || input.object_lock_mode.is_some()
         || input.object_lock_retain_until_date.is_some()
@@ -1785,7 +2292,6 @@ fn reject_put_extensions(input: &PutObjectInput) -> S3Result<()> {
         || input.ssekms_encryption_context.is_some()
         || input.ssekms_key_id.is_some()
         || input.storage_class.is_some()
-        || input.tagging.is_some()
         || input.website_redirect_location.is_some()
         || input.write_offset_bytes.is_some()
     {
@@ -1794,15 +2300,7 @@ fn reject_put_extensions(input: &PutObjectInput) -> S3Result<()> {
     Ok(())
 }
 
-fn put_condition(input: &PutObjectInput) -> S3Result<mutation::PutCondition> {
-    match input.if_none_match.as_ref() {
-        None => Ok(mutation::PutCondition::None),
-        Some(ETagCondition::Any) => Ok(mutation::PutCondition::IfNoneMatchAny),
-        Some(ETagCondition::ETag(_)) => Err(s3_error!(NotImplemented)),
-    }
-}
-
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct RequestChecksums {
     algorithm: Option<ChecksumAlgorithm>,
     crc32: Option<String>,
@@ -1826,6 +2324,28 @@ impl From<&PutObjectInput> for RequestChecksums {
 }
 
 impl RequestChecksums {
+    fn from_upload_part(input: &UploadPartInput) -> Self {
+        Self {
+            algorithm: input.checksum_algorithm.clone(),
+            crc32: input.checksum_crc32.clone(),
+            crc32c: input.checksum_crc32c.clone(),
+            crc64nvme: input.checksum_crc64nvme.clone(),
+            sha1: input.checksum_sha1.clone(),
+            sha256: input.checksum_sha256.clone(),
+        }
+    }
+
+    fn from_complete(input: &CompleteMultipartUploadInput) -> Self {
+        Self {
+            algorithm: None,
+            crc32: input.checksum_crc32.clone(),
+            crc32c: input.checksum_crc32c.clone(),
+            crc64nvme: input.checksum_crc64nvme.clone(),
+            sha1: input.checksum_sha1.clone(),
+            sha256: input.checksum_sha256.clone(),
+        }
+    }
+
     fn merge_trailers(&mut self, trailers: Option<&s3s::TrailingHeaders>) -> S3Result<()> {
         let Some(headers) = trailers.and_then(s3s::TrailingHeaders::take) else {
             return Ok(());
@@ -1839,11 +2359,8 @@ impl RequestChecksums {
     }
 
     fn verify(&self, digests: &crate::content::Digests) -> S3Result<()> {
-        verify_base64_checksum(self.crc32.as_deref(), &digests.crc32.to_be_bytes())?;
-        verify_base64_checksum(self.crc32c.as_deref(), &digests.crc32c.to_be_bytes())?;
-        verify_base64_checksum(self.crc64nvme.as_deref(), &digests.crc64nvme.to_be_bytes())?;
-        verify_base64_checksum(self.sha1.as_deref(), &digests.sha1)?;
-        verify_base64_checksum(self.sha256.as_deref(), &digests.sha256)?;
+        self.ensure_single_value()?;
+        self.verify_values(digests)?;
         if let Some(algorithm) = &self.algorithm {
             let supplied = match algorithm.as_str() {
                 ChecksumAlgorithm::CRC32 => self.crc32.is_some(),
@@ -1859,6 +2376,500 @@ impl RequestChecksums {
         }
         Ok(())
     }
+
+    fn verify_values(&self, digests: &crate::content::Digests) -> S3Result<()> {
+        verify_base64_checksum(self.crc32.as_deref(), &digests.crc32.to_be_bytes())?;
+        verify_base64_checksum(self.crc32c.as_deref(), &digests.crc32c.to_be_bytes())?;
+        verify_base64_checksum(self.crc64nvme.as_deref(), &digests.crc64nvme.to_be_bytes())?;
+        verify_base64_checksum(self.sha1.as_deref(), &digests.sha1)?;
+        verify_base64_checksum(self.sha256.as_deref(), &digests.sha256)?;
+        Ok(())
+    }
+
+    fn stored(&self, digests: &crate::content::Digests) -> crate::attributes::Checksums {
+        let mut stored = crate::attributes::Checksums {
+            crc32: self.crc32.clone(),
+            crc32c: self.crc32c.clone(),
+            crc64nvme: self.crc64nvme.clone(),
+            sha1: self.sha1.clone(),
+            sha256: self.sha256.clone(),
+            checksum_type: Some(ChecksumType::FULL_OBJECT.to_owned()),
+        };
+        if stored.is_empty() {
+            stored = default_checksums(digests);
+        }
+        stored
+    }
+
+    fn stored_for_algorithm(
+        &self,
+        digests: &crate::content::Digests,
+        algorithm: Option<&str>,
+    ) -> S3Result<crate::attributes::Checksums> {
+        let stored = self.stored(digests);
+        if !self.values_empty() {
+            return Ok(stored);
+        }
+        algorithm
+            .map(|algorithm| calculated_checksums(digests, algorithm))
+            .transpose()
+            .map(|value| value.unwrap_or(stored))
+    }
+
+    fn values_empty(&self) -> bool {
+        self.crc32.is_none()
+            && self.crc32c.is_none()
+            && self.crc64nvme.is_none()
+            && self.sha1.is_none()
+            && self.sha256.is_none()
+    }
+
+    fn ensure_single_value(&self) -> S3Result<()> {
+        let count = [
+            self.crc32.is_some(),
+            self.crc32c.is_some(),
+            self.crc64nvme.is_some(),
+            self.sha1.is_some(),
+            self.sha256.is_some(),
+        ]
+        .into_iter()
+        .filter(|present| *present)
+        .count();
+        if count > 1 {
+            return Err(s3_error!(
+                InvalidRequest,
+                "Only one object checksum algorithm can be supplied"
+            ));
+        }
+        Ok(())
+    }
+
+    fn has_algorithm(&self, algorithm: &str) -> bool {
+        match algorithm {
+            ChecksumAlgorithm::CRC32 => self.crc32.is_some(),
+            ChecksumAlgorithm::CRC32C => self.crc32c.is_some(),
+            ChecksumAlgorithm::CRC64NVME => self.crc64nvme.is_some(),
+            ChecksumAlgorithm::SHA1 => self.sha1.is_some(),
+            ChecksumAlgorithm::SHA256 => self.sha256.is_some(),
+            _ => false,
+        }
+    }
+}
+
+fn multipart_checksum_profile(
+    algorithm: Option<&ChecksumAlgorithm>,
+    checksum_type: Option<&ChecksumType>,
+) -> S3Result<(Option<String>, Option<String>)> {
+    let Some(algorithm) = algorithm else {
+        if checksum_type.is_some() {
+            return Err(s3_error!(InvalidRequest));
+        }
+        return Ok((None, None));
+    };
+    let checksum_type = checksum_type.map(ChecksumType::as_str).unwrap_or_else(|| {
+        if algorithm.as_str() == ChecksumAlgorithm::CRC64NVME {
+            ChecksumType::FULL_OBJECT
+        } else {
+            ChecksumType::COMPOSITE
+        }
+    });
+    let supported = matches!(
+        (algorithm.as_str(), checksum_type),
+        (
+            ChecksumAlgorithm::CRC32 | ChecksumAlgorithm::CRC32C | ChecksumAlgorithm::CRC64NVME,
+            ChecksumType::FULL_OBJECT
+        ) | (
+            ChecksumAlgorithm::CRC32
+                | ChecksumAlgorithm::CRC32C
+                | ChecksumAlgorithm::SHA1
+                | ChecksumAlgorithm::SHA256,
+            ChecksumType::COMPOSITE
+        )
+    );
+    if !supported {
+        return Err(s3_error!(
+            InvalidRequest,
+            "Invalid multipart checksum profile"
+        ));
+    }
+    Ok((
+        Some(algorithm.as_str().to_owned()),
+        Some(checksum_type.to_owned()),
+    ))
+}
+
+fn default_checksums(digests: &crate::content::Digests) -> crate::attributes::Checksums {
+    crate::attributes::Checksums {
+        crc64nvme: Some(
+            base64::engine::general_purpose::STANDARD.encode(digests.crc64nvme.to_be_bytes()),
+        ),
+        checksum_type: Some(ChecksumType::FULL_OBJECT.to_owned()),
+        ..Default::default()
+    }
+}
+
+fn calculated_checksums(
+    digests: &crate::content::Digests,
+    algorithm: &str,
+) -> S3Result<crate::attributes::Checksums> {
+    let encode = |value: &[u8]| base64::engine::general_purpose::STANDARD.encode(value);
+    let mut checksums = crate::attributes::Checksums {
+        checksum_type: Some(ChecksumType::FULL_OBJECT.to_owned()),
+        ..Default::default()
+    };
+    match algorithm {
+        ChecksumAlgorithm::CRC32 => checksums.crc32 = Some(encode(&digests.crc32.to_be_bytes())),
+        ChecksumAlgorithm::CRC32C => {
+            checksums.crc32c = Some(encode(&digests.crc32c.to_be_bytes()));
+        }
+        ChecksumAlgorithm::CRC64NVME => {
+            checksums.crc64nvme = Some(encode(&digests.crc64nvme.to_be_bytes()));
+        }
+        ChecksumAlgorithm::SHA1 => checksums.sha1 = Some(encode(&digests.sha1)),
+        ChecksumAlgorithm::SHA256 => checksums.sha256 = Some(encode(&digests.sha256)),
+        _ => return Err(s3_error!(InvalidRequest, "Unsupported checksum algorithm")),
+    }
+    Ok(checksums)
+}
+
+fn composite_checksums<'a>(
+    parts: impl IntoIterator<Item = &'a crate::attributes::Checksums>,
+    algorithm: &str,
+) -> S3Result<crate::attributes::Checksums> {
+    let mut concatenated = Vec::new();
+    let mut part_count = 0_usize;
+    for checksums in parts {
+        let encoded = checksum_value(checksums, algorithm).ok_or_else(|| s3_error!(InvalidPart))?;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|_| s3_error!(InvalidPart))?;
+        concatenated.extend_from_slice(&decoded);
+        part_count = part_count
+            .checked_add(1)
+            .ok_or_else(|| s3_error!(InternalError))?;
+    }
+    let encode = |value: &[u8]| {
+        format!(
+            "{}-{part_count}",
+            base64::engine::general_purpose::STANDARD.encode(value)
+        )
+    };
+    let mut checksums = crate::attributes::Checksums {
+        checksum_type: Some(ChecksumType::COMPOSITE.to_owned()),
+        ..Default::default()
+    };
+    match algorithm {
+        ChecksumAlgorithm::CRC32 => {
+            let value = u32::try_from(crc_fast::checksum(
+                crc_fast::CrcAlgorithm::Crc32IsoHdlc,
+                &concatenated,
+            ))
+            .map_err(|_| s3_error!(InternalError))?;
+            checksums.crc32 = Some(encode(&value.to_be_bytes()));
+        }
+        ChecksumAlgorithm::CRC32C => {
+            let value = u32::try_from(crc_fast::checksum(
+                crc_fast::CrcAlgorithm::Crc32Iscsi,
+                &concatenated,
+            ))
+            .map_err(|_| s3_error!(InternalError))?;
+            checksums.crc32c = Some(encode(&value.to_be_bytes()));
+        }
+        ChecksumAlgorithm::SHA1 => {
+            use sha1::Digest as _;
+            checksums.sha1 = Some(encode(&sha1::Sha1::digest(&concatenated)));
+        }
+        ChecksumAlgorithm::SHA256 => {
+            use sha2::Digest as _;
+            checksums.sha256 = Some(encode(&sha2::Sha256::digest(&concatenated)));
+        }
+        _ => {
+            return Err(s3_error!(
+                InvalidRequest,
+                "Invalid composite checksum algorithm"
+            ));
+        }
+    }
+    Ok(checksums)
+}
+
+fn checksum_value<'a>(
+    checksums: &'a crate::attributes::Checksums,
+    algorithm: &str,
+) -> Option<&'a str> {
+    match algorithm {
+        ChecksumAlgorithm::CRC32 => checksums.crc32.as_deref(),
+        ChecksumAlgorithm::CRC32C => checksums.crc32c.as_deref(),
+        ChecksumAlgorithm::CRC64NVME => checksums.crc64nvme.as_deref(),
+        ChecksumAlgorithm::SHA1 => checksums.sha1.as_deref(),
+        ChecksumAlgorithm::SHA256 => checksums.sha256.as_deref(),
+        _ => None,
+    }
+}
+
+fn request_checksums_match(
+    requested: &RequestChecksums,
+    calculated: &crate::attributes::Checksums,
+) -> bool {
+    [
+        (requested.crc32.as_ref(), calculated.crc32.as_ref()),
+        (requested.crc32c.as_ref(), calculated.crc32c.as_ref()),
+        (requested.crc64nvme.as_ref(), calculated.crc64nvme.as_ref()),
+        (requested.sha1.as_ref(), calculated.sha1.as_ref()),
+        (requested.sha256.as_ref(), calculated.sha256.as_ref()),
+    ]
+    .into_iter()
+    .all(|(requested, actual)| {
+        requested.is_none_or(|requested| {
+            actual.is_some_and(|actual| {
+                actual == requested
+                    || actual.rsplit_once('-').is_some_and(|(digest, count)| {
+                        digest == requested && count.parse::<u32>().is_ok()
+                    })
+            })
+        })
+    })
+}
+
+fn completed_part_checksums_match(
+    part: &CompletedPart,
+    stored: &crate::attributes::Checksums,
+) -> S3Result<()> {
+    let matches = [
+        (part.checksum_crc32.as_ref(), stored.crc32.as_ref()),
+        (part.checksum_crc32c.as_ref(), stored.crc32c.as_ref()),
+        (part.checksum_crc64nvme.as_ref(), stored.crc64nvme.as_ref()),
+        (part.checksum_sha1.as_ref(), stored.sha1.as_ref()),
+        (part.checksum_sha256.as_ref(), stored.sha256.as_ref()),
+    ]
+    .into_iter()
+    .all(|(requested, actual)| requested.is_none_or(|requested| actual == Some(requested)));
+    if matches {
+        Ok(())
+    } else {
+        Err(s3_error!(InvalidPart))
+    }
+}
+
+fn completed_part_checksum_value<'a>(part: &'a CompletedPart, algorithm: &str) -> Option<&'a str> {
+    match algorithm {
+        ChecksumAlgorithm::CRC32 => part.checksum_crc32.as_deref(),
+        ChecksumAlgorithm::CRC32C => part.checksum_crc32c.as_deref(),
+        ChecksumAlgorithm::CRC64NVME => part.checksum_crc64nvme.as_deref(),
+        ChecksumAlgorithm::SHA1 => part.checksum_sha1.as_deref(),
+        ChecksumAlgorithm::SHA256 => part.checksum_sha256.as_deref(),
+        _ => None,
+    }
+}
+
+fn response_checksums(
+    mode: Option<&ChecksumMode>,
+    checksums: Option<&crate::attributes::Checksums>,
+) -> S3Result<crate::attributes::Checksums> {
+    match mode {
+        None => Ok(crate::attributes::Checksums::default()),
+        Some(value) if value.as_str() == ChecksumMode::ENABLED => {
+            Ok(checksums.cloned().unwrap_or_default())
+        }
+        Some(_) => Err(s3_error!(InvalidArgument)),
+    }
+}
+
+fn read_selection(
+    size: u64,
+    attributes: Option<&crate::attributes::ObjectAttributes>,
+    requested_range: Option<&Range>,
+    part_number: Option<i32>,
+) -> S3Result<ReadSelection> {
+    if requested_range.is_some() && part_number.is_some() {
+        return Err(s3_error!(InvalidRequest));
+    }
+    let object_checksums = attributes.map(|value| value.checksums.clone());
+    let parts = attributes
+        .map(|value| value.parts.as_slice())
+        .unwrap_or_default();
+    if let Some(part_number) = part_number {
+        if !(1..=10_000).contains(&part_number) {
+            return Err(s3_error!(InvalidArgument));
+        }
+        if parts.is_empty() {
+            if part_number != 1 {
+                return Err(s3_error!(InvalidRange));
+            }
+            return Ok(ReadSelection {
+                range: 0..size,
+                content_range: None,
+                parts_count: None,
+                checksums: object_checksums,
+            });
+        }
+        let mut offset = 0_u64;
+        let mut selected = None;
+        for part in parts {
+            let end = offset
+                .checked_add(part.size)
+                .ok_or_else(|| s3_error!(InternalError))?;
+            if part.number == part_number {
+                selected = Some((offset..end, part.checksums.clone()));
+            }
+            offset = end;
+        }
+        if offset != size {
+            return Err(s3_error!(InternalError));
+        }
+        let (range, checksums) = selected.ok_or_else(|| s3_error!(InvalidRange))?;
+        return Ok(ReadSelection {
+            content_range: content_range(&range, size),
+            range,
+            parts_count: Some(i32::try_from(parts.len()).map_err(|_| s3_error!(InternalError))?),
+            checksums: Some(checksums),
+        });
+    }
+    let Some(requested_range) = requested_range else {
+        return Ok(ReadSelection {
+            range: 0..size,
+            content_range: None,
+            parts_count: None,
+            checksums: object_checksums,
+        });
+    };
+    let checked = requested_range.check(size)?;
+    let range = checked.start..checked.end;
+    let checksums = if range.start == 0 && range.end == size {
+        object_checksums
+    } else {
+        part_checksums_for_range(parts, &range)
+    };
+    Ok(ReadSelection {
+        content_range: content_range(&range, size),
+        range,
+        parts_count: None,
+        checksums,
+    })
+}
+
+fn part_checksums_for_range(
+    parts: &[crate::attributes::PartAttributes],
+    requested: &std::ops::Range<u64>,
+) -> Option<crate::attributes::Checksums> {
+    let mut offset = 0_u64;
+    for part in parts {
+        let end = offset.checked_add(part.size)?;
+        if requested.start == offset && requested.end == end {
+            return Some(part.checksums.clone());
+        }
+        offset = end;
+    }
+    None
+}
+
+fn content_range(range: &std::ops::Range<u64>, size: u64) -> Option<String> {
+    (range.start < range.end).then(|| format!("bytes {}-{}/{}", range.start, range.end - 1, size))
+}
+
+fn tag_count(attributes: Option<&crate::attributes::ObjectAttributes>) -> S3Result<Option<i32>> {
+    attributes
+        .filter(|value| !value.tags.is_empty())
+        .map(|value| i32::try_from(value.tags.len()).map_err(|_| s3_error!(InternalError)))
+        .transpose()
+}
+
+fn checksum_dto(checksums: &crate::attributes::Checksums) -> Checksum {
+    Checksum {
+        checksum_crc32: checksums.crc32.clone(),
+        checksum_crc32c: checksums.crc32c.clone(),
+        checksum_crc64nvme: checksums.crc64nvme.clone(),
+        checksum_sha1: checksums.sha1.clone(),
+        checksum_sha256: checksums.sha256.clone(),
+        checksum_type: checksums.checksum_type.clone().map(ChecksumType::from),
+    }
+}
+
+fn object_attribute_names(values: &[ObjectAttributes]) -> std::collections::BTreeSet<&str> {
+    // s3s 0.14 yields one DTO item per header line, while AWS SDKs encode this
+    // Smithy list as one comma-delimited header value.
+    values
+        .iter()
+        .flat_map(|value| value.as_str().split(','))
+        .map(str::trim)
+        .collect()
+}
+
+fn object_parts(
+    parts: &[crate::attributes::PartAttributes],
+    marker: Option<i32>,
+    max: Option<i32>,
+) -> S3Result<GetObjectAttributesParts> {
+    let marker = marker.unwrap_or(0);
+    let max = max.unwrap_or(1000);
+    let max_usize = usize::try_from(max).map_err(|_| s3_error!(InvalidArgument))?;
+    let mut selected = parts
+        .iter()
+        .filter(|part| part.number > marker)
+        .collect::<Vec<_>>();
+    let truncated = selected.len() > max_usize;
+    selected.truncate(max_usize);
+    let next = truncated
+        .then(|| selected.last().map(|part| part.number))
+        .flatten();
+    Ok(GetObjectAttributesParts {
+        is_truncated: Some(truncated),
+        max_parts: Some(max),
+        next_part_number_marker: next,
+        part_number_marker: Some(marker),
+        parts: Some(
+            selected
+                .into_iter()
+                .map(|part| {
+                    Ok(ObjectPart {
+                        checksum_crc32: part.checksums.crc32.clone(),
+                        checksum_crc32c: part.checksums.crc32c.clone(),
+                        checksum_crc64nvme: part.checksums.crc64nvme.clone(),
+                        checksum_sha1: part.checksums.sha1.clone(),
+                        checksum_sha256: part.checksums.sha256.clone(),
+                        part_number: Some(part.number),
+                        size: Some(i64::try_from(part.size).map_err(|_| s3_error!(InternalError))?),
+                    })
+                })
+                .collect::<S3Result<Vec<_>>>()?,
+        ),
+        total_parts_count: Some(i32::try_from(parts.len()).map_err(|_| s3_error!(InternalError))?),
+    })
+}
+
+fn parse_tagging_header(value: Option<&str>) -> S3Result<BTreeMap<String, String>> {
+    let tags = value
+        .map(|value| url::form_urlencoded::parse(value.as_bytes()).into_owned())
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    validate_tags(tags)
+}
+
+fn validate_tags(
+    tags: impl IntoIterator<Item = (String, String)>,
+) -> S3Result<BTreeMap<String, String>> {
+    let mut validated = BTreeMap::new();
+    for (key, value) in tags {
+        if key.is_empty()
+            || key.chars().count() > 128
+            || value.chars().count() > 256
+            || key.to_ascii_lowercase().starts_with("aws:")
+            || !key.chars().all(valid_tag_character)
+            || !value.chars().all(valid_tag_character)
+            || validated.insert(key, value).is_some()
+            || validated.len() > 10
+        {
+            return Err(s3_error!(InvalidTag));
+        }
+    }
+    Ok(validated)
+}
+
+fn valid_tag_character(value: char) -> bool {
+    value.is_alphanumeric()
+        || (value.is_whitespace() && !value.is_control())
+        || matches!(value, '+' | '-' | '=' | '.' | '_' | ':' | '/' | '@')
 }
 
 fn merge_checksum_header(
@@ -1918,7 +2929,6 @@ fn reject_copy_extensions(input: &CopyObjectInput) -> S3Result<()> {
     if !directive_supported
         || input.acl.is_some()
         || input.bucket_key_enabled.is_some()
-        || input.checksum_algorithm.is_some()
         || input.copy_source_sse_customer_algorithm.is_some()
         || input.copy_source_sse_customer_key.is_some()
         || input.copy_source_sse_customer_key_md5.is_some()
@@ -1939,8 +2949,6 @@ fn reject_copy_extensions(input: &CopyObjectInput) -> S3Result<()> {
         || input.ssekms_encryption_context.is_some()
         || input.ssekms_key_id.is_some()
         || input.storage_class.is_some()
-        || input.tagging.is_some()
-        || input.tagging_directive.is_some()
         || input.website_redirect_location.is_some()
     {
         return Err(s3_error!(NotImplemented));
@@ -1951,8 +2959,6 @@ fn reject_copy_extensions(input: &CopyObjectInput) -> S3Result<()> {
 fn reject_create_multipart_extensions(input: &CreateMultipartUploadInput) -> S3Result<()> {
     if input.acl.is_some()
         || input.bucket_key_enabled.is_some()
-        || input.checksum_algorithm.is_some()
-        || input.checksum_type.is_some()
         || input.expected_bucket_owner.is_some()
         || input.grant_full_control.is_some()
         || input.grant_read.is_some()
@@ -1969,7 +2975,6 @@ fn reject_create_multipart_extensions(input: &CreateMultipartUploadInput) -> S3R
         || input.ssekms_encryption_context.is_some()
         || input.ssekms_key_id.is_some()
         || input.storage_class.is_some()
-        || input.tagging.is_some()
         || input.website_redirect_location.is_some()
     {
         return Err(s3_error!(NotImplemented));
@@ -1978,13 +2983,7 @@ fn reject_create_multipart_extensions(input: &CreateMultipartUploadInput) -> S3R
 }
 
 fn reject_upload_part_extensions(input: &UploadPartInput) -> S3Result<()> {
-    if input.checksum_algorithm.is_some()
-        || input.checksum_crc32.is_some()
-        || input.checksum_crc32c.is_some()
-        || input.checksum_crc64nvme.is_some()
-        || input.checksum_sha1.is_some()
-        || input.checksum_sha256.is_some()
-        || input.expected_bucket_owner.is_some()
+    if input.expected_bucket_owner.is_some()
         || input.request_payer.is_some()
         || input.sse_customer_algorithm.is_some()
         || input.sse_customer_key.is_some()
@@ -1996,16 +2995,7 @@ fn reject_upload_part_extensions(input: &UploadPartInput) -> S3Result<()> {
 }
 
 fn reject_complete_multipart_extensions(input: &CompleteMultipartUploadInput) -> S3Result<()> {
-    if input.checksum_crc32.is_some()
-        || input.checksum_crc32c.is_some()
-        || input.checksum_crc64nvme.is_some()
-        || input.checksum_sha1.is_some()
-        || input.checksum_sha256.is_some()
-        || input.checksum_type.is_some()
-        || input.expected_bucket_owner.is_some()
-        || input.if_match.is_some()
-        || input.if_none_match.is_some()
-        || input.mpu_object_size.is_some()
+    if input.expected_bucket_owner.is_some()
         || input.request_payer.is_some()
         || input.sse_customer_algorithm.is_some()
         || input.sse_customer_key.is_some()
@@ -2065,8 +3055,11 @@ fn stored_to_pending(
 ) -> crate::attributes::PutAttributes {
     crate::attributes::PutAttributes {
         etag_override: None,
-        completion_upload_id: None,
+        completion_upload_id: value.completion_upload_id.clone(),
         logical_size: Some(value.size),
+        checksums: value.checksums.clone(),
+        tags: value.tags.clone(),
+        parts: value.parts.clone(),
         cache_control: value.cache_control.clone(),
         content_disposition: value.content_disposition.clone(),
         content_encoding: value.content_encoding.clone(),
@@ -2144,7 +3137,6 @@ impl Gateway {
 
 fn reject_get_extensions(input: &GetObjectInput) -> S3Result<()> {
     if input.version_id.is_some()
-        || input.part_number.is_some()
         || input.request_payer.is_some()
         || input.sse_customer_algorithm.is_some()
         || input.sse_customer_key.is_some()
@@ -2157,7 +3149,6 @@ fn reject_get_extensions(input: &GetObjectInput) -> S3Result<()> {
 
 fn reject_head_extensions(input: &HeadObjectInput) -> S3Result<()> {
     if input.version_id.is_some()
-        || input.part_number.is_some()
         || input.request_payer.is_some()
         || input.sse_customer_algorithm.is_some()
         || input.sse_customer_key.is_some()
@@ -2378,6 +3369,173 @@ mod tests {
         assert!(encoded.contains("%28"));
     }
 
+    #[test]
+    fn object_tags_decode_form_encoding_and_reject_duplicate_keys() {
+        let tags = parse_tagging_header(Some("project=crab+gateway&path=main%2Ftable")).unwrap();
+        assert_eq!(
+            tags.get("project").map(String::as_str),
+            Some("crab gateway")
+        );
+        assert_eq!(tags.get("path").map(String::as_str), Some("main/table"));
+        assert!(parse_tagging_header(Some("duplicate=one&duplicate=two")).is_err());
+        assert!(parse_tagging_header(Some("aws%3Areserved=value")).is_err());
+        assert!(parse_tagging_header(Some("invalid=%26")).is_err());
+    }
+
+    #[test]
+    fn metadata_only_conversion_preserves_multipart_identity() {
+        let attributes = crate::attributes::ObjectAttributes {
+            blob_oid: "0123456789012345678901234567890123456789".to_owned(),
+            etag: "multipart-etag".to_owned(),
+            size: 7,
+            modified_seconds: 1,
+            completion_upload_id: Some("upload-id".to_owned()),
+            checksums: crate::attributes::Checksums::default(),
+            tags: BTreeMap::new(),
+            parts: vec![crate::attributes::PartAttributes {
+                number: 1,
+                size: 7,
+                checksums: crate::attributes::Checksums::default(),
+            }],
+            cache_control: None,
+            content_disposition: None,
+            content_encoding: None,
+            content_language: None,
+            content_type: None,
+            expires: None,
+            metadata: BTreeMap::new(),
+        };
+
+        let pending = stored_to_pending(&attributes);
+
+        assert_eq!(pending.completion_upload_id.as_deref(), Some("upload-id"));
+        assert_eq!(pending.parts, attributes.parts);
+    }
+
+    #[test]
+    fn part_number_and_aligned_range_select_part_checksums() {
+        let first = crate::attributes::PartAttributes {
+            number: 1,
+            size: 5,
+            checksums: crate::attributes::Checksums {
+                sha256: Some("first".to_owned()),
+                ..Default::default()
+            },
+        };
+        let second = crate::attributes::PartAttributes {
+            number: 2,
+            size: 3,
+            checksums: crate::attributes::Checksums {
+                sha256: Some("second".to_owned()),
+                ..Default::default()
+            },
+        };
+        let attributes = crate::attributes::ObjectAttributes {
+            blob_oid: "0123456789012345678901234567890123456789".to_owned(),
+            etag: "multipart-etag".to_owned(),
+            size: 8,
+            modified_seconds: 1,
+            completion_upload_id: Some("upload-id".to_owned()),
+            checksums: crate::attributes::Checksums::default(),
+            tags: BTreeMap::new(),
+            parts: vec![first, second],
+            cache_control: None,
+            content_disposition: None,
+            content_encoding: None,
+            content_language: None,
+            content_type: None,
+            expires: None,
+            metadata: BTreeMap::new(),
+        };
+
+        let selected = read_selection(8, Some(&attributes), None, Some(2)).unwrap();
+        let aligned = read_selection(
+            8,
+            Some(&attributes),
+            Some(&Range::parse("bytes=5-7").unwrap()),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            (
+                selected.range,
+                selected.parts_count,
+                selected.checksums.and_then(|value| value.sha256),
+                aligned.checksums.and_then(|value| value.sha256),
+            ),
+            (
+                5..8,
+                Some(2),
+                Some("second".to_owned()),
+                Some("second".to_owned())
+            )
+        );
+    }
+
+    #[test]
+    fn object_attribute_header_expands_the_aws_comma_delimited_list() {
+        let values = vec![ObjectAttributes::from(
+            "ETag,Checksum,ObjectSize,ObjectParts".to_owned(),
+        )];
+        assert_eq!(
+            object_attribute_names(&values),
+            std::collections::BTreeSet::from([
+                ObjectAttributes::CHECKSUM,
+                ObjectAttributes::ETAG,
+                ObjectAttributes::OBJECT_PARTS,
+                ObjectAttributes::OBJECT_SIZE,
+            ])
+        );
+    }
+
+    #[test]
+    fn multipart_checksum_profile_accepts_only_validated_full_object_algorithms() {
+        let algorithm = ChecksumAlgorithm::from_static(ChecksumAlgorithm::CRC64NVME);
+        let full = ChecksumType::from_static(ChecksumType::FULL_OBJECT);
+        assert_eq!(
+            multipart_checksum_profile(Some(&algorithm), Some(&full)).unwrap(),
+            (
+                Some(ChecksumAlgorithm::CRC64NVME.to_owned()),
+                Some(ChecksumType::FULL_OBJECT.to_owned())
+            )
+        );
+        let composite = ChecksumType::from_static(ChecksumType::COMPOSITE);
+        assert!(multipart_checksum_profile(Some(&algorithm), Some(&composite)).is_err());
+        let sha256 = ChecksumAlgorithm::from_static(ChecksumAlgorithm::SHA256);
+        assert!(multipart_checksum_profile(Some(&sha256), Some(&composite)).is_ok());
+    }
+
+    #[test]
+    fn composite_sha256_hashes_ordered_binary_part_checksums() {
+        use sha2::Digest as _;
+
+        let encode = |value: &[u8]| base64::engine::general_purpose::STANDARD.encode(value);
+        let first = sha2::Sha256::digest(b"first");
+        let second = sha2::Sha256::digest(b"second");
+        let parts = [
+            crate::attributes::Checksums {
+                sha256: Some(encode(&first)),
+                ..Default::default()
+            },
+            crate::attributes::Checksums {
+                sha256: Some(encode(&second)),
+                ..Default::default()
+            },
+        ];
+        let expected = sha2::Sha256::digest([first.as_slice(), second.as_slice()].concat());
+        let actual = composite_checksums(parts.iter(), ChecksumAlgorithm::SHA256).unwrap();
+
+        assert_eq!(
+            actual.sha256.as_deref(),
+            Some(format!("{}-2", encode(&expected)).as_str())
+        );
+        assert_eq!(
+            actual.checksum_type.as_deref(),
+            Some(ChecksumType::COMPOSITE)
+        );
+    }
+
     #[tokio::test]
     async fn content_above_inline_threshold_is_stored_as_streamable_lfs() {
         use futures_util::TryStreamExt as _;
@@ -2429,35 +3587,46 @@ mod tests {
 
         let body = b"123456789";
         let encode = |bytes: &[u8]| base64::engine::general_purpose::STANDARD.encode(bytes);
-        let checksums = RequestChecksums {
-            algorithm: Some(ChecksumAlgorithm::from_static(ChecksumAlgorithm::CRC32)),
-            crc32: Some(encode(
-                &u32::try_from(crc_fast::checksum(
-                    crc_fast::CrcAlgorithm::Crc32IsoHdlc,
-                    body,
-                ))
-                .unwrap()
-                .to_be_bytes(),
-            )),
-            crc32c: Some(encode(
-                &u32::try_from(crc_fast::checksum(crc_fast::CrcAlgorithm::Crc32Iscsi, body))
-                    .unwrap()
-                    .to_be_bytes(),
-            )),
-            crc64nvme: Some(encode(
-                &crc_fast::checksum(crc_fast::CrcAlgorithm::Crc64Nvme, body).to_be_bytes(),
-            )),
-            sha1: Some(encode(&sha1::Sha1::digest(body))),
-            sha256: Some(encode(&sha2::Sha256::digest(body))),
-        };
         let mut writer = crate::content::SpoolWriter::new().await.unwrap();
         writer.write(body, u64::MAX).await.unwrap();
         let spool = writer.finish().await.unwrap();
-        checksums.verify(&spool.digests).unwrap();
+        for algorithm in [
+            ChecksumAlgorithm::CRC32,
+            ChecksumAlgorithm::CRC32C,
+            ChecksumAlgorithm::CRC64NVME,
+            ChecksumAlgorithm::SHA1,
+            ChecksumAlgorithm::SHA256,
+        ] {
+            let calculated = calculated_checksums(&spool.digests, algorithm).unwrap();
+            RequestChecksums {
+                algorithm: Some(ChecksumAlgorithm::from_static(algorithm)),
+                crc32: calculated.crc32,
+                crc32c: calculated.crc32c,
+                crc64nvme: calculated.crc64nvme,
+                sha1: calculated.sha1,
+                sha256: calculated.sha256,
+            }
+            .verify(&spool.digests)
+            .unwrap();
+        }
 
-        let mut invalid = checksums;
-        invalid.sha256 = Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_owned());
+        let invalid = RequestChecksums {
+            algorithm: Some(ChecksumAlgorithm::from_static(ChecksumAlgorithm::SHA256)),
+            sha256: Some(encode(&sha2::Sha256::digest(b"different"))),
+            ..Default::default()
+        };
         let error = invalid.verify(&spool.digests).unwrap_err();
         assert_eq!(error.code().as_str(), "BadDigest");
+    }
+
+    #[test]
+    fn object_checksums_reject_multiple_algorithms() {
+        let checksums = RequestChecksums {
+            crc32: Some("AAAAAA==".to_owned()),
+            sha256: Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_owned()),
+            ..Default::default()
+        };
+
+        assert!(checksums.ensure_single_value().is_err());
     }
 }

--- a/crates/crab-s3-gateway/src/lib.rs
+++ b/crates/crab-s3-gateway/src/lib.rs
@@ -23,6 +23,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("invalid gateway TOML configuration")]
     Toml(#[from] toml::de::Error),
+    #[error("invalid S3 endpoint domain")]
+    Host(#[from] s3s::host::DomainError),
     #[error("object storage configuration failed")]
     Storage(#[from] crab_storage::StorageError),
     #[error("repository reader configuration failed")]

--- a/crates/crab-s3-gateway/src/lib.rs
+++ b/crates/crab-s3-gateway/src/lib.rs
@@ -31,8 +31,8 @@ pub enum Error {
     Remote(#[from] crab_remote_git::Error),
     #[error("repository read publication failed")]
     Write(#[from] crab_write::WriteError),
-    #[error("repository did not become readable before the publication deadline")]
-    ReadinessTimeout,
+    #[error("repository metadata failed")]
+    Metadata(#[from] crab_metadata::error::MetadataError),
     #[error("repository cache setup failed")]
     Cache(#[from] crab_cache_store::CacheStoreError),
     #[error("repository hydration failed")]

--- a/crates/crab-s3-gateway/src/multipart.rs
+++ b/crates/crab-s3-gateway/src/multipart.rs
@@ -54,6 +54,11 @@ pub(crate) struct Part {
     pub(crate) etag: String,
     pub(crate) size: u64,
     pub(crate) modified_seconds: u64,
+    #[serde(
+        default,
+        skip_serializing_if = "crate::attributes::Checksums::is_empty"
+    )]
+    pub(crate) checksums: crate::attributes::Checksums,
     path: String,
 }
 
@@ -71,9 +76,15 @@ pub(crate) struct Session {
     revision: u64,
     state: State,
     pub(crate) attributes: PutAttributes,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) checksum_algorithm: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) checksum_type: Option<String>,
     pub(crate) parts: BTreeMap<i32, Part>,
     selected_parts: Option<Vec<(i32, String)>>,
     completion_etag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) completion_checksums: Option<crate::attributes::Checksums>,
 }
 
 pub(crate) struct Loaded {
@@ -81,33 +92,39 @@ pub(crate) struct Loaded {
     etag: ETag,
 }
 
-pub(crate) async fn create(
-    repository: &Repository,
-    bucket: &str,
-    key: &str,
-    branch: &str,
-    path: &str,
-    principal: &str,
-    attributes: PutAttributes,
-    now: u64,
-) -> Result<Session> {
+pub(crate) struct Initiation<'a> {
+    pub(crate) bucket: &'a str,
+    pub(crate) key: &'a str,
+    pub(crate) branch: &'a str,
+    pub(crate) path: &'a str,
+    pub(crate) principal: &'a str,
+    pub(crate) attributes: PutAttributes,
+    pub(crate) checksum_algorithm: Option<String>,
+    pub(crate) checksum_type: Option<String>,
+    pub(crate) now: u64,
+}
+
+pub(crate) async fn create(repository: &Repository, initiation: Initiation<'_>) -> Result<Session> {
     for _ in 0..8 {
         let id = ulid::Ulid::new().to_string();
         let session = Session {
             version: VERSION,
             id: id.clone(),
-            bucket: bucket.to_owned(),
-            key: key.to_owned(),
-            branch: branch.to_owned(),
-            path: path.to_owned(),
-            principal: principal.to_owned(),
-            created_seconds: now,
+            bucket: initiation.bucket.to_owned(),
+            key: initiation.key.to_owned(),
+            branch: initiation.branch.to_owned(),
+            path: initiation.path.to_owned(),
+            principal: initiation.principal.to_owned(),
+            created_seconds: initiation.now,
             revision: 0,
             state: State::Open,
-            attributes: attributes.clone(),
+            attributes: initiation.attributes.clone(),
+            checksum_algorithm: initiation.checksum_algorithm.clone(),
+            checksum_type: initiation.checksum_type.clone(),
             parts: BTreeMap::new(),
             selected_parts: None,
             completion_etag: None,
+            completion_checksums: None,
         };
         let bytes = serde_json::to_vec(&session)?;
         match repository
@@ -153,6 +170,7 @@ pub(crate) async fn register_part(
     number: i32,
     spool: &crate::content::Spool,
     etag: String,
+    checksums: crate::attributes::Checksums,
     now: u64,
     cancel: &tokio_util::sync::CancellationToken,
 ) -> Result<Part> {
@@ -180,6 +198,7 @@ pub(crate) async fn register_part(
         etag,
         size: spool.size,
         modified_seconds: now,
+        checksums,
         path,
     };
     loaded.session.parts.insert(number, part.clone());
@@ -284,6 +303,7 @@ pub(crate) async fn complete(
     repository: &Repository,
     mut loaded: Loaded,
     etag: String,
+    checksums: crate::attributes::Checksums,
 ) -> Result<()> {
     if matches!(loaded.session.state, State::Completed)
         && loaded.session.completion_etag.as_deref() == Some(&etag)
@@ -295,6 +315,7 @@ pub(crate) async fn complete(
     }
     loaded.session.state = State::Completed;
     loaded.session.completion_etag = Some(etag);
+    loaded.session.completion_checksums = Some(checksums);
     loaded.session.revision = loaded.session.revision.saturating_add(1);
     save(repository, &loaded).await?;
     if let Err(error) = cleanup_parts(repository, &loaded.session.id).await {
@@ -427,13 +448,17 @@ mod tests {
         let repository = fixture().await;
         let session = create(
             &repository,
-            "repo",
-            "main/file.bin",
-            "refs/heads/main",
-            "file.bin",
-            "user",
-            PutAttributes::default(),
-            10,
+            Initiation {
+                bucket: "repo",
+                key: "main/file.bin",
+                branch: "refs/heads/main",
+                path: "file.bin",
+                principal: "user",
+                attributes: PutAttributes::default(),
+                checksum_algorithm: None,
+                checksum_type: None,
+                now: 10,
+            },
         )
         .await
         .unwrap();
@@ -447,6 +472,7 @@ mod tests {
             1,
             &spool,
             etag.clone(),
+            crate::attributes::Checksums::default(),
             11,
             &tokio_util::sync::CancellationToken::new(),
         )
@@ -474,13 +500,17 @@ mod tests {
         let repository = fixture().await;
         let session = create(
             &repository,
-            "repo",
-            "main/file.bin",
-            "refs/heads/main",
-            "file.bin",
-            "user",
-            PutAttributes::default(),
-            10,
+            Initiation {
+                bucket: "repo",
+                key: "main/file.bin",
+                branch: "refs/heads/main",
+                path: "file.bin",
+                principal: "user",
+                attributes: PutAttributes::default(),
+                checksum_algorithm: None,
+                checksum_type: None,
+                now: 10,
+            },
         )
         .await
         .unwrap();
@@ -494,6 +524,7 @@ mod tests {
             1,
             &spool,
             etag.clone(),
+            crate::attributes::Checksums::default(),
             11,
             &tokio_util::sync::CancellationToken::new(),
         )
@@ -505,9 +536,14 @@ mod tests {
         let loaded = load(&repository, &session.id).await.unwrap();
         freeze(&repository, loaded, &selected, 1024).await.unwrap();
         let loaded = load(&repository, &session.id).await.unwrap();
-        complete(&repository, loaded, "result-etag".to_owned())
-            .await
-            .unwrap();
+        complete(
+            &repository,
+            loaded,
+            "result-etag".to_owned(),
+            crate::attributes::Checksums::default(),
+        )
+        .await
+        .unwrap();
 
         let loaded = load(&repository, &session.id).await.unwrap();
         assert_eq!(

--- a/crates/crab-s3-gateway/src/mutation.rs
+++ b/crates/crab-s3-gateway/src/mutation.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::BTreeMap,
+    collections::HashMap,
     io::Write as _,
     sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
+        Arc, Weak,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -11,16 +11,21 @@ use std::{
 use bytes::Bytes;
 use crab_coordination::{GcFenceHeartbeat, GcFenceLease, PushLock};
 use crab_metadata::{git_visibility, manifests::PackManifestEntry, ref_journal::RefJournalEdit};
-use crab_remote_git::{EntryMode, OperationKind, RemoteGitRepository, Revision};
+use crab_remote_git::{EntryKind, EntryMode, OperationKind, RemoteGitRepository, Revision};
 use gix_hash::ObjectId;
 use gix_object::{Kind, WriteTo as _, bstr::BString, tree};
 use md5::Digest as _;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
 
 use crate::{attributes, gateway::Repository};
 
 const LOCK_TTL: Duration = Duration::from_secs(300);
 const MAX_GENERATED_PACK_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_QUEUED_WRITES_PER_REF: usize = 64;
+const WRITE_QUEUE_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_REPREPARE_ATTEMPTS: usize = 8;
+const TREE_PAGE_SIZE: usize = 4_096;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
@@ -34,6 +39,12 @@ pub(crate) enum Error {
     PreconditionFailed,
     #[error("repository mutation was cancelled")]
     Cancelled,
+    #[error("repository write queue is full")]
+    Overloaded,
+    #[error("repository write queue wait timed out")]
+    AdmissionTimeout,
+    #[error("repository write admission state is unavailable")]
+    AdmissionState,
     #[error("system clock is before the Unix epoch")]
     Clock(#[from] std::time::SystemTimeError),
     #[error("repository read failed")]
@@ -64,7 +75,12 @@ pub(crate) enum Error {
 
 impl From<crate::Error> for Error {
     fn from(error: crate::Error) -> Self {
-        Self::Attributes(Box::new(error))
+        match error {
+            crate::Error::Remote(source) => Self::Remote(source),
+            crate::Error::Metadata(source) => Self::Metadata(source),
+            crate::Error::Write(source) => Self::Write(source),
+            error => Self::Attributes(Box::new(error)),
+        }
     }
 }
 
@@ -95,6 +111,155 @@ pub(crate) struct Outcome {
     pub(crate) etag: Option<String>,
 }
 
+pub(crate) struct Coordinator {
+    runtime: Arc<crab_remote_git::RemoteGitRuntime>,
+    options: crab_remote_git::RepositoryOptions,
+    admission: WriteAdmission,
+}
+
+impl Coordinator {
+    pub(crate) fn new(
+        runtime: Arc<crab_remote_git::RemoteGitRuntime>,
+        options: crab_remote_git::RepositoryOptions,
+    ) -> Self {
+        Self {
+            runtime,
+            options,
+            admission: WriteAdmission::default(),
+        }
+    }
+
+    pub(crate) async fn apply(
+        &self,
+        repository: &Repository,
+        branch: &str,
+        path: &crab_remote_git::GitPath,
+        change: Change,
+        principal: &str,
+        cancel: &CancellationToken,
+    ) -> Result<Outcome> {
+        repository.maintenance.begin();
+        let result = async {
+            let _admitted = self
+                .admission
+                .acquire(&repository.config.name, branch, cancel)
+                .await?;
+            apply_admitted(
+                repository,
+                Arc::clone(&self.runtime),
+                self.options,
+                branch,
+                path,
+                change,
+                principal,
+                cancel,
+            )
+            .await
+        }
+        .await;
+        if let Some(epoch) = repository.maintenance.finish() {
+            crate::repository::schedule_readability(
+                repository,
+                Arc::clone(&self.runtime),
+                self.options,
+                cancel.clone(),
+                epoch,
+            );
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+async fn apply(
+    repository: &Repository,
+    runtime: Arc<crab_remote_git::RemoteGitRuntime>,
+    options: crab_remote_git::RepositoryOptions,
+    branch: &str,
+    path: &crab_remote_git::GitPath,
+    change: Change,
+    principal: &str,
+    cancel: &CancellationToken,
+) -> Result<Outcome> {
+    Coordinator::new(runtime, options)
+        .apply(repository, branch, path, change, principal, cancel)
+        .await
+}
+
+#[derive(Default)]
+struct WriteAdmission {
+    refs: std::sync::Mutex<HashMap<String, Weak<RefQueue>>>,
+}
+
+struct RefQueue {
+    gate: Arc<Semaphore>,
+    admitted: AtomicUsize,
+}
+
+struct WritePermit {
+    queue: Arc<RefQueue>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl Drop for WritePermit {
+    fn drop(&mut self) {
+        self.queue.admitted.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+impl WriteAdmission {
+    async fn acquire(
+        &self,
+        repository: &str,
+        branch: &str,
+        cancel: &CancellationToken,
+    ) -> Result<WritePermit> {
+        check_cancelled(cancel)?;
+        let key = format!("{repository}\0{branch}");
+        let queue = {
+            let mut refs = self.refs.lock().map_err(|_| Error::AdmissionState)?;
+            refs.retain(|_, queue| queue.strong_count() > 0);
+            match refs.get(&key).and_then(Weak::upgrade) {
+                Some(queue) => queue,
+                None => {
+                    let queue = Arc::new(RefQueue {
+                        gate: Arc::new(Semaphore::new(1)),
+                        admitted: AtomicUsize::new(0),
+                    });
+                    refs.insert(key, Arc::downgrade(&queue));
+                    queue
+                }
+            }
+        };
+        queue
+            .admitted
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |value| {
+                (value < MAX_QUEUED_WRITES_PER_REF).then_some(value + 1)
+            })
+            .map_err(|_| Error::Overloaded)?;
+        let acquired = tokio::select! {
+            () = cancel.cancelled() => Err(Error::Cancelled),
+            result = tokio::time::timeout(WRITE_QUEUE_TIMEOUT, Arc::clone(&queue.gate).acquire_owned()) => {
+                match result {
+                    Ok(Ok(permit)) => Ok(permit),
+                    Ok(Err(_)) => Err(Error::AdmissionState),
+                    Err(_) => Err(Error::AdmissionTimeout),
+                }
+            }
+        };
+        match acquired {
+            Ok(permit) => Ok(WritePermit {
+                queue,
+                _permit: permit,
+            }),
+            Err(error) => {
+                queue.admitted.fetch_sub(1, Ordering::AcqRel);
+                Err(error)
+            }
+        }
+    }
+}
+
 struct RefLease {
     holder: String,
     stop: CancellationToken,
@@ -108,13 +273,36 @@ impl RefLease {
         cancel: &CancellationToken,
     ) -> Result<Self> {
         check_cancelled(cancel)?;
-        let mut lock = PushLock::acquire_ref(
-            repository.store.inner(),
-            repository.layout.repo_prefix(),
-            branch,
-            LOCK_TTL,
-        )
-        .await?;
+        let deadline = tokio::time::Instant::now() + WRITE_QUEUE_TIMEOUT;
+        let mut attempt = 0u32;
+        let mut lock = loop {
+            match PushLock::acquire_ref(
+                repository.store.inner(),
+                repository.layout.repo_prefix(),
+                branch,
+                LOCK_TTL,
+            )
+            .await
+            {
+                Ok(lock) => break lock,
+                Err(crab_coordination::CoordinationError::PushLockHeld { .. })
+                    if tokio::time::Instant::now() < deadline =>
+                {
+                    let delay = Duration::from_millis(
+                        25u64.saturating_mul(1u64.checked_shl(attempt.min(4)).unwrap_or(16)),
+                    );
+                    attempt = attempt.saturating_add(1);
+                    tokio::select! {
+                        () = cancel.cancelled() => return Err(Error::Cancelled),
+                        () = tokio::time::sleep(delay) => {}
+                    }
+                }
+                Err(crab_coordination::CoordinationError::PushLockHeld { .. }) => {
+                    return Err(Error::AdmissionTimeout);
+                }
+                Err(error) => return Err(error.into()),
+            }
+        };
         let holder = lock.holder().to_owned();
         let stop = CancellationToken::new();
         let stopped = stop.clone();
@@ -142,7 +330,7 @@ impl RefLease {
     }
 }
 
-pub(crate) async fn apply(
+async fn apply_admitted(
     repository: &Repository,
     runtime: Arc<crab_remote_git::RemoteGitRuntime>,
     options: crab_remote_git::RepositoryOptions,
@@ -152,8 +340,6 @@ pub(crate) async fn apply(
     principal: &str,
     cancel: &CancellationToken,
 ) -> Result<Outcome> {
-    let lease = RefLease::acquire(repository, branch, cancel).await?;
-    let maintenance_runtime = Arc::clone(&runtime);
     let mut fences = Vec::new();
     let result = async {
         for domain in [
@@ -166,15 +352,14 @@ pub(crate) async fn apply(
             let heartbeat = GcFenceHeartbeat::spawn(&fence, cancel.clone(), LOCK_TTL / 3);
             fences.push((fence, heartbeat));
         }
-        Box::pin(apply_locked(
+        Box::pin(apply_with_fences(
             repository,
-            runtime,
+            Arc::clone(&runtime),
             options,
             branch,
             path,
             change,
             principal,
-            &lease.holder,
             cancel,
         ))
         .await
@@ -186,16 +371,13 @@ pub(crate) async fn apply(
             tracing::warn!(%error, "S3 GC fence cleanup failed");
         }
     }
-    lease.release().await;
     if result.is_ok() {
-        crate::repository::ensure_readable(repository, maintenance_runtime, options, cancel)
-            .await?;
+        repository.read_views.invalidate().await;
     }
     result
 }
 
-#[expect(clippy::too_many_arguments)]
-async fn apply_locked(
+async fn apply_with_fences(
     repository: &Repository,
     runtime: Arc<crab_remote_git::RemoteGitRuntime>,
     options: crab_remote_git::RepositoryOptions,
@@ -203,100 +385,150 @@ async fn apply_locked(
     path: &crab_remote_git::GitPath,
     change: Change,
     principal: &str,
-    holder: &str,
     cancel: &CancellationToken,
 ) -> Result<Outcome> {
-    check_cancelled(cancel)?;
-    let remote = crate::repository::open_current(repository, runtime, options, cancel).await?;
-    let old = remote
-        .refs()
-        .entries
-        .iter()
-        .find(|reference| reference.name == branch)
-        .map(|reference| reference.target);
-    let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
-        &repository.store,
-        &repository.layout,
-    )
-    .await?;
-    if snapshot.manifest.generation != remote.generation()
-        || snapshot.journal.refs.get(branch).map(String::as_str)
-            != old.as_ref().map(ToString::to_string).as_deref()
-    {
-        return Err(crab_write::WriteError::RefChanged {
-            ref_name: branch.to_owned(),
-            path: repository.layout.repo_prefix().to_owned(),
+    for _ in 0..MAX_REPREPARE_ATTEMPTS {
+        check_cancelled(cancel)?;
+        let prepared = prepare_and_upload(
+            repository,
+            Arc::clone(&runtime),
+            options,
+            branch,
+            path,
+            change.clone(),
+            principal,
+            cancel,
+        )
+        .await?;
+        let prepared = match prepared {
+            Prepared::Noop(outcome) => return Ok(outcome),
+            Prepared::Commit(prepared) => prepared,
+        };
+        let lease = RefLease::acquire(repository, branch, cancel).await?;
+        let published =
+            publish_prepared(repository, branch, &lease.holder, &prepared, cancel).await;
+        lease.release().await;
+        match published? {
+            Publish::Committed => {
+                return Ok(Outcome {
+                    etag: prepared.etag,
+                });
+            }
+            Publish::Reprepare => repository.read_views.invalidate().await,
         }
-        .into());
     }
-    let mut attribute_manifest = match old {
-        Some(old) => attributes::load(repository, old)
-            .await
-            .map_err(|error| Error::Attributes(Box::new(error)))?,
-        None => attributes::Manifest::default(),
-    };
-    let operation = remote.operation(OperationKind::Repository, cancel).await?;
-    let built = build_commit(
-        &remote,
-        &operation,
-        old,
-        path,
-        change,
-        principal,
-        &attribute_manifest,
-    )
+    Err(crab_write::WriteError::RefChanged {
+        ref_name: branch.to_owned(),
+        path: repository.layout.repo_prefix().to_owned(),
+    }
+    .into())
+}
+
+struct UploadedMutation {
+    parent: Option<ObjectId>,
+    commit: ObjectId,
+    etag: Option<String>,
+    pack: PackManifestEntry,
+    evidence_hash: String,
+}
+
+enum Prepared {
+    Noop(Outcome),
+    Commit(UploadedMutation),
+}
+
+enum Publish {
+    Committed,
+    Reprepare,
+}
+
+async fn prepare_and_upload(
+    repository: &Repository,
+    runtime: Arc<crab_remote_git::RemoteGitRuntime>,
+    options: crab_remote_git::RepositoryOptions,
+    branch: &str,
+    path: &crab_remote_git::GitPath,
+    change: Change,
+    principal: &str,
+    cancel: &CancellationToken,
+) -> Result<Prepared> {
+    let view = repository
+        .read_views
+        .current(repository, runtime, options, cancel)
+        .await?;
+    let parent = view
+        .remote()
+        .refs()
+        .find(branch)
+        .map(|reference| reference.target);
+    let operation = view
+        .remote()
+        .operation(OperationKind::Repository, cancel)
+        .await?;
+    let built = async {
+        let snapshot = match parent {
+            Some(parent) => Some(view.snapshot(&parent.to_string(), &operation).await?),
+            None => None,
+        };
+        let path_string = std::str::from_utf8(path.as_bytes())
+            .map_err(|_| std::io::Error::other("S3 object path is not UTF-8"))?;
+        let current_attributes = match &snapshot {
+            Some(snapshot) => match snapshot.entry(path, &operation).await? {
+                Some(entry) if entry.kind == EntryKind::Blob => {
+                    view.object_attributes(
+                        repository,
+                        snapshot.commit_oid(),
+                        path_string,
+                        entry.oid,
+                    )
+                    .await?
+                }
+                Some(_) | None => None,
+            },
+            None => None,
+        };
+        build_commit(
+            view.remote(),
+            &operation,
+            parent,
+            path,
+            change,
+            principal,
+            current_attributes.as_ref(),
+        )
+        .await
+    }
     .await;
     let built = match operation.finish(Ok(())).await {
         Ok(()) => built?,
         Err(error) => return Err(error.into()),
     };
     let built = match built {
-        Build::Noop(outcome) => return Ok(outcome),
+        Build::Noop(outcome) => return Ok(Prepared::Noop(outcome)),
         Build::Commit(built) => *built,
     };
+    upload_built(repository, parent, built, cancel)
+        .await
+        .map(Prepared::Commit)
+}
+
+async fn upload_built(
+    repository: &Repository,
+    parent: Option<ObjectId>,
+    built: BuiltCommit,
+    cancel: &CancellationToken,
+) -> Result<UploadedMutation> {
     let (pack_owner, pack) = prepare_pack(built.objects.clone(), cancel).await?;
     check_cancelled(cancel)?;
     let pack_id = pack.content_hash().to_hex().to_string();
-    repository
-        .store
-        .put_multipart_file_retry(
-            &repository.layout.pack_path(&pack_id),
-            pack.pack_path(),
-            pack.size(),
-            *pack.content_hash().as_bytes(),
-            8 * 1024 * 1024,
-            cancel,
-            None,
-        )
-        .await?;
-    for (source, target) in [
-        (
-            pack.index_path(),
-            repository.layout.pack_index_path(&pack_id),
-        ),
-        (
-            pack.reverse_path(),
-            repository.layout.pack_reverse_index_path(&pack_id),
-        ),
-        (
-            pack.kinds_path(),
-            repository.layout.pack_kind_metadata_path(&pack_id),
-        ),
-    ] {
-        check_cancelled(cancel)?;
-        repository
-            .store
-            .put_exact(&target, tokio::fs::read(source).await?.into())
-            .await?;
-    }
     let visible_objects = built
         .objects
         .iter()
         .map(|(kind, bytes)| object_id(*kind, bytes).map(|oid| oid.to_string()))
         .collect::<std::result::Result<Vec<_>, _>>()?;
-    let evidence = match old {
-        Some(old) => git_visibility::GitVisibilityEdit::from_delta_objects(
-            Some(old.to_string()),
+    let evidence = match parent {
+        Some(parent) => git_visibility::GitVisibilityEdit::from_delta_objects(
+            Some(parent.to_string()),
             built.commit.to_string(),
             visible_objects,
             vec![],
@@ -307,43 +539,126 @@ async fn apply_locked(
             visible_objects,
         ),
     };
-    let evidence_hash =
-        git_visibility::upload_edit(&repository.store, &repository.layout, &evidence).await?;
-    match built.attributes.clone() {
-        Some(attributes) => attribute_manifest.put(built.path.clone(), attributes),
-        None => attribute_manifest.remove(&built.path),
-    }
-    attributes::save(repository, built.commit, &attribute_manifest)
+    let pack_upload = async {
+        repository
+            .store
+            .put_multipart_file_retry(
+                &repository.layout.pack_path(&pack_id),
+                pack.pack_path(),
+                pack.size(),
+                *pack.content_hash().as_bytes(),
+                8 * 1024 * 1024,
+                cancel,
+                None,
+            )
+            .await?;
+        Ok::<(), Error>(())
+    };
+    let sidecar_upload = |source: &std::path::Path, target| {
+        let source = source.to_owned();
+        async move {
+            check_cancelled(cancel)?;
+            repository
+                .store
+                .put_exact(&target, tokio::fs::read(source).await?.into())
+                .await?;
+            Ok::<(), Error>(())
+        }
+    };
+    let evidence_upload = async {
+        git_visibility::upload_edit(&repository.store, &repository.layout, &evidence)
+            .await
+            .map_err(Error::from)
+    };
+    let attributes_upload = async {
+        attributes::save_delta(
+            repository,
+            built.commit,
+            parent,
+            built.path.clone(),
+            built.attributes.clone(),
+        )
         .await
-        .map_err(|error| Error::Attributes(Box::new(error)))?;
+        .map_err(Error::from)
+    };
+    let (_, _, _, _, evidence_hash, _) = tokio::try_join!(
+        pack_upload,
+        sidecar_upload(
+            pack.index_path(),
+            repository.layout.pack_index_path(&pack_id)
+        ),
+        sidecar_upload(
+            pack.reverse_path(),
+            repository.layout.pack_reverse_index_path(&pack_id)
+        ),
+        sidecar_upload(
+            pack.kinds_path(),
+            repository.layout.pack_kind_metadata_path(&pack_id)
+        ),
+        evidence_upload,
+        attributes_upload,
+    )?;
     check_cancelled(cancel)?;
+    let uploaded = UploadedMutation {
+        parent,
+        commit: built.commit,
+        etag: built.etag,
+        pack: PackManifestEntry {
+            pack_id: pack_id.clone(),
+            content_hash: pack_id,
+            size: pack.size(),
+            object_count: pack.object_count().into(),
+            ref_tips: vec![built.commit.to_string()],
+        },
+        evidence_hash,
+    };
+    drop(pack);
+    drop(pack_owner);
+    Ok(uploaded)
+}
+
+async fn publish_prepared(
+    repository: &Repository,
+    branch: &str,
+    holder: &str,
+    prepared: &UploadedMutation,
+    cancel: &CancellationToken,
+) -> Result<Publish> {
+    check_cancelled(cancel)?;
+    let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+        &repository.store,
+        &repository.layout,
+    )
+    .await?;
+    let current = snapshot
+        .journal
+        .refs
+        .get(branch)
+        .map(|oid| oid.parse::<ObjectId>())
+        .transpose()
+        .map_err(|_| std::io::Error::other("repository ref contains an invalid object ID"))?;
+    if current != prepared.parent {
+        return Ok(Publish::Reprepare);
+    }
     crab_write::journal::commit_edits(
         &repository.store,
         &repository.layout,
         &snapshot,
         vec![RefJournalEdit {
             ref_name: branch.to_owned(),
-            old_oid: old.map(|oid| oid.to_string()),
-            new_oid: Some(built.commit.to_string()),
+            old_oid: prepared.parent.map(|oid| oid.to_string()),
+            new_oid: Some(prepared.commit.to_string()),
             peeled_oid: None,
             lock_holder: Some(holder.to_owned()),
-            visibility_evidence_hash: Some(evidence_hash),
+            visibility_evidence_hash: Some(prepared.evidence_hash.clone()),
         }],
-        old.is_none().then(|| branch.to_owned()),
-        vec![PackManifestEntry {
-            pack_id: pack_id.clone(),
-            content_hash: pack_id,
-            size: pack.size(),
-            object_count: pack.object_count().into(),
-            ref_tips: vec![built.commit.to_string()],
-        }],
+        prepared.parent.is_none().then(|| branch.to_owned()),
+        vec![prepared.pack.clone()],
         vec![],
         crab_write::journal::CommitOptions::new(LOCK_TTL, cancel),
     )
     .await?;
-    drop(pack);
-    drop(pack_owner);
-    Ok(Outcome { etag: built.etag })
+    Ok(Publish::Committed)
 }
 
 struct BuiltCommit {
@@ -359,16 +674,9 @@ enum Build {
     Commit(Box<BuiltCommit>),
 }
 
-#[derive(Default)]
-struct TreeNode {
+struct TreeFrame {
     old_oid: Option<ObjectId>,
-    files: BTreeMap<Vec<u8>, TreeLeaf>,
-    directories: BTreeMap<Vec<u8>, TreeNode>,
-}
-
-struct TreeLeaf {
-    oid: ObjectId,
-    mode: EntryMode,
+    entries: Vec<tree::Entry>,
 }
 
 async fn build_commit(
@@ -378,19 +686,57 @@ async fn build_commit(
     path: &crab_remote_git::GitPath,
     change: Change,
     principal: &str,
-    attribute_manifest: &attributes::Manifest,
+    current_attributes: Option<&attributes::ObjectAttributes>,
 ) -> Result<Build> {
-    let mut root = TreeNode::default();
-    if let Some(parent) = parent {
-        let snapshot = remote
-            .snapshot(&Revision::Commit(parent), operation)
-            .await?;
-        root.old_oid = Some(snapshot.root_tree_oid());
-        for entry in snapshot.list_tree_recursive(operation).await? {
-            insert_entry(&mut root, &entry)?;
+    let components = path.components().map(<[u8]>::to_vec).collect::<Vec<_>>();
+    let (name, directories) = components.split_last().ok_or(Error::IsDirectory)?;
+    let snapshot = match parent {
+        Some(parent) => Some(
+            remote
+                .snapshot(&Revision::Commit(parent), operation)
+                .await?,
+        ),
+        None => None,
+    };
+    let mut frames = Vec::with_capacity(directories.len() + 1);
+    let mut directory_path = crab_remote_git::GitPath::root();
+    let mut directory_oid = snapshot.as_ref().map(|value| value.root_tree_oid());
+    for depth in 0..=directories.len() {
+        let entries = match (&snapshot, directory_oid) {
+            (Some(snapshot), Some(_)) => {
+                load_directory(snapshot, &directory_path, operation).await?
+            }
+            (None, None) | (Some(_), None) => Vec::new(),
+            (None, Some(_)) => {
+                return Err(std::io::Error::other("empty repository has a root tree").into());
+            }
+        };
+        frames.push(TreeFrame {
+            old_oid: directory_oid,
+            entries,
+        });
+        if depth == directories.len() {
+            break;
         }
+        let component = &directories[depth];
+        directory_oid = match find_entry(&frames[depth].entries, component) {
+            Some(entry) if entry.mode == tree::EntryKind::Tree.into() => Some(entry.oid),
+            Some(_) => return Err(Error::NotDirectory),
+            None => None,
+        };
+        directory_path = push_component(&directory_path, component)?;
     }
-    let old = root.file(path)?.map(|leaf| (leaf.oid, leaf.mode));
+    let leaf_entries = &mut frames
+        .last_mut()
+        .ok_or_else(|| std::io::Error::other("object path has no parent tree"))?
+        .entries;
+    let old = match find_entry(leaf_entries, name) {
+        Some(entry) if entry.mode == tree::EntryKind::Tree.into() => {
+            return Err(Error::IsDirectory);
+        }
+        Some(entry) => Some((entry.oid, entry_mode(entry.mode)?)),
+        None => None,
+    };
     let path_string = std::str::from_utf8(path.as_bytes())
         .map_err(|_| std::io::Error::other("S3 object path is not UTF-8"))?;
     let (etag, changed, pending_attributes) = match change {
@@ -418,13 +764,20 @@ async fn build_commit(
                 .unwrap_or_else(|| digest.iter().map(|byte| format!("{byte:02x}")).collect());
             if attributes.completion_upload_id.is_some()
                 && old.is_some_and(|(old_oid, mode)| old_oid == oid && mode == EntryMode::Regular)
-                && attribute_manifest
-                    .object(path_string, oid)
+                && current_attributes
                     .is_some_and(|stored| stored.matches_pending(&attributes, &etag, logical_size))
             {
                 return Ok(Build::Noop(Outcome { etag: Some(etag) }));
             }
-            root.put(path, oid)?;
+            replace_entry(
+                leaf_entries,
+                name,
+                Some(tree::Entry {
+                    mode: tree::EntryKind::Blob.into(),
+                    filename: BString::from(name.clone()),
+                    oid,
+                }),
+            );
             let changed = old
                 .filter(|(old_oid, _)| *old_oid == oid)
                 .map(|_| None)
@@ -446,8 +799,7 @@ async fn build_commit(
             let etag = attributes.etag_override.clone().ok_or_else(|| {
                 std::io::Error::other("attribute-only mutation is missing object ETag")
             })?;
-            if attribute_manifest
-                .object(path_string, expected)
+            if current_attributes
                 .is_some_and(|stored| stored.matches_pending(&attributes, &etag, logical_size))
             {
                 return Ok(Build::Noop(Outcome { etag: Some(etag) }));
@@ -458,7 +810,7 @@ async fn build_commit(
             if old.is_none() {
                 return Ok(Build::Noop(Outcome { etag: None }));
             }
-            root.delete(path)?;
+            replace_entry(leaf_entries, name, None);
             (None, None, None)
         }
     };
@@ -466,7 +818,32 @@ async fn build_commit(
     if let Some(bytes) = changed {
         objects.push((Kind::Blob, bytes));
     }
-    let tree = encode_node(&root, &mut objects)?;
+    let mut tree_oid = None;
+    for depth in (0..frames.len()).rev() {
+        let frame = &mut frames[depth];
+        let empty = frame.entries.is_empty();
+        let oid = if depth > 0 && empty {
+            None
+        } else {
+            Some(encode_tree(
+                frame.old_oid,
+                std::mem::take(&mut frame.entries),
+                &mut objects,
+            )?)
+        };
+        if depth == 0 {
+            tree_oid = oid;
+            break;
+        }
+        let directory_name = &directories[depth - 1];
+        let entry = oid.map(|oid| tree::Entry {
+            mode: tree::EntryKind::Tree.into(),
+            filename: BString::from(directory_name.clone()),
+            oid,
+        });
+        replace_entry(&mut frames[depth - 1].entries, directory_name, entry);
+    }
+    let tree = tree_oid.ok_or_else(|| std::io::Error::other("root tree was not encoded"))?;
     let seconds = now_seconds()?;
     let object_attributes = pending_attributes.map(|(oid, pending, size)| {
         attributes::ObjectAttributes::new(
@@ -477,7 +854,14 @@ async fn build_commit(
             *pending,
         )
     });
-    let commit_bytes = commit_bytes(tree, parent, principal, seconds);
+    let attribute_identity = serde_json::to_vec(&(
+        path_string,
+        parent.map(|oid| oid.to_string()),
+        &object_attributes,
+    ))
+    .map_err(|source| Error::Attributes(Box::new(crate::Error::Attributes { source })))?;
+    let attribute_digest = blake3::hash(&attribute_identity).to_hex();
+    let commit_bytes = commit_bytes(tree, parent, principal, seconds, attribute_digest.as_str());
     let commit = object_id(Kind::Commit, &commit_bytes)?;
     objects.push((Kind::Commit, commit_bytes));
     Ok(Build::Commit(Box::new(BuiltCommit {
@@ -489,127 +873,100 @@ async fn build_commit(
     })))
 }
 
-fn insert_entry(root: &mut TreeNode, entry: &crab_remote_git::TreeEntry) -> Result<()> {
-    let components = entry.path.components().collect::<Vec<_>>();
-    let (name, parents) = components.split_last().ok_or(Error::NotDirectory)?;
-    let mut node = root;
-    for component in parents {
-        node = node.directories.entry((*component).to_vec()).or_default();
-    }
-    if entry.mode == EntryMode::Tree {
-        node.directories
-            .entry((*name).to_vec())
-            .or_default()
-            .old_oid = Some(entry.oid);
-    } else {
-        node.files.insert(
-            (*name).to_vec(),
-            TreeLeaf {
-                oid: entry.oid,
-                mode: entry.mode,
-            },
-        );
-    }
-    Ok(())
-}
-
-impl TreeNode {
-    fn file(&self, path: &crab_remote_git::GitPath) -> Result<Option<&TreeLeaf>> {
-        let components = path.components().collect::<Vec<_>>();
-        let (name, parents) = components.split_last().ok_or(Error::IsDirectory)?;
-        let mut node = self;
-        for component in parents {
-            if node.files.contains_key(*component) {
-                return Err(Error::NotDirectory);
-            }
-            let Some(next) = node.directories.get(*component) else {
-                return Ok(None);
-            };
-            node = next;
-        }
-        if node.directories.contains_key(*name) {
-            return Err(Error::IsDirectory);
-        }
-        Ok(node.files.get(*name))
-    }
-
-    fn put(&mut self, path: &crab_remote_git::GitPath, oid: ObjectId) -> Result<()> {
-        let components = path.components().collect::<Vec<_>>();
-        let (name, parents) = components.split_last().ok_or(Error::IsDirectory)?;
-        let mut node = self;
-        for component in parents {
-            if node.files.contains_key(*component) {
-                return Err(Error::NotDirectory);
-            }
-            node = node.directories.entry((*component).to_vec()).or_default();
-        }
-        if node.directories.contains_key(*name) {
-            return Err(Error::IsDirectory);
-        }
-        node.files.insert(
-            (*name).to_vec(),
-            TreeLeaf {
-                oid,
-                mode: EntryMode::Regular,
-            },
-        );
-        Ok(())
-    }
-
-    fn delete(&mut self, path: &crab_remote_git::GitPath) -> Result<()> {
-        let components = path.components().collect::<Vec<_>>();
-        let (name, parents) = components.split_last().ok_or(Error::IsDirectory)?;
-        delete_from(self, parents, name)
-    }
-}
-
-fn delete_from(node: &mut TreeNode, parents: &[&[u8]], name: &[u8]) -> Result<()> {
-    let Some((component, rest)) = parents.split_first() else {
-        node.files.remove(name);
-        return Ok(());
-    };
-    if node.files.contains_key(*component) {
-        return Err(Error::NotDirectory);
-    }
-    let Some(child) = node.directories.get_mut(*component) else {
-        return Ok(());
-    };
-    delete_from(child, rest, name)?;
-    if child.files.is_empty() && child.directories.is_empty() {
-        node.directories.remove(*component);
-    }
-    Ok(())
-}
-
-fn encode_node(node: &TreeNode, objects: &mut Vec<(Kind, Vec<u8>)>) -> Result<ObjectId> {
-    let mut entries = Vec::with_capacity(node.files.len() + node.directories.len());
-    for (name, child) in &node.directories {
-        let oid = encode_node(child, objects)?;
-        entries.push(tree::Entry {
-            mode: tree::EntryKind::Tree.into(),
-            filename: BString::from(name.clone()),
-            oid,
-        });
-    }
-    for (name, leaf) in &node.files {
-        let mode = match leaf.mode {
-            EntryMode::Regular => tree::EntryKind::Blob,
-            EntryMode::Executable => tree::EntryKind::BlobExecutable,
-            EntryMode::Symlink => tree::EntryKind::Link,
-            EntryMode::Submodule => tree::EntryKind::Commit,
-            EntryMode::Tree => return Err(Error::IsDirectory),
+async fn load_directory(
+    snapshot: &crab_remote_git::RemoteGitSnapshot,
+    path: &crab_remote_git::GitPath,
+    operation: &crab_remote_git::OperationContext,
+) -> Result<Vec<tree::Entry>> {
+    let mut cursor = None;
+    let mut entries = Vec::new();
+    loop {
+        let page = snapshot
+            .list_directory(
+                path,
+                &crab_remote_git::PageRequest::new(TREE_PAGE_SIZE, cursor)?,
+                operation,
+            )
+            .await?;
+        entries.extend(page.items.into_iter().map(tree_entry));
+        let Some(next) = page.next else {
+            break;
         };
-        entries.push(tree::Entry {
-            mode: mode.into(),
-            filename: BString::from(name.clone()),
-            oid: leaf.oid,
-        });
+        cursor = Some(next);
     }
+    Ok(entries)
+}
+
+fn tree_entry(entry: crab_remote_git::TreeEntry) -> tree::Entry {
+    let name = entry
+        .path
+        .components()
+        .last()
+        .map(<[u8]>::to_vec)
+        .unwrap_or_default();
+    tree::Entry {
+        mode: git_entry_mode(entry.mode),
+        filename: BString::from(name),
+        oid: entry.oid,
+    }
+}
+
+fn entry_mode(mode: gix_object::tree::EntryMode) -> Result<EntryMode> {
+    Ok(match mode.kind() {
+        tree::EntryKind::Tree => EntryMode::Tree,
+        tree::EntryKind::Blob => EntryMode::Regular,
+        tree::EntryKind::BlobExecutable => EntryMode::Executable,
+        tree::EntryKind::Link => EntryMode::Symlink,
+        tree::EntryKind::Commit => EntryMode::Submodule,
+    })
+}
+
+fn git_entry_mode(mode: EntryMode) -> gix_object::tree::EntryMode {
+    match mode {
+        EntryMode::Tree => tree::EntryKind::Tree,
+        EntryMode::Regular => tree::EntryKind::Blob,
+        EntryMode::Executable => tree::EntryKind::BlobExecutable,
+        EntryMode::Symlink => tree::EntryKind::Link,
+        EntryMode::Submodule => tree::EntryKind::Commit,
+    }
+    .into()
+}
+
+fn find_entry<'a>(entries: &'a [tree::Entry], name: &[u8]) -> Option<&'a tree::Entry> {
+    entries
+        .iter()
+        .find(|entry| <BString as AsRef<[u8]>>::as_ref(&entry.filename) == name)
+}
+
+fn replace_entry(entries: &mut Vec<tree::Entry>, name: &[u8], replacement: Option<tree::Entry>) {
+    entries.retain(|entry| <BString as AsRef<[u8]>>::as_ref(&entry.filename) != name);
+    if let Some(replacement) = replacement {
+        entries.push(replacement);
+    }
+}
+
+fn push_component(
+    parent: &crab_remote_git::GitPath,
+    component: &[u8],
+) -> Result<crab_remote_git::GitPath> {
+    let mut path = parent.as_bytes().to_vec();
+    if !path.is_empty() {
+        path.push(b'/');
+    }
+    path.extend_from_slice(component);
+    crab_remote_git::GitPath::new(path).map_err(Error::Remote)
+}
+
+fn encode_tree(
+    old_oid: Option<ObjectId>,
+    mut entries: Vec<tree::Entry>,
+    objects: &mut Vec<(Kind, Vec<u8>)>,
+) -> Result<ObjectId> {
     entries.sort();
     let mut bytes = Vec::new();
     gix_object::Tree { entries }.write_to(&mut bytes)?;
     let oid = object_id(Kind::Tree, &bytes)?;
-    if node.old_oid != Some(oid) {
+    if old_oid != Some(oid) {
         objects.push((Kind::Tree, bytes));
     }
     Ok(oid)
@@ -620,6 +977,7 @@ fn commit_bytes(
     parent: Option<ObjectId>,
     principal: &str,
     seconds: u64,
+    attribute_digest: &str,
 ) -> Vec<u8> {
     let name: String = principal
         .chars()
@@ -636,7 +994,7 @@ fn commit_bytes(
         .map(|oid| format!("parent {oid}\n"))
         .unwrap_or_default();
     format!(
-        "tree {tree}\n{parent}author {name} <{email}@users.crab.invalid> {seconds} +0000\ncommitter {name} <{email}@users.crab.invalid> {seconds} +0000\n\nUpdate object through Crab S3 gateway\n"
+        "tree {tree}\n{parent}author {name} <{email}@users.crab.invalid> {seconds} +0000\ncommitter {name} <{email}@users.crab.invalid> {seconds} +0000\n\nUpdate object through Crab S3 gateway\n\nCrab-S3-Attributes: {attribute_digest}\n"
     )
     .into_bytes()
 }
@@ -736,6 +1094,7 @@ fn check_cancelled(cancel: &CancellationToken) -> Result<()> {
 mod tests {
     use super::*;
     use crate::{RepositoryAccess, RepositoryConfig};
+    use std::collections::BTreeMap;
 
     async fn fixture() -> (
         Repository,
@@ -776,24 +1135,22 @@ mod tests {
         cancel: &CancellationToken,
         path: &str,
     ) -> Bytes {
-        let remote = RemoteGitRepository::open(
-            repository.store.clone(),
-            repository.layout.clone(),
-            repository.identity.clone(),
-            runtime,
-            crab_remote_git::RepositoryOptions::default(),
-            cancel,
-        )
-        .await
-        .unwrap();
-        let operation = remote
+        let view = repository
+            .read_views
+            .current(
+                repository,
+                runtime,
+                crab_remote_git::RepositoryOptions::default(),
+                cancel,
+            )
+            .await
+            .unwrap();
+        let operation = view
+            .remote()
             .operation(OperationKind::Repository, cancel)
             .await
             .unwrap();
-        let snapshot = remote
-            .snapshot(&Revision::parse("refs/heads/main").unwrap(), &operation)
-            .await
-            .unwrap();
+        let snapshot = view.snapshot("refs/heads/main", &operation).await.unwrap();
         let blob = snapshot
             .read_blob(
                 &crab_remote_git::GitPath::new(path.as_bytes().to_vec()).unwrap(),
@@ -810,22 +1167,23 @@ mod tests {
         runtime: Arc<crab_remote_git::RemoteGitRuntime>,
         cancel: &CancellationToken,
     ) -> ObjectId {
-        RemoteGitRepository::open(
-            repository.store.clone(),
-            repository.layout.clone(),
-            repository.identity.clone(),
-            runtime,
-            crab_remote_git::RepositoryOptions::default(),
-            cancel,
-        )
-        .await
-        .unwrap()
-        .refs()
-        .entries
-        .iter()
-        .find(|reference| reference.name == "refs/heads/main")
-        .unwrap()
-        .target
+        repository
+            .read_views
+            .current(
+                repository,
+                runtime,
+                crab_remote_git::RepositoryOptions::default(),
+                cancel,
+            )
+            .await
+            .unwrap()
+            .remote()
+            .refs()
+            .entries
+            .iter()
+            .find(|reference| reference.name == "refs/heads/main")
+            .unwrap()
+            .target
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1049,6 +1407,122 @@ mod tests {
             read(&repository, Arc::clone(&runtime), &cancel, "manifest").await,
             "first"
         );
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn same_ref_writes_queue_and_all_commit() {
+        let (repository, runtime, cancel) = fixture().await;
+        let repository = Arc::new(repository);
+        let coordinator = Arc::new(Coordinator::new(
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+        ));
+        let mut writes = tokio::task::JoinSet::new();
+        for index in 0..8 {
+            let repository = Arc::clone(&repository);
+            let coordinator = Arc::clone(&coordinator);
+            let cancel = cancel.clone();
+            writes.spawn(async move {
+                let path = format!("queued/{index}.txt");
+                coordinator
+                    .apply(
+                        &repository,
+                        "refs/heads/main",
+                        &crab_remote_git::GitPath::new(path.into_bytes()).unwrap(),
+                        Change::Put {
+                            bytes: Bytes::from(format!("value-{index}")),
+                            attributes: Box::new(attributes::PutAttributes::default()),
+                            condition: PutCondition::None,
+                        },
+                        "user",
+                        &cancel,
+                    )
+                    .await
+            });
+        }
+        while let Some(result) = writes.join_next().await {
+            result.unwrap().unwrap();
+        }
+        let mut canonical = None;
+        for _ in 0..100 {
+            let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+                &repository.store,
+                &repository.layout,
+            )
+            .await
+            .unwrap();
+            if snapshot.journal.transactions.is_empty() {
+                canonical = RemoteGitRepository::open(
+                    repository.store.clone(),
+                    repository.layout.clone(),
+                    repository.identity.clone(),
+                    Arc::clone(&runtime),
+                    crab_remote_git::RepositoryOptions::default(),
+                    &cancel,
+                )
+                .await
+                .ok();
+                if canonical.is_some() {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let canonical = canonical.expect("background maintenance should publish a readable view");
+        assert!(canonical.refs().find("refs/heads/main").is_some());
+        for index in 0..8 {
+            assert_eq!(
+                read(
+                    &repository,
+                    Arc::clone(&runtime),
+                    &cancel,
+                    &format!("queued/{index}.txt"),
+                )
+                .await,
+                format!("value-{index}")
+            );
+        }
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn each_commit_persists_only_its_path_attribute_delta() {
+        let (repository, runtime, cancel) = fixture().await;
+        for path in ["first.txt", "second.txt"] {
+            apply(
+                &repository,
+                Arc::clone(&runtime),
+                crab_remote_git::RepositoryOptions::default(),
+                "refs/heads/main",
+                &crab_remote_git::GitPath::new(path.as_bytes().to_vec()).unwrap(),
+                Change::Put {
+                    bytes: Bytes::from(path.to_owned()),
+                    attributes: Box::new(attributes::PutAttributes::default()),
+                    condition: PutCondition::None,
+                },
+                "user",
+                &cancel,
+            )
+            .await
+            .unwrap();
+        }
+        let commit = tip(&repository, Arc::clone(&runtime), &cancel).await;
+        let path = repository
+            .layout
+            .repo_path(&format!("s3/attributes/{commit}.json"));
+        let (bytes, _) = repository.store.get_with_etag(&path).await.unwrap();
+        let stored: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(stored["version"], 2);
+        assert!(stored.get("objects").is_none());
+        assert_eq!(stored["changes"].as_object().unwrap().len(), 1);
+        assert!(stored["changes"].get("second.txt").is_some());
+
+        let manifest = attributes::load(&repository, commit).await.unwrap();
+        for path in ["first.txt", "second.txt"] {
+            let oid = object_id(Kind::Blob, path.as_bytes()).unwrap();
+            assert!(manifest.object(path, oid).is_some());
+        }
         runtime.shutdown().await;
     }
 }

--- a/crates/crab-s3-gateway/src/mutation.rs
+++ b/crates/crab-s3-gateway/src/mutation.rs
@@ -75,6 +75,10 @@ pub(crate) enum Change {
         attributes: Box<attributes::PutAttributes>,
         condition: PutCondition,
     },
+    Attributes {
+        expected: ObjectId,
+        attributes: Box<attributes::PutAttributes>,
+    },
     Delete,
 }
 
@@ -83,6 +87,7 @@ pub(crate) enum PutCondition {
     #[default]
     None,
     IfNoneMatchAny,
+    IfMatch(ObjectId),
 }
 
 #[derive(Clone, Debug)]
@@ -394,8 +399,15 @@ async fn build_commit(
             attributes,
             condition,
         } => {
-            if matches!(condition, PutCondition::IfNoneMatchAny) && old.is_some() {
-                return Err(Error::PreconditionFailed);
+            match condition {
+                PutCondition::None => {}
+                PutCondition::IfNoneMatchAny if old.is_some() => {
+                    return Err(Error::PreconditionFailed);
+                }
+                PutCondition::IfMatch(expected) if old.is_none_or(|(oid, _)| oid != expected) => {
+                    return Err(Error::PreconditionFailed);
+                }
+                PutCondition::IfNoneMatchAny | PutCondition::IfMatch(_) => {}
             }
             let oid = object_id(Kind::Blob, &bytes)?;
             let digest = md5::Md5::digest(&bytes);
@@ -418,6 +430,29 @@ async fn build_commit(
                 .map(|_| None)
                 .unwrap_or_else(|| Some(bytes.to_vec()));
             (Some(etag), changed, Some((oid, attributes, logical_size)))
+        }
+        Change::Attributes {
+            expected,
+            attributes,
+        } => {
+            if old.is_none_or(|(oid, mode)| {
+                oid != expected || !matches!(mode, EntryMode::Regular | EntryMode::Executable)
+            }) {
+                return Err(Error::PreconditionFailed);
+            }
+            let logical_size = attributes.logical_size.ok_or_else(|| {
+                std::io::Error::other("attribute-only mutation is missing object size")
+            })?;
+            let etag = attributes.etag_override.clone().ok_or_else(|| {
+                std::io::Error::other("attribute-only mutation is missing object ETag")
+            })?;
+            if attribute_manifest
+                .object(path_string, expected)
+                .is_some_and(|stored| stored.matches_pending(&attributes, &etag, logical_size))
+            {
+                return Ok(Build::Noop(Outcome { etag: Some(etag) }));
+            }
+            (Some(etag), None, Some((expected, attributes, logical_size)))
         }
         Change::Delete => {
             if old.is_none() {
@@ -881,6 +916,102 @@ mod tests {
         .unwrap();
         let second = tip(&repository, Arc::clone(&runtime), &cancel).await;
         assert_eq!(first, second);
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn attribute_only_mutation_preserves_object_bytes() {
+        let (repository, runtime, cancel) = fixture().await;
+        let path = crab_remote_git::GitPath::new(b"object.bin".to_vec()).unwrap();
+        let bytes = Bytes::from_static(b"stable content");
+        apply(
+            &repository,
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            "refs/heads/main",
+            &path,
+            Change::Put {
+                bytes: bytes.clone(),
+                attributes: Box::new(attributes::PutAttributes::default()),
+                condition: PutCondition::None,
+            },
+            "user",
+            &cancel,
+        )
+        .await
+        .unwrap();
+        let oid = object_id(Kind::Blob, &bytes).unwrap();
+        let mut tags = BTreeMap::new();
+        tags.insert("project".to_owned(), "crab".to_owned());
+        apply(
+            &repository,
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            "refs/heads/main",
+            &path,
+            Change::Attributes {
+                expected: oid,
+                attributes: Box::new(attributes::PutAttributes {
+                    etag_override: Some(crate::gateway::md5_hex(&bytes)),
+                    logical_size: Some(bytes.len() as u64),
+                    tags,
+                    ..Default::default()
+                }),
+            },
+            "user",
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "object.bin").await,
+            bytes
+        );
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn if_match_rejects_a_stale_object_identity() {
+        let (repository, runtime, cancel) = fixture().await;
+        let path = crab_remote_git::GitPath::new(b"manifest".to_vec()).unwrap();
+        let put = |bytes, condition| {
+            apply(
+                &repository,
+                Arc::clone(&runtime),
+                crab_remote_git::RepositoryOptions::default(),
+                "refs/heads/main",
+                &path,
+                Change::Put {
+                    bytes,
+                    attributes: Box::new(attributes::PutAttributes::default()),
+                    condition,
+                },
+                "user",
+                &cancel,
+            )
+        };
+        put(Bytes::from_static(b"first"), PutCondition::None)
+            .await
+            .unwrap();
+        let first_oid = object_id(Kind::Blob, b"first").unwrap();
+        put(
+            Bytes::from_static(b"second"),
+            PutCondition::IfMatch(first_oid),
+        )
+        .await
+        .unwrap();
+        let stale = put(
+            Bytes::from_static(b"third"),
+            PutCondition::IfMatch(first_oid),
+        )
+        .await;
+
+        assert!(matches!(stale, Err(Error::PreconditionFailed)));
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "manifest").await,
+            "second"
+        );
         runtime.shutdown().await;
     }
 

--- a/crates/crab-s3-gateway/src/mutation.rs
+++ b/crates/crab-s3-gateway/src/mutation.rs
@@ -157,12 +157,12 @@ impl Coordinator {
             .await
         }
         .await;
-        if let Some(epoch) = repository.maintenance.finish() {
+        if let Some((epoch, maintenance_cancel)) = repository.maintenance.finish(cancel) {
             crate::repository::schedule_readability(
                 repository,
                 Arc::clone(&self.runtime),
                 self.options,
-                cancel.clone(),
+                maintenance_cancel,
                 epoch,
             );
         }

--- a/crates/crab-s3-gateway/src/mutation.rs
+++ b/crates/crab-s3-gateway/src/mutation.rs
@@ -30,6 +30,8 @@ pub(crate) enum Error {
     NotDirectory,
     #[error("object path names a directory")]
     IsDirectory,
+    #[error("object write precondition failed")]
+    PreconditionFailed,
     #[error("repository mutation was cancelled")]
     Cancelled,
     #[error("system clock is before the Unix epoch")]
@@ -71,8 +73,16 @@ pub(crate) enum Change {
     Put {
         bytes: Bytes,
         attributes: Box<attributes::PutAttributes>,
+        condition: PutCondition,
     },
     Delete,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) enum PutCondition {
+    #[default]
+    None,
+    IfNoneMatchAny,
 }
 
 #[derive(Clone, Debug)]
@@ -379,7 +389,14 @@ async fn build_commit(
     let path_string = std::str::from_utf8(path.as_bytes())
         .map_err(|_| std::io::Error::other("S3 object path is not UTF-8"))?;
     let (etag, changed, pending_attributes) = match change {
-        Change::Put { bytes, attributes } => {
+        Change::Put {
+            bytes,
+            attributes,
+            condition,
+        } => {
+            if matches!(condition, PutCondition::IfNoneMatchAny) && old.is_some() {
+                return Err(Error::PreconditionFailed);
+            }
             let oid = object_id(Kind::Blob, &bytes)?;
             let digest = md5::Md5::digest(&bytes);
             let logical_size = attributes.logical_size.unwrap_or(bytes.len() as u64);
@@ -789,6 +806,7 @@ mod tests {
                 Change::Put {
                     bytes: Bytes::copy_from_slice(body.as_bytes()),
                     attributes: Box::new(attributes::PutAttributes::default()),
+                    condition: PutCondition::None,
                 },
                 "user",
                 &cancel,
@@ -834,6 +852,7 @@ mod tests {
                 completion_upload_id: Some("upload-id".to_owned()),
                 ..Default::default()
             }),
+            condition: PutCondition::None,
         };
         apply(
             &repository,
@@ -862,6 +881,43 @@ mod tests {
         .unwrap();
         let second = tip(&repository, Arc::clone(&runtime), &cancel).await;
         assert_eq!(first, second);
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn if_none_match_wildcard_preserves_an_existing_object() {
+        let (repository, runtime, cancel) = fixture().await;
+        let path = crab_remote_git::GitPath::new(b"manifest".to_vec()).unwrap();
+        let put = |bytes, condition| {
+            apply(
+                &repository,
+                Arc::clone(&runtime),
+                crab_remote_git::RepositoryOptions::default(),
+                "refs/heads/main",
+                &path,
+                Change::Put {
+                    bytes,
+                    attributes: Box::new(attributes::PutAttributes::default()),
+                    condition,
+                },
+                "user",
+                &cancel,
+            )
+        };
+        put(Bytes::from_static(b"first"), PutCondition::IfNoneMatchAny)
+            .await
+            .unwrap();
+        let result = put(
+            Bytes::from_static(b"replacement"),
+            PutCondition::IfNoneMatchAny,
+        )
+        .await;
+
+        assert!(matches!(result, Err(Error::PreconditionFailed)));
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "manifest").await,
+            "first"
+        );
         runtime.shutdown().await;
     }
 }

--- a/crates/crab-s3-gateway/src/repository.rs
+++ b/crates/crab-s3-gateway/src/repository.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{
-        Arc,
+        Arc, Mutex as StdMutex, MutexGuard,
         atomic::{AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
@@ -124,6 +124,7 @@ pub(crate) struct ReadViewCache {
 pub(crate) struct WriteMaintenance {
     epoch: AtomicU64,
     active: AtomicUsize,
+    cancellation: StdMutex<CancellationToken>,
 }
 
 impl WriteMaintenance {
@@ -131,21 +132,39 @@ impl WriteMaintenance {
         Self {
             epoch: AtomicU64::new(0),
             active: AtomicUsize::new(0),
+            cancellation: StdMutex::new(CancellationToken::new()),
         }
     }
 
     pub(crate) fn begin(&self) {
         self.epoch.fetch_add(1, Ordering::AcqRel);
         self.active.fetch_add(1, Ordering::AcqRel);
+        self.cancellation().cancel();
     }
 
-    pub(crate) fn finish(&self) -> Option<u64> {
-        (self.active.fetch_sub(1, Ordering::AcqRel) == 1)
-            .then(|| self.epoch.load(Ordering::Acquire))
+    pub(crate) fn finish(&self, parent: &CancellationToken) -> Option<(u64, CancellationToken)> {
+        if self.active.fetch_sub(1, Ordering::AcqRel) != 1 {
+            return None;
+        }
+        let epoch = self.epoch.load(Ordering::Acquire);
+        let mut cancellation = self.cancellation();
+        if !self.is_idle_at(epoch) {
+            return None;
+        }
+        let token = parent.child_token();
+        *cancellation = token.clone();
+        Some((epoch, token))
     }
 
     fn is_idle_at(&self, epoch: u64) -> bool {
         self.active.load(Ordering::Acquire) == 0 && self.epoch.load(Ordering::Acquire) == epoch
+    }
+
+    fn cancellation(&self) -> MutexGuard<'_, CancellationToken> {
+        match self.cancellation.lock() {
+            Ok(cancellation) => cancellation,
+            Err(poisoned) => poisoned.into_inner(),
+        }
     }
 }
 
@@ -266,6 +285,26 @@ pub(crate) fn schedule_readability(
 mod tests {
     use super::*;
     use crate::{RepositoryAccess, RepositoryConfig};
+
+    #[test]
+    fn foreground_write_cancels_scheduled_maintenance() {
+        let parent = CancellationToken::new();
+        let maintenance = WriteMaintenance::new();
+        maintenance.begin();
+        let (_, first) = maintenance
+            .finish(&parent)
+            .expect("idle repository schedules maintenance");
+
+        maintenance.begin();
+        assert!(first.is_cancelled());
+        let (_, second) = maintenance
+            .finish(&parent)
+            .expect("new idle epoch schedules replacement maintenance");
+        assert!(!second.is_cancelled());
+
+        parent.cancel();
+        assert!(second.is_cancelled());
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_refreshes_share_one_generation_view() {

--- a/crates/crab-s3-gateway/src/repository.rs
+++ b/crates/crab-s3-gateway/src/repository.rs
@@ -1,89 +1,322 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
-use crab_remote_git::{RemoteGitRepository, RemoteGitRuntime, RepositoryOptions};
+use crab_remote_git::{
+    OperationContext, RemoteGitRepository, RemoteGitRuntime, RemoteGitSnapshot, RepositoryOptions,
+    Revision,
+};
+use gix_hash::ObjectId;
+use tokio::sync::{Mutex, OnceCell, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use crate::gateway::Repository;
 
 const MAINTENANCE_TTL: Duration = Duration::from_secs(60);
 
-pub(crate) async fn open_current(
-    repository: &Repository,
-    runtime: Arc<RemoteGitRuntime>,
-    options: RepositoryOptions,
-    cancel: &CancellationToken,
-) -> crate::Result<RemoteGitRepository> {
-    let open = || {
-        RemoteGitRepository::open(
-            repository.store.clone(),
-            repository.layout.clone(),
-            repository.identity.clone(),
-            Arc::clone(&runtime),
-            options,
-            cancel,
-        )
-    };
-    match open().await {
-        Ok(remote) if remote.refs().is_empty() || remote.commit_graph_available() => {
-            return Ok(remote);
-        }
-        Ok(_) | Err(crab_remote_git::Error::RepositoryIndexing { .. }) => {}
-        Err(error) => return Err(error.into()),
-    }
-    ensure_readable(repository, Arc::clone(&runtime), options, cancel).await?;
-    open().await.map_err(Into::into)
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReadViewKey {
+    generation: u64,
+    snapshot_digest: String,
 }
 
-pub(crate) async fn ensure_readable(
+struct CachedReadView {
+    observed_at: tokio::time::Instant,
+    view: Arc<ReadView>,
+}
+
+type ObjectAttributeKey = (ObjectId, String, ObjectId);
+type ObjectAttributeCell = Arc<OnceCell<Option<crate::attributes::ObjectAttributes>>>;
+
+/// Generation- and journal-keyed immutable repository state shared by requests.
+pub(crate) struct ReadView {
+    key: ReadViewKey,
+    remote: RemoteGitRepository,
+    snapshots: Mutex<HashMap<String, Arc<OnceCell<RemoteGitSnapshot>>>>,
+    manifests: Mutex<HashMap<ObjectId, Arc<OnceCell<Arc<crate::attributes::Manifest>>>>>,
+    objects: Mutex<HashMap<ObjectAttributeKey, ObjectAttributeCell>>,
+}
+
+impl ReadView {
+    pub(crate) fn remote(&self) -> &RemoteGitRepository {
+        &self.remote
+    }
+
+    pub(crate) async fn snapshot(
+        &self,
+        revision: &str,
+        operation: &OperationContext,
+    ) -> crate::Result<RemoteGitSnapshot> {
+        let cell = {
+            let mut snapshots = self.snapshots.lock().await;
+            Arc::clone(
+                snapshots
+                    .entry(revision.to_owned())
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        cell.get_or_try_init(|| async {
+            self.remote
+                .snapshot(&Revision::parse(revision)?, operation)
+                .await
+                .map_err(Into::into)
+        })
+        .await
+        .cloned()
+    }
+
+    pub(crate) async fn attributes(
+        &self,
+        repository: &Repository,
+        commit: ObjectId,
+    ) -> crate::Result<Arc<crate::attributes::Manifest>> {
+        let cell = {
+            let mut manifests = self.manifests.lock().await;
+            Arc::clone(
+                manifests
+                    .entry(commit)
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        cell.get_or_try_init(|| async {
+            crate::attributes::load(repository, commit)
+                .await
+                .map(Arc::new)
+        })
+        .await
+        .cloned()
+    }
+
+    pub(crate) async fn object_attributes(
+        &self,
+        repository: &Repository,
+        commit: ObjectId,
+        path: &str,
+        oid: ObjectId,
+    ) -> crate::Result<Option<crate::attributes::ObjectAttributes>> {
+        let key = (commit, path.to_owned(), oid);
+        let cell = {
+            let mut objects = self.objects.lock().await;
+            Arc::clone(
+                objects
+                    .entry(key)
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        cell.get_or_try_init(|| crate::attributes::load_object(repository, commit, path, oid))
+            .await
+            .cloned()
+    }
+}
+
+/// Singleflight refresh and immutable generation reuse for one repository.
+pub(crate) struct ReadViewCache {
+    cached: RwLock<Option<CachedReadView>>,
+    refresh: Mutex<()>,
+}
+
+/// Coalesces repository maintenance until the local write burst is idle.
+pub(crate) struct WriteMaintenance {
+    epoch: AtomicU64,
+    active: AtomicUsize,
+}
+
+impl WriteMaintenance {
+    pub(crate) fn new() -> Self {
+        Self {
+            epoch: AtomicU64::new(0),
+            active: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn begin(&self) {
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        self.active.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub(crate) fn finish(&self) -> Option<u64> {
+        (self.active.fetch_sub(1, Ordering::AcqRel) == 1)
+            .then(|| self.epoch.load(Ordering::Acquire))
+    }
+
+    fn is_idle_at(&self, epoch: u64) -> bool {
+        self.active.load(Ordering::Acquire) == 0 && self.epoch.load(Ordering::Acquire) == epoch
+    }
+}
+
+impl ReadViewCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            cached: RwLock::new(None),
+            refresh: Mutex::new(()),
+        }
+    }
+
+    pub(crate) async fn current(
+        &self,
+        repository: &Repository,
+        runtime: Arc<RemoteGitRuntime>,
+        options: RepositoryOptions,
+        cancel: &CancellationToken,
+    ) -> crate::Result<Arc<ReadView>> {
+        let requested_at = tokio::time::Instant::now();
+        let _refresh = self.refresh.lock().await;
+        if let Some(view) = self.observed_since(requested_at).await {
+            return Ok(view);
+        }
+        let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+            &repository.store,
+            &repository.layout,
+        )
+        .await?;
+        let observed_at = tokio::time::Instant::now();
+        let key = ReadViewKey {
+            generation: snapshot.manifest.generation,
+            snapshot_digest: snapshot.digest()?,
+        };
+        let existing = self
+            .cached
+            .read()
+            .await
+            .as_ref()
+            .filter(|cached| cached.view.key == key)
+            .map(|cached| Arc::clone(&cached.view));
+        let view = match existing {
+            Some(view) => view,
+            None => Arc::new(ReadView {
+                key,
+                remote: RemoteGitRepository::from_snapshot(
+                    repository.layout.clone(),
+                    &snapshot,
+                    repository.identity.clone(),
+                    runtime,
+                    options,
+                    cancel,
+                )
+                .await?,
+                snapshots: Mutex::new(HashMap::new()),
+                manifests: Mutex::new(HashMap::new()),
+                objects: Mutex::new(HashMap::new()),
+            }),
+        };
+        *self.cached.write().await = Some(CachedReadView {
+            observed_at,
+            view: Arc::clone(&view),
+        });
+        Ok(view)
+    }
+
+    pub(crate) async fn invalidate(&self) {
+        *self.cached.write().await = None;
+    }
+
+    async fn observed_since(&self, requested_at: tokio::time::Instant) -> Option<Arc<ReadView>> {
+        self.cached
+            .read()
+            .await
+            .as_ref()
+            .filter(|cached| cached.observed_at >= requested_at)
+            .map(|cached| Arc::clone(&cached.view))
+    }
+}
+
+pub(crate) fn schedule_readability(
     repository: &Repository,
     runtime: Arc<RemoteGitRuntime>,
     options: RepositoryOptions,
-    cancel: &CancellationToken,
-) -> crate::Result<()> {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
-    loop {
-        let store = repository.store.clone();
-        let layout = repository.layout.clone();
-        let identity = repository.identity.clone();
-        let publication_runtime = Arc::clone(&runtime);
-        let publication_cancel = cancel.clone();
-        // The publication future is deeply nested. A task boundary prevents its
-        // poll stack from accumulating with the request handler's read retry.
-        tokio::spawn(async move {
-            crab_write::generation::ensure_readable(
-                &store,
-                &layout,
-                &identity,
-                publication_runtime,
-                options,
-                MAINTENANCE_TTL,
-                &publication_cancel,
-            )
-            .await
-        })
-        .await??;
-        let opened = RemoteGitRepository::open(
-            repository.store.clone(),
-            repository.layout.clone(),
-            repository.identity.clone(),
-            Arc::clone(&runtime),
-            options,
-            cancel,
-        )
-        .await;
-        match opened {
-            Ok(remote) if remote.refs().is_empty() || remote.commit_graph_available() => {
-                return Ok(());
-            }
-            Ok(_) | Err(crab_remote_git::Error::RepositoryIndexing { .. }) => {}
-            Err(error) => return Err(error.into()),
-        }
-        if tokio::time::Instant::now() >= deadline {
-            return Err(crate::Error::ReadinessTimeout);
-        }
+    cancel: CancellationToken,
+    epoch: u64,
+) {
+    let store = repository.store.clone();
+    let layout = repository.layout.clone();
+    let identity = repository.identity.clone();
+    let maintenance = Arc::clone(&repository.maintenance);
+    tokio::spawn(async move {
+        // Let a short write burst accumulate in the journal so one owner can
+        // compact it, instead of racing every acknowledgement with maintenance.
         tokio::select! {
-            () = cancel.cancelled() => return Err(crab_remote_git::Error::Cancelled.into()),
+            () = cancel.cancelled() => return,
             () = tokio::time::sleep(Duration::from_millis(100)) => {}
         }
+        if !maintenance.is_idle_at(epoch) {
+            return;
+        }
+        if let Err(error) = crab_write::generation::ensure_readable(
+            &store,
+            &layout,
+            &identity,
+            runtime,
+            options,
+            MAINTENANCE_TTL,
+            &cancel,
+        )
+        .await
+        {
+            tracing::warn!(%error, "S3 repository background read maintenance failed");
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RepositoryAccess, RepositoryConfig};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_refreshes_share_one_generation_view() {
+        let store = crab_storage::Store::new(Arc::new(object_store::memory::InMemory::new()));
+        let layout = crab_storage::StoreLayout::new(store.clone(), "read-view-test".to_owned());
+        crab_write::initialize::initialize_repository(&store, &layout, "refs/heads/main")
+            .await
+            .unwrap();
+        let repository = Arc::new(
+            Repository::new(
+                RepositoryConfig {
+                    name: "repo".to_owned(),
+                    provider: crab_storage::StorageProviderKind::Local,
+                    bucket: "memory".to_owned(),
+                    prefix: "read-view-test".to_owned(),
+                    default_branch: "main".to_owned(),
+                    members: vec![crate::RepositoryMember {
+                        principal: "user".to_owned(),
+                        access: RepositoryAccess::Read,
+                    }],
+                    protected_branches: Vec::new(),
+                },
+                store,
+            )
+            .unwrap(),
+        );
+        let runtime = Arc::new(RemoteGitRuntime::default());
+        let barrier = Arc::new(tokio::sync::Barrier::new(16));
+        let mut reads = tokio::task::JoinSet::new();
+        for _ in 0..16 {
+            let repository = Arc::clone(&repository);
+            let runtime = Arc::clone(&runtime);
+            let barrier = Arc::clone(&barrier);
+            reads.spawn(async move {
+                barrier.wait().await;
+                repository
+                    .read_views
+                    .current(
+                        &repository,
+                        runtime,
+                        RepositoryOptions::default(),
+                        &CancellationToken::new(),
+                    )
+                    .await
+                    .unwrap()
+            });
+        }
+        let first = reads.join_next().await.unwrap().unwrap();
+        while let Some(result) = reads.join_next().await {
+            assert!(Arc::ptr_eq(&first, &result.unwrap()));
+        }
+        runtime.shutdown().await;
     }
 }

--- a/crates/crab-s3-gateway/src/server.rs
+++ b/crates/crab-s3-gateway/src/server.rs
@@ -2,7 +2,7 @@ use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::{conn::auto::Builder as ConnectionBuilder, graceful::GracefulShutdown},
 };
-use s3s::service::S3ServiceBuilder;
+use s3s::{host::SingleDomain, service::S3ServiceBuilder};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
@@ -11,11 +11,15 @@ use crate::{Config, Result, gateway::Gateway};
 /// Serve the configured gateway until SIGINT or SIGTERM.
 pub async fn serve(config: Config) -> Result<()> {
     config.validate()?;
+    let endpoint_domain = config.endpoint_domain.clone();
     let listener = TcpListener::bind(config.listen).await?;
     let cancellation = CancellationToken::new();
     let gateway = Gateway::new(config, cancellation.clone())?;
     let mut builder = S3ServiceBuilder::new(gateway.clone());
     builder.set_auth(gateway.auth());
+    if let Some(domain) = endpoint_domain {
+        builder.set_host(SingleDomain::new(&domain)?);
+    }
     let service = builder.build();
     let connections = ConnectionBuilder::new(TokioExecutor::new());
     let graceful = GracefulShutdown::new();


### PR DESCRIPTION
## Summary

- add atomic strong `If-Match` and `If-None-Match: *` publication for `PutObject` and multipart completion
- implement bucket region/versioning discovery, object attributes, object tagging, and optional virtual-hosted routing
- validate and persist CRC32, CRC32C, CRC64NVME, SHA1, and SHA256 checksums, including full-object and composite multipart profiles
- expose multipart part metadata and part-number GET/HEAD; return part checksums for part-aligned reads and suppress full-object checksums on partial ranges
- preserve S3 tag/checksum/part metadata across restart and metadata-only commits
- add a generation/journal-keyed read-view module with singleflight snapshots and attributes; HEAD and attributed LIST avoid blob payload reads
- make writes path-local: rewrite only ancestor trees and persist one versioned attribute delta per commit
- prepare outside the branch lease, parallelize immutable pack/sidecar/visibility/attribute uploads, then revalidate and publish under the lease
- admit same-ref writes through a fair bounded queue and coalesce asynchronous catalog/commit-graph maintenance until local write bursts are idle
- cancel in-flight derived maintenance when foreground writes arrive, then reschedule it after the write burst becomes idle
- serve validated committed journal snapshots immediately, without waiting for derived catalog compaction

## Why

LanceDB 0.38.0 requires conditional object creation, and general S3 clients also depend on region discovery, checksums, tags, multipart inspection, and both path-style and virtual-hosted addressing. The gateway previously rejected or omitted these surfaces. Its old per-request repository open and repository-wide mutation path also imposed roughly 59 ms warm read latency and exposed branch-lock conflicts directly to concurrent S3 clients.

## Architecture

The deep module seam is `RemoteGitRepository::from_snapshot`: it consumes a validated immutable manifest+journal snapshot without requiring the derived locator/catalog. The gateway's read-view implementation owns generation identity, singleflight refresh, snapshot caching, and exact-object attribute caching. The mutation implementation owns path-local tree construction, pre-lease immutable preparation, revalidation, fair per-ref admission, and publication. Derived catalog and commit-graph maintenance remains behind the existing `crab-write` interface and is coalesced after the local repository write burst is idle.

## Compatibility boundary

This closes the practical object-store gaps modeled by `s3s` 0.14. It does not claim the Crab namespace is an AWS account: bucket creation/deletion, policies/ACL/IAM, version IDs/delete markers, lifecycle/replication/notifications, storage classes, SSE/KMS, Object Lock, access points/S3 Express/Outposts, browser POST/Select/Torrent, conditional DELETE, and destination COPY conditions remain explicit `NotImplemented` surfaces. Crab also intentionally retains `REF/path` keys and Git-safe path restrictions. Newer checksum fields not modeled by `s3s` 0.14 (MD5, SHA512, and XXHash variants) require a protocol dependency upgrade.

## Local loopback performance

Same client, Rust release binary, RustFS backing store, 1 KiB objects, retries disabled:

| Operation | Before | After |
| --- | ---: | ---: |
| HEAD sequential | 16.83 TPS, 58.76 ms p50 | 233.75 TPS, 2.14 ms p50 |
| GET sequential | 16.88 TPS | 374.59 TPS, 2.16 ms p50 |
| HEAD, 16-way | 108.59 TPS, 145.97 ms p50 | 1362.72 TPS, 6.50 ms p50 |
| GET, 16-way | 108.82 TPS | 1337.93 TPS, 6.51 ms p50 |
| PUT sequential | 0.54 TPS, 1689 ms p50 | 1.45 TPS, 657.52 ms p50 |
| PUT, same branch, 16-way | 1 success / 15 `OperationAborted` without retries | 16/16 success, 0.93 TPS, 7.66 s p50 |

Direct RustFS in the same run measured 1287 HEAD TPS, 1296 GET TPS, and 82 concurrent PUT TPS. These are development-host measurements, not an AWS S3 service benchmark; they show warm Crab reads approaching the local backend while one durable Git commit per PUT remains the write-throughput boundary.

### 512 MiB pandas/Parquet contention qualification

The final release binary was exercised after deliberately starting background repository maintenance on the same branch. The unfixed build remained blocked in `CompleteMultipartUpload` for more than 183 seconds; the fix yielded maintenance to the foreground write and completed the same workload normally.

| Operation | Result |
| --- | ---: |
| Multipart write, 512.26 MiB | 20.60 s, 24.87 MiB/s |
| Full pandas read, 512 MiB | 2.33 s, 219.48 MiB/s |
| Integrity | all 67,108,864 deterministic int64 values matched |

The benchmark and trigger objects were deleted and confirmed absent after verification. Measurements are local loopback with RustFS, not an AWS service benchmark.

## Xet-backed range GET

S3 `Range` GET and copy-source ranges over existing Crab/Xet pointers now prune reconstruction to overlapping chunks, preserve unaligned first-chunk offsets, and write only the selected logical bytes to bounded temporary storage. Cold low-coverage reads use bounded origin xorb requests; high-coverage reads may deliberately fetch and cache a complete verified xorb. Complete GET keeps whole-file hash and size verification. Gateway-originated large PUT/multipart objects remain on Crab’s verified LFS path and therefore support byte ranges but do not gain Xet deduplication.

Live proof used the RustFS qualification repository’s 20 MiB Xet-backed `large.bin`: a signed `bytes=1048699-2097399` GET returned 1,048,701 exact bytes and `Content-Range: bytes 1048699-2097399/20971520`; the selected bytes matched a complete GET, while a cold gateway cache retained a 131 KiB decoded range and no complete xorb. Suffix and open-ended 65,537-byte requests also matched exactly.

## Proof

- rebased onto `origin/main` at `bc542b71e6b`
- `cargo fmt --all -- --check`
- `cargo test -p crab-remote-git -p crab-s3-gateway --locked` (107 remote unit + 72 remote integration + 28 gateway tests + doctests)
- `cargo clippy -p crab-s3-gateway -p crab-remote-git --all-targets --locked -- -D warnings`
- `cargo test -p crab-read --locked --lib` (156 tests)
- `cargo test -p crab-cache-store --locked --lib xorb` (15 selective/full-xorb policy tests)
- `cargo clippy -p crab-read -p crab-s3-gateway --all-targets --locked -- -D warnings`
- `CARGO_TARGET_DIR=... make nfs-feature-gate` (489 crab-vfs tests, including the VFS source-policy regressions)
- `cargo clippy -p crab-vfs --all-targets --features nfs --locked -- -D warnings`
- `python3 crab/scripts/check-architecture-gates.py`
- `cargo build -p crab-s3-gateway --release --locked`
- concurrent regression: eight same-ref writes all commit, asynchronous maintenance drains the journal, and the canonical remote reader opens the resulting generation
- live boto3 benchmark and cleanup against RustFS-backed Crab with retries disabled
- live LanceDB 0.38.0 open/add/vector-search/delete through the ordinary S3 URI and storage options; row count restored after smoke
- prior branch qualification uploaded and read back a 10 GiB multipart object; the final compatibility revision reverified multipart publication with checksum and part metadata

AWS contracts checked against:

- https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity-upload.html
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAttributes.html
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html
