### PR TITLE
perf(push): keep incremental latency bounded

### DIFF
--- a/crab/docs/design/push.md
+++ b/crab/docs/design/push.md
@@ -770,9 +770,12 @@ remote.
    PUT {prefix}/packs/pack-{blake3_hash}.kinds
        body = checksummed one-byte-per-object kind table in pack-offset order
 
-4. Install every pack locally and derive exact locators:
-   Copy each pack + idx into .git/objects/pack/ so the NEXT push can
-   compute an incremental remote-object set without a round-trip.
+4. Strictly index every pack and derive exact locators:
+   Keep the generated pack and its `.idx`/`.rev` evidence in a temporary
+   directory under `.git/objects/`, outside `.git/objects/pack/`. This gives
+   `git index-pack` the source repository context without permanently adding
+   one local pack per push. The next push uses the committed ref-tip frontier
+   or generation-bound locator rather than a Crab-generated source-ODB copy.
    Index construction, checksum binding, and canonical `.idx` upload are
    pre-commit requirements. The `.kinds` sidecar is bound to the verified
    Git pack checksum, index object count, and its BLAKE3 checksum, so the

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -1632,6 +1632,7 @@ struct UploadedGitPack {
     entry: PackManifestEntry,
     idx_path: PathBuf,
     kind_metadata_published: bool,
+    _evidence_dir: Arc<tempfile::TempDir>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -13169,10 +13170,14 @@ impl PushPipeline {
                 .iter()
                 .map(|update| update.new_sha.clone())
                 .collect::<Vec<_>>();
-            let pack_dir = self.objects_dir()?.join("pack");
+            let evidence_dir = Arc::new(
+                tempfile::Builder::new()
+                    .prefix(".crab-push-evidence-")
+                    .tempdir_in(self.objects_dir()?)?,
+            );
             let mut uploaded = Vec::with_capacity(packed_files.len());
             let ref_tips = &ref_tips;
-            let pack_dir = &pack_dir;
+            let evidence_dir = &evidence_dir;
             let multipart_journal = multipart_journal
                 .as_deref()
                 .map(|journal| journal as &dyn crab_storage::multipart::MultipartJournal);
@@ -13181,7 +13186,7 @@ impl PushPipeline {
                 let pack_sha = packed.pack_blake3_hex.clone();
                 let pack_path = self.router.pack_path(&pack_sha);
                 let installed = pack::install_pack_file_locally_with_timeout(
-                    pack_dir,
+                    evidence_dir.path(),
                     packed.pack_path.as_ref(),
                     &pack_sha,
                     self.config.receive_max_input_size,
@@ -13347,6 +13352,7 @@ impl PushPipeline {
                     entry,
                     idx_path: installed.idx_path,
                     kind_metadata_published: kind_metadata.is_some(),
+                    _evidence_dir: Arc::clone(evidence_dir),
                 }))
             });
             let concurrency = self
@@ -16553,13 +16559,13 @@ impl PushPipeline {
         check_cancelled(&self.cancel)?;
 
         // Step 10b: connectivity check. Before we move refs, prove every
-        // object reachable from each new tip exists locally — at this
-        // point step 10 has already installed the freshly-uploaded pack
-        // into `.git/objects/pack/`, so the same ODB git will serve to
-        // fetchers is what we walk here. A missing object at this stage
-        // is either a pack-gen bug or a corrupt local ODB; either way it
-        // is strictly safer to reject the push than to commit a ref
-        // that points at incomplete history.
+        // object reachable from each new tip exists locally. Step 10 strictly
+        // indexed the outgoing non-thin pack in a temporary evidence directory;
+        // keeping it out of `.git/objects/pack/` prevents repeated pushes from
+        // making every source-ODB walk scan an ever-growing pack set. The source
+        // ODB still owns every packed object, so a missing object here is either
+        // a pack-gen bug or a corrupt local ODB. It is strictly safer to reject
+        // the push than to commit a ref that points at incomplete history.
         //
         // Surfaces per-ref failures via
         // [`CrabError::PushConnectivityMissing`] which is mapped to
@@ -21716,7 +21722,7 @@ mod tests {
         }
     }
 
