### PR TITLE
fix(s3): support real object-store client conventions

### DIFF
--- a/crab/docs/architecture/crab-s3-gateway.md
+++ b/crab/docs/architecture/crab-s3-gateway.md
@@ -83,8 +83,8 @@ are addressed explicitly; they are not an infinite synthetic directory tree.
 S3 keys are not Git paths. Current `crab-sdk/src/value.rs::GitPath` rejects empty
 and parent components; Git trees also cannot contain both file `a` and file
 `a/b`. A release must specify either a restricted repository-path profile or a
-lossless object-key representation, including folder markers and Git-client
-round trips. No silent normalization, dropped markers or false full-key parity.
+lossless object-key representation, including explicit folder-marker behavior
+and Git-client round trips. No silent normalization or false full-key parity.
 
 ## Versioning and write visibility
 

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -71,8 +71,12 @@ complete logical key is at most 1024 UTF-8 bytes. Its repository path is
 non-empty, uses `/` separators, and has components of 1–255 bytes. Empty, `.`,
 `..`, and case-insensitive `.git` components are rejected. NUL, ASCII control
 characters, repeated separators, leading or trailing separators, and trailing
-folder-marker objects are rejected. The gateway never normalizes Unicode or
-path separators.
+folder-marker objects are rejected. Empty `REF/path/` PUT and DELETE requests
+are accepted as virtual directory hints for filesystem clients. They are
+validated and authorized against `REF/path`, but are not persisted, listed, or
+returned as objects because Git trees already represent non-empty directories.
+Non-empty marker PUTs are rejected. The gateway never normalizes Unicode or path
+separators.
 
 Writes create ordinary non-executable Git blobs. They reject a path whose
 ancestor is a blob or whose existing entry is a tree. Overwriting a symlink,
@@ -137,7 +141,7 @@ virtual-hosted addressing under that base domain; DNS and TLS wildcard coverage
 remain deployment responsibilities. HTTPS is mandatory beyond loopback and is
 terminated by the deployment ingress. Browser POST, bucket create/delete, ACLs, policies, IAM,
 version mutation/listing, Select, object lock, retention, torrent, website, inventory,
-replication, acceleration, notification, storage-class selection, and all SSE
+replication, acceleration, notification, non-standard storage classes, and all SSE
 request headers return `NotImplemented` or the operation-specific documented S3
 error before mutation.
 
@@ -147,12 +151,12 @@ Supported operations:
 | --- | --- |
 | `ListBuckets`, `HeadBucket`, `GetBucketLocation`, `GetBucketVersioning` | Authorized logical repositories only; deterministic order; configured region; honest unversioned response |
 | `GetObject`, `HeadObject`, `GetObjectAttributes` | metadata, response overrides, RFC dates, ETag/date conditions, checksum mode, object size, ETag, part-number reads, and paginated multipart-part attributes; one byte range including open and suffix forms |
-| `ListObjects`, `ListObjectsV2` | prefix, delimiter `/`, marker/start-after, max keys, reusable keys, common prefixes |
-| `PutObject` | body up to 5 GiB, atomic `If-Match` and `If-None-Match: *`, `Content-MD5`, SigV4 payload hash, CRC32/CRC32C/CRC64NVME/SHA1/SHA256 checksums, tags, metadata and standard content headers |
+| `ListObjects`, `ListObjectsV2` | prefix, delimiter `/`, marker/start-after, max keys, reusable keys, common prefixes, and the `RestoreStatus` optional-object hint |
+| `PutObject` | body up to 5 GiB, atomic `If-Match` and `If-None-Match: *`, `Content-MD5`, SigV4 payload hash, CRC32/CRC32C/CRC64NVME/SHA1/SHA256 checksums, tags, metadata, standard content headers, explicit `STANDARD` storage class, and virtual empty directory-marker hints |
 | `GetObjectTagging`, `PutObjectTagging`, `DeleteObjectTagging` | Up to ten current-object tags; tag changes publish metadata-only commits without changing object bytes or ETag |
