### PR TITLE
fix(sdk): align executable capability versions

### DIFF
--- a/crab/src/main.rs
+++ b/crab/src/main.rs
@@ -3149,12 +3149,14 @@ async fn run_cli_stub(cli: Cli, cancel: CancellationToken) -> Result<ExitCode> {
             Ok(ExitCode::SUCCESS)
         }
         Some(Cmd::SdkCapabilities { json: true }) => {
-            let capabilities =
-                crab_remote::local::ExecutableCapabilities::current_with_build(format!(
+            let capabilities = crab_remote::local::ExecutableCapabilities::for_executable(
+                env!("CRAB_BUILD_VERSION").to_owned(),
+                format!(
                     "crab/{}+{}",
-                    env!("CARGO_PKG_VERSION"),
+                    env!("CRAB_BUILD_VERSION"),
                     env!("CRAB_BUILD_GIT_SHA")
-                ));
+                ),
+            );
             let encoded = serde_json::to_string(&capabilities)
                 .map_err(|error| CrabError::Internal(error.to_string()))?;
             println!("{encoded}");

--- a/crab/tests/sdk_capabilities.rs
+++ b/crab/tests/sdk_capabilities.rs
@@ -1,0 +1,32 @@
+use std::process::Command;
+
+fn crab_json(args: &[&str]) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_crab"))
+        .args(args)
+        .output()
+        .expect("run crab");
+    assert!(
+        output.status.success(),
+        "crab {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("parse crab JSON output")
+}
+
+#[test]
+fn sdk_capabilities_report_the_executable_version() {
+    let capabilities = crab_json(&["sdk-capabilities", "--json"]);
+    let version = crab_json(&["version", "--json"]);
+
+    assert_eq!(
+        capabilities["crab_version"],
+        version["data"]["crab_version"]
+    );
+}
+
+#[test]
+fn sdk_capabilities_report_canonical_staging_format() {
+    let capabilities = crab_json(&["sdk-capabilities", "--json"]);
+
+    assert_eq!(capabilities["staging_format_version"], 1);
+}

--- a/crates/crab-remote/src/local.rs
+++ b/crates/crab-remote/src/local.rs
@@ -16,7 +16,7 @@ pub const CAPABILITIES_SCHEMA_VERSION: u32 = 1;
 /// Minimum compatible local-workflow protocol implemented by this crate.
 pub const LOCAL_WORKFLOW_PROTOCOL_VERSION: u32 = 1;
 pub const STORAGE_FORMAT_VERSION: u32 = 1;
-pub const STAGING_FORMAT_VERSION: u32 = 3;
+pub const STAGING_FORMAT_VERSION: u32 = 1;
 
 /// Process-local bridge to the canonical durable publication-plan owner.
 pub const PUBLICATION_PLAN_ID_ENV: &str = "CRAB_INTERNAL_MIRROR_PLAN_ID";
@@ -27,7 +27,7 @@ pub const CURRENT_CAPABILITIES_JSON: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     "\",\"product_build\":\"crab-remote/",
     env!("CARGO_PKG_VERSION"),
-    "\",\"local_workflow_protocol\":1,\"storage_format_version\":1,\"staging_format_version\":3,\"operations\":[\"clone\",\"fetch-content\",\"stage\",\"hydrate\",\"dehydrate\",\"filter-process\",\"remote-helper\"]}"
+    "\",\"local_workflow_protocol\":1,\"storage_format_version\":1,\"staging_format_version\":1,\"operations\":[\"clone\",\"fetch-content\",\"stage\",\"hydrate\",\"dehydrate\",\"filter-process\",\"remote-helper\"]}"
 );
 
 /// Capabilities advertised by a Crab executable to a local SDK client.
@@ -60,9 +60,15 @@ impl ExecutableCapabilities {
     /// Return current capabilities with the executable's exact build identity.
     #[must_use]
     pub fn current_with_build(product_build: String) -> Self {
+        Self::for_executable(env!("CARGO_PKG_VERSION").to_owned(), product_build)
+    }
+
+    /// Return current capabilities for an executable release and build.
+    #[must_use]
+    pub fn for_executable(crab_version: String, product_build: String) -> Self {
         Self {
             schema_version: CAPABILITIES_SCHEMA_VERSION,
-            crab_version: env!("CARGO_PKG_VERSION").to_owned(),
+            crab_version,
             product_build,
             local_workflow_protocol: LOCAL_WORKFLOW_PROTOCOL_VERSION,
             storage_format_version: STORAGE_FORMAT_VERSION,

--- a/crates/crab-staging/README.md
+++ b/crates/crab-staging/README.md
@@ -30,10 +30,11 @@ lockfile        ── process-wide advisory flock
 push upload / recipe publication
 ```
 
-`StagingArea::open` acquires an exclusive process lock, runs migrations and
-crash recovery, and opens the current segment. `StagingAreaReadOnly` acquires
-a shared lock for concurrent push readers. In-process index and writer locks
-are scoped so no synchronous mutex is held across an async suspension.
+`StagingArea::open` acquires an exclusive process lock, validates the canonical
+schema, runs crash recovery, and opens the current segment.
+`StagingAreaReadOnly` acquires a shared lock for concurrent push readers.
+In-process index and writer locks are scoped so no synchronous mutex is held
+across an async suspension.
 
 `stage_chunks_batch` is the hot path: it deduplicates, appends, inserts
 locators atomically, and performs the configured flush check. `flush_pending`


### PR DESCRIPTION
## Summary

- reset the advertised local staging format from 3 to the canonical staging layout version 1
- report the Crab executable release version from `CRAB_BUILD_VERSION` instead of the internal `crab-remote` crate version
- add real-binary regressions for both capability fields
- correct staging documentation that previously claimed the canonical index runs migrations

## Compatibility

The SDK handshake validates the staging format exactly. The updated Crab executable and SDK must ship together because older SDK builds expecting format 3 will reject the new format 1, and the updated SDK will reject older executables advertising format 3.

## Verification

- `cargo test -p crab --locked --test sdk_capabilities`
- `cargo test -p crab-remote --locked --features local`
- `cargo test -p crab-sdk --locked --features local`
- `cargo clippy -p crab-remote --locked --features local --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- rebuilt CLI reports `crab_version: 1.2.2` and `staging_format_version: 1`

Full `crab` clippy remains blocked by pre-existing warnings on current `origin/main`; the scoped `crab-remote` lint passes.