-    use crate::test::git_repo::{CleanGitEnvGuard, GitDirGuard};
+    use crate::test::git_repo::{CleanGitEnvGuard, GitDirGuard, TEST_GIT_REPO};
 
     fn pack_manifest_entry_with_tips(ref_tips: Vec<String>) -> PackManifestEntry {
         let pack_id = "a".repeat(64);
@@ -23258,6 +23264,49 @@ mod tests {
             0,
             "an unrelated ref advance must reuse immutable dependencies"
         );
+    }
+
+    #[tokio::test]
+    async fn uploading_push_pack_does_not_install_it_in_source_object_database() {
+        let _guard = GitDirGuard::new();
+        let (store, router) = test_store_router("push-pack-evidence");
+        let source_pack_dir = TEST_GIT_REPO.git_dir.join("objects/pack");
+        let source_pack_count = || {
+            std::fs::read_dir(&source_pack_dir)
+                .map(|entries| {
+                    entries
+                        .filter_map(std::result::Result::ok)
+                        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "pack"))
+                        .count()
+                })
+                .unwrap_or_default()
+        };
+        let source_packs_before = source_pack_count();
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            vec![make_spec("refs/heads/main")],
+            Some(store),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router,
+            None,
+            CancellationToken::new(),
+            None,
+        );
+
+        pipeline.prepare_git_pack().await.expect("prepare pack");
+        pipeline.upload_packs().await.expect("upload pack");
+
+        let uploaded = pipeline.uploaded_packs.lock().await;
+        assert!(!uploaded.is_empty());
+        assert!(
+            uploaded
+                .iter()
+                .all(|pack| !pack.idx_path.starts_with(&source_pack_dir)),
+            "outgoing pack evidence must not enter the source object database"
+        );
+        assert_eq!(source_pack_count(), source_packs_before);
     }
 
     #[tokio::test]
@@ -35831,6 +35880,7 @@ mod tests {
             let shard_hash = MerkleHash::from([1u64, 2, 3, 4]);
             pipeline.uploaded_shard_hashes.lock().await.push(shard_hash);
         }