-| `DeleteObject`, `DeleteObjects` | S3 missing-key success, per-key authorization/results, quiet mode, and at most 1000 XML entries |
-| `CopyObject` | pinned source, source conditions/range where defined, metadata/tag `COPY`/`REPLACE`, checksum selection, separately authorized destination |
-| Multipart create/upload/copy/list/abort/complete | durable opaque sessions, conditional completion, validated full-object CRC and composite CRC/SHA checksums, part replacement, ordered selection, 10,000 parts, 5 GiB per part, 50 TB completed objects, restart and multi-instance retry |
+| `DeleteObject`, `DeleteObjects` | S3 missing-key success, virtual directory-marker deletion, per-key authorization/results, quiet mode, and at most 1000 XML entries |
+| `CopyObject` | pinned source, source conditions/range where defined, metadata/tag `COPY`/`REPLACE`, checksum selection, explicit `STANDARD` storage class, separately authorized destination |
+| Multipart create/upload/copy/list/abort/complete | durable opaque sessions, conditional completion, validated full-object CRC and composite CRC/SHA checksums, part replacement, explicit `STANDARD` storage class, ordered selection, 10,000 parts, 5 GiB per part, 50 TB completed objects, restart and multi-instance retry |
 
 Modeled unsupported request headers and query parameters are rejected rather
 than ignored. Multi-range GET returns `InvalidRange`. `versionId` returns

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -20,7 +20,11 @@ multipart full-object and composite checksum profiles are returned by object
 and part inspection APIs. Path-style addressing is always available. Set
 `endpoint_domain` to also accept virtual-hosted requests. Single PUTs and
 multipart parts support up to 5 GiB, and multipart completion supports S3's
