### PR TITLE
perf(clone): overlap catalog scan with pack transfer

### DIFF
--- a/crab/src/cmd/clone.rs
+++ b/crab/src/cmd/clone.rs
@@ -890,29 +890,11 @@ async fn prepare_complete_clone_inventory(
     if !head_visible {
         return Ok(None);
     }
-    let wants = visible_refs
-        .iter()
-        .filter_map(|name| repository.refs().find(name).map(|entry| entry.target))
-        .collect::<Vec<_>>();
-    if wants.is_empty() {
-        return Ok(None);
-    }
-    let request = crab_read::UploadPackRequest {
-        wants,
-        ..crab_read::UploadPackRequest::default()
-    };
-    let plan = crab_read::plan_upload_pack_catalog(
-        &repository,
-        &visibility,
-        &visible_refs,
-        &request,
-        cancel,
-    )
-    .await?;
     let report_progress = |update| progress.report(update);
     let inventory = repository
         .download_complete_pack_inventory(
-            &plan.object_ids,
+            &visibility,
+            &visible_refs,
             workspace_parent,
             cancel,
             Some(&report_progress),

--- a/crates/crab-remote-git/README.md
+++ b/crates/crab-remote-git/README.md
@@ -148,6 +148,12 @@ consume new request admission. Pack inventory size is a preflight bound and an
 integrity check, not the byte-accounting authority. These stream paths retain
 backpressure and verification before returning the completed artifact.
 
+Complete-inventory clone transfer starts after the catalog visibility bitmap
+proves every catalog ordinal is visible. Pack bodies use a locator-free transfer
+operation while a separate operation scans the pinned catalog concurrently;
+the downloaded pack indexes must still cover that exact OID set before the
+inventory is returned. Partial visibility keeps the normal planned-pack path.
+
 Operation-owned coalesced ranges and packed-entry metadata reads use the same
 admission boundary: failed headers charge a request but no advertised body,
 and each facade retry reserves its own request and response bytes. An early

--- a/crates/crab-remote-git/src/operation.rs
+++ b/crates/crab-remote-git/src/operation.rs
@@ -189,6 +189,31 @@ impl OperationContext {
         cancellation: &CancellationToken,
         limits: OperationLimits,
     ) -> Result<Self> {
+        Self::open_inner(state, kind, cancellation, limits, true).await
+    }
+
+    pub(crate) async fn open_pack_transfer(
+        state: Arc<RepositoryState>,
+        cancellation: &CancellationToken,
+        limits: OperationLimits,
+    ) -> Result<Self> {
+        Self::open_inner(
+            state,
+            OperationKind::UploadPack,
+            cancellation,
+            limits,
+            false,
+        )
+        .await
+    }
+
+    async fn open_inner(
+        state: Arc<RepositoryState>,
+        kind: OperationKind,
+        cancellation: &CancellationToken,
+        limits: OperationLimits,
+        open_catalog: bool,
+    ) -> Result<Self> {
         let task_token = state.runtime.operation_token();
         let runtime_cancellation = state.runtime.background_cancellation();
         let started = Instant::now();
@@ -205,7 +230,7 @@ impl OperationContext {
         let span = operation_span(correlation_id, kind);
         check_cancelled(cancellation)?;
         check_cancelled(&runtime_cancellation)?;
-        let session = if let Some(catalog) = state.catalog_identity {
+        let session = if open_catalog && let Some(catalog) = state.catalog_identity {
             // Keep catalog acquisition and later page reads on the same budget.
             // The pinned repository store remains reusable by other operations.
             let store = state
@@ -282,6 +307,26 @@ impl OperationContext {
             span,
             _task_token: task_token,
         })
+    }
+
+    pub(crate) async fn all_catalog_object_ids(&self) -> Result<Vec<gix_hash::ObjectId>> {
+        check_cancelled(&self.cancellation)?;
+        let session = self
+            .session
+            .as_ref()
+            .and_then(TrackedLocatorSession::session)
+            .ok_or(Error::InternalInvariant {
+                invariant: "catalog object scan has no locator session",
+            })?;
+        let object_ids = tokio::select! {
+            biased;
+            () = self.cancellation.cancelled() => return Err(Error::Cancelled),
+            object_ids = session.all_object_ids() => object_ids?,
+        };
+        Ok(object_ids
+            .into_iter()
+            .map(gix_hash::ObjectId::from)
+            .collect())
     }
 
     /// Return the cancellation token governing all work in this operation.
@@ -1314,9 +1359,14 @@ fn record_drop(span: &tracing::Span, correlation_id: u64) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fmt::Write as _;
     use std::sync::{Arc, Mutex};
 
+    use crab_metadata::git_object_locator::GitObjectCatalogIdentity;
+    use crab_storage::{Store, StoreLayout};
+    use crab_xet::hash::MerkleHash;
+    use object_store::memory::InMemory;
     use tracing::Subscriber;
     use tracing::field::{Field, Visit};
     use tracing::span::{Attributes, Id, Record};
@@ -1324,6 +1374,57 @@ mod tests {
     use tracing_subscriber::prelude::*;
 
     use super::*;
+
+    #[tokio::test]
+    async fn pack_transfer_operation_does_not_open_the_catalog() {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(object_store);
+        let state = Arc::new(crate::state::RepositoryState {
+            store: store.clone(),
+            layout: StoreLayout::new(store, "org/repo".to_owned()),
+            runtime: Arc::new(crate::RemoteGitRuntime::default()),
+            identity: crate::RepositoryIdentity::new("memory", "org/repo", 1)
+                .expect("repository identity"),
+            options: crate::RepositoryOptions::default(),
+            generation: 1,
+            git_validation_digest: Arc::from("validation"),
+            manifest_etag: "etag".to_owned(),
+            shard_index_hash: Arc::from("shards"),
+            catalog_identity: Some(GitObjectCatalogIdentity {
+                generation: 1,
+                pack_index_hash: MerkleHash::from([1; 32]),
+                object_count: 1,
+                catalog_digest: MerkleHash::from([2; 32]),
+            }),
+            inventory: HashMap::new(),
+            refs: crate::RepositoryRefs::default(),
+            reader: None,
+            commit_graph: None,
+            shallow_closure: None,
+        });
+        let cancellation = CancellationToken::new();
+
+        let regular = OperationContext::open(
+            Arc::clone(&state),
+            OperationKind::UploadPack,
+            &cancellation,
+            crate::OperationLimits::default(),
+        )
+        .await;
+        assert!(regular.is_err());
+
+        let transfer = OperationContext::open_pack_transfer(
+            state,
+            &cancellation,
+            crate::OperationLimits::default(),
+        )
+        .await
+        .expect("pack transfer operation");
+        transfer
+            .finish(Ok(()))
+            .await
+            .expect("finish pack transfer operation");
+    }
 
     #[derive(Clone, Default)]
     struct Capture(Arc<Mutex<String>>);

--- a/crates/crab-remote-git/src/operation.rs
+++ b/crates/crab-remote-git/src/operation.rs
@@ -1413,17 +1413,20 @@ mod tests {
         .await;
         assert!(regular.is_err());
 
+        let concurrent_cancellation = cancellation.child_token();
         let transfer = OperationContext::open_pack_transfer(
             state,
-            &cancellation,
+            &concurrent_cancellation,
             crate::OperationLimits::default(),
         )
         .await
         .expect("pack transfer operation");
-        transfer
-            .finish(Ok(()))
-            .await
-            .expect("finish pack transfer operation");
+        concurrent_cancellation.cancel();
+        assert!(transfer.cancellation().is_cancelled());
+        assert!(matches!(
+            transfer.finish::<()>(Err(Error::Cancelled)).await,
+            Err(Error::Cancelled)
+        ));
     }
 
     #[derive(Clone, Default)]

--- a/crates/crab-remote-git/src/pack.rs
+++ b/crates/crab-remote-git/src/pack.rs
@@ -473,11 +473,14 @@ impl RemoteGitRepository {
             return Ok(None);
         }
 
+        // Both operations must descend from the same child. Cancelling it on
+        // either failure stops already-running body reads in the sibling.
+        let concurrent_cancellation = cancellation.child_token();
         // Pack streams do not query the locator. Keeping them on a separate
         // operation lets transfer start while the exact catalog scan runs.
         let operation = crate::OperationContext::open_pack_transfer(
             Arc::clone(&self.state),
-            cancellation,
+            &concurrent_cancellation,
             self.state.options.operation_limits(),
         )
         .await?;
@@ -487,7 +490,6 @@ impl RemoteGitRepository {
             let workspace = tempfile::tempdir_in(workspace_parent).map_err(io_error)?;
             let download_dir = workspace.path().join("source-packs");
             std::fs::create_dir_all(&download_dir).map_err(io_error)?;
-            let concurrent_cancellation = cancellation.child_token();
             let download = async {
                 let result = download_repack_sources(
                     &operation,

--- a/crates/crab-remote-git/src/pack.rs
+++ b/crates/crab-remote-git/src/pack.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 
 use crab_git::pack::VerifiedPackIdentity;
 use crab_metadata::git_object_locator::GitPackInventoryEntry;
+use crab_metadata::git_visibility::GitCatalogVisibilityIndex;
 use flate2::{Compression, write::ZlibEncoder};
 use futures_util::stream::{self, StreamExt as _, TryStreamExt as _};
 use gix_hash::ObjectId;
@@ -414,49 +415,98 @@ impl GeneratedPack {
 }
 
 impl RemoteGitRepository {
-    /// Download the canonical pack inventory when it exactly covers a large selection.
+    fn complete_catalog_is_visible(
+        repository_catalog: Option<crab_metadata::git_object_locator::GitObjectCatalogIdentity>,
+        visibility_catalog: crab_metadata::git_object_locator::GitObjectCatalogIdentity,
+        visible_objects: u64,
+    ) -> Result<bool> {
+        if repository_catalog != Some(visibility_catalog) {
+            return Err(Error::RepositoryState {
+                reason: crate::RepositoryStateError::VisibilityProofMismatch,
+            });
+        }
+        Ok(visible_objects == visibility_catalog.object_count)
+    }
+
+    /// Download the canonical pack inventory when visible refs cover the complete catalog.
     ///
-    /// The selected IDs must already have passed generation-pinned authorization.
-    /// `None` means the inventory is not a complete large-repository clone candidate.
+    /// The visibility proof must match this repository's generation-pinned catalog. Pack
+    /// transfer overlaps the exact catalog/index comparison, and no inventory is returned
+    /// until that integrity check passes. `None` means the visible selection is incomplete
+    /// or too small for a complete-inventory clone.
     pub async fn download_complete_pack_inventory(
         &self,
-        object_ids: &[ObjectId],
+        visibility: &GitCatalogVisibilityIndex,
+        visible_ref_names: &[String],
         workspace_parent: &Path,
         cancellation: &CancellationToken,
         progress: Option<&(dyn Fn(PackDownloadProgress) + Send + Sync)>,
     ) -> Result<Option<DownloadedPackInventory>> {
+        let catalog_identity = visibility.catalog_identity().map_err(Error::Metadata)?;
+        let visible_objects = u64::try_from(
+            visibility.object_count_for_refs(visible_ref_names.iter().map(String::as_str)),
+        )
+        .unwrap_or(u64::MAX);
+        let complete_catalog_visible = Self::complete_catalog_is_visible(
+            self.state.catalog_identity,
+            catalog_identity,
+            visible_objects,
+        )?;
         let inventory = self.state.inventory.values().copied().collect::<Vec<_>>();
         let inventory_objects = inventory
             .iter()
             .fold(0_u64, |total, pack| total.saturating_add(pack.object_count));
         let source_artifact_bytes = repack_source_artifact_bytes(&inventory)?;
-        if object_ids.len() < COMPLETE_PACK_CONSOLIDATION_MIN_OBJECTS
+        if visible_objects < COMPLETE_PACK_CONSOLIDATION_MIN_OBJECTS as u64
+            || !complete_catalog_visible
             || inventory.is_empty()
-            || inventory_objects < u64::try_from(object_ids.len()).unwrap_or(u64::MAX)
+            || inventory_objects < visible_objects
             || source_artifact_bytes > self.state.options.operation_limits().max_fetched_bytes
         {
             return Ok(None);
         }
 
-        let operation = self
-            .operation(OperationKind::UploadPack, cancellation)
-            .await?;
+        // Pack streams do not query the locator. Keeping them on a separate
+        // operation lets transfer start while the exact catalog scan runs.
+        let operation = crate::OperationContext::open_pack_transfer(
+            Arc::clone(&self.state),
+            cancellation,
+            self.state.options.operation_limits(),
+        )
+        .await?;
         let result = async {
             // Keep the temporary inventory on the clone destination's
             // filesystem so installation can hard-link multi-gigabyte packs.
             let workspace = tempfile::tempdir_in(workspace_parent).map_err(io_error)?;
             let download_dir = workspace.path().join("source-packs");
             std::fs::create_dir_all(&download_dir).map_err(io_error)?;
-            let packs = download_repack_sources(
+            let download = download_repack_sources(
                 &operation,
                 inventory,
                 &download_dir,
                 cancellation,
                 progress,
-            )
-            .await?;
+            );
+            let catalog = async {
+                let catalog_operation = self
+                    .operation(OperationKind::UploadPack, cancellation)
+                    .await?;
+                let object_ids = catalog_operation.all_catalog_object_ids().await;
+                catalog_operation.finish(object_ids).await
+            };
+            // Await both operations so each one closes its pinned metadata session even
+            // when its sibling fails.
+            let (packs, selected_oids) = tokio::join!(download, catalog);
+            let packs = packs?;
+            let selected_oids = selected_oids?;
+            if u64::try_from(selected_oids.len()).unwrap_or(u64::MAX)
+                != catalog_identity.object_count
+            {
+                return Err(Error::Corrupt {
+                    stage: crate::CorruptionStage::Locator,
+                });
+            }
             let check_packs = packs.clone();
-            let selected_oids = object_ids.to_vec();
             let covers = tokio::task::spawn_blocking(move || {
                 crab_git::repack::source_pack_inventory_covers_object_ids(
                     &check_packs,
@@ -3015,6 +3065,47 @@ mod tests {
         assert!(
             !RemoteGitRepository::near_complete_pack_consolidation_candidate(1, 101_000, 100_000,)
         );
+    }
+
+    #[test]
+    fn complete_inventory_requires_matching_fully_visible_catalog() {
+        let catalog = crab_metadata::git_object_locator::GitObjectCatalogIdentity {
+            generation: 7,
+            pack_index_hash: MerkleHash::from([1; 32]),
+            object_count: 100_000,
+            catalog_digest: MerkleHash::from([2; 32]),
+        };
+        assert!(
+            RemoteGitRepository::complete_catalog_is_visible(
+                Some(catalog),
+                catalog,
+                catalog.object_count,
+            )
+            .expect("matching complete catalog")
+        );
+        assert!(
+            !RemoteGitRepository::complete_catalog_is_visible(
+                Some(catalog),
+                catalog,
+                catalog.object_count - 1,
+            )
+            .expect("partial visibility")
+        );
+
+        let mismatched = crab_metadata::git_object_locator::GitObjectCatalogIdentity {
+            generation: catalog.generation + 1,
+            ..catalog
+        };
+        assert!(matches!(
+            RemoteGitRepository::complete_catalog_is_visible(
+                Some(catalog),
+                mismatched,
+                mismatched.object_count,
+            ),
+            Err(Error::RepositoryState {
+                reason: crate::RepositoryStateError::VisibilityProofMismatch,
+            })
+        ));
     }
 
     #[test]

--- a/crates/crab-remote-git/src/pack.rs
+++ b/crates/crab-remote-git/src/pack.rs
@@ -417,10 +417,14 @@ impl GeneratedPack {
 impl RemoteGitRepository {
     fn complete_catalog_is_visible(
         repository_catalog: Option<crab_metadata::git_object_locator::GitObjectCatalogIdentity>,
+        repository_validation_digest: &str,
         visibility_catalog: crab_metadata::git_object_locator::GitObjectCatalogIdentity,
+        visibility_validation_digest: &str,
         visible_objects: u64,
     ) -> Result<bool> {
-        if repository_catalog != Some(visibility_catalog) {
+        if repository_catalog != Some(visibility_catalog)
+            || repository_validation_digest != visibility_validation_digest
+        {
             return Err(Error::RepositoryState {
                 reason: crate::RepositoryStateError::VisibilityProofMismatch,
             });
@@ -442,6 +446,7 @@ impl RemoteGitRepository {
         cancellation: &CancellationToken,
         progress: Option<&(dyn Fn(PackDownloadProgress) + Send + Sync)>,
     ) -> Result<Option<DownloadedPackInventory>> {
+        visibility.validate().map_err(Error::Metadata)?;
         let catalog_identity = visibility.catalog_identity().map_err(Error::Metadata)?;
         let visible_objects = u64::try_from(
             visibility.object_count_for_refs(visible_ref_names.iter().map(String::as_str)),
@@ -449,7 +454,9 @@ impl RemoteGitRepository {
         .unwrap_or(u64::MAX);
         let complete_catalog_visible = Self::complete_catalog_is_visible(
             self.state.catalog_identity,
+            &self.state.git_validation_digest,
             catalog_identity,
+            &visibility.git_validation_digest,
             visible_objects,
         )?;
         let inventory = self.state.inventory.values().copied().collect::<Vec<_>>();
@@ -480,25 +487,40 @@ impl RemoteGitRepository {
             let workspace = tempfile::tempdir_in(workspace_parent).map_err(io_error)?;
             let download_dir = workspace.path().join("source-packs");
             std::fs::create_dir_all(&download_dir).map_err(io_error)?;
-            let download = download_repack_sources(
-                &operation,
-                inventory,
-                &download_dir,
-                cancellation,
-                progress,
-            );
+            let concurrent_cancellation = cancellation.child_token();
+            let download = async {
+                let result = download_repack_sources(
+                    &operation,
+                    inventory,
+                    &download_dir,
+                    &concurrent_cancellation,
+                    progress,
+                )
+                .await;
+                if result.is_err() {
+                    concurrent_cancellation.cancel();
+                }
+                result
+            };
             let catalog = async {
-                let catalog_operation = self
-                    .operation(OperationKind::UploadPack, cancellation)
-                    .await?;
-                let object_ids = catalog_operation.all_catalog_object_ids().await;
-                catalog_operation.finish(object_ids).await
+                let result = async {
+                    let catalog_operation = self
+                        .operation(OperationKind::UploadPack, &concurrent_cancellation)
+                        .await?;
+                    let object_ids = catalog_operation.all_catalog_object_ids().await;
+                    catalog_operation.finish(object_ids).await
+                }
+                .await;
+                if result.is_err() {
+                    concurrent_cancellation.cancel();
+                }
+                result
             };
             // Await both operations so each one closes its pinned metadata session even
-            // when its sibling fails.
+            // when its sibling fails. Cancellation stops unnecessary origin reads, while
+            // the result merge retains the error that caused sibling cancellation.
             let (packs, selected_oids) = tokio::join!(download, catalog);
-            let packs = packs?;
-            let selected_oids = selected_oids?;
+            let (packs, selected_oids) = merge_inventory_parts(packs, selected_oids)?;
             if u64::try_from(selected_oids.len()).unwrap_or(u64::MAX)
                 != catalog_identity.object_count
             {
@@ -1187,6 +1209,22 @@ impl RemoteGitRepository {
             )
             .await?;
         Ok(generated.as_ref().clone())
+    }
+}
+
+fn merge_inventory_parts<T, U>(packs: Result<T>, catalog: Result<U>) -> Result<(T, U)> {
+    match (packs, catalog) {
+        (Ok(packs), Ok(catalog)) => Ok((packs, catalog)),
+        (Err(Error::Cancelled), Err(catalog_error))
+            if !matches!(catalog_error, Error::Cancelled) =>
+        {
+            Err(catalog_error)
+        }
+        (Err(pack_error), Err(Error::Cancelled)) if !matches!(pack_error, Error::Cancelled) => {
+            Err(pack_error)
+        }
+        (Err(pack_error), _) => Err(pack_error),
+        (_, Err(catalog_error)) => Err(catalog_error),
     }
 }
 
@@ -3078,7 +3116,9 @@ mod tests {
         assert!(
             RemoteGitRepository::complete_catalog_is_visible(
                 Some(catalog),
+                "validation",
                 catalog,
+                "validation",
                 catalog.object_count,
             )
             .expect("matching complete catalog")
@@ -3086,7 +3126,9 @@ mod tests {
         assert!(
             !RemoteGitRepository::complete_catalog_is_visible(
                 Some(catalog),
+                "validation",
                 catalog,
+                "validation",
                 catalog.object_count - 1,
             )
             .expect("partial visibility")
@@ -3099,11 +3141,48 @@ mod tests {
         assert!(matches!(
             RemoteGitRepository::complete_catalog_is_visible(
                 Some(catalog),
+                "validation",
                 mismatched,
+                "validation",
                 mismatched.object_count,
             ),
             Err(Error::RepositoryState {
                 reason: crate::RepositoryStateError::VisibilityProofMismatch,
+            })
+        ));
+        assert!(matches!(
+            RemoteGitRepository::complete_catalog_is_visible(
+                Some(catalog),
+                "validation",
+                catalog,
+                "other-validation",
+                catalog.object_count,
+            ),
+            Err(Error::RepositoryState {
+                reason: crate::RepositoryStateError::VisibilityProofMismatch,
+            })
+        ));
+    }
+
+    #[test]
+    fn concurrent_inventory_errors_retain_the_failure_that_cancelled_its_sibling() {
+        let pack_error = Error::InternalInvariant {
+            invariant: "pack failure",
+        };
+        let catalog_error = Error::InternalInvariant {
+            invariant: "catalog failure",
+        };
+
+        assert!(matches!(
+            merge_inventory_parts::<(), ()>(Err(Error::Cancelled), Err(catalog_error)),
+            Err(Error::InternalInvariant {
+                invariant: "catalog failure",
+            })
+        ));
+        assert!(matches!(
+            merge_inventory_parts::<(), ()>(Err(pack_error), Err(Error::Cancelled)),
+            Err(Error::InternalInvariant {
+                invariant: "pack failure",
             })
         ));
     }

--- a/packages/web/content/docs/cli/reference/crab-clone.mdx
+++ b/packages/web/content/docs/cli/reference/crab-clone.mdx
@@ -68,6 +68,10 @@ repository creation, Crab configuration, and checkout as separate steps. Large
 pack downloads include transferred pack-body bytes, total pack-body bytes,
 completed pack count, and transfer rate. `--jsonl` emits the same measurements with the
 `downloading_git_packs` operation; `--json` remains a single terminal result.
+For a complete large-repository clone, downloading starts as soon as the compact
+visibility catalog authorizes the full pack inventory. Crab overlaps the full
+catalog/index integrity comparison with transfer instead of completing that
+repository-sized scan before the first pack byte.
 
 ### Hydrate selected content
 


### PR DESCRIPTION
## Summary

- authorize complete large-repository clones from the compact catalog visibility bitmap instead of materializing every OID before transfer
- start canonical pack downloads on a locator-free operation while the exact pinned-catalog scan runs concurrently
- retain fail-closed catalog identity, visibility, object-count, and exact pack-index coverage checks before installation
- preserve the existing upload-pack planner for partial visibility and shallow clones
- document the progressive clone behavior

## Performance

Measured against the same warm local RustFS Kubernetes remote with 1,646,244 Git objects:

- before: 1.85-1.90 seconds from Reading repository metadata to Downloading Git packs
- after: 0.17-0.19 seconds
- result: about 90% lower pre-download latency, with pack progress appearing about 10x sooner

## Verification

- full Kubernetes clone completed with 1,646,244 objects in one 1.22 GiB pack
- cloned HEAD matched the source repository HEAD
- git fsck --full passed
- cargo test -p crab-remote-git --locked: 205 tests passed including doctests
- cargo test -p crab --lib cmd::clone::tests:: --locked: 41 tests passed
- cargo clippy -p crab-remote-git --all-targets --locked -- -D warnings
- CI-equivalent Crab correctness/suspicious Clippy gate
- cargo fmt --all -- --check
- npm run check:links: 398 pages and 4,306 fragments checked