+        let evidence_dir = Arc::new(tempfile::tempdir().unwrap());
         pipeline.uploaded_packs.lock().await.extend([
             UploadedGitPack {
                 entry: PackManifestEntry {
@@ -35842,6 +35892,7 @@ mod tests {
                 },
                 idx_path: PathBuf::from("pack_abc.idx"),
                 kind_metadata_published: false,
+                _evidence_dir: Arc::clone(&evidence_dir),
             },
             UploadedGitPack {
                 entry: PackManifestEntry {
@@ -35853,6 +35904,7 @@ mod tests {
                 },
                 idx_path: PathBuf::from("pack_def.idx"),
                 kind_metadata_published: false,
+                _evidence_dir: evidence_dir,
             },
         ]);
         pipeline

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -20,6 +20,7 @@ use crate::segmented::{self, SegmentKind, ShardSegmentEntry};
 use crate::segmented_store;
 
 const DEFAULT_HISTORY_READ_CONCURRENCY: usize = 32;
+const REPOSITORY_SNAPSHOT_CAPTURE_ATTEMPTS: usize = 3;
 
 /// One validated immutable historical manifest root.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -360,46 +361,67 @@ pub async fn read_repository_snapshot(
     store: &Store,
     router: &StoreLayout<Store>,
 ) -> Result<RepositorySnapshot> {
-    // Markers are captured first so compaction may safely remove them after
-    // publishing a newer manifest without stranding an old-manifest reader.
-    let active_transactions = list_active_transactions(store, router).await?;
-    let (manifest, manifest_etag) = read_manifest(store, router).await?;
-    // Preserve the absent-manifest contract for uninitialized metadata readers,
-    // but never return repository state without its authoritative layout.
-    let layout = read_canonical_layout(store, router).await?;
-    let packs = if manifest.pack_index_hash.is_empty() {
-        Vec::new()
-    } else {
-        read_bulk_pack_list(store, router, &manifest.pack_index_hash).await?
-    };
-    let shards = if manifest.shard_index_hash.is_empty() {
-        Vec::new()
-    } else {
-        read_bulk_shard_list(store, router, &manifest.shard_index_hash).await?
-    };
-    let journal = materialize_ref_journal(
-        store,
-        router,
-        &manifest,
-        &packs,
-        &shards,
-        &active_transactions,
-    )
-    .await?;
-    // Repository-open validation may predate this capture. Recheck its boundary
-    // so an invalid current descriptor cannot authorize the returned snapshot.
-    if read_canonical_layout(store, router).await? != layout {
-        return Err(MetadataError::CorruptObject {
-            path: router.layout_descriptor_path().to_string(),
-            reason: "repository layout changed during snapshot capture".to_owned(),
+    for attempt in 1..=REPOSITORY_SNAPSHOT_CAPTURE_ATTEMPTS {
+        // Markers are captured first so compaction may safely remove them after
+        // publishing a newer manifest without stranding an old-manifest reader.
+        let active_transactions = list_active_transactions(store, router).await?;
+        let (manifest, manifest_etag) = read_manifest(store, router).await?;
+        // Preserve the absent-manifest contract for uninitialized metadata readers,
+        // but never return repository state without its authoritative layout.
+        let layout = read_canonical_layout(store, router).await?;
+        let packs = if manifest.pack_index_hash.is_empty() {
+            Vec::new()
+        } else {
+            read_bulk_pack_list(store, router, &manifest.pack_index_hash).await?
+        };
+        let shards = if manifest.shard_index_hash.is_empty() {
+            Vec::new()
+        } else {
+            read_bulk_shard_list(store, router, &manifest.shard_index_hash).await?
+        };
+        let journal = match materialize_ref_journal(
+            store,
+            router,
+            &manifest,
+            &packs,
+            &shards,
+            &active_transactions,
+        )
+        .await
+        {
+            Ok(journal) => journal,
+            Err(error) if attempt < REPOSITORY_SNAPSHOT_CAPTURE_ATTEMPTS => {
+                let current_transactions = list_active_transactions(store, router).await?;
+                let (_, current_etag) = read_manifest(store, router).await?;
+                if current_etag == manifest_etag && current_transactions == active_transactions {
+                    return Err(error);
+                }
+                tracing::debug!(
+                    attempt,
+                    "repository snapshot crossed a manifest or journal compaction boundary; retrying capture"
+                );
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        // Repository-open validation may predate this capture. Recheck its boundary
+        // so an invalid current descriptor cannot authorize the returned snapshot.
+        if read_canonical_layout(store, router).await? != layout {
+            return Err(MetadataError::CorruptObject {
+                path: router.layout_descriptor_path().to_string(),
+                reason: "repository layout changed during snapshot capture".to_owned(),
+            });
+        }
+        return Ok(RepositorySnapshot {
+            layout,
+            manifest,
+            manifest_etag,
+            journal,
         });
     }
-    Ok(RepositorySnapshot {
-        layout,
-        manifest,
-        manifest_etag,
-        journal,
-    })
+    Err(MetadataError::Internal(
+        "repository snapshot capture exhausted its retry budget".to_owned(),
+    ))
 }
 
 /// Fold committed journal transactions into one bounded manifest snapshot.
@@ -815,14 +837,14 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::fmt;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::Duration;
 
     use futures_util::stream::BoxStream;
     use object_store::memory::InMemory;
     use object_store::{
         CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-        PutMultipartOptions, PutOptions, PutPayload, PutResult,
+        ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
     };
 
     use crate::manifests::{compact_pack_index, compact_shard_index};
@@ -960,6 +982,174 @@ mod tests {
             assert!(read_repository_snapshot(&store, &router).await.is_err());
             assert_eq!(read_manifest(&store, &router).await.unwrap().0, manifest);
         }
+    }
+
+    struct ManifestTransitionStore {
+        inner: Arc<InMemory>,
+        manifest_path: object_store::path::Path,
+        active_marker_path: object_store::path::Path,
+        replacement_manifest: Bytes,
+        transitioned: AtomicBool,
+    }
+
+    impl ManifestTransitionStore {
+        fn new(
+            inner: Arc<InMemory>,
+            manifest_path: object_store::path::Path,
+            active_marker_path: object_store::path::Path,
+            replacement_manifest: Bytes,
+        ) -> Self {
+            Self {
+                inner,
+                manifest_path,
+                active_marker_path,
+                replacement_manifest,
+                transitioned: AtomicBool::new(false),
+            }
+        }
+
+        fn transitioned(&self) -> bool {
+            self.transitioned.load(Ordering::Acquire)
+        }
+    }
+
+    impl fmt::Debug for ManifestTransitionStore {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("ManifestTransitionStore")
+        }
+    }
+
+    impl fmt::Display for ManifestTransitionStore {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("ManifestTransitionStore")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for ManifestTransitionStore {
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: PutPayload,
+            options: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, options).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            if location == &self.manifest_path && !self.transitioned.swap(true, Ordering::AcqRel) {
+                self.inner
+                    .put(
+                        &self.manifest_path,
+                        self.replacement_manifest.clone().into(),
+                    )
+                    .await?;
+                self.inner.delete(&self.active_marker_path).await?;
+            }
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, object_store::Result<object_store::path::Path>>,
+        ) -> BoxStream<'static, object_store::Result<object_store::path::Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_retries_when_compaction_crosses_capture_boundary() {
+        let inner = Arc::new(InMemory::new());
+        let setup_store = Store::new(inner.clone());
+        let setup_router = test_layout(setup_store.clone());
+        crate::layout_descriptor::ensure_canonical_layout(&setup_store, &setup_router)
+            .await
+            .unwrap();
+        let mut base = Manifest::default_for_repo("refs/heads/main");
+        base.refs
+            .insert("refs/heads/main".to_owned(), "a".repeat(40));
+        base.seal_git_validation();
+        create_manifest(&setup_store, &setup_router, &base)
+            .await
+            .unwrap();
+        let head = read_ref_head(&setup_store, &setup_router, "refs/heads/main")
+            .await
+            .unwrap();
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([("refs/heads/main".to_owned(), None)]),
+            vec![RefJournalEdit {
+                ref_name: "refs/heads/main".to_owned(),
+                old_oid: Some("a".repeat(40)),
+                new_oid: Some("b".repeat(40)),
+                peeled_oid: None,
+                lock_holder: None,
+                visibility_evidence_hash: None,
+            }],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let committed =
+            commit_ref_transaction(&setup_store, &setup_router, &transaction, &[head], || false)
+                .await
+                .unwrap();
+
+        let mut compacted = next_manifest(&base);
+        compacted
+            .refs
+            .insert("refs/heads/main".to_owned(), "b".repeat(40));
+        compacted.seal_git_validation();
+        let transition = Arc::new(ManifestTransitionStore::new(
+            inner,
+            setup_router.manifest_path(),
+            setup_router.ref_journal_active_path(&committed.transaction_id),
+            Bytes::from(serialize_manifest(&compacted).unwrap()),
+        ));
+        let store = Store::new(transition.clone());
+        let router = test_layout(store.clone());
+
+        let snapshot = read_repository_snapshot(&store, &router).await.unwrap();
+
+        assert!(transition.transitioned());
+        assert_eq!(snapshot.manifest, compacted);
+        assert_eq!(snapshot.journal.refs["refs/heads/main"], "b".repeat(40));
+        assert!(snapshot.journal.transactions.is_empty());
     }
 
     struct DelayedGetStore {


### PR DESCRIPTION
## Summary

- keep generated pack index and reverse-index evidence in a temporary directory outside the source Git object database
- retry repository snapshot capture when concurrent journal compaction changes the manifest or active transaction boundary
- document the bounded push-pack evidence lifecycle and add regressions for both paths

## Performance evidence

Local RustFS on the 1.26 GB Kubernetes qualification remote, after 498 real-history replay pushes, then 200 empty-commit incremental pushes while the generation owner ran every 2 seconds:

- pushes 1-50: median 563.3 ms, p95 632.1 ms
- pushes 151-200: median 548.0 ms, p95 783.2 ms
- all 200: median 555.9 ms, p95 653.6 ms
- 46 concurrent ref-journal compactions, zero push or owner errors
- source object database remained at 0 packs
- post-run maintenance reduced 204 active remote packs to 3 and reached published/no-maintenance state

The previous build failed at the concurrent compaction boundary around push 89. This candidate completed all 200 pushes and the final-window median was 2.7% lower than the first window.

## Verification

- cargo fmt --all --check
- cargo test -p crab-metadata --features storage --locked (238 passed)
- cargo clippy -p crab-metadata --features storage --all-targets --locked -- -D warnings
- cargo test -p crab --lib uploading_push_pack_does_not_install_it_in_source_object_database --locked
- cargo test -p crab --lib under_lock_refresh_ --locked (2 passed)
- release build and live RustFS push/owner qualification