-50 TB object limit.
+50 TB object limit. Explicit `STANDARD` storage-class hints and the
+`RestoreStatus` listing hint are accepted. Empty trailing-slash PUT and DELETE
+requests are treated as validated virtual directory hints for filesystem
+clients; they do not create marker blobs because Git trees represent
+directories.
 Large payloads use bounded-memory spooling and Crab's verified LFS content path.
 Objects already stored as Crab/Xet pointers retain Xet deduplication: partial
 GET and copy-source ranges limit reconstruction to overlapping Xet chunks and

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -403,7 +403,7 @@ impl Gateway {
                 .map_err(remote_error)?
                 .ok_or_else(|| s3_error!(NoSuchKey))?;
             if entry.kind != EntryKind::Blob {
-                return Err(s3_error!(InvalidObjectState));
+                return Err(object_entry_error(entry.kind));
             }
             let path = std::str::from_utf8(address.path.as_bytes())
                 .map_err(|_| s3_error!(InvalidObjectState))?;
@@ -455,9 +455,18 @@ impl Gateway {
         bucket: &str,
         key: &str,
     ) -> S3Result<(&Repository, namespace::ObjectAddress, String)> {
+        let address = namespace::object_address(key).map_err(namespace_error)?;
+        self.writable_object_address(req, bucket, address)
+    }
+
+    fn writable_object_address<'a, T>(
+        &'a self,
+        req: &S3Request<T>,
+        bucket: &str,
+        address: namespace::ObjectAddress,
+    ) -> S3Result<(&'a Repository, namespace::ObjectAddress, String)> {
         let principal = self.principal(req)?.to_owned();
         let repository = self.repository(req, bucket, RepositoryAccess::Write)?;
-        let address = namespace::object_address(key).map_err(namespace_error)?;
         let branch = address
             .branch
             .as_deref()
@@ -901,11 +910,19 @@ impl S3 for Gateway {
             .try_acquire()
             .map_err(|_| s3_error!(SlowDown))?;
         reject_put_extensions(&req.input)?;
-        let (repository, address, principal) =
-            self.writable_address(&req, &req.input.bucket, &req.input.key)?;
-        let condition = self
-            .put_condition(repository, &req.input.key, &req.input)
-            .await?;
+        let marker_address =
+            namespace::directory_marker_address(&req.input.key).map_err(namespace_error)?;
+        let is_directory_marker = marker_address.is_some();
+        let (repository, address, principal) = match marker_address {
+            Some(address) => self.writable_object_address(&req, &req.input.bucket, address)?,
+            None => self.writable_address(&req, &req.input.bucket, &req.input.key)?,
+        };
+        let condition = if is_directory_marker {
+            virtual_marker_put_condition(&req.input)?
+        } else {
+            self.put_condition(repository, &req.input.key, &req.input)
+                .await?
+        };
         let content_length = req.input.content_length;
         let content_md5 = req.input.content_md5.clone();
         let mut checksums = RequestChecksums::from(&req.input);
@@ -913,7 +930,11 @@ impl S3 for Gateway {
         let spool = crate::content::spool_body(
             req.input.body,
             content_length,
-            crate::content::MAX_PUT_OBJECT_BYTES,
+            if is_directory_marker {
+                0
+            } else {
+                crate::content::MAX_PUT_OBJECT_BYTES
+            },
         )
         .await
         .map_err(content_error)?;
@@ -922,6 +943,20 @@ impl S3 for Gateway {
         checksums.verify(&spool.digests)?;
         let stored_checksums = checksums.stored(&spool.digests);
         let etag = crate::content::md5_hex(&spool.digests.md5);
+        if is_directory_marker {
+            // Filesystem clients use empty trailing-slash PUTs as directory hints.
+            // Git trees already represent non-empty directories, so no blob is published.
+            return Ok(S3Response::new(PutObjectOutput {
+                e_tag: Some(ETag::Strong(etag)),
+                checksum_crc32: stored_checksums.crc32,
+                checksum_crc32c: stored_checksums.crc32c,
+                checksum_crc64nvme: stored_checksums.crc64nvme,
+                checksum_sha1: stored_checksums.sha1,
+                checksum_sha256: stored_checksums.sha256,
+                checksum_type: stored_checksums.checksum_type.map(ChecksumType::from),
+                ..Default::default()
+            }));
+        }
         let bytes = mutation_bytes(repository, &spool).await?;
         let outcome = self
             .mutations
@@ -1188,8 +1223,16 @@ impl S3 for Gateway {
             .try_acquire()
             .map_err(|_| s3_error!(SlowDown))?;
         reject_delete_extensions(&req.input)?;
-        let (repository, address, principal) =
-            self.writable_address(&req, &req.input.bucket, &req.input.key)?;
+        let marker_address =
+            namespace::directory_marker_address(&req.input.key).map_err(namespace_error)?;
+        let is_directory_marker = marker_address.is_some();
+        let (repository, address, principal) = match marker_address {
+            Some(address) => self.writable_object_address(&req, &req.input.bucket, address)?,
+            None => self.writable_address(&req, &req.input.bucket, &req.input.key)?,
+        };
+        if is_directory_marker {
+            return Ok(S3Response::new(DeleteObjectOutput::default()));
+        }
         self.mutations
             .apply(
                 repository,
@@ -1250,9 +1293,18 @@ impl S3 for Gateway {
                 continue;
             }
             let key = object.key;
-            let result = async {
-                let address = namespace::object_address(&key).map_err(namespace_error)?;
+            let result: S3Result<()> = async {
+                let marker_address =
+                    namespace::directory_marker_address(&key).map_err(namespace_error)?;
+                let is_directory_marker = marker_address.is_some();
+                let address = match marker_address {
+                    Some(address) => address,
+                    None => namespace::object_address(&key).map_err(namespace_error)?,
+                };
                 let branch = writable_branch(repository, &address)?;
+                if is_directory_marker {
+                    return Ok(());
+                }
                 self.mutations
                     .apply(
                         repository,
@@ -1263,7 +1315,8 @@ impl S3 for Gateway {
                         &self.cancellation,
                     )
                     .await
-                    .map_err(mutation_error)
+                    .map_err(mutation_error)?;
+                Ok(())
             }
             .await;
             match result {
@@ -2190,7 +2243,7 @@ impl S3 for Gateway {
             .delimiter
             .as_deref()
             .is_some_and(|value| value != "/")
-            || req.input.optional_object_attributes.is_some()
+            || !supported_list_attributes(req.input.optional_object_attributes.as_ref())
             || req.input.request_payer.is_some()
         {
             return Err(s3_error!(NotImplemented));
@@ -2391,13 +2444,23 @@ fn reject_put_extensions(input: &PutObjectInput) -> S3Result<()> {
         || input.sse_customer_key_md5.is_some()
         || input.ssekms_encryption_context.is_some()
         || input.ssekms_key_id.is_some()
-        || input.storage_class.is_some()
+        || !standard_storage_class(input.storage_class.as_ref())
         || input.website_redirect_location.is_some()
         || input.write_offset_bytes.is_some()
     {
         return Err(s3_error!(NotImplemented));
     }
     Ok(())
+}
+
+fn virtual_marker_put_condition(input: &PutObjectInput) -> S3Result<mutation::PutCondition> {
+    if input.if_match.is_some() {
+        return Err(s3_error!(PreconditionFailed));
+    }
+    match input.if_none_match {
+        None | Some(ETagCondition::Any) => Ok(mutation::PutCondition::None),
+        Some(ETagCondition::ETag(_)) => Err(s3_error!(InvalidRequest)),
+    }
 }
 
 #[derive(Clone, Default)]
@@ -2768,7 +2831,8 @@ fn response_checksums(
 ) -> S3Result<crate::attributes::Checksums> {
     match mode {
         None => Ok(crate::attributes::Checksums::default()),
-        Some(value) if value.as_str() == ChecksumMode::ENABLED => {
+        // AWS SDKs emit different casing for this modeled header value.
+        Some(value) if value.as_str().eq_ignore_ascii_case(ChecksumMode::ENABLED) => {
             Ok(checksums.cloned().unwrap_or_default())
         }
         Some(_) => Err(s3_error!(InvalidArgument)),
@@ -3048,7 +3112,7 @@ fn reject_copy_extensions(input: &CopyObjectInput) -> S3Result<()> {
         || input.sse_customer_key_md5.is_some()
         || input.ssekms_encryption_context.is_some()
         || input.ssekms_key_id.is_some()
-        || input.storage_class.is_some()
+        || !standard_storage_class(input.storage_class.as_ref())
         || input.website_redirect_location.is_some()
     {
         return Err(s3_error!(NotImplemented));
@@ -3074,12 +3138,24 @@ fn reject_create_multipart_extensions(input: &CreateMultipartUploadInput) -> S3R
         || input.sse_customer_key_md5.is_some()
         || input.ssekms_encryption_context.is_some()
         || input.ssekms_key_id.is_some()
-        || input.storage_class.is_some()
+        || !standard_storage_class(input.storage_class.as_ref())
         || input.website_redirect_location.is_some()
     {
         return Err(s3_error!(NotImplemented));
     }
     Ok(())
+}
+
+fn standard_storage_class(storage_class: Option<&StorageClass>) -> bool {
+    storage_class.is_none_or(|value| value.as_str() == StorageClass::STANDARD)
+}
+
+fn supported_list_attributes(values: Option<&OptionalObjectAttributesList>) -> bool {
+    values.is_none_or(|values| {
+        values
+            .iter()
+            .all(|value| value.as_str() == OptionalObjectAttributes::RESTORE_STATUS)
+    })
 }
 
 fn reject_upload_part_extensions(input: &UploadPartInput) -> S3Result<()> {
@@ -3342,6 +3418,7 @@ fn namespace_error(error: namespace::NamespaceError) -> s3s::S3Error {
 fn remote_error(error: crab_remote_git::Error) -> s3s::S3Error {
     match error {
         crab_remote_git::Error::PathNotFound => s3_error!(NoSuchKey),
+        crab_remote_git::Error::EntryNotBlob { actual } => object_entry_error(actual),
         crab_remote_git::Error::Revision { .. } => s3_error!(NoSuchKey),
         crab_remote_git::Error::Cancelled => s3_error!(RequestTimeout),
         crab_remote_git::Error::LimitExceeded { .. } => s3_error!(SlowDown),
@@ -3349,6 +3426,14 @@ fn remote_error(error: crab_remote_git::Error) -> s3s::S3Error {
             tracing::error!(error = ?error, "S3 repository read failed");
             s3_error!(InternalError)
         }
+    }
+}
+
+fn object_entry_error(kind: EntryKind) -> s3s::S3Error {
+    if kind == EntryKind::Tree {
+        s3_error!(NoSuchKey)
+    } else {
+        s3_error!(InvalidObjectState)
     }
 }
 
@@ -3732,5 +3817,71 @@ mod tests {
         };
 
         assert!(checksums.ensure_single_value().is_err());
+    }
+
+    #[test]
+    fn checksum_mode_accepts_case_insensitive_enabled_value() {
+        let mode = ChecksumMode::from_static("enabled");
+        let checksums = crate::attributes::Checksums {
+            sha256: Some("checksum".to_owned()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            response_checksums(Some(&mode), Some(&checksums))
+                .unwrap()
+                .sha256,
+            checksums.sha256
+        );
+    }
+
+    #[test]
+    fn copy_accepts_explicit_standard_storage_class() {
+        let input = CopyObjectInput::builder()
+            .bucket("repo".to_owned())
+            .key("main/copy.bin".to_owned())
+            .copy_source(CopySource::Bucket {
+                bucket: "repo".into(),
+                key: "main/source.bin".into(),
+                version_id: None,
+            })
+            .storage_class(Some(StorageClass::from_static(StorageClass::STANDARD)))
+            .build()
+            .unwrap();
+
+        reject_copy_extensions(&input).unwrap();
+    }
+
+    #[test]
+    fn git_trees_are_absent_from_the_object_namespace() {
+        assert_eq!(
+            object_entry_error(EntryKind::Tree).code().as_str(),
+            "NoSuchKey"
+        );
+        assert_eq!(
+            object_entry_error(EntryKind::Submodule).code().as_str(),
+            "InvalidObjectState"
+        );
+    }
+
+    #[test]
+    fn virtual_directory_marker_supports_create_if_absent() {
+        let input = PutObjectInput::builder()
+            .bucket("repo".to_owned())
+            .key("main/path/".to_owned())
+            .if_none_match(Some(ETagCondition::Any))
+            .build()
+            .unwrap();
+
+        assert!(virtual_marker_put_condition(&input).is_ok());
+    }
+
+    #[test]
+    fn list_accepts_the_restore_status_optional_attribute() {
+        let values = vec![OptionalObjectAttributes::from_static(
+            OptionalObjectAttributes::RESTORE_STATUS,
+        )];
+
+        assert!(supported_list_attributes(Some(&values)));
     }
 }

--- a/crates/crab-s3-gateway/src/multipart.rs
+++ b/crates/crab-s3-gateway/src/multipart.rs
@@ -9,6 +9,7 @@ use crate::{attributes::PutAttributes, gateway::Repository};
 const VERSION: u32 = 1;
 const MAX_RECORD_BYTES: u64 = 8 * 1024 * 1024;
 const MAX_PARTS: usize = 10_000;
+const MAX_STATE_UPDATE_ATTEMPTS: usize = 16;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
@@ -201,13 +202,22 @@ pub(crate) async fn register_part(
         checksums,
         path,
     };
-    loaded.session.parts.insert(number, part.clone());
-    if loaded.session.parts.len() > MAX_PARTS {
-        return Err(Error::PartNumber);
+    for _ in 0..MAX_STATE_UPDATE_ATTEMPTS {
+        if !matches!(loaded.session.state, State::Open) {
+            return Err(Error::NotOpen);
+        }
+        loaded.session.parts.insert(number, part.clone());
+        if loaded.session.parts.len() > MAX_PARTS {
+            return Err(Error::PartNumber);
+        }
+        loaded.session.revision = loaded.session.revision.saturating_add(1);
+        match save(repository, &loaded).await {
+            Ok(()) => return Ok(part),
+            Err(Error::Conflict) => loaded = load(repository, &loaded.session.id).await?,
+            Err(error) => return Err(error),
+        }
     }
-    loaded.session.revision = loaded.session.revision.saturating_add(1);
-    save(repository, &loaded).await?;
-    Ok(part)
+    Err(Error::Conflict)
 }
 
 pub(crate) async fn part_stream(
@@ -493,6 +503,66 @@ mod tests {
         assert!(list(&repository).await.unwrap().is_empty());
         let terminal = load(&repository, &session.id).await.unwrap();
         assert!(matches!(terminal.session.state, State::Aborted));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_distinct_parts_merge_into_the_session() {
+        let repository = fixture().await;
+        let session = create(
+            &repository,
+            Initiation {
+                bucket: "repo",
+                key: "main/file.bin",
+                branch: "refs/heads/main",
+                path: "file.bin",
+                principal: "user",
+                attributes: PutAttributes::default(),
+                checksum_algorithm: None,
+                checksum_type: None,
+                now: 10,
+            },
+        )
+        .await
+        .unwrap();
+        let first_loaded = load(&repository, &session.id).await.unwrap();
+        let second_loaded = load(&repository, &session.id).await.unwrap();
+        let first_body = Bytes::from_static(b"first part");
+        let second_body = Bytes::from_static(b"second part");
+        let first_spool = spool(&first_body).await;
+        let second_spool = spool(&second_body).await;
+        let first_cancel = tokio_util::sync::CancellationToken::new();
+        let second_cancel = tokio_util::sync::CancellationToken::new();
+
+        let (first, second) = tokio::join!(
+            register_part(
+                &repository,
+                first_loaded,
+                1,
+                &first_spool,
+                crate::gateway::md5_hex(&first_body),
+                crate::attributes::Checksums::default(),
+                11,
+                &first_cancel,
+            ),
+            register_part(
+                &repository,
+                second_loaded,
+                2,
+                &second_spool,
+                crate::gateway::md5_hex(&second_body),
+                crate::attributes::Checksums::default(),
+                12,
+                &second_cancel,
+            )
+        );
+
+        first.unwrap();
+        second.unwrap();
+        let reloaded = load(&repository, &session.id).await.unwrap();
+        assert_eq!(
+            reloaded.session.parts.keys().copied().collect::<Vec<_>>(),
+            vec![1, 2]
+        );
     }
 
     #[tokio::test]

--- a/crates/crab-s3-gateway/src/namespace.rs
+++ b/crates/crab-s3-gateway/src/namespace.rs
@@ -39,6 +39,16 @@ pub(crate) fn object_address(key: &str) -> Result<ObjectAddress, NamespaceError>
     })
 }
 
+pub(crate) fn directory_marker_address(key: &str) -> Result<Option<ObjectAddress>, NamespaceError> {
+    let Some(path) = key.strip_suffix('/') else {
+        return Ok(None);
+    };
+    if key.len() > MAX_KEY_BYTES {
+        return Err(NamespaceError::InvalidPath);
+    }
+    object_address(path).map(Some)
+}
+
 pub(crate) fn listing_reference(prefix: &str) -> Result<Option<(String, String)>, NamespaceError> {
     let Some((encoded_ref, path_prefix)) = prefix.split_once('/') else {
         if prefix.is_empty() {
@@ -136,5 +146,26 @@ mod tests {
         for key in ["main~/a", "main^/a", "main@{1}/a"] {
             assert!(object_address(key).is_err(), "{key}");
         }
+    }
+
+    #[test]
+    fn directory_markers_preserve_the_validated_object_address() {
+        let address = directory_marker_address("main/path/to/table/")
+            .unwrap()
+            .unwrap();
+        assert_eq!(address.reference, "refs/heads/main");
+        assert_eq!(address.path.as_bytes(), b"path/to/table");
+    }
+
+    #[test]
+    fn invalid_directory_markers_are_rejected() {
+        for key in ["main/", "main/path//"] {
+            assert!(directory_marker_address(key).is_err(), "{key}");
+        }
+    }
+
+    #[test]
+    fn ordinary_keys_are_not_directory_markers() {
+        assert_eq!(directory_marker_address("main/path").unwrap(), None);
     }
 }


### PR DESCRIPTION
## Summary

- merge concurrent multipart part registrations with conditional state retries instead of exposing storage CAS conflicts to clients
- accept the request conventions emitted by common S3 clients: case-insensitive checksum mode, explicit `STANDARD` storage class, and the `RestoreStatus` list hint
- treat validated empty trailing-slash PUT/DELETE requests as virtual filesystem directory hints without adding marker blobs to Git
- report Git trees as absent objects so filesystem clients can fall back from HEAD to prefix listing
- update the frozen protocol contract and crate README with these compatibility boundaries

## Why

This is a follow-up to #166 based on live compatibility qualification rather than synthetic request construction alone. PyArrow, rclone, Spark/S3A, and Trino each exposed a distinct real request shape that the gateway previously rejected. Each source fix is generic to the S3 contract and has a regression test.

## Live interoperability proof

All clients used the release gateway against the same RustFS-backed Crab repository. Writes were then read through the client and recovered through an independent `crab://` clone.

| Client | Qualified behavior |
| --- | --- |
| DuckDB 1.5.1 | Read 1.5M-row Parquet, filtered it, and wrote/read 35,289,510 bytes with exact row invariants |
| LanceDB 0.38.0 | Opened, added, vector-searched, and persisted Lance transaction, manifest, and data objects |
| PyArrow 25.0.1 | Ranged Parquet reads plus a 250k-row write/read round trip |
| Polars 1.44.2 | Predicate read plus a 200k-row write/read round trip |
| delta-rs 1.6.3 | Overwrite, append, history, and four simultaneous optimistic commits; 190k unique rows at version 5 |
| rclone 1.75.1 | 500 MiB, 16-part concurrent multipart upload; eight-stream exact-SHA readback; server-side copy, move, and delete |
| PyIceberg 0.12.0 | Two snapshots/appends with 150k rows and durable metadata, manifest, and Parquet objects |
| Spark 4.2.0 / Hadoop 3.5.0 | Standard S3A temporary-directory/rename flow; 100k unique rows across four Parquet parts plus `_SUCCESS` |
| Trino 483 | Native-S3 ranged read of 1.5M rows; Hive write/read of 1,000 rows remained readable after a fresh Trino process |
| ClickHouse 26.8.2.7 | Read 1.5M Parquet rows and wrote/read 100k rows with exact bounds and uniqueness |

The retained rclone object is 524,288,000 bytes. A fresh build from this branch returned an unaligned `bytes=1048573-2097159` request as 1,048,587 bytes with `Content-Range: bytes 1048573-2097159/524288000`.

An independent Crab clone passed `git fsck --full --strict`. Direct Git blobs and S3 logical objects matched SHA-256 for PyArrow, ClickHouse, Spark, and Trino samples.

## Compatibility findings

- A deliberately excessive Delta Lake burst exceeded the gateway's 32-request admission bound and received S3 `SlowDown`; the same four-writer optimistic-commit workload at normal file fanout completed correctly. No partial Delta commit became visible.
- The qualification repository reached 345 immutable packs and emits Crab's existing repack recommendation. Clone and strict Git validation still succeed; pack compaction is an operational follow-up, not changed here.
- The workload surfaced background visibility-maintenance warnings during the heaviest write burst. Foreground results remained readable, active transactions drained, and the final independent clone was coherent. This PR does not speculate on a lower-layer change without a retained reproducer.

## Proof

- rebased on `origin/main` at `30fae435174`
- `cargo fmt --all -- --check`
- `RUST_MIN_STACK=8388608 cargo test -p crab-s3-gateway --locked` (37 passed)
- `cargo clippy -p crab-s3-gateway --locked --all-targets -- -D warnings`
- `cargo build -p crab-s3-gateway --release --locked`
- live AWS CLI smoke against the rebuilt release binary: 500 MiB HEAD/range GET and virtual marker PUT/list/delete
- full live client matrix above and independent Git validation

On this macOS host, the current unmodified `origin/main` also stack-overflows in `mutation::tests::same_ref_writes_queue_and_all_commit` with Tokio's default worker stack; the test passes with an 8 MiB worker stack. GitHub CI for the same `origin/main` SHA is green. This branch does not change that test or mutation path.
