### PR TITLE
feat: report clone and large-push progress

### DIFF
--- a/crab/src/cmd/clone.rs
+++ b/crab/src/cmd/clone.rs
@@ -15,7 +15,8 @@ use std::future::Future;
 use std::io::{Stdout, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Instant;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
@@ -26,6 +27,7 @@ use crate::core::output::event_payloads::{
 };
 use crate::core::output::{JsonlStream, OutputMode};
 use crate::core::perf_phase::PhaseTimer;
+use crate::git::progress::{format_bytes, format_rate, is_tty};
 
 /// Arguments for the `crab clone` command.
 #[derive(Clone)]
@@ -83,6 +85,131 @@ fn emit_phase(stream: Option<&std::sync::Mutex<JsonlStream<Stdout>>>, payload: P
         let output = s.emit_schema_event(PERF_PHASE_SCHEMA, "event", payload);
         crate::core::output::report_progress_output(output);
     }
+}
+
+const CLONE_PROGRESS_INTERVAL: Duration = Duration::from_millis(500);
+
+struct ClonePackProgressReporter {
+    mode: OutputMode,
+    jsonl_stream: Option<Arc<Mutex<JsonlStream<Stdout>>>>,
+    started: OnceLock<Instant>,
+    state: Mutex<ClonePackProgressState>,
+}
+
+#[derive(Default)]
+struct ClonePackProgressState {
+    last_report: Option<Instant>,
+    tty_line_open: bool,
+}
+
+impl ClonePackProgressReporter {
+    fn new(mode: OutputMode, jsonl_stream: Option<Arc<Mutex<JsonlStream<Stdout>>>>) -> Self {
+        Self {
+            mode,
+            jsonl_stream,
+            started: OnceLock::new(),
+            state: Mutex::new(ClonePackProgressState::default()),
+        }
+    }
+
+    fn report(&self, progress: crab_remote_git::PackDownloadProgress) {
+        let elapsed = self
+            .started
+            .get_or_init(Instant::now)
+            .elapsed()
+            .as_secs_f64();
+        let rate = if elapsed > 0.0 {
+            progress.bytes_downloaded as f64 / elapsed
+        } else {
+            0.0
+        };
+
+        match self.mode {
+            OutputMode::Json => {}
+            OutputMode::Jsonl => {
+                if let Some(stream) = &self.jsonl_stream
+                    && let Ok(mut stream) = stream.lock()
+                {
+                    let output = stream.emit_progress(ProgressPayload {
+                        operation: "downloading_git_packs".to_owned(),
+                        current: progress.packs_completed,
+                        total: progress.packs_total,
+                        bytes: progress.bytes_downloaded,
+                        total_bytes: progress.total_bytes,
+                        rate_bytes_per_sec: rate,
+                        xorbs_produced: None,
+                    });
+                    crate::core::output::report_progress_output(output);
+                }
+            }
+            OutputMode::Text => self.report_text(progress, rate),
+        }
+    }
+
+    fn report_text(&self, progress: crab_remote_git::PackDownloadProgress, rate: f64) {
+        let now = Instant::now();
+        let complete = progress.packs_completed == progress.packs_total
+            && progress.bytes_downloaded == progress.total_bytes;
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        if !complete
+            && state
+                .last_report
+                .is_some_and(|last| now.duration_since(last) < CLONE_PROGRESS_INTERVAL)
+        {
+            return;
+        }
+
+        let message = format_clone_pack_progress(progress, rate);
+        if is_tty() {
+            eprint!("\r\x1b[2K{message}");
+            let _ = std::io::stderr().flush();
+            state.tty_line_open = true;
+            if complete {
+                eprintln!();
+                state.tty_line_open = false;
+            }
+        } else {
+            eprintln!("{message}");
+        }
+        state.last_report = Some(now);
+    }
+}
+
+impl Drop for ClonePackProgressReporter {
+    fn drop(&mut self) {
+        if self.mode == OutputMode::Text
+            && let Ok(state) = self.state.lock()
+            && state.tty_line_open
+        {
+            eprintln!();
+        }
+    }
+}
+
+fn format_clone_pack_progress(
+    progress: crab_remote_git::PackDownloadProgress,
+    rate_bytes_per_sec: f64,
+) -> String {
+    let percent = if progress.total_bytes == 0 {
+        0
+    } else {
+        ((u128::from(progress.bytes_downloaded) * 100) / u128::from(progress.total_bytes)).min(100)
+            as u64
+    };
+    let mut message = format!(
+        "Downloading Git packs: {percent}% ({} / {}, {}/{} packs",
+        format_bytes(progress.bytes_downloaded),
+        format_bytes(progress.total_bytes),
+        progress.packs_completed,
+        progress.packs_total,
+    );
+    if rate_bytes_per_sec > 0.0 {
+        let _ = write!(&mut message, ", {}", format_rate(rate_bytes_per_sec));
+    }
+    message.push(')');
+    message
 }
 
 /// Clone a repository, creating the target directory under `parent`.
@@ -145,23 +272,23 @@ pub async fn run_clone_in(
     }
 
     // Set up JSONL stream for streaming mode.
-    let jsonl_stream: Option<std::sync::Mutex<JsonlStream<Stdout>>> =
-        if args.mode == OutputMode::Jsonl {
-            Some(std::sync::Mutex::new(JsonlStream::new(
-                "clone.event",
-                "1.0",
-                std::io::stdout(),
-            )))
-        } else {
-            None
-        };
+    let jsonl_stream: Option<Arc<Mutex<JsonlStream<Stdout>>>> = if args.mode == OutputMode::Jsonl {
+        Some(Arc::new(Mutex::new(JsonlStream::new(
+            "clone.event",
+            "1.0",
+            std::io::stdout(),
+        ))))
+    } else {
+        None
+    };
 
     // Step 1: Fetch the repository without populating the worktree yet.
     // The checkout happens only after local checkout settings are
     // configured, otherwise lazy clones pay the non-lazy smudge cost during
     // their first materialization.
-    // Note: git itself prints "Cloning into '...'" via inherited stderr,
-    // so we don't duplicate that message here.
+    if !args.mode.is_machine() {
+        eprintln!("Reading repository metadata...");
+    }
 
     // Emit progress for the git clone phase.
     if let Some(stream) = &jsonl_stream
@@ -180,20 +307,28 @@ pub async fn run_clone_in(
     }
 
     let phase = PhaseTimer::start("clone", "pack_fetch");
+    let pack_progress = ClonePackProgressReporter::new(args.mode, jsonl_stream.clone());
     if args.depth.is_none()
         && let Some(prepared) = Box::pin(prepare_complete_clone_inventory(
             target_dir.parent().unwrap_or(parent),
             args,
             cancel,
+            &pack_progress,
         ))
         .await?
     {
+        if !args.mode.is_machine() {
+            eprintln!("Creating local Git repository...");
+        }
         run_complete_inventory_clone(parent, args, &target_dir, &prepared)?;
     } else {
+        if !args.mode.is_machine() {
+            eprintln!("Fetching Git history...");
+        }
         run_git_clone_no_checkout(parent, args, &target_dir)?;
     }
     scrub_git_pack_appledouble_files(&target_dir)?;
-    emit_phase(jsonl_stream.as_ref(), phase.finish(0, 0, 1));
+    emit_phase(jsonl_stream.as_deref(), phase.finish(0, 0, 1));
 
     check_cancelled(cancel)?;
 
@@ -229,9 +364,12 @@ pub async fn run_clone_in(
     check_cancelled(cancel)?;
 
     // Step 5: Populate the working tree after crab config is ready.
+    if !args.mode.is_machine() {
+        eprintln!("Checking out files...");
+    }
     let phase = PhaseTimer::start("clone", "checkout");
     checkout_head(&target_dir, &args.url, args.mode)?;
-    emit_phase(jsonl_stream.as_ref(), phase.finish(0, 0, 1));
+    emit_phase(jsonl_stream.as_deref(), phase.finish(0, 0, 1));
 
     // Historical revisions may predate project configuration. Persist the
     // explicit clone location for subsequent reads only after checkout, so
@@ -269,7 +407,7 @@ pub async fn run_clone_in(
             // from the local cache.
             tracing::warn!(error = %e, "clone: post-clone shard sync failed (non-fatal)");
         }
-        emit_phase(jsonl_stream.as_ref(), phase.finish(0, 0, 1));
+        emit_phase(jsonl_stream.as_deref(), phase.finish(0, 0, 1));
     }
 
     check_cancelled(cancel)?;
@@ -325,7 +463,7 @@ pub async fn run_clone_in(
         let phase = PhaseTimer::start("clone", "hydration");
         run_post_checkout_hydrate(&target_dir, &hydrate_args, cancel).await?;
         emit_phase(
-            jsonl_stream.as_ref(),
+            jsonl_stream.as_deref(),
             phase.finish(0, 0, effective_include.len() as u64),
         );
 
@@ -367,7 +505,7 @@ pub async fn run_clone_in(
         };
         let phase = PhaseTimer::start("clone", "hydration");
         run_post_checkout_hydrate(&target_dir, &hydrate_args, cancel).await?;
-        emit_phase(jsonl_stream.as_ref(), phase.finish(0, 0, 1));
+        emit_phase(jsonl_stream.as_deref(), phase.finish(0, 0, 1));
 
         if !args.mode.is_machine() {
             eprintln!("Clone complete. All files hydrated.");
@@ -717,6 +855,7 @@ async fn prepare_complete_clone_inventory(
     workspace_parent: &Path,
     args: &CloneArgs,
     cancel: &CancellationToken,
+    progress: &ClonePackProgressReporter,
 ) -> Result<Option<PreparedCompleteClone>> {
     let config = crate::core::config::Config::resolve_local()?;
     let parsed = crate::git::url::CrabUrl::parse(&args.url)?;
@@ -770,8 +909,14 @@ async fn prepare_complete_clone_inventory(
         cancel,
     )
     .await?;
+    let report_progress = |update| progress.report(update);
     let inventory = repository
-        .download_complete_pack_inventory(&plan.object_ids, workspace_parent, cancel)
+        .download_complete_pack_inventory(
+            &plan.object_ids,
+            workspace_parent,
+            cancel,
+            Some(&report_progress),
+        )
         .await
         .map_err(|error| CrabError::Protocol(error.to_string()))?;
     Ok(inventory.map(|inventory| PreparedCompleteClone {
@@ -1519,6 +1664,21 @@ fn record_pointer_extension(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clone_pack_progress_reports_bytes_packs_and_rate() {
+        let progress = crab_remote_git::PackDownloadProgress {
+            packs_completed: 1,
+            packs_total: 3,
+            bytes_downloaded: 40 * 1024 * 1024,
+            total_bytes: 1024 * 1024 * 1024,
+        };
+
+        assert_eq!(
+            format_clone_pack_progress(progress, 12.5 * 1024.0 * 1024.0),
+            "Downloading Git packs: 3% (40.0 MiB / 1.0 GiB, 1/3 packs, 12.5 MiB/s)"
+        );
+    }
 
     fn git_in(repo: &Path, args: &[&str]) {
         let status = std::process::Command::new("git")

--- a/crab/src/cmd/push.rs
+++ b/crab/src/cmd/push.rs
@@ -28,7 +28,9 @@ use crate::git::push::{
     acquire_push_lock_leases, configure_active_active_push_coordinator, record_push_audit_event,
     release_push_lock_leases,
 };
-use crate::git::push_native::{NativePushConfig, NativePushInputs, run_native_push};
+use crate::git::push_native::{
+    NativePushConfig, NativePushInputs, NativePushProgressStream, run_native_push,
+};
 use crate::git::push_staging::PushStaging;
 use crate::git::push_state::PushState;
 use crate::git::remote_helper::{AGENT_REBASE_FETCH_REF_FILTERING_ENV, PushSpec};
@@ -844,6 +846,11 @@ async fn run_push_once(
     native_config.verbose = args.verbose;
     native_config.progress = mode == OutputMode::Text;
     native_config.followtags = args.follow_tags;
+    if let Some(stream) = &jsonl_stream {
+        native_config.output_mode = Some(OutputMode::Jsonl);
+        native_config.jsonl_progress_stream =
+            Some(NativePushProgressStream::Stdout(Arc::clone(stream)));
+    }
 
     let native_result = run_native_push(
         &native_config,

--- a/crab/src/git/progress.rs
+++ b/crab/src/git/progress.rs
@@ -14,7 +14,8 @@ use std::io::{Stderr, Stdout, Write};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{
-    AtomicBool, AtomicU8, AtomicU64, Ordering::Acquire, Ordering::Relaxed, Ordering::Release,
+    AtomicBool, AtomicU8, AtomicU64, Ordering::AcqRel, Ordering::Acquire, Ordering::Relaxed,
+    Ordering::Release,
 };
 use std::time::Duration;
 
@@ -565,6 +566,7 @@ pub struct NativePushProgress {
 
     // Phase tracking
     phase: AtomicU8,
+    phase_started: Mutex<Instant>,
 
     // Packing counters
     pack_files_total: AtomicU64,
@@ -584,10 +586,20 @@ pub struct NativePushProgress {
     meta_total: AtomicU64,
     meta_done: AtomicU64,
 
+    // Git pack upload counters
+    git_packs_total: AtomicU64,
+    git_packs_done: AtomicU64,
+    git_pack_bodies_done: AtomicU64,
+    git_upload_started: AtomicBool,
+    git_objects_total: AtomicU64,
+    git_bytes_total: AtomicU64,
+    git_bytes_done: AtomicU64,
+
     /// EWMA-based smoothed transfer rate. Tracks `(bytes_completed,
     /// transfer_bytes_completed)` with a 3s half-life so the displayed
     /// MiB/s decays gracefully during stalls and isn't noisy on startup.
     speed_tracker: Mutex<SpeedTracker>,
+    git_speed_tracker: Mutex<SpeedTracker>,
     /// Shared group-progress backing the `CompletionTracker`. Lives here
     /// so the file-level completion aggregation survives across phases.
     group_progress: Arc<GroupProgress>,
@@ -608,9 +620,6 @@ impl NativePushProgress {
     /// Prefer [`NativePushProgress::with_mode`] for new call sites.
     #[must_use]
     pub fn new(enabled: bool, color: bool, verbose: bool) -> Self {
-        let upload_progress = UploadGroupProgress::new();
-        let group_progress = Arc::clone(&upload_progress.file_data);
-        let completion_tracker = Arc::new(CompletionTracker::new(upload_progress));
         let backend = if !enabled {
             ProgressBackend::Silent
         } else if is_tty() {
@@ -622,30 +631,7 @@ impl NativePushProgress {
                 stderr: std::io::stderr(),
             }
         };
-        Self {
-            enabled,
-            color,
-            verbose,
-            backend,
-            phase: AtomicU8::new(0),
-            pack_files_total: AtomicU64::new(0),
-            pack_files_done: AtomicU64::new(0),
-            pack_xorbs_produced: AtomicU64::new(0),
-            pack_bytes_total: AtomicU64::new(0),
-            pack_bytes_done: AtomicU64::new(0),
-            upload_xorbs_total: AtomicU64::new(0),
-            upload_xorbs_done: AtomicU64::new(0),
-            upload_bytes_total: AtomicU64::new(0),
-            upload_bytes_done: AtomicU64::new(0),
-            upload_totals_final: AtomicBool::new(false),
-            meta_total: AtomicU64::new(0),
-            meta_done: AtomicU64::new(0),
-            speed_tracker: Mutex::new(
-                SpeedTracker::new(Duration::from_secs(3)).with_min_observations(2),
-            ),
-            group_progress,
-            completion_tracker,
-        }
+        Self::with_backend(enabled, color, verbose, backend)
     }
 
     /// Create a progress tracker with output mode selection.
@@ -661,9 +647,6 @@ impl NativePushProgress {
         mode: OutputMode,
         stream: Option<Arc<Mutex<JsonlStream<Stdout>>>>,
     ) -> Self {
-        let upload_progress = UploadGroupProgress::new();
-        let group_progress = Arc::clone(&upload_progress.file_data);
-        let completion_tracker = Arc::new(CompletionTracker::new(upload_progress));
         let (enabled, backend) = match mode {
             OutputMode::Text => {
                 let backend = if is_tty() {
@@ -687,30 +670,7 @@ impl NativePushProgress {
             }
             OutputMode::Json => (false, ProgressBackend::Silent),
         };
-        Self {
-            enabled,
-            color,
-            verbose,
-            backend,
-            phase: AtomicU8::new(0),
-            pack_files_total: AtomicU64::new(0),
-            pack_files_done: AtomicU64::new(0),
-            pack_xorbs_produced: AtomicU64::new(0),
-            pack_bytes_total: AtomicU64::new(0),
-            pack_bytes_done: AtomicU64::new(0),
-            upload_xorbs_total: AtomicU64::new(0),
-            upload_xorbs_done: AtomicU64::new(0),
-            upload_bytes_total: AtomicU64::new(0),
-            upload_bytes_done: AtomicU64::new(0),
-            upload_totals_final: AtomicBool::new(false),
-            meta_total: AtomicU64::new(0),
-            meta_done: AtomicU64::new(0),
-            speed_tracker: Mutex::new(
-                SpeedTracker::new(Duration::from_secs(3)).with_min_observations(2),
-            ),
-            group_progress,
-            completion_tracker,
-        }
+        Self::with_backend(enabled, color, verbose, backend)
     }
 
     /// Create a progress tracker that emits JSONL to stderr.
@@ -725,9 +685,6 @@ impl NativePushProgress {
         mode: OutputMode,
         stream: Option<Arc<Mutex<JsonlStream<Stderr>>>>,
     ) -> Self {
-        let upload_progress = UploadGroupProgress::new();
-        let group_progress = Arc::clone(&upload_progress.file_data);
-        let completion_tracker = Arc::new(CompletionTracker::new(upload_progress));
         let (enabled, backend) = match mode {
             OutputMode::Text => {
                 let backend = if is_tty() {
@@ -750,12 +707,20 @@ impl NativePushProgress {
             }
             OutputMode::Json => (false, ProgressBackend::Silent),
         };
+        Self::with_backend(enabled, color, verbose, backend)
+    }
+
+    fn with_backend(enabled: bool, color: bool, verbose: bool, backend: ProgressBackend) -> Self {
+        let upload_progress = UploadGroupProgress::new();
+        let group_progress = Arc::clone(&upload_progress.file_data);
+        let completion_tracker = Arc::new(CompletionTracker::new(upload_progress));
         Self {
             enabled,
             color,
             verbose,
             backend,
             phase: AtomicU8::new(0),
+            phase_started: Mutex::new(Instant::now()),
             pack_files_total: AtomicU64::new(0),
             pack_files_done: AtomicU64::new(0),
             pack_xorbs_produced: AtomicU64::new(0),
@@ -768,7 +733,17 @@ impl NativePushProgress {
             upload_totals_final: AtomicBool::new(false),
             meta_total: AtomicU64::new(0),
             meta_done: AtomicU64::new(0),
+            git_packs_total: AtomicU64::new(0),
+            git_packs_done: AtomicU64::new(0),
+            git_pack_bodies_done: AtomicU64::new(0),
+            git_upload_started: AtomicBool::new(false),
+            git_objects_total: AtomicU64::new(0),
+            git_bytes_total: AtomicU64::new(0),
+            git_bytes_done: AtomicU64::new(0),
             speed_tracker: Mutex::new(
+                SpeedTracker::new(Duration::from_secs(3)).with_min_observations(2),
+            ),
+            git_speed_tracker: Mutex::new(
                 SpeedTracker::new(Duration::from_secs(3)).with_min_observations(2),
             ),
             group_progress,
@@ -1028,6 +1003,132 @@ impl NativePushProgress {
         self.meta_total.store(n, Relaxed);
     }
 
+    /// Start the repository discovery phase before totals are known.
+    pub fn begin_discovery(&self) {
+        self.set_phase(Self::PHASE_DISCOVERING);
+        if matches!(self.backend, ProgressBackend::Line { .. }) {
+            eprintln!("Discovering changes...");
+        }
+    }
+
+    /// Start Git pack generation before its object and byte totals are known.
+    pub fn begin_git_pack(&self) {
+        self.git_packs_total.store(0, Relaxed);
+        self.git_packs_done.store(0, Relaxed);
+        self.git_pack_bodies_done.store(0, Relaxed);
+        self.git_upload_started.store(false, Release);
+        self.git_objects_total.store(0, Relaxed);
+        self.git_bytes_total.store(0, Relaxed);
+        self.git_bytes_done.store(0, Relaxed);
+        self.set_phase(Self::PHASE_GIT_PACKING);
+        if matches!(self.backend, ProgressBackend::Line { .. }) {
+            eprintln!("Packing Git objects...");
+        }
+    }
+
+    /// Start concurrent data packing and Git reachability preparation.
+    pub fn begin_push_preparation(&self) {
+        self.set_phase(Self::PHASE_STREAMING);
+        if matches!(self.backend, ProgressBackend::Line { .. }) {
+            eprintln!("Preparing data and Git objects...");
+        }
+    }
+
+    /// Record generated Git pack totals and transition to transfer progress.
+    pub fn set_git_upload_totals(&self, packs: u64, objects: u64, bytes: u64) {
+        let pack_elapsed = self.phase_elapsed();
+        self.git_packs_total.store(packs, Relaxed);
+        self.git_objects_total.store(objects, Relaxed);
+        self.git_bytes_total.store(bytes, Relaxed);
+        if matches!(self.backend, ProgressBackend::Line { .. }) {
+            eprintln!(
+                "Packing Git objects: {objects} objects in {packs} packs ({})  {} {}",
+                format_bytes(bytes),
+                self.checkmark(),
+                Self::fmt_elapsed(pack_elapsed),
+            );
+            eprintln!("Verifying Git packs...");
+        }
+        self.set_phase(Self::PHASE_GIT_VERIFYING);
+    }
+
+    /// Start remote transfer after local pack verification succeeds.
+    pub fn begin_git_upload(&self) {
+        if self.git_upload_started.swap(true, AcqRel) {
+            return;
+        }
+        self.set_phase(Self::PHASE_GIT_UPLOADING);
+        if matches!(self.backend, ProgressBackend::Line { .. }) {
+            eprintln!("Uploading Git objects...");
+        }
+    }
+
+    /// Mark one pack body durable and advance to sidecar publication when ready.
+    pub fn finish_git_pack_body(&self) {
+        let done = self.git_pack_bodies_done.fetch_add(1, AcqRel) + 1;
+        if done != self.git_packs_total.load(Acquire) {
+            return;
+        }
+        self.set_phase(Self::PHASE_GIT_PUBLISHING);
+        if matches!(self.backend, ProgressBackend::Line { .. }) {
+            eprintln!("Publishing Git metadata...");
+        }
+    }
+
+    /// Add durable or already-present Git pack bytes to transfer progress.
+    pub fn add_git_upload_bytes(&self, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+        let total = self.git_bytes_done.fetch_add(bytes, Relaxed) + bytes;
+        if let Ok(mut tracker) = self.git_speed_tracker.lock() {
+            tracker.update(total, total);
+        }
+    }
+
+    /// Mark one generated Git pack as durably available on the remote.
+    pub fn inc_git_pack(&self) {
+        self.git_packs_done.fetch_add(1, Relaxed);
+    }
+
+    /// Complete Git-object publication and begin final ref publication.
+    pub fn finish_git_objects(&self) {
+        if !self.enabled {
+            return;
+        }
+        let packs = self.git_packs_done.load(Relaxed);
+        let objects = self.git_objects_total.load(Relaxed);
+        let bytes = self.git_bytes_done.load(Relaxed);
+        match &self.backend {
+            ProgressBackend::Line { .. } => {
+                eprintln!(
+                    "Git objects ready: {objects} objects in {packs} packs ({})  {}",
+                    format_bytes(bytes),
+                    self.checkmark(),
+                );
+            }
+            ProgressBackend::Jsonl { stream } => {
+                let payload = self.git_upload_payload();
+                if let Ok(mut stream) = stream.lock() {
+                    let output = stream.emit_progress(payload);
+                    crate::core::output::report_progress_output(output);
+                }
+            }
+            ProgressBackend::JsonlStderr { stream } => {
+                let payload = self.git_upload_payload();
+                if let Ok(mut stream) = stream.lock() {
+                    let output = stream.emit_progress(payload);
+                    crate::core::output::report_progress_output(output);
+                }
+            }
+            ProgressBackend::Tty { .. } | ProgressBackend::Silent => {}
+        }
+        self.set_phase(Self::PHASE_FINALIZING);
+        if matches!(self.backend, ProgressBackend::Line { .. }) {
+            eprintln!("Finalizing push...");
+        }
+    }
+
     /// Print dedup feedback line to stderr in yellow.
     ///
     /// Shows dedup ratio, skipped bytes/chunks, and optionally defrag-prevented bytes.
@@ -1244,21 +1345,85 @@ impl NativePushProgress {
 
     // -- Phase constants ----------------------------------------------------
 
+    /// Phase: discovering local changes and remote boundaries.
+    pub const PHASE_DISCOVERING: u8 = 1;
     /// Phase: packing files into xorbs.
-    pub const PHASE_PACKING: u8 = 1;
+    pub const PHASE_PACKING: u8 = 2;
     /// Phase: uploading xorbs to remote.
-    pub const PHASE_UPLOADING: u8 = 2;
+    pub const PHASE_UPLOADING: u8 = 3;
     /// Phase: both packing and uploading active (streaming pipeline).
-    pub const PHASE_STREAMING: u8 = 3;
+    pub const PHASE_STREAMING: u8 = 4;
     /// Phase: uploading metadata (shards + file-index).
-    pub const PHASE_METADATA: u8 = 4;
+    pub const PHASE_METADATA: u8 = 5;
+    /// Phase: generating ordinary Git pack files.
+    pub const PHASE_GIT_PACKING: u8 = 6;
+    /// Phase: verifying generated Git pack contents locally.
+    pub const PHASE_GIT_VERIFYING: u8 = 7;
+    /// Phase: uploading ordinary Git pack files.
+    pub const PHASE_GIT_UPLOADING: u8 = 8;
+    /// Phase: publishing Git pack indexes and locator metadata.
+    pub const PHASE_GIT_PUBLISHING: u8 = 9;
+    /// Phase: atomically publishing repository metadata and refs.
+    pub const PHASE_FINALIZING: u8 = 10;
 
     /// Set the current pipeline phase.
     pub fn set_phase(&self, phase: u8) {
+        if let Ok(mut started) = self.phase_started.lock() {
+            *started = Instant::now();
+        }
         self.phase.store(phase, Relaxed);
     }
 
     // -- Live progress rendering --------------------------------------------
+
+    fn phase_elapsed(&self) -> Duration {
+        self.phase_started
+            .lock()
+            .map(|started| started.elapsed())
+            .unwrap_or_default()
+    }
+
+    fn render_discovery_line(&self) -> String {
+        format!(
+            "Discovering changes: {:.1}s elapsed",
+            self.phase_elapsed().as_secs_f64()
+        )
+    }
+
+    fn render_git_pack_line(&self) -> String {
+        format!(
+            "Packing Git objects: {:.1}s elapsed",
+            self.phase_elapsed().as_secs_f64()
+        )
+    }
+
+    fn render_git_verify_line(&self) -> String {
+        format!(
+            "Verifying Git packs: {:.1}s elapsed",
+            self.phase_elapsed().as_secs_f64()
+        )
+    }
+
+    fn render_git_publish_line(&self) -> String {
+        format!(
+            "Publishing Git metadata: {:.1}s elapsed",
+            self.phase_elapsed().as_secs_f64()
+        )
+    }
+
+    fn render_git_prepare_line(&self) -> String {
+        format!(
+            "Preparing Git objects: {:.1}s elapsed",
+            self.phase_elapsed().as_secs_f64()
+        )
+    }
+
+    fn render_finalizing_line(&self) -> String {
+        format!(
+            "Finalizing push: {:.1}s elapsed",
+            self.phase_elapsed().as_secs_f64()
+        )
+    }
 
     /// Render the packing progress line.
     fn render_pack_line(&self) -> String {
@@ -1373,6 +1538,52 @@ impl NativePushProgress {
         format!("Uploading metadata: {bar} {pct:>3}%  {done}/{total} entries")
     }
 
+    fn render_git_upload_line(&self) -> String {
+        let done = self.git_pack_bodies_done.load(Relaxed);
+        let total = self.git_packs_total.load(Relaxed);
+        let bytes = self.git_bytes_done.load(Relaxed);
+        let total_bytes = self.git_bytes_total.load(Relaxed);
+        let fraction = if total_bytes > 0 {
+            bytes as f64 / total_bytes as f64
+        } else if total > 0 {
+            done as f64 / total as f64
+        } else {
+            0.0
+        };
+        let pct = (fraction * 100.0).min(100.0) as u64;
+        let bar = render_bar(fraction, 30, self.color);
+        let rate = self
+            .git_speed_tracker
+            .lock()
+            .ok()
+            .and_then(|tracker| tracker.rates().1)
+            .unwrap_or(0.0);
+        format!(
+            "Uploading Git objects: {bar} {pct:>3}%  {done}/{total} packs, {} / {} | {}",
+            format_bytes(bytes),
+            format_bytes(total_bytes),
+            format_rate(rate),
+        )
+    }
+
+    fn git_upload_payload(&self) -> ProgressPayload {
+        let rate = self
+            .git_speed_tracker
+            .lock()
+            .ok()
+            .and_then(|tracker| tracker.rates().1)
+            .unwrap_or(0.0);
+        ProgressPayload {
+            operation: "uploading_git_objects".to_owned(),
+            current: self.git_pack_bodies_done.load(Relaxed),
+            total: self.git_packs_total.load(Relaxed),
+            bytes: self.git_bytes_done.load(Relaxed),
+            total_bytes: self.git_bytes_total.load(Relaxed),
+            rate_bytes_per_sec: rate,
+            xorbs_produced: None,
+        }
+    }
+
     /// Render live progress to stderr (TTY mode) or emit JSONL progress events.
     ///
     /// In TTY mode, reads atomic counters, formats the appropriate progress
@@ -1425,6 +1636,15 @@ impl NativePushProgress {
     fn build_jsonl_progress_payload(&self) -> Option<ProgressPayload> {
         let phase = self.phase.load(Relaxed);
         let payload = match phase {
+            Self::PHASE_DISCOVERING => ProgressPayload {
+                operation: "discovering".to_owned(),
+                current: 0,
+                total: 0,
+                bytes: 0,
+                total_bytes: 0,
+                rate_bytes_per_sec: 0.0,
+                xorbs_produced: None,
+            },
             Self::PHASE_PACKING => {
                 let done = self.pack_files_done.load(Relaxed);
                 let total = self.pack_files_total.load(Relaxed);
@@ -1471,6 +1691,19 @@ impl NativePushProgress {
                 }
             }
             Self::PHASE_STREAMING => {
+                if self.pack_files_total.load(Relaxed) == 0
+                    && self.upload_xorbs_total.load(Relaxed) == 0
+                {
+                    return Some(ProgressPayload {
+                        operation: "preparing_git_objects".to_owned(),
+                        current: 0,
+                        total: 0,
+                        bytes: 0,
+                        total_bytes: 0,
+                        rate_bytes_per_sec: 0.0,
+                        xorbs_produced: None,
+                    });
+                }
                 // In streaming mode, report the upload progress (more useful
                 // than packing for consumers tracking overall throughput).
                 let done = self.upload_xorbs_done.load(Relaxed);
@@ -1516,6 +1749,43 @@ impl NativePushProgress {
                     xorbs_produced: None,
                 }
             }
+            Self::PHASE_GIT_PACKING => ProgressPayload {
+                operation: "packing_git_objects".to_owned(),
+                current: 0,
+                total: 0,
+                bytes: 0,
+                total_bytes: 0,
+                rate_bytes_per_sec: 0.0,
+                xorbs_produced: None,
+            },
+            Self::PHASE_GIT_VERIFYING => ProgressPayload {
+                operation: "verifying_git_objects".to_owned(),
+                current: 0,
+                total: self.git_packs_total.load(Relaxed),
+                bytes: 0,
+                total_bytes: self.git_bytes_total.load(Relaxed),
+                rate_bytes_per_sec: 0.0,
+                xorbs_produced: None,
+            },
+            Self::PHASE_GIT_UPLOADING => self.git_upload_payload(),
+            Self::PHASE_GIT_PUBLISHING => ProgressPayload {
+                operation: "publishing_git_metadata".to_owned(),
+                current: self.git_packs_done.load(Relaxed),
+                total: self.git_packs_total.load(Relaxed),
+                bytes: self.git_bytes_done.load(Relaxed),
+                total_bytes: self.git_bytes_total.load(Relaxed),
+                rate_bytes_per_sec: 0.0,
+                xorbs_produced: None,
+            },
+            Self::PHASE_FINALIZING => ProgressPayload {
+                operation: "finalizing_push".to_owned(),
+                current: 0,
+                total: 0,
+                bytes: 0,
+                total_bytes: 0,
+                rate_bytes_per_sec: 0.0,
+                xorbs_produced: None,
+            },
             _ => return None,
         };
         Some(payload)
@@ -1525,12 +1795,26 @@ impl NativePushProgress {
     fn render_live_tty(&self, prev_lines: &mut usize) {
         let phase = self.phase.load(Relaxed);
         let lines = match phase {
+            Self::PHASE_DISCOVERING => vec![self.render_discovery_line()],
             Self::PHASE_PACKING => vec![self.render_pack_line()],
             Self::PHASE_UPLOADING => vec![self.render_upload_line()],
             Self::PHASE_STREAMING => {
-                vec![self.render_pack_line(), self.render_streaming_upload_line()]
+                let mut lines = Vec::new();
+                if self.pack_files_total.load(Relaxed) > 0
+                    || self.upload_xorbs_total.load(Relaxed) > 0
+                {
+                    lines.push(self.render_pack_line());
+                    lines.push(self.render_streaming_upload_line());
+                }
+                lines.push(self.render_git_prepare_line());
+                lines
             }
             Self::PHASE_METADATA => vec![self.render_meta_line()],
+            Self::PHASE_GIT_PACKING => vec![self.render_git_pack_line()],
+            Self::PHASE_GIT_VERIFYING => vec![self.render_git_verify_line()],
+            Self::PHASE_GIT_UPLOADING => vec![self.render_git_upload_line()],
+            Self::PHASE_GIT_PUBLISHING => vec![self.render_git_publish_line()],
+            Self::PHASE_FINALIZING => vec![self.render_finalizing_line()],
             _ => Vec::new(),
         };
         render_tty_frame(&mut std::io::stderr().lock(), &lines, prev_lines);
@@ -1596,6 +1880,14 @@ impl NativePushProgress {
         });
 
         Some((handle, cancel))
+    }
+
+    /// Stop a live ticker and wait for its final frame to be written.
+    pub async fn finish_ticker(ticker: Option<(JoinHandle<()>, CancellationToken)>) {
+        if let Some((handle, cancel)) = ticker {
+            cancel.cancel();
+            let _ = handle.await;
+        }
     }
 }
 
@@ -1796,10 +2088,16 @@ mod tests {
     #[test]
     fn phase_constants_are_distinct() {
         let phases = [
+            NativePushProgress::PHASE_DISCOVERING,
             NativePushProgress::PHASE_PACKING,
             NativePushProgress::PHASE_UPLOADING,
             NativePushProgress::PHASE_STREAMING,
             NativePushProgress::PHASE_METADATA,
+            NativePushProgress::PHASE_GIT_PACKING,
+            NativePushProgress::PHASE_GIT_VERIFYING,
+            NativePushProgress::PHASE_GIT_UPLOADING,
+            NativePushProgress::PHASE_GIT_PUBLISHING,
+            NativePushProgress::PHASE_FINALIZING,
         ];
         for (i, a) in phases.iter().enumerate() {
             for (j, b) in phases.iter().enumerate() {
@@ -1808,6 +2106,89 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn discovery_phase_renders_before_totals_are_known() {
+        let p = NativePushProgress::new(true, false, false);
+        p.begin_discovery();
+
+        let line = p.render_discovery_line();
+
+        assert!(line.starts_with("Discovering changes:"));
+        assert!(line.contains("elapsed"));
+    }
+
+    #[test]
+    fn git_pack_phase_renders_while_pack_objects_is_running() {
+        let p = NativePushProgress::new(true, false, false);
+        p.begin_git_pack();
+
+        let line = p.render_git_pack_line();
+
+        assert!(line.starts_with("Packing Git objects:"));
+        assert!(line.contains("elapsed"));
+    }
+
+    #[test]
+    fn git_pack_lifecycle_distinguishes_local_and_remote_work() {
+        let p = NativePushProgress::new(true, false, false);
+        p.begin_git_pack();
+        assert_eq!(p.phase(), NativePushProgress::PHASE_GIT_PACKING);
+
+        p.set_git_upload_totals(1, 10, 2048);
+        assert_eq!(p.phase(), NativePushProgress::PHASE_GIT_VERIFYING);
+
+        p.begin_git_upload();
+        assert_eq!(p.phase(), NativePushProgress::PHASE_GIT_UPLOADING);
+
+        p.finish_git_pack_body();
+        assert_eq!(p.phase(), NativePushProgress::PHASE_GIT_PUBLISHING);
+
+        p.finish_git_objects();
+        assert_eq!(p.phase(), NativePushProgress::PHASE_FINALIZING);
+        let payload = p
+            .build_jsonl_progress_payload()
+            .expect("finalizing payload");
+        assert_eq!(payload.operation, "finalizing_push");
+    }
+
+    #[test]
+    fn git_upload_progress_tracks_pack_bytes_and_completion() {
+        let p = NativePushProgress::new(true, false, false);
+        p.set_git_upload_totals(2, 100, 1024);
+        p.begin_git_upload();
+        p.add_git_upload_bytes(512);
+        p.finish_git_pack_body();
+
+        let halfway = p.render_git_upload_line();
+        assert!(halfway.contains(" 50%"));
+        assert!(halfway.contains("1/2 packs"));
+        assert!(halfway.contains("512 B / 1.0 KiB"));
+
+        p.add_git_upload_bytes(512);
+        p.finish_git_pack_body();
+        let complete = p.render_git_upload_line();
+        assert!(complete.contains("100%"));
+        assert!(complete.contains("2/2 packs"));
+    }
+
+    #[test]
+    fn git_upload_jsonl_uses_distinct_operation() {
+        let p = NativePushProgress::new(true, false, false);
+        p.set_git_upload_totals(1, 10, 2048);
+        p.begin_git_upload();
+        p.add_git_upload_bytes(1024);
+
+        let payload = p
+            .build_jsonl_progress_payload()
+            .expect("Git upload payload");
+
+        assert_eq!(payload.operation, "uploading_git_objects");
+        assert_eq!(payload.current, 0);
+        assert_eq!(payload.total, 1);
+        assert_eq!(payload.bytes, 1024);
+        assert_eq!(payload.total_bytes, 2048);
     }
 
     // -- render_pack_line ----------------------------------------------------

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -11914,12 +11914,13 @@ impl PushPipeline {
     ) -> Result<XorbUploadStreamSummary> {
         use futures_util::StreamExt;
 
-        if let Some(progress) = &self.progress {
-            progress.set_phase(NativePushProgress::PHASE_STREAMING);
+        if let Some(progress) = &self.progress
+            && progress.phase() != NativePushProgress::PHASE_STREAMING
+        {
+            progress.begin_push_preparation();
         }
         let mut summary = XorbUploadStreamSummary::default();
         let mut first_error = None;
-        let mut progress_ticker = None;
         let payload_bound = XORB_UPLOAD_IN_FLIGHT_PAYLOAD_LIMIT
             .div_ceil(XORB_MULTIPART_PART_SIZE.saturating_mul(4))
             .max(1);
@@ -11983,9 +11984,6 @@ impl PushPipeline {
                             summary.planned_xorbs,
                             summary.planned_bytes,
                         );
-                        if progress_ticker.is_none() && !batch.is_empty() {
-                            progress_ticker = progress.start_ticker();
-                        }
                     }
 
                     if first_error.is_some() {
@@ -12025,10 +12023,6 @@ impl PushPipeline {
         if let Some(progress) = &self.progress {
             progress.set_upload_totals(summary.planned_xorbs, summary.planned_bytes);
             progress.mark_upload_totals_final();
-        }
-        if let Some((handle, cancel)) = progress_ticker {
-            cancel.cancel();
-            let _ = handle.await;
         }
         if let Some(error) = first_error {
             self.uploaded_xorbs.lock().await.clear();
@@ -12902,6 +12896,9 @@ impl PushPipeline {
             pack_count = packed_files.len(),
             "step 10: bounded push pack set generated"
         );
+        if let Some(progress) = &self.progress {
+            progress.set_git_upload_totals(packed_files.len() as u64, object_count, pack_bytes);
+        }
 
         if let Some(store) = &self.store {
             let multipart_journal = self.multipart_journal().await?;
@@ -12922,6 +12919,14 @@ impl PushPipeline {
                 .map(|journal| journal as &dyn crab_storage::multipart::MultipartJournal);
             let mut jobs = packed_files.iter().enumerate().map(|(index, packed)| async move {
                 check_cancelled(&self.cancel)?;
+                let credited_bytes = std::sync::atomic::AtomicU64::new(0);
+                let on_part_done = |bytes: u64| {
+                    let previous = credited_bytes.fetch_add(bytes, std::sync::atomic::Ordering::Relaxed);
+                    let accepted = bytes.min(packed.pack_size.saturating_sub(previous));
+                    if let Some(progress) = &self.progress {
+                        progress.add_git_upload_bytes(accepted);
+                    }
+                };
                 let pack_sha = packed.pack_blake3_hex.clone();
                 let pack_path = self.router.pack_path(&pack_sha);
                 let installed = pack::install_pack_file_locally_with_timeout(
@@ -12938,7 +12943,10 @@ impl PushPipeline {
                     } => CrabError::PushMalformedObject { oid, kind, detail },
                     error => error,
                 })?;
-                if !upload_push_pack_file_body(
+                if let Some(progress) = &self.progress {
+                    progress.begin_git_upload();
+                }
+                let uploaded = upload_push_pack_file_body(
                     store,
                     &pack_path,
                     packed.pack_path.as_ref(),
@@ -12947,9 +12955,13 @@ impl PushPipeline {
                     &self.cancel,
                     multipart_journal,
                     self.metrics.as_deref(),
+                    Some(&on_part_done),
                 )
-                .await?
-                {
+                .await?;
+                if let Some(progress) = &self.progress {
+                    progress.finish_git_pack_body();
+                }
+                if !uploaded {
                     debug!(pack_id = %pack_sha, "step 10: pack already exists remotely, skipping body upload");
                 }
                 let mut locations = crab_git::pack_locator::PackLocationIter::open(
@@ -13087,6 +13099,13 @@ impl PushPipeline {
                     git_sha1 = %installed.git_sha1,
                     "step 10: bounded pack and immutable locator evidence uploaded"
                 );
+                if let Some(progress) = &self.progress {
+                    let credited = credited_bytes
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        .min(packed.pack_size);
+                    progress.add_git_upload_bytes(packed.pack_size.saturating_sub(credited));
+                    progress.inc_git_pack();
+                }
                 Ok::<_, CrabError>((index, UploadedGitPack {
                     entry,
                     idx_path: installed.idx_path,
@@ -13132,6 +13151,19 @@ impl PushPipeline {
 
         debug!("step 10: pack upload complete");
         Ok(())
+    }
+
+    async fn upload_packs_with_progress(&self) -> Result<()> {
+        if let Some(progress) = &self.progress {
+            progress.begin_git_pack();
+        }
+        let result = self.upload_packs().await;
+        if result.is_ok()
+            && let Some(progress) = &self.progress
+        {
+            progress.finish_git_objects();
+        }
+        result
     }
 
     /// Compute the remote reachability boundary for incremental packs.
@@ -14157,7 +14189,7 @@ impl PushPipeline {
         self.git_object_candidates.lock().await.clear();
         self.connectivity_frontier_tips.lock().await.clear();
         self.prepare_git_pack().await?;
-        self.upload_packs().await
+        self.upload_packs_with_progress().await
     }
 
     async fn read_remote_shard_for_proof(
@@ -16216,9 +16248,9 @@ impl PushPipeline {
         // Cancellation check after every DAG member is joined.
         check_cancelled(&self.cancel)?;
 
-        // Steps 8–10: metadata/Git uploads (immutable data must be durable before ref moves)
-        // Progress is reported inline (no background ticker) to avoid
-        // cursor-control conflicts with tracing output on stderr.
+        // Steps 8–10: metadata/Git uploads (immutable data must be durable before ref moves).
+        // Metadata reports its bounded summary inline; the native orchestrator's
+        // pipeline ticker follows Git packing, verification, transfer, and publication.
         //
         // Cancellation is checked between each upload step so Ctrl-C during
         // a long upload phase responds within one step boundary rather than
@@ -16241,7 +16273,10 @@ impl PushPipeline {
         self.emit_perf_phase(shard_upload_phase.finish(0, shard_upload_bytes, shard_upload_count));
         check_cancelled(&self.cancel)?;
         let pack_upload_phase = PhaseTimer::start("push", "pack_upload");
-        self.at_stage(PushFailureStage::GitPackUpload, self.upload_packs().await)?;
+        self.at_stage(
+            PushFailureStage::GitPackUpload,
+            self.upload_packs_with_progress().await,
+        )?;
         let (pack_upload_bytes, pack_upload_count) = {
             let packs = self.uploaded_packs.lock().await;
             (
@@ -18143,6 +18178,7 @@ async fn upload_push_pack_file_body(
     cancel: &CancellationToken,
     journal: Option<&dyn crab_storage::multipart::MultipartJournal>,
     metrics: Option<&Metrics>,
+    on_part_done: Option<&(dyn Fn(u64) + Send + Sync)>,
 ) -> Result<bool> {
     if store.staging_write_prefix().is_some() {
         let pack_bytes = tokio::fs::read(pack_file).await?;
@@ -18151,6 +18187,9 @@ async fn upload_push_pack_file_body(
         store
             .verify_written_size_and_hash(pack_path, pack_size, &pack_blake3)
             .await?;
+        if let Some(on_part_done) = on_part_done {
+            on_part_done(pack_size);
+        }
         return Ok(true);
     }
 
@@ -18186,7 +18225,7 @@ async fn upload_push_pack_file_body(
                 &pack_blake3,
                 PACK_MULTIPART_THRESHOLD_BYTES as usize,
                 cancel,
-                None,
+                on_part_done,
                 journal,
             )
             .await?;
@@ -18211,6 +18250,9 @@ async fn upload_push_pack_file_body(
         store
             .verify_written_size_and_hash(pack_path, pack_size, &pack_blake3)
             .await?;
+        if let Some(on_part_done) = on_part_done {
+            on_part_done(pack_size);
+        }
     }
     Ok(true)
 }
@@ -20984,6 +21026,7 @@ mod tests {
             &CancellationToken::new(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -21024,6 +21067,7 @@ mod tests {
             &CancellationToken::new(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -21034,6 +21078,7 @@ mod tests {
             body.len() as u64,
             *pack_hash.as_bytes(),
             &CancellationToken::new(),
+            None,
             None,
             None,
         )
@@ -21072,6 +21117,7 @@ mod tests {
             &CancellationToken::new(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -21102,6 +21148,7 @@ mod tests {
             body.len() as u64,
             [7; 32],
             &CancellationToken::new(),
+            None,
             None,
             None,
         )

--- a/crab/src/git/push_native.rs
+++ b/crab/src/git/push_native.rs
@@ -34,6 +34,15 @@ use crab_staging::StagingAreaReadOnly;
 pub(crate) const MIRROR_GIT_ONLY_ENV: &str = "CRAB_INTERNAL_MIRROR_GIT_ONLY";
 pub(crate) const MIRROR_PLAN_ID_ENV: &str = crab_remote::local::PUBLICATION_PLAN_ID_ENV;
 
+/// Destination for structured native-push progress.
+#[derive(Debug, Clone)]
+pub enum NativePushProgressStream {
+    /// Direct CLI output, where stdout carries the JSONL event stream.
+    Stdout(std::sync::Arc<std::sync::Mutex<crate::core::output::JsonlStream<std::io::Stdout>>>),
+    /// Remote-helper output, where stderr is separate from Git's protocol stdout.
+    Stderr(std::sync::Arc<std::sync::Mutex<crate::core::output::JsonlStream<std::io::Stderr>>>),
+}
+
 /// Configuration for the native push pipeline.
 #[derive(Debug, Clone)]
 pub struct NativePushConfig {
@@ -49,15 +58,11 @@ pub struct NativePushConfig {
     pub color: bool,
     /// Whether to show per-file and per-xorb detail.
     pub verbose: bool,
-    /// Output mode for structured progress. When `Jsonl` with a stderr
-    /// stream, progress events go to stderr (remote helper context where
-    /// git owns stdout).
+    /// Output mode for structured progress.
     pub output_mode: Option<crate::core::output::OutputMode>,
-    /// Shared JSONL stream writing to stderr. Set by the remote helper
-    /// when `CRAB_PROGRESS_FORMAT=jsonl` — JSONL events MUST go to
-    /// stderr because git owns stdout in the remote helper context.
-    pub jsonl_stderr_stream:
-        Option<std::sync::Arc<std::sync::Mutex<crate::core::output::JsonlStream<std::io::Stderr>>>>,
+    /// Shared JSONL destination. The CLI uses stdout; the remote helper uses
+    /// stderr because Git owns helper stdout.
+    pub jsonl_progress_stream: Option<NativePushProgressStream>,
     /// When `true`, `run_native_push` augments the explicit spec
     /// list with extra `PushSpec` entries for annotated tags whose
     /// targets are in the pushed commit set. Mirrors git's
@@ -175,7 +180,7 @@ impl NativePushConfig {
             color: true,
             verbose: false,
             output_mode: None,
-            jsonl_stderr_stream: None,
+            jsonl_progress_stream: None,
             followtags: false,
             mirror_git_only: false,
         }
@@ -304,23 +309,29 @@ async fn run_native_push_inner(
     let pipeline_start = Instant::now();
 
     // Create the progress tracker, shared across all pipeline stages.
-    // When the remote helper sets `CRAB_PROGRESS_FORMAT=jsonl`, progress
-    // events go to stderr via JsonlStream<Stderr> because git owns stdout.
-    let progress =
-        if let (Some(mode), Some(stream)) = (config.output_mode, &config.jsonl_stderr_stream) {
+    let progress = match (config.output_mode, config.jsonl_progress_stream.as_ref()) {
+        (Some(mode), Some(NativePushProgressStream::Stdout(stream))) => {
+            Arc::new(NativePushProgress::with_mode(
+                config.color,
+                config.verbose,
+                mode,
+                Some(Arc::clone(stream)),
+            ))
+        }
+        (Some(mode), Some(NativePushProgressStream::Stderr(stream))) => {
             Arc::new(NativePushProgress::with_mode_stderr(
                 config.color,
                 config.verbose,
                 mode,
                 Some(Arc::clone(stream)),
             ))
-        } else {
-            Arc::new(NativePushProgress::new(
-                config.progress,
-                config.color,
-                config.verbose,
-            ))
-        };
+        }
+        _ => Arc::new(NativePushProgress::new(
+            config.progress,
+            config.color,
+            config.verbose,
+        )),
+    };
 
     info!(
         specs = specs.len(),
@@ -338,7 +349,7 @@ async fn run_native_push_inner(
         delegated_push.git_dir = Some(git_dirs.per_worktree.clone());
     }
     if delegated_push.perf_phase_sink.is_none()
-        && let Some(stream) = &config.jsonl_stderr_stream
+        && let Some(NativePushProgressStream::Stderr(stream)) = &config.jsonl_progress_stream
     {
         delegated_push.perf_phase_sink = Some(PerfPhaseSink::Stderr(Arc::clone(stream)));
     }
@@ -394,6 +405,8 @@ async fn run_native_push_inner(
             }
         }
     }
+    progress.begin_discovery();
+    let discovery_ticker = progress.start_ticker();
     let discovery = if config.mirror_git_only {
         phase_discover_git_only(specs, &git_dirs)
     } else {
@@ -406,8 +419,14 @@ async fn run_native_push_inner(
             &git_dirs,
         )
     };
-    let (mut pointers, mut commit_entries, mut sha_map) =
-        release_native_locks_on_error(discovery, &mut pre_acquired_locks).await?;
+    let discovery = release_native_locks_on_error(discovery, &mut pre_acquired_locks).await;
+    let (mut pointers, mut commit_entries, mut sha_map) = match discovery {
+        Ok(discovery) => discovery,
+        Err(error) => {
+            NativePushProgress::finish_ticker(discovery_ticker).await;
+            return Err(error);
+        }
+    };
 
     // If the incremental walk found no pointers but staging has live
     // files, the push state is stale — a prior push recorded the tip
@@ -435,14 +454,22 @@ async fn run_native_push_inner(
                 false,
                 &git_dirs,
             );
-            let (full_pointers, full_entries, full_sha_map) =
-                release_native_locks_on_error(full_discovery, &mut pre_acquired_locks).await?;
+            let full_discovery =
+                release_native_locks_on_error(full_discovery, &mut pre_acquired_locks).await;
+            let (full_pointers, full_entries, full_sha_map) = match full_discovery {
+                Ok(discovery) => discovery,
+                Err(error) => {
+                    NativePushProgress::finish_ticker(discovery_ticker).await;
+                    return Err(error);
+                }
+            };
             pointers = full_pointers;
             commit_entries = full_entries;
             sha_map = full_sha_map;
         }
     }
 
+    NativePushProgress::finish_ticker(discovery_ticker).await;
     progress.report_discover(
         pointers.len() as u64,
         commit_entries.len() as u64,
@@ -537,6 +564,8 @@ async fn run_native_push_inner(
     // them on all exit paths — success, failure, and cancellation.
     release_native_locks_on_error(check_cancelled(&cancel), &mut pre_acquired_locks).await?;
 
+    progress.begin_push_preparation();
+    let pipeline_ticker = progress.start_ticker();
     let result = if config.push.protected_push.is_some() {
         debug!("native push: protected push skips client-owned push lock");
         let prepopulated = PrePopulatedWalk {
@@ -616,6 +645,7 @@ async fn run_native_push_inner(
             }
         }
     };
+    NativePushProgress::finish_ticker(pipeline_ticker).await;
 
     // ── Update push state on success ───────────────────────────────
     if result.all_ok() {

--- a/crab/src/git/remote_helper.rs
+++ b/crab/src/git/remote_helper.rs
@@ -1762,7 +1762,9 @@ fn native_push_config_for_helper(
     // helper protocol instead of user text.
     if progress_mode == OutputMode::Jsonl {
         native_config.output_mode = Some(progress_mode);
-        native_config.jsonl_stderr_stream = jsonl_stderr_stream.map(Arc::clone);
+        native_config.jsonl_progress_stream = jsonl_stderr_stream
+            .map(Arc::clone)
+            .map(crate::git::push_native::NativePushProgressStream::Stderr);
     }
     native_config.mirror_git_only =
         std::env::var_os(crate::git::push_native::MIRROR_GIT_ONLY_ENV).is_some();

--- a/crates/crab-remote-git/src/lib.rs
+++ b/crates/crab-remote-git/src/lib.rs
@@ -38,6 +38,7 @@ pub use pack::{
     DownloadedPackInventory, GENERATED_PACK_CACHE_VERSION, GeneratedPack, GeneratedPackCacheKey,
     GeneratedPackLease, GeneratedPackLeaseAttempt, GeneratedPackLeaseError,
     GeneratedPackLeaseProvider, GeneratedPackRequestCacheError, GeneratedPackRequestCacheKey,
+    PackDownloadProgress,
 };
 pub use path::GitPath;
 pub use reader::{RemoteGitObject, RemoteGitObjectMetadata};

--- a/crates/crab-remote-git/src/operation.rs
+++ b/crates/crab-remote-git/src/operation.rs
@@ -593,6 +593,7 @@ impl OperationContext {
         pack_id: crab_xet::hash::MerkleHash,
         expected_size: u64,
         destination: &std::path::Path,
+        progress: Option<&(dyn Fn(u64) + Send + Sync)>,
     ) -> Result<crab_git::pack::VerifiedPackIdentity> {
         let reader = self.state.reader.as_ref().ok_or(Error::EmptyRepository)?;
         reader
@@ -602,6 +603,7 @@ impl OperationContext {
                 destination,
                 &self.budget,
                 &self.cancellation,
+                progress,
             )
             .await
     }

--- a/crates/crab-remote-git/src/pack.rs
+++ b/crates/crab-remote-git/src/pack.rs
@@ -6,6 +6,7 @@ use std::future::Future;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use crab_git::pack::VerifiedPackIdentity;
@@ -314,6 +315,19 @@ pub struct DownloadedPackInventory {
     packs: Vec<crab_git::repack::RepackSource>,
 }
 
+/// Aggregate progress while canonical Git packs are downloaded for local installation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PackDownloadProgress {
+    /// Pack bodies and sidecars fully downloaded and verified.
+    pub packs_completed: u64,
+    /// Total canonical packs selected for download.
+    pub packs_total: u64,
+    /// Pack-body bytes written locally.
+    pub bytes_downloaded: u64,
+    /// Total pack-body bytes selected for download.
+    pub total_bytes: u64,
+}
+
 impl DownloadedPackInventory {
     /// Return the verified pack bodies and committed Git index sidecars.
     #[must_use]
@@ -409,6 +423,7 @@ impl RemoteGitRepository {
         object_ids: &[ObjectId],
         workspace_parent: &Path,
         cancellation: &CancellationToken,
+        progress: Option<&(dyn Fn(PackDownloadProgress) + Send + Sync)>,
     ) -> Result<Option<DownloadedPackInventory>> {
         let inventory = self.state.inventory.values().copied().collect::<Vec<_>>();
         let inventory_objects = inventory
@@ -432,8 +447,14 @@ impl RemoteGitRepository {
             let workspace = tempfile::tempdir_in(workspace_parent).map_err(io_error)?;
             let download_dir = workspace.path().join("source-packs");
             std::fs::create_dir_all(&download_dir).map_err(io_error)?;
-            let packs =
-                download_repack_sources(&operation, inventory, &download_dir, cancellation).await?;
+            let packs = download_repack_sources(
+                &operation,
+                inventory,
+                &download_dir,
+                cancellation,
+                progress,
+            )
+            .await?;
             let check_packs = packs.clone();
             let selected_oids = object_ids.to_vec();
             let covers = tokio::task::spawn_blocking(move || {
@@ -552,7 +573,8 @@ impl RemoteGitRepository {
             std::fs::create_dir_all(&download_dir).map_err(io_error)?;
             let source_download_started = Instant::now();
             let sources =
-                download_repack_sources(&operation, inventory, &download_dir, cancellation).await?;
+                download_repack_sources(&operation, inventory, &download_dir, cancellation, None)
+                    .await?;
             let source_download_ms = source_download_started.elapsed().as_millis() as u64;
             let wants = wants.to_vec();
             let common_haves = common_haves.to_vec();
@@ -797,7 +819,8 @@ impl RemoteGitRepository {
         std::fs::create_dir_all(&download_dir).map_err(io_error)?;
         let source_download_started = Instant::now();
         let sources =
-            download_repack_sources(operation, inventory, &download_dir, cancellation).await?;
+            download_repack_sources(operation, inventory, &download_dir, cancellation, None)
+                .await?;
         let source_download_ms = source_download_started.elapsed().as_millis() as u64;
         let inventory_check_started = Instant::now();
         let check_sources = sources.clone();
@@ -961,7 +984,8 @@ impl RemoteGitRepository {
         std::fs::create_dir_all(&download_dir).map_err(io_error)?;
         let source_download_started = Instant::now();
         let sources =
-            download_repack_sources(operation, inventory, &download_dir, cancellation).await?;
+            download_repack_sources(operation, inventory, &download_dir, cancellation, None)
+                .await?;
         let source_download_ms = source_download_started.elapsed().as_millis() as u64;
         let selected_oids = object_ids.to_vec();
         let repacked = tokio::task::spawn_blocking(move || {
@@ -1228,37 +1252,84 @@ async fn download_repack_sources(
     inventory: Vec<GitPackInventoryEntry>,
     download_dir: &Path,
     cancellation: &CancellationToken,
+    progress: Option<&(dyn Fn(PackDownloadProgress) + Send + Sync)>,
 ) -> Result<Vec<crab_git::repack::RepackSource>> {
+    let packs_total = inventory.len() as u64;
+    let total_bytes = inventory
+        .iter()
+        .fold(0_u64, |total, pack| total.saturating_add(pack.pack_size));
+    let bytes_downloaded = AtomicU64::new(0);
+    let packs_completed = AtomicU64::new(0);
+    if let Some(progress) = progress {
+        progress(PackDownloadProgress {
+            packs_completed: 0,
+            packs_total,
+            bytes_downloaded: 0,
+            total_bytes,
+        });
+    }
     download_repack_sources_with(
         inventory,
         download_dir.to_owned(),
         cancellation,
         SOURCE_PACK_DOWNLOAD_CONCURRENCY,
-        |pack, path| async move {
-            let index_maximum =
-                crab_git::max_pack_index_size(pack.object_count).ok_or(Error::Corrupt {
-                    stage: crate::CorruptionStage::Inventory,
-                })?;
-            let reverse_maximum =
-                crab_git::pack_reverse_index_size(pack.object_count).ok_or(Error::Corrupt {
-                    stage: crate::CorruptionStage::Inventory,
-                })?;
-            let index_path = path.with_extension("idx");
-            let reverse_index_path = path.with_extension("rev");
-            // The body and its immutable sidecars are independent objects.
-            // Keep the pack-level fanout bounded by the surrounding stream,
-            // while overlapping their latency under the runtime origin
-            // semaphore.
-            let (verified_identity, (), ()) = tokio::try_join!(
-                operation.download_pack_to_path(pack.pack_id, pack.pack_size, &path),
-                operation.download_pack_index_to_path(pack.pack_id, index_maximum, &index_path,),
-                operation.download_pack_reverse_index_to_path(
-                    pack.pack_id,
-                    reverse_maximum,
-                    &reverse_index_path,
-                ),
-            )?;
-            Ok(Some(verified_identity))
+        |pack, path| {
+            let bytes_downloaded = &bytes_downloaded;
+            let packs_completed = &packs_completed;
+            async move {
+                let index_maximum =
+                    crab_git::max_pack_index_size(pack.object_count).ok_or(Error::Corrupt {
+                        stage: crate::CorruptionStage::Inventory,
+                    })?;
+                let reverse_maximum =
+                    crab_git::pack_reverse_index_size(pack.object_count).ok_or(Error::Corrupt {
+                        stage: crate::CorruptionStage::Inventory,
+                    })?;
+                let index_path = path.with_extension("idx");
+                let reverse_index_path = path.with_extension("rev");
+                let report_bytes = |bytes: u64| {
+                    let bytes_downloaded = bytes_downloaded
+                        .fetch_add(bytes, Ordering::Relaxed)
+                        .saturating_add(bytes);
+                    if let Some(progress) = progress {
+                        progress(PackDownloadProgress {
+                            packs_completed: packs_completed.load(Ordering::Relaxed),
+                            packs_total,
+                            bytes_downloaded,
+                            total_bytes,
+                        });
+                    }
+                };
+                // The body and its immutable sidecars are independent objects.
+                // Keep the pack-level fanout bounded by the surrounding stream,
+                // while overlapping their latency under the runtime origin
+                // semaphore.
+                let (verified_identity, (), ()) = tokio::try_join!(
+                    operation.download_pack_to_path(
+                        pack.pack_id,
+                        pack.pack_size,
+                        &path,
+                        Some(&report_bytes),
+                    ),
+                    operation
+                        .download_pack_index_to_path(pack.pack_id, index_maximum, &index_path,),
+                    operation.download_pack_reverse_index_to_path(
+                        pack.pack_id,
+                        reverse_maximum,
+                        &reverse_index_path,
+                    ),
+                )?;
+                let completed = packs_completed.fetch_add(1, Ordering::Relaxed) + 1;
+                if let Some(progress) = progress {
+                    progress(PackDownloadProgress {
+                        packs_completed: completed,
+                        packs_total,
+                        bytes_downloaded: bytes_downloaded.load(Ordering::Relaxed),
+                        total_bytes,
+                    });
+                }
+                Ok(Some(verified_identity))
+            }
         },
     )
     .await
@@ -2274,7 +2345,7 @@ async fn try_reuse_single_pack(
     let file = NamedTempFile::new().map_err(io_error)?;
     let path = file.path().to_owned();
     let verified_identity = operation
-        .download_pack_to_path(inventory.pack_id, inventory.pack_size, file.path())
+        .download_pack_to_path(inventory.pack_id, inventory.pack_size, file.path(), None)
         .await?;
     if verified_identity.git_sha1 != expected_checksum {
         return Err(Error::Corrupt {

--- a/crates/crab-remote-git/src/reader.rs
+++ b/crates/crab-remote-git/src/reader.rs
@@ -1472,6 +1472,7 @@ impl RemoteGitReader {
         destination: &std::path::Path,
         budget: &OperationBudget,
         cancellation: &CancellationToken,
+        progress: Option<&(dyn Fn(u64) + Send + Sync)>,
     ) -> Result<VerifiedPackIdentity> {
         use tokio::io::AsyncWriteExt as _;
 
@@ -1526,6 +1527,9 @@ impl RemoteGitReader {
                 .ok_or(Error::Corrupt {
                     stage: CorruptionStage::PackEntry,
                 })?;
+            if let Some(progress) = progress {
+                progress(chunk.len() as u64);
+            }
         }
         file.flush().await.map_err(|source| {
             Error::Metadata(crab_metadata::error::MetadataError::Io { source })
@@ -2570,6 +2574,7 @@ mod tests {
                 destination.path(),
                 &budget,
                 &CancellationToken::new(),
+                None,
             )
             .await;
         assert!(matches!(

--- a/packages/web/content/docs/cli/reference/crab-clone.mdx
+++ b/packages/web/content/docs/cli/reference/crab-clone.mdx
@@ -61,6 +61,14 @@ crab clone acme/models
 Both forms persist `crab://crab.build/acme/models` in `.git/config` and
 `crab.toml`. Resolved placement and transfer credentials remain in memory.
 
+## Progress output
+
+Interactive clones report repository discovery, Git pack download, local
+repository creation, Crab configuration, and checkout as separate steps. Large
+pack downloads include transferred pack-body bytes, total pack-body bytes,
+completed pack count, and transfer rate. `--jsonl` emits the same measurements with the
+`downloading_git_packs` operation; `--json` remains a single terminal result.
+
 ### Hydrate selected content
 
 ```bash

--- a/packages/web/content/docs/cli/reference/crab-push.mdx
+++ b/packages/web/content/docs/cli/reference/crab-push.mdx
@@ -112,6 +112,21 @@ crab push --jsonl
 For `git push`, set `CRAB_PROGRESS_FORMAT=jsonl` to receive the equivalent
 remote-helper event stream on stderr because Git owns helper stdout.
 
+## Progress for large pushes
+
+Text output reports each long-running phase as it starts, so initial pushes do
+not appear stalled while Crab walks a large history or runs Git pack
+compression. Once pack sizes are known, the Git-object upload shows completed
+bytes, pack count, and transfer rate. Crab-managed data packing/upload and
+metadata/ref publication remain separate phases, making CPU work, object-store
+transfer, and final publication distinguishable.
+
+JSONL output uses `discovering`, `preparing_git_objects`,
+`packing_git_objects`, `verifying_git_objects`, `uploading_git_objects`, and
+`publishing_git_metadata` operations for those phases. `finalizing_push`
+covers atomic repository metadata and ref publication. The upload event includes
+pack and byte totals when pack generation finishes.
+
 ## Related
 
 - [Managed Service Quickstart](/docs/cli/managed-service)

--- a/packages/web/content/docs/cli/reference/structured-output.mdx
+++ b/packages/web/content/docs/cli/reference/structured-output.mdx
@@ -256,6 +256,10 @@ These commands accept both flags. `--json` emits only the terminal result;
 | `crab prune` | `prune` | `prune.event` |
 | `crab clone` | `clone` | `clone.event` |
 
+During a complete-inventory clone, `clone.event` progress records use the
+`downloading_git_packs` operation and populate pack counts, transferred
+pack-body bytes, total pack-body bytes, and `rate_bytes_per_sec`.
+
 `crab push --rebase-on-non-fast-forward` result payloads include
 `integration_retries`, `integration_retry_limit`, and, when retries occur,
 `integration_retry_stages`. The stage map uses bounded names such as


### PR DESCRIPTION
## Summary

- show immediate discovery and preparation feedback before large native pushes know their totals
- distinguish Git pack generation, local verification, body upload, pack metadata publication, and final atomic ref publication
- report Git pack bytes, completed pack bodies, object count, and transfer rate during initial pushes
- stream the same phase model as push.event JSONL for both direct crab push and the Git remote helper
- retain the existing clone metadata and canonical-pack download progress from the first commit
- document interactive and structured push progress

## Proof

- cargo test -p crab-remote-git (123 unit + 79 integration + 1 doctest)
- cargo test -p crab cmd::clone::tests --lib (41 tests)
- cargo test -p crab --lib git::progress::tests:: (56 tests)
- cargo test -p crab --lib git::push_native::tests:: (25 tests)
- cargo test -p crab --lib cmd::push::tests:: (42 tests)
- cargo test -p crab --lib upload_push_pack_file_body (4 tests)
- strict crab-remote-git clippy
- repository CI-equivalent crab correctness/suspicious clippy gate
- web production build and link check (398 pages, 4306 fragments)
- live RustFS clone of the retained Kubernetes fixture: immediate metadata output, continuous progress across 1.2 GiB / 3 packs, successful 31,280-file checkout, clean worktree, and HEAD identical to the replay source
- live RustFS initial Kubernetes push: immediate discovery and phase feedback, 1,646,244 Git objects in one 1.2 GiB pack, byte/rate upload progress, successful publication in 177.3 seconds
- live text-mode initial push smoke: all phases through final ref publication visible
- live direct crab push --jsonl smoke: push.event progress and one terminal result share stdout safely with perf.phase telemetry

## Performance contract

Clone download adds one relaxed atomic update per received storage chunk. Push upload adds one atomic byte update per completed multipart part and phase-boundary atomics outside the hot loop. Terminal rendering remains on the existing 100 ms ticker, while JSONL retains its 250 ms rate limit. Pack generation, upload concurrency, durable verification, publication ordering, and ref-CAS semantics are unchanged.