### PR TITLE
perf(push): cache immutable ref transactions

### DIFF
--- a/crab/scripts/e2e/run_cache_service_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_cache_service_rustfs_smoke.py
@@ -5080,6 +5080,12 @@ class CacheServiceRustfsSmoke:
             return "xorb", self.cache_root / "xorbs" / hash_hex[:2] / hash_hex
         if key.startswith(".crab/shards/"):
             return "shard", self.cache_root / "shards" / hash_hex[:2] / hash_hex
+        if "/refs/journal/transactions/" in key:
+            hash_hex = hash_hex.removesuffix(".json")
+            return (
+                "ref-transaction",
+                self.cache_root / "ref-transactions" / hash_hex[:2] / hash_hex,
+            )
         raise SmokeError(f"unsupported integrity repair key: {key}")
 
     def corrupt_persisted_cache_file(self, path: Path, object_type: str) -> int:
@@ -5102,6 +5108,10 @@ class CacheServiceRustfsSmoke:
             (
                 ".crab/shards/{first-two-hex}/{hash}",
                 lambda key: key.startswith(".crab/shards/"),
+            ),
+            (
+                "{repo}/refs/journal/transactions/{hash}.json",
+                lambda key: "/refs/journal/transactions/" in key,
             ),
         ):
             key, origin_body = self.origin_object_matching(pattern, predicate)

--- a/crab/scripts/e2e/run_cache_service_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_cache_service_rustfs_smoke.py
@@ -67,6 +67,7 @@ EXPECTED_IMMUTABLE_ROUTE_PATTERNS = [
     "{repo}/packs/pack-{id}.idx",
     "{repo}/generated-packs/v1/artifacts/{first-two-hex}/{hash}.pack",
     "{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json",
+    "{repo}/refs/journal/transactions/{hash}.json",
     "{repo}/file_index_db/compacted/*.sst",
     "{repo}/file_index_db/manifest/*.manifest",
     "{repo}/file_index_db/wal/*.sst",
@@ -87,6 +88,11 @@ EXPECTED_MUTABLE_ROUTE_PATTERNS = [
     ".crab/ref-registry/*",
     "{repo}/file_index_db/manifest/current",
     ".crab/chunk_index_db/manifest/current",
+]
+EXPECTED_IMMUTABLE_POISONING_PATTERNS = [
+    ".crab/xorbs/{first-two-hex}/{hash}",
+    ".crab/shards/{first-two-hex}/{hash}",
+    "{repo}/refs/journal/transactions/{hash}.json",
 ]
 
 
@@ -3712,6 +3718,8 @@ class CacheServiceRustfsSmoke:
     def synthetic_immutable_route_specs(self) -> list[tuple[str, str, bytes]]:
         prefix = f"{REMOTE_PREFIX}/{self.run_id}/route-contract-immutable"
         generated_hash = "9" * 64
+        transaction_body = b'{"version":1,"edits":[]}'
+        transaction_hash = "6003afa08563fa5cc27ad45ebb7def0282eaafb8bf1e17e1ba139d62465f57de"
         specs = [
             ("{repo}/packs/pack-{id}.pack", f"{prefix}/packs/pack-route-contract.pack"),
             ("{repo}/packs/pack-{id}.idx", f"{prefix}/packs/pack-route-contract.idx"),
@@ -3722,6 +3730,10 @@ class CacheServiceRustfsSmoke:
             (
                 "{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json",
                 f"{prefix}/generated-packs/v1/requests/99/{generated_hash}.json",
+            ),
+            (
+                "{repo}/refs/journal/transactions/{hash}.json",
+                f"{prefix}/refs/journal/transactions/{transaction_hash}.json",
             ),
             (
                 "{repo}/file_index_db/compacted/*.sst",
@@ -3741,7 +3753,13 @@ class CacheServiceRustfsSmoke:
             ),
         ]
         return [
-            (pattern, key, deterministic_bytes(4096, f"{self.run_id}:{pattern}"))
+            (
+                pattern,
+                key,
+                transaction_body
+                if pattern == "{repo}/refs/journal/transactions/{hash}.json"
+                else deterministic_bytes(4096, f"{self.run_id}:{pattern}"),
+            )
             for pattern, key in specs
         ]
 
@@ -3883,19 +3901,16 @@ class CacheServiceRustfsSmoke:
             == sorted(EXPECTED_IMMUTABLE_ROUTE_PATTERNS),
             {"patterns": [record["pattern"] for record in self.report.immutable_route_write_behaviors]},
         )
-        self.assert_immutable_route_pattern_rejects_poisoning(
-            ".crab/xorbs/{first-two-hex}/{hash}", xorb_key, xorb_body
-        )
-        self.assert_immutable_route_pattern_rejects_poisoning(
-            ".crab/shards/{first-two-hex}/{hash}", shard_key, shard_body
-        )
+        poisoning_specs = {
+            pattern: (key, data) for pattern, key, data in real_specs + synthetic_specs
+        }
+        for pattern in EXPECTED_IMMUTABLE_POISONING_PATTERNS:
+            key, data = poisoning_specs[pattern]
+            self.assert_immutable_route_pattern_rejects_poisoning(pattern, key, data)
         self.check(
             "route-contract-immutable-poisoning-patterns-covered",
             sorted(record["pattern"] for record in self.report.immutable_poisoning_controls)
-            == [
-                ".crab/shards/{first-two-hex}/{hash}",
-                ".crab/xorbs/{first-two-hex}/{hash}",
-            ],
+            == sorted(EXPECTED_IMMUTABLE_POISONING_PATTERNS),
             {"patterns": [record["pattern"] for record in self.report.immutable_poisoning_controls]},
         )
 

--- a/crab/scripts/e2e/run_cache_service_rustfs_smoke.py
+++ b/crab/scripts/e2e/run_cache_service_rustfs_smoke.py
@@ -5100,6 +5100,10 @@ class CacheServiceRustfsSmoke:
     def verify_persisted_cache_integrity_repairs(self, support_repo: Path) -> None:
         state = self.require_proxy_state()
         fixtures: list[dict[str, Any]] = []
+        synthetic = {
+            pattern: (key, data)
+            for pattern, key, data in self.synthetic_immutable_route_specs()
+        }
         for pattern, predicate in (
             (
                 ".crab/xorbs/{first-two-hex}/{hash}",
@@ -5114,7 +5118,9 @@ class CacheServiceRustfsSmoke:
                 lambda key: "/refs/journal/transactions/" in key,
             ),
         ):
-            key, origin_body = self.origin_object_matching(pattern, predicate)
+            key, origin_body = synthetic.get(pattern) or self.origin_object_matching(
+                pattern, predicate
+            )
             object_type, cache_file = self.cache_file_for_integrity_key(key)
             status, headers, body = self.cache_get(key)
             self.check(

--- a/crab/scripts/e2e/run_large_repo_rustfs.py
+++ b/crab/scripts/e2e/run_large_repo_rustfs.py
@@ -602,7 +602,8 @@ class LargeRepositoryQualification:
         self.logs.mkdir(parents=True)
         self.artifacts.mkdir()
         self.temp_root.mkdir()
-        self.cache_root.mkdir()
+        # Crab rejects group/world-accessible cache roots before reading them.
+        self.cache_root.mkdir(mode=0o700)
         self.clone_root.mkdir()
         if self.args.team_load:
             self.fetch_root.mkdir()

--- a/crab/scripts/e2e/test_run_cache_service_rustfs_smoke.py
+++ b/crab/scripts/e2e/test_run_cache_service_rustfs_smoke.py
@@ -127,6 +127,23 @@ class OriginFixtureSafetyTests(unittest.TestCase):
         self.smoke.run_aws.assert_not_called()
 
 
+class CacheIntegrityFixtureTests(unittest.TestCase):
+    def test_ref_transaction_uses_local_cache_hash_path(self) -> None:
+        smoke = object.__new__(smoke_module.CacheServiceRustfsSmoke)
+        smoke.cache_root = Path("cache")
+        transaction_hash = "a" * 64
+
+        object_type, path = smoke.cache_file_for_integrity_key(
+            f"repo/refs/journal/transactions/{transaction_hash}.json"
+        )
+
+        self.assertEqual(object_type, "ref-transaction")
+        self.assertEqual(
+            path,
+            Path("cache/ref-transactions/aa") / transaction_hash,
+        )
+
+
 class ReportAuditTests(unittest.TestCase):
     def test_audit_uses_packaged_verifier_not_report_selected_code(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/crab/scripts/e2e/test_verify_large_repo_rustfs_report.py
+++ b/crab/scripts/e2e/test_verify_large_repo_rustfs_report.py
@@ -9,6 +9,7 @@ import importlib.util
 import json
 import os
 import shutil
+import stat
 import sys
 import tempfile
 import threading
@@ -151,6 +152,31 @@ class QualificationHarnessTests(unittest.TestCase):
             source.write_text("replacement build", encoding="utf-8")
 
             self.assertEqual(resolved.read_text(encoding="utf-8"), "first build")
+
+    @unittest.skipUnless(os.name == "posix", "private directory modes are POSIX-specific")
+    def test_setup_creates_a_private_cache_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "run"
+            qualification = QUALIFICATION.LargeRepositoryQualification.__new__(
+                QUALIFICATION.LargeRepositoryQualification
+            )
+            qualification.args = SimpleNamespace(team_load=False)
+            qualification.run_root = root
+            qualification.logs = root / "logs"
+            qualification.artifacts = root / "artifacts"
+            qualification.temp_root = root / "tmp"
+            qualification.cache_root = root / "cache"
+            qualification.clone_root = root / "clones"
+            qualification.bin_root = root / "bin"
+            qualification.crab_source_bin = Path(sys.executable)
+            qualification.crab_bin = qualification.bin_root / "crab"
+            qualification.report_lock = threading.RLock()
+            qualification.report = {"artifacts": {}}
+
+            qualification.setup()
+
+            mode = stat.S_IMODE(qualification.cache_root.stat().st_mode)
+            self.assertEqual(mode & 0o077, 0)
 
 
 def resources() -> dict[str, Any]:

--- a/crab/scripts/verify-cache-service-smoke-report.py
+++ b/crab/scripts/verify-cache-service-smoke-report.py
@@ -23,6 +23,7 @@ EXPECTED_IMMUTABLE_ROUTE_PATTERNS = [
     "{repo}/packs/pack-{id}.idx",
     "{repo}/generated-packs/v1/artifacts/{first-two-hex}/{hash}.pack",
     "{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json",
+    "{repo}/refs/journal/transactions/{hash}.json",
     "{repo}/file_index_db/compacted/*.sst",
     "{repo}/file_index_db/manifest/*.manifest",
     "{repo}/file_index_db/wal/*.sst",
@@ -35,6 +36,7 @@ EXPECTED_IMMUTABLE_ROUTE_PATTERNS = [
 EXPECTED_IMMUTABLE_POISONING_PATTERNS = [
     ".crab/xorbs/{first-two-hex}/{hash}",
     ".crab/shards/{first-two-hex}/{hash}",
+    "{repo}/refs/journal/transactions/{hash}.json",
 ]
 EXPECTED_MUTABLE_ROUTE_PATTERNS = [
     "{repo}/refs/heads/*",

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -97,6 +97,9 @@ use crab_xet::xorb::parser::{XorbParser, xorb_metadata_region};
 
 const RECIPE_PAGE_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const RECIPE_PAGE_CACHE_ENTRY_OVERHEAD: usize = 128;
+// Keep normal push snapshots within one journal download batch. The existing
+// reader-safe compactor owns all manifest CAS and concurrent-writer handling.
+const PUSH_REF_JOURNAL_COMPACTION_THRESHOLD: usize = 32;
 
 fn bulk_data_bytes(bulk: &BulkData) -> u64 {
     let shard_segment_bytes: u64 = bulk
@@ -6940,22 +6943,14 @@ impl PushPipeline {
             return Ok(());
         };
 
-        match crate::metadata::manifest::read_repository_snapshot_with_cache(
+        let mut snapshot = match crate::metadata::manifest::read_repository_snapshot_with_cache(
             store,
             self.caching_store.as_ref(),
             &self.router,
         )
         .await
         {
-            Ok(snapshot) => {
-                debug!(
-                    generation = snapshot.manifest.generation,
-                    refs = snapshot.journal.refs.len(),
-                    "read base manifest"
-                );
-                *self.manifest_etag.lock().await = Some(snapshot.manifest_etag.clone());
-                *self.base_snapshot.lock().await = Some(Arc::new(snapshot));
-            }
+            Ok(snapshot) => snapshot,
             Err(CrabError::NotFound { path }) if path == self.router.manifest_path().as_ref() => {
                 return Err(CrabError::CorruptObject {
                     path,
@@ -6963,7 +6958,40 @@ impl PushPipeline {
                 });
             }
             Err(e) => return Err(e),
+        };
+
+        if snapshot.journal.transactions.len() >= PUSH_REF_JOURNAL_COMPACTION_THRESHOLD {
+            info!(
+                transactions = snapshot.journal.transactions.len(),
+                threshold = PUSH_REF_JOURNAL_COMPACTION_THRESHOLD,
+                "compacting deep ref journal before push"
+            );
+            if compact_ref_journal_for_reader(
+                store,
+                &self.router,
+                self.config.lock_ttl,
+                None,
+                &self.cancel,
+            )
+            .await?
+            {
+                snapshot = crate::metadata::manifest::read_repository_snapshot_with_cache(
+                    store,
+                    self.caching_store.as_ref(),
+                    &self.router,
+                )
+                .await?;
+            }
         }
+
+        debug!(
+            generation = snapshot.manifest.generation,
+            refs = snapshot.journal.refs.len(),
+            transactions = snapshot.journal.transactions.len(),
+            "read base manifest"
+        );
+        *self.manifest_etag.lock().await = Some(snapshot.manifest_etag.clone());
+        *self.base_snapshot.lock().await = Some(Arc::new(snapshot));
 
         Ok(())
     }
@@ -23972,6 +24000,79 @@ mod tests {
         .await
         .expect("admission completes the pending handoff");
         assert_eq!(repository.generation(), compacted.manifest.generation);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn push_base_read_compacts_journal_at_the_bounded_depth() {
+        let (store, router) = test_store_router("push-bounded-journal");
+        ensure_test_layout(&store, &router).await;
+        let initial = Manifest::default_for_repo("refs/heads/main");
+        create_manifest_with_etag(&store, &router, &initial)
+            .await
+            .expect("create initial manifest");
+
+        let mut old_oid = None;
+        for ordinal in 1..=PUSH_REF_JOURNAL_COMPACTION_THRESHOLD {
+            let expected = crate::metadata::manifest::read_ref_journal_head(
+                &store,
+                &router,
+                "refs/heads/main",
+            )
+            .await
+            .expect("read ref head");
+            let new_oid = format!("{ordinal:040x}");
+            let transaction = crate::metadata::manifest::RefJournalTransaction::new(
+                BTreeMap::from([(
+                    "refs/heads/main".to_owned(),
+                    expected.visible_transaction.clone(),
+                )]),
+                vec![crate::metadata::manifest::RefJournalEdit {
+                    ref_name: "refs/heads/main".to_owned(),
+                    old_oid: old_oid.clone(),
+                    new_oid: Some(new_oid.clone()),
+                    peeled_oid: None,
+                    lock_holder: None,
+                    visibility_evidence_hash: None,
+                }],
+                None,
+                Vec::new(),
+                Vec::new(),
+            )
+            .expect("build transaction");
+            crate::metadata::manifest::commit_ref_journal_transaction(
+                &store,
+                &router,
+                &transaction,
+                &[expected],
+            )
+            .await
+            .expect("commit transaction");
+            old_oid = Some(new_oid);
+        }
+
+        let pipeline = PushPipeline::new(
+            PushConfig::default(),
+            Vec::new(),
+            Some(store),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router,
+            None,
+            CancellationToken::new(),
+            None,
+        );
+        pipeline
+            .read_base_manifest()
+            .await
+            .expect("read and compact the bounded journal");
+        let snapshot = pipeline.base_snapshot.lock().await.clone().unwrap();
+
+        assert!(snapshot.journal.transactions.is_empty());
+        assert_eq!(
+            snapshot.journal.refs.get("refs/heads/main"),
+            old_oid.as_ref()
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -8446,13 +8446,14 @@ impl PushPipeline {
             .as_ref()
             .map(|snapshot| snapshot.materialized_manifest());
         let current_snapshot =
-            crate::metadata::manifest::read_repository_snapshot_with_cache(
+            crate::metadata::manifest::read_repository_snapshot_with_cache_reusing(
                 store,
                 self.caching_store.as_ref(),
                 &self.router,
+                base_snapshot.as_deref(),
             )
-                .await
-                .map_err(|error| match error {
+            .await
+        .map_err(|error| match error {
                     CrabError::NotFound { path }
                         if path == self.router.manifest_path().as_ref() =>
                     {
@@ -13489,10 +13490,14 @@ impl PushPipeline {
         let store = self.store.as_ref().ok_or_else(|| {
             CrabError::Internal("under-lock base refresh requires a store".to_owned())
         })?;
-        let current = crate::metadata::manifest::read_repository_snapshot_with_cache(
+        let previous = self.base_snapshot.lock().await.clone().ok_or_else(|| {
+            CrabError::Internal("under-lock base refresh requires a base snapshot".to_owned())
+        })?;
+        let current = crate::metadata::manifest::read_repository_snapshot_with_cache_reusing(
             store,
             self.caching_store.as_ref(),
             &self.router,
+            Some(&previous),
         )
         .await?;
         let prior_etag = {
@@ -14772,10 +14777,12 @@ impl PushPipeline {
         let store = self.store.as_ref().ok_or_else(|| {
             CrabError::Internal("candidate metadata requires an object store".to_owned())
         })?;
-        let snapshot = crate::metadata::manifest::read_repository_snapshot_with_cache(
+        let previous = self.base_snapshot.lock().await.clone();
+        let snapshot = crate::metadata::manifest::read_repository_snapshot_with_cache_reusing(
             store,
             self.caching_store.as_ref(),
             &self.router,
+            previous.as_deref(),
         )
         .await?;
         let initial_manifest = snapshot.manifest.generation == 0

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6940,7 +6940,13 @@ impl PushPipeline {
             return Ok(());
         };
 
-        match crate::metadata::manifest::read_repository_snapshot(store, &self.router).await {
+        match crate::metadata::manifest::read_repository_snapshot_with_cache(
+            store,
+            self.caching_store.as_ref(),
+            &self.router,
+        )
+        .await
+        {
             Ok(snapshot) => {
                 debug!(
                     generation = snapshot.manifest.generation,
@@ -8440,7 +8446,11 @@ impl PushPipeline {
             .as_ref()
             .map(|snapshot| snapshot.materialized_manifest());
         let current_snapshot =
-            crate::metadata::manifest::read_repository_snapshot(store, &self.router)
+            crate::metadata::manifest::read_repository_snapshot_with_cache(
+                store,
+                self.caching_store.as_ref(),
+                &self.router,
+            )
                 .await
                 .map_err(|error| match error {
                     CrabError::NotFound { path }
@@ -13479,8 +13489,12 @@ impl PushPipeline {
         let store = self.store.as_ref().ok_or_else(|| {
             CrabError::Internal("under-lock base refresh requires a store".to_owned())
         })?;
-        let current =
-            crate::metadata::manifest::read_repository_snapshot(store, &self.router).await?;
+        let current = crate::metadata::manifest::read_repository_snapshot_with_cache(
+            store,
+            self.caching_store.as_ref(),
+            &self.router,
+        )
+        .await?;
         let prior_etag = {
             let prior = self.base_snapshot.lock().await;
             // Journal commits do not change the compacted manifest's ETag.
@@ -14758,8 +14772,12 @@ impl PushPipeline {
         let store = self.store.as_ref().ok_or_else(|| {
             CrabError::Internal("candidate metadata requires an object store".to_owned())
         })?;
-        let snapshot =
-            crate::metadata::manifest::read_repository_snapshot(store, &self.router).await?;
+        let snapshot = crate::metadata::manifest::read_repository_snapshot_with_cache(
+            store,
+            self.caching_store.as_ref(),
+            &self.router,
+        )
+        .await?;
         let initial_manifest = snapshot.manifest.generation == 0
             && snapshot.manifest.refs.is_empty()
             && snapshot.manifest.shard_index_hash.is_empty()

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -97,9 +97,6 @@ use crab_xet::xorb::parser::{XorbParser, xorb_metadata_region};
 
 const RECIPE_PAGE_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const RECIPE_PAGE_CACHE_ENTRY_OVERHEAD: usize = 128;
-// Keep normal push snapshots within one journal download batch. The existing
-// reader-safe compactor owns all manifest CAS and concurrent-writer handling.
-const PUSH_REF_JOURNAL_COMPACTION_THRESHOLD: usize = 32;
 
 fn bulk_data_bytes(bulk: &BulkData) -> u64 {
     let shard_segment_bytes: u64 = bulk
@@ -6943,14 +6940,22 @@ impl PushPipeline {
             return Ok(());
         };
 
-        let mut snapshot = match crate::metadata::manifest::read_repository_snapshot_with_cache(
+        match crate::metadata::manifest::read_repository_snapshot_with_cache(
             store,
             self.caching_store.as_ref(),
             &self.router,
         )
         .await
         {
-            Ok(snapshot) => snapshot,
+            Ok(snapshot) => {
+                debug!(
+                    generation = snapshot.manifest.generation,
+                    refs = snapshot.journal.refs.len(),
+                    "read base manifest"
+                );
+                *self.manifest_etag.lock().await = Some(snapshot.manifest_etag.clone());
+                *self.base_snapshot.lock().await = Some(Arc::new(snapshot));
+            }
             Err(CrabError::NotFound { path }) if path == self.router.manifest_path().as_ref() => {
                 return Err(CrabError::CorruptObject {
                     path,
@@ -6958,40 +6963,7 @@ impl PushPipeline {
                 });
             }
             Err(e) => return Err(e),
-        };
-
-        if snapshot.journal.transactions.len() >= PUSH_REF_JOURNAL_COMPACTION_THRESHOLD {
-            info!(
-                transactions = snapshot.journal.transactions.len(),
-                threshold = PUSH_REF_JOURNAL_COMPACTION_THRESHOLD,
-                "compacting deep ref journal before push"
-            );
-            if compact_ref_journal_for_reader(
-                store,
-                &self.router,
-                self.config.lock_ttl,
-                None,
-                &self.cancel,
-            )
-            .await?
-            {
-                snapshot = crate::metadata::manifest::read_repository_snapshot_with_cache(
-                    store,
-                    self.caching_store.as_ref(),
-                    &self.router,
-                )
-                .await?;
-            }
         }
-
-        debug!(
-            generation = snapshot.manifest.generation,
-            refs = snapshot.journal.refs.len(),
-            transactions = snapshot.journal.transactions.len(),
-            "read base manifest"
-        );
-        *self.manifest_etag.lock().await = Some(snapshot.manifest_etag.clone());
-        *self.base_snapshot.lock().await = Some(Arc::new(snapshot));
 
         Ok(())
     }
@@ -24000,79 +23972,6 @@ mod tests {
         .await
         .expect("admission completes the pending handoff");
         assert_eq!(repository.generation(), compacted.manifest.generation);
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn push_base_read_compacts_journal_at_the_bounded_depth() {
-        let (store, router) = test_store_router("push-bounded-journal");
-        ensure_test_layout(&store, &router).await;
-        let initial = Manifest::default_for_repo("refs/heads/main");
-        create_manifest_with_etag(&store, &router, &initial)
-            .await
-            .expect("create initial manifest");
-
-        let mut old_oid = None;
-        for ordinal in 1..=PUSH_REF_JOURNAL_COMPACTION_THRESHOLD {
-            let expected = crate::metadata::manifest::read_ref_journal_head(
-                &store,
-                &router,
-                "refs/heads/main",
-            )
-            .await
-            .expect("read ref head");
-            let new_oid = format!("{ordinal:040x}");
-            let transaction = crate::metadata::manifest::RefJournalTransaction::new(
-                BTreeMap::from([(
-                    "refs/heads/main".to_owned(),
-                    expected.visible_transaction.clone(),
-                )]),
-                vec![crate::metadata::manifest::RefJournalEdit {
-                    ref_name: "refs/heads/main".to_owned(),
-                    old_oid: old_oid.clone(),
-                    new_oid: Some(new_oid.clone()),
-                    peeled_oid: None,
-                    lock_holder: None,
-                    visibility_evidence_hash: None,
-                }],
-                None,
-                Vec::new(),
-                Vec::new(),
-            )
-            .expect("build transaction");
-            crate::metadata::manifest::commit_ref_journal_transaction(
-                &store,
-                &router,
-                &transaction,
-                &[expected],
-            )
-            .await
-            .expect("commit transaction");
-            old_oid = Some(new_oid);
-        }
-
-        let pipeline = PushPipeline::new(
-            PushConfig::default(),
-            Vec::new(),
-            Some(store),
-            None,
-            None,
-            router.repo_prefix().to_owned(),
-            router,
-            None,
-            CancellationToken::new(),
-            None,
-        );
-        pipeline
-            .read_base_manifest()
-            .await
-            .expect("read and compact the bounded journal");
-        let snapshot = pipeline.base_snapshot.lock().await.clone().unwrap();
-
-        assert!(snapshot.journal.transactions.is_empty());
-        assert_eq!(
-            snapshot.journal.refs.get("refs/heads/main"),
-            old_oid.as_ref()
-        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crab/src/git/push_native.rs
+++ b/crab/src/git/push_native.rs
@@ -371,7 +371,13 @@ async fn run_native_push_inner(
         // client; the protected upload store is not a canonical read handle.
         Some(prepared_ref_frontier(&session.ref_updates))
     } else {
-        match crate::metadata::manifest::read_repository_snapshot(&store, &router).await {
+        match crate::metadata::manifest::read_repository_snapshot_with_cache(
+            &store,
+            caching_store.as_ref(),
+            &router,
+        )
+        .await
+        {
             Ok(snapshot) => Some(snapshot.journal.refs),
             Err(CrabError::NotFound { path })
                 if config.followtags && path == router.manifest_path().as_ref() =>

--- a/crab/src/metadata/manifest.rs
+++ b/crab/src/metadata/manifest.rs
@@ -40,6 +40,19 @@ pub async fn read_repository_snapshot(
         .map_err(CrabError::from)
 }
 
+/// Read a coherent snapshot while caching only immutable metadata objects.
+pub async fn read_repository_snapshot_with_cache(
+    store: &Store,
+    caching_store: Option<&crab_cache_store::CachingStore>,
+    router: &StoreLayout,
+) -> Result<RepositorySnapshot> {
+    let read_store = caching_store
+        .map(crab_cache_store::CachingStore::cache_aware_storage)
+        .map(Store::from)
+        .unwrap_or_else(|| store.clone());
+    read_repository_snapshot(&read_store, router).await
+}
+
 pub async fn read_ref_journal_head(
     store: &Store,
     router: &StoreLayout,
@@ -190,6 +203,114 @@ pub async fn select_manifest_history(
     )
     .await
     .map_err(CrabError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use crab_cache::LocalCache;
+    use crab_storage::test_support::CountingObjectStore;
+    use object_store::memory::InMemory;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn snapshot_cache_repairs_transactions_and_rereads_mutable_state() {
+        let memory: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let counted = Arc::new(CountingObjectStore::new(memory));
+        let store = Store::new(Arc::clone(&counted) as Arc<dyn object_store::ObjectStore>);
+        let router = StoreLayout::new(store.clone(), "snapshot-cache".to_owned());
+        crate::core::remote_layout::initialize(&store, &router)
+            .await
+            .expect("initialize repository layout");
+        crate::cmd::init::create_initial_manifest(&store, &router, "refs/heads/main")
+            .await
+            .expect("create initial manifest");
+
+        let head = read_ref_journal_head(&store, &router, "refs/heads/main")
+            .await
+            .expect("read initial ref head");
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([("refs/heads/main".to_owned(), None)]),
+            vec![RefJournalEdit {
+                ref_name: "refs/heads/main".to_owned(),
+                old_oid: None,
+                new_oid: Some("a".repeat(40)),
+                peeled_oid: None,
+                lock_holder: None,
+                visibility_evidence_hash: None,
+            }],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("build ref transaction");
+        let transaction_id = transaction.id().expect("transaction identity");
+        commit_ref_journal_transaction(&store, &router, &transaction, &[head])
+            .await
+            .expect("commit ref transaction");
+
+        let tempdir = tempfile::tempdir().expect("cache directory");
+        let cache = Arc::new(LocalCache::new(tempdir.path().join("cache")));
+        let caching_store = crab_cache_store::CachingStore::new_with_local_cache(
+            store.as_storage().clone(),
+            crab_cache_store::CacheConfig::default(),
+            Arc::clone(&cache),
+        )
+        .expect("cache store");
+        let transaction_path = router.ref_journal_transaction_path(&transaction_id);
+        counted.reset();
+
+        let first = read_repository_snapshot_with_cache(&store, Some(&caching_store), &router)
+            .await
+            .expect("first snapshot");
+        assert_eq!(
+            first.journal.refs.get("refs/heads/main"),
+            Some(&"a".repeat(40))
+        );
+        assert!(counted.requests().iter().any(|request| {
+            request.location == transaction_path.as_ref()
+                && request.kind == crab_storage::test_support::ObjectReadKind::Full
+        }));
+
+        cache
+            .put_unchecked_for_test(
+                &crab_cache::CacheKey::RefTransaction(
+                    blake3::Hash::from_hex(&transaction_id).expect("transaction hash"),
+                ),
+                b"corrupt transaction",
+            )
+            .await
+            .expect("corrupt cached transaction");
+        counted.reset();
+        let repaired = read_repository_snapshot_with_cache(&store, Some(&caching_store), &router)
+            .await
+            .expect("snapshot after cache repair");
+        assert_eq!(first.journal, repaired.journal);
+        assert!(counted.requests().iter().any(|request| {
+            request.location == transaction_path.as_ref()
+                && request.kind == crab_storage::test_support::ObjectReadKind::Full
+        }));
+
+        counted.reset();
+        counted.block_body_reads_for(&transaction_path);
+        let second = read_repository_snapshot_with_cache(&store, Some(&caching_store), &router)
+            .await
+            .expect("cached snapshot");
+        assert_eq!(first.journal, second.journal);
+        assert!(
+            counted
+                .requests()
+                .iter()
+                .all(|request| request.location != transaction_path.as_ref())
+        );
+        assert!(counted.requests().iter().any(|request| {
+            request.location == router.manifest_path().as_ref()
+                && request.kind == crab_storage::test_support::ObjectReadKind::Full
+        }));
+    }
 }
 
 pub async fn read_bulk_shard_list(

--- a/crab/src/metadata/manifest.rs
+++ b/crab/src/metadata/manifest.rs
@@ -46,11 +46,33 @@ pub async fn read_repository_snapshot_with_cache(
     caching_store: Option<&crab_cache_store::CachingStore>,
     router: &StoreLayout,
 ) -> Result<RepositorySnapshot> {
+    read_repository_snapshot_with_cache_reusing(store, caching_store, router, None).await
+}
+
+/// Reuse a verified snapshot when every mutable dependency is unchanged.
+pub async fn read_repository_snapshot_with_cache_reusing(
+    store: &Store,
+    caching_store: Option<&crab_cache_store::CachingStore>,
+    router: &StoreLayout,
+    previous: Option<&RepositorySnapshot>,
+) -> Result<RepositorySnapshot> {
     let read_store = caching_store
         .map(crab_cache_store::CachingStore::cache_aware_storage)
         .map(Store::from)
         .unwrap_or_else(|| store.clone());
-    read_repository_snapshot(&read_store, router).await
+    match previous {
+        Some(previous) => {
+            let layout = storage_layout(&read_store, router);
+            crab_metadata::manifest_store::read_repository_snapshot_reusing(
+                read_store.as_storage(),
+                &layout,
+                previous,
+            )
+            .await
+            .map_err(CrabError::from)
+        }
+        None => read_repository_snapshot(&read_store, router).await,
+    }
 }
 
 pub async fn read_ref_journal_head(
@@ -310,6 +332,27 @@ mod tests {
             request.location == router.manifest_path().as_ref()
                 && request.kind == crab_storage::test_support::ObjectReadKind::Full
         }));
+
+        counted.reset();
+        let reused =
+            read_repository_snapshot_with_cache_reusing(&store, None, &router, Some(&first))
+                .await
+                .expect("reuse unchanged snapshot");
+        assert_eq!(reused, first);
+        let requests = counted.requests();
+        assert!(requests.iter().any(|request| {
+            request.location == router.manifest_path().as_ref()
+                && request.kind == crab_storage::test_support::ObjectReadKind::Full
+        }));
+        assert!(requests.iter().any(|request| {
+            request.location == router.layout_descriptor_path().as_ref()
+                && request.kind == crab_storage::test_support::ObjectReadKind::Full
+        }));
+        assert!(
+            requests
+                .iter()
+                .all(|request| request.location != transaction_path.as_ref())
+        );
     }
 }
 

--- a/crates/crab-cache-server/src/cache_store.rs
+++ b/crates/crab-cache-server/src/cache_store.rs
@@ -1865,7 +1865,9 @@ fn make_meta_key(object_type: ObjectType, hash: &[u8; 32]) -> [u8; META_KEY_LEN]
 
 fn storage_id_bytes(key: &ServerObjectKey) -> Option<[u8; 32]> {
     match key.object_type {
-        ObjectType::Xorb | ObjectType::Shard => parse_hash_hex(&key.hash),
+        ObjectType::Xorb | ObjectType::Shard | ObjectType::RefTransaction => {
+            parse_hash_hex(&key.hash)
+        }
         ObjectType::Pack | ObjectType::PackIndex => {
             let mut hasher = blake3::Hasher::new();
             hasher.update(&[key.object_type.as_u8()]);
@@ -1880,14 +1882,6 @@ fn storage_id_bytes(key: &ServerObjectKey) -> Option<[u8; 32]> {
             hasher.update(key.repo_path.as_bytes());
             hasher.update(b"\0");
             hasher.update(key.hash.as_bytes());
-            Some(*hasher.finalize().as_bytes())
-        }
-        ObjectType::RefTransaction => {
-            let hash = parse_hash_hex(&key.hash)?;
-            let mut hasher = blake3::Hasher::new();
-            hasher.update(&[key.object_type.as_u8()]);
-            hasher.update(b"\0");
-            hasher.update(&hash);
             Some(*hasher.finalize().as_bytes())
         }
     }
@@ -2070,6 +2064,22 @@ mod tests {
                 "xorbs/ab/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
             )
         );
+    }
+
+    #[test]
+    fn ref_transaction_object_path_uses_content_identity() {
+        let store = test_store();
+        let hash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        let key = ServerObjectKey {
+            bucket: "test-bucket".to_owned(),
+            repo_path: "org/repo".to_owned(),
+            object_type: ObjectType::RefTransaction,
+            hash: hash.to_owned(),
+        };
+
+        let path = store.object_path(&key);
+
+        assert!(path.ends_with(Path::new("ref-transactions").join("ab").join(hash)));
     }
 
     #[test]

--- a/crates/crab-cache-server/src/cache_store.rs
+++ b/crates/crab-cache-server/src/cache_store.rs
@@ -92,6 +92,7 @@ pub enum ObjectType {
     Pack,
     PackIndex,
     Metadata,
+    RefTransaction,
 }
 
 impl ObjectType {
@@ -102,6 +103,7 @@ impl ObjectType {
             Self::Shard => "shards",
             Self::Pack | Self::PackIndex => "packs",
             Self::Metadata => "metadata",
+            Self::RefTransaction => "ref-transactions",
         }
     }
 
@@ -112,6 +114,7 @@ impl ObjectType {
             Self::Pack => "pack",
             Self::PackIndex => "pack_index",
             Self::Metadata => "metadata",
+            Self::RefTransaction => "ref_transaction",
         }
     }
 
@@ -122,6 +125,7 @@ impl ObjectType {
             Self::Pack => 3,
             Self::PackIndex => 4,
             Self::Metadata => 5,
+            Self::RefTransaction => 6,
         }
     }
 
@@ -132,6 +136,7 @@ impl ObjectType {
             3 => Some(Self::Pack),
             4 => Some(Self::PackIndex),
             5 => Some(Self::Metadata),
+            6 => Some(Self::RefTransaction),
             _ => None,
         }
     }
@@ -144,6 +149,7 @@ impl ObjectType {
             "pack" => Some(Self::Pack),
             "pack-index" | "pack_index" | "packindex" => Some(Self::PackIndex),
             "metadata" => Some(Self::Metadata),
+            "ref-transaction" | "ref_transaction" | "reftransaction" => Some(Self::RefTransaction),
             _ => None,
         }
     }
@@ -211,7 +217,7 @@ impl CacheEvictionCounters {
             ObjectType::Shard => &self.shard,
             ObjectType::Pack => &self.pack,
             ObjectType::PackIndex => &self.pack_index,
-            ObjectType::Metadata => &self.metadata,
+            ObjectType::Metadata | ObjectType::RefTransaction => &self.metadata,
         };
         counter.fetch_add(1, Ordering::Relaxed);
     }
@@ -673,12 +679,13 @@ impl CacheStore {
 
     /// Verify cached immutable objects whose key is their content identity.
     ///
-    /// Xorbs use aggregate xorb identity from metadata, while shards are keyed
-    /// by the Blake3/Merkle content hash of their serialized bytes.
+    /// Xorbs use aggregate xorb identity from metadata, shards use the
+    /// Blake3/Merkle content hash, and ref transactions use plain Blake3.
     pub fn verify_cached_object_identity(&self, key: &ServerObjectKey) -> Result<bool> {
         match key.object_type {
             ObjectType::Xorb => self.verify_cached_xorb_identity(key),
             ObjectType::Shard => self.verify_cached_shard_identity(key),
+            ObjectType::RefTransaction => self.verify_cached_ref_transaction_identity(key),
             _ => Ok(true),
         }
     }
@@ -714,6 +721,46 @@ impl CacheStore {
             expected = %expected,
             actual = %actual,
             "cached shard identity mismatch, evicting"
+        );
+        self.evict_invalid_cache_file(key, &path)?;
+        Ok(false)
+    }
+
+    fn verify_cached_ref_transaction_identity(&self, key: &ServerObjectKey) -> Result<bool> {
+        debug_assert_eq!(key.object_type, ObjectType::RefTransaction);
+
+        let path = self.object_path(key);
+        let expected = match blake3::Hash::from_hex(&key.hash) {
+            Ok(hash) => hash,
+            Err(_) => return Ok(false),
+        };
+        let data = match std::fs::read(&path) {
+            Ok(data) => data,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                self.remove_metadata_for_missing_file(key, &path)?;
+                return Ok(false);
+            }
+            Err(e) => {
+                return Err(CacheServiceError::InternalError(
+                    format!(
+                        "failed to read cached ref transaction {}: {e}",
+                        path.display()
+                    )
+                    .into(),
+                ));
+            }
+        };
+
+        let actual = blake3::hash(&data);
+        if actual == expected {
+            return Ok(true);
+        }
+
+        warn!(
+            path = %path.display(),
+            expected = %expected.to_hex(),
+            actual = %actual.to_hex(),
+            "cached ref transaction identity mismatch, evicting"
         );
         self.evict_invalid_cache_file(key, &path)?;
         Ok(false)
@@ -1069,7 +1116,7 @@ impl CacheStore {
                 Some(ObjectType::Xorb) => xorb_count += 1,
                 Some(ObjectType::Shard) => shard_count += 1,
                 Some(ObjectType::Pack | ObjectType::PackIndex) => pack_count += 1,
-                Some(ObjectType::Metadata) => metadata_count += 1,
+                Some(ObjectType::Metadata | ObjectType::RefTransaction) => metadata_count += 1,
                 None => {}
             }
         }
@@ -1632,11 +1679,12 @@ fn reconcile_unindexed_files(
     initial_bytes: &mut u64,
     integrity: &mut CacheIntegrityStats,
 ) -> Result<()> {
-    for dir_name in ["xorbs", "shards", "packs", "metadata"] {
+    for dir_name in ["xorbs", "shards", "packs", "metadata", "ref-transactions"] {
         let recoverable_type = match dir_name {
             "xorbs" => Some(ObjectType::Xorb),
             "shards" => Some(ObjectType::Shard),
             "metadata" => Some(ObjectType::Metadata),
+            "ref-transactions" => Some(ObjectType::RefTransaction),
             _ => None,
         };
         let object_dir = root.join(dir_name);
@@ -1834,6 +1882,14 @@ fn storage_id_bytes(key: &ServerObjectKey) -> Option<[u8; 32]> {
             hasher.update(key.hash.as_bytes());
             Some(*hasher.finalize().as_bytes())
         }
+        ObjectType::RefTransaction => {
+            let hash = parse_hash_hex(&key.hash)?;
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(&[key.object_type.as_u8()]);
+            hasher.update(b"\0");
+            hasher.update(&hash);
+            Some(*hasher.finalize().as_bytes())
+        }
     }
 }
 
@@ -1889,7 +1945,7 @@ fn epoch_millis() -> u64 {
 /// they're evicted last.
 fn eviction_type_weight(type_byte: u8) -> u8 {
     match type_byte {
-        3..=5 => 1, // Pack / PackIndex / Metadata
+        3..=6 => 1, // Pack / PackIndex / Metadata / RefTransaction
         1 => 3,     // Shard — evict last
         _ => 0,     // Xorb and unknown values — evict first
     }
@@ -1986,6 +2042,7 @@ mod tests {
             ObjectType::Pack,
             ObjectType::PackIndex,
             ObjectType::Metadata,
+            ObjectType::RefTransaction,
         ] {
             assert_eq!(ObjectType::from_u8(ot.as_u8()), Some(ot));
         }
@@ -1999,6 +2056,7 @@ mod tests {
         assert_eq!(ObjectType::Pack.dir_name(), "packs");
         assert_eq!(ObjectType::PackIndex.dir_name(), "packs");
         assert_eq!(ObjectType::Metadata.dir_name(), "metadata");
+        assert_eq!(ObjectType::RefTransaction.dir_name(), "ref-transactions");
     }
 
     #[test]
@@ -2187,6 +2245,31 @@ mod tests {
         assert_eq!(stats.runtime_integrity.missing_files_repaired, 0);
         assert_eq!(stats.runtime_integrity.invalid_objects_evicted, 1);
         assert_eq!(stats.runtime_integrity.metadata_entries_recreated, 0);
+    }
+
+    #[test]
+    fn verify_cached_object_identity_evicts_corrupt_ref_transaction() {
+        let store = test_store();
+        let data = Bytes::from_static(br#"{"version":1,"edits":[]}"#);
+        let hash = blake3::hash(&data);
+        let key = ServerObjectKey {
+            bucket: "b".into(),
+            repo_path: "r".into(),
+            object_type: ObjectType::RefTransaction,
+            hash: hash.to_hex().to_string(),
+        };
+
+        store.put_unverified(&key, data).unwrap();
+        assert!(store.verify_cached_object_identity(&key).unwrap());
+
+        std::fs::write(store.object_path(&key), b"corrupt transaction").unwrap();
+
+        assert!(!store.verify_cached_object_identity(&key).unwrap());
+        assert!(!store.object_path(&key).exists());
+        assert_eq!(store.current_bytes(), 0);
+        let stats = store.stats().unwrap();
+        assert_eq!(stats.metadata_count, 0);
+        assert_eq!(stats.runtime_integrity.invalid_objects_evicted, 1);
     }
 
     #[test]
@@ -3086,6 +3169,10 @@ mod tests {
         assert_eq!(
             ObjectType::from_name("metadata"),
             Some(ObjectType::Metadata)
+        );
+        assert_eq!(
+            ObjectType::from_name("ref-transaction"),
+            Some(ObjectType::RefTransaction)
         );
         assert_eq!(ObjectType::from_name("unknown"), None);
     }

--- a/crates/crab-cache-server/src/evidence.rs
+++ b/crates/crab-cache-server/src/evidence.rs
@@ -28,6 +28,7 @@ const EXPECTED_IMMUTABLE_ROUTE_PATTERNS: &[&str] = &[
     "{repo}/packs/pack-{id}.idx",
     "{repo}/generated-packs/v1/artifacts/{first-two-hex}/{hash}.pack",
     "{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json",
+    "{repo}/refs/journal/transactions/{hash}.json",
     "{repo}/file_index_db/compacted/*.sst",
     "{repo}/file_index_db/manifest/*.manifest",
     "{repo}/file_index_db/wal/*.sst",

--- a/crates/crab-cache-server/src/handlers.rs
+++ b/crates/crab-cache-server/src/handlers.rs
@@ -349,7 +349,10 @@ pub async fn read_object(
     if cached_object_valid_for_read(&state, &cache_key, &hash) {
         if matches!(
             object_type,
-            ObjectType::Pack | ObjectType::PackIndex | ObjectType::Metadata
+            ObjectType::Pack
+                | ObjectType::PackIndex
+                | ObjectType::Metadata
+                | ObjectType::RefTransaction
         ) {
             // Keep large immutable cache hits file-backed so a pack does not
             // consume one response-sized allocation on the cache server.
@@ -777,7 +780,44 @@ async fn validate_staged_cache_object(
                 Err(CacheServiceError::HashMismatch { expected, actual })
             }
         }
+        ObjectType::RefTransaction => {
+            verify_streamed_ref_transaction_body(staged.temp_path.as_ref(), &key.hash).await
+        }
         ObjectType::Pack | ObjectType::PackIndex | ObjectType::Metadata => Ok(()),
+    }
+}
+
+async fn verify_streamed_ref_transaction_body(
+    path: &FsPath,
+    expected_hash: &str,
+) -> std::result::Result<(), CacheServiceError> {
+    let expected =
+        blake3::Hash::from_hex(expected_hash).map_err(|_| CacheServiceError::BadRequest {
+            reason: format!("invalid ref transaction hash: {expected_hash}"),
+        })?;
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| push_warming_temp_io_cache_error("open", e))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .await
+            .map_err(|e| push_warming_temp_io_cache_error("hash", e))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let actual = hasher.finalize();
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(CacheServiceError::HashMismatch {
+            expected: expected.to_hex().to_string(),
+            actual: actual.to_hex().to_string(),
+        })
     }
 }
 
@@ -1359,6 +1399,7 @@ fn check_mutable_read_action(
 /// - `.crab/shards/ab/abcdef...`  → Shard (CLI global path)
 /// - `org/repo/packs/sha.pack`        → Pack
 /// - `org/repo/packs/sha.idx`         → PackIndex
+/// - ref-journal transaction bodies   → RefTransaction
 /// - versioned SlateDB metadata objects → Metadata
 fn parse_object_path(path: &str) -> Option<(String, String, ObjectType, String)> {
     let parsed = parse_cache_object_path(path)?;
@@ -1368,6 +1409,7 @@ fn parse_object_path(path: &str) -> Option<(String, String, ObjectType, String)>
         CacheObjectKind::Pack => ObjectType::Pack,
         CacheObjectKind::PackIndex => ObjectType::PackIndex,
         CacheObjectKind::GeneratedPack => ObjectType::Pack,
+        CacheObjectKind::RefTransaction => ObjectType::RefTransaction,
         CacheObjectKind::Metadata => ObjectType::Metadata,
     };
     Some((
@@ -1585,7 +1627,10 @@ async fn fetch_and_cache_data_locked(
     if cached_object_valid_for_read(state, key, expected_hash) {
         if matches!(
             key.object_type,
-            ObjectType::Pack | ObjectType::PackIndex | ObjectType::Metadata
+            ObjectType::Pack
+                | ObjectType::PackIndex
+                | ObjectType::Metadata
+                | ObjectType::RefTransaction
         ) {
             match state.cache_store.get_file(key) {
                 Ok(Some(cached)) => {
@@ -1693,7 +1738,10 @@ async fn commit_origin_fill_or_read_temp(
             }
             if matches!(
                 key.object_type,
-                ObjectType::Pack | ObjectType::PackIndex | ObjectType::Metadata
+                ObjectType::Pack
+                    | ObjectType::PackIndex
+                    | ObjectType::Metadata
+                    | ObjectType::RefTransaction
             ) {
                 return match state.cache_store.get_file(key) {
                     Ok(Some(cached)) => Ok(CachedFetchBody::OpenFile {
@@ -1760,7 +1808,10 @@ async fn read_staged_temp_body(
 }
 
 fn is_integrity_checked_object(object_type: ObjectType) -> bool {
-    matches!(object_type, ObjectType::Shard | ObjectType::Xorb)
+    matches!(
+        object_type,
+        ObjectType::Shard | ObjectType::Xorb | ObjectType::RefTransaction
+    )
 }
 
 async fn ingest_cached_shard(state: &AppState, shard_hash: &str, data: &Bytes) {
@@ -3070,6 +3121,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_object_rejects_corrupt_ref_transaction_body() {
+        let valid = Bytes::from_static(br#"{"version":1,"edits":[]}"#);
+        let hash = blake3::hash(&valid);
+        let path = format!("org/repo/refs/journal/transactions/{}.json", hash.to_hex());
+        let key = ServerObjectKey {
+            bucket: String::new(),
+            repo_path: "org/repo".to_string(),
+            object_type: ObjectType::RefTransaction,
+            hash: hash.to_hex().to_string(),
+        };
+        let TestDedupState { state, _tempdir } = test_dedup_state();
+        let state = Arc::new(state);
+
+        let response = write_object(
+            State(Arc::clone(&state)),
+            Path(path),
+            axum::Extension(test_identity()),
+            Body::from(Bytes::from_static(b"corrupt transaction")),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert!(state.cache_store.get(&key).unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn write_object_waits_for_body_permit_before_polling_body() {
         let TestDedupState {
             mut state,
@@ -3169,6 +3246,17 @@ mod tests {
         assert_eq!(repo, "org/repo");
         assert_eq!(ot, ObjectType::PackIndex);
         assert_eq!(hash, "pack-abc");
+    }
+
+    #[test]
+    fn parse_ref_transaction_path() {
+        let hash = hex_hash('d');
+        let path = format!("org/repo/refs/journal/transactions/{hash}.json");
+        let (bucket, repo, object_type, identity) = parse_object_path(&path).unwrap();
+        assert_eq!(bucket, "");
+        assert_eq!(repo, "org/repo");
+        assert_eq!(object_type, ObjectType::RefTransaction);
+        assert_eq!(identity, hash);
     }
 
     #[test]

--- a/crates/crab-cache-server/src/metrics.rs
+++ b/crates/crab-cache-server/src/metrics.rs
@@ -67,7 +67,7 @@ impl TrafficByObjectTypeCounters {
             ObjectType::Shard => &self.shard,
             ObjectType::Pack => &self.pack,
             ObjectType::PackIndex => &self.pack_index,
-            ObjectType::Metadata => &self.metadata,
+            ObjectType::Metadata | ObjectType::RefTransaction => &self.metadata,
         }
     }
 

--- a/crates/crab-cache-server/tests/cache_server_preflight_cli.rs
+++ b/crates/crab-cache-server/tests/cache_server_preflight_cli.rs
@@ -1422,11 +1422,11 @@ fn evidence_summarize_reports_customer_proof_without_config() {
     );
     assert_eq!(
         summary["routes"]["expected_immutable_route_count"].as_u64(),
-        Some(14)
+        Some(immutable_route_patterns().len() as u64)
     );
     assert_eq!(
         summary["routes"]["immutable_route_count"].as_u64(),
-        Some(14)
+        Some(immutable_route_patterns().len() as u64)
     );
     assert_eq!(
         summary["routes"]["expected_mutable_route_count"].as_u64(),
@@ -2128,6 +2128,7 @@ fn immutable_route_patterns() -> Vec<&'static str> {
         "{repo}/packs/pack-{id}.idx",
         "{repo}/generated-packs/v1/artifacts/{first-two-hex}/{hash}.pack",
         "{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json",
+        "{repo}/refs/journal/transactions/{hash}.json",
         "{repo}/file_index_db/compacted/*.sst",
         "{repo}/file_index_db/manifest/*.manifest",
         "{repo}/file_index_db/wal/*.sst",

--- a/crates/crab-cache-store/src/lib.rs
+++ b/crates/crab-cache-store/src/lib.rs
@@ -1513,7 +1513,7 @@ fn immutable_read_limit(path: &Path) -> Option<u64> {
         CacheKey::Chunk(_) => Some(MAX_CACHE_CHUNK_BYTES),
         CacheKey::Shard(_) => Some(MAX_CACHE_SHARD_BYTES),
         CacheKey::Xorb(_) => Some(MAX_XORB_SIZE as u64),
-        CacheKey::Stage(_) | CacheKey::Manifest { .. } => None,
+        CacheKey::RefTransaction(_) | CacheKey::Stage(_) | CacheKey::Manifest { .. } => None,
     }
 }
 
@@ -2460,6 +2460,40 @@ mod tests {
 
     #[cfg(feature = "remote-client")]
     #[tokio::test]
+    async fn ref_transaction_uses_verified_cache_service_body_across_fresh_clients() {
+        let server = start_test_cache_server().await;
+        let body = Bytes::from_static(br#"{"version":1,"edits":[]}"#);
+        let hash = blake3::hash(&body);
+        let path = Path::from(format!(
+            "org/repo/refs/journal/transactions/{}.json",
+            hash.to_hex()
+        ));
+        server
+            .origin
+            .put(&path, PutPayload::from_bytes(body.clone()))
+            .await
+            .unwrap();
+
+        let config = cache_service_config(server.addr);
+        for client in ["transaction-client-a", "transaction-client-b"] {
+            let store = CachingStore::new_with_local_cache(
+                Store::new(Arc::new(InMemory::new())),
+                &config,
+                Arc::new(LocalCache::new(server._tempdir.path().join(client))),
+            )
+            .unwrap();
+            assert_eq!(store.get_with_etag(&path).await.unwrap().0, body);
+        }
+
+        assert_eq!(
+            server.origin_get_count.load(Ordering::Relaxed),
+            1,
+            "fresh clients should reuse the server's verified transaction"
+        );
+    }
+
+    #[cfg(feature = "remote-client")]
+    #[tokio::test]
     async fn download_to_path_uses_cache_service_for_pack_bodies() {
         let server = start_test_cache_server().await;
         let body = Bytes::from_static(b"pack body served from cache");
@@ -3320,6 +3354,39 @@ mod tests {
         assert_eq!(got, good_body);
         let cached = cache
             .get_or_fetch(&CacheKey::Xorb(hash), || async {
+                panic!("verified origin fallback should populate local cache")
+            })
+            .await
+            .unwrap();
+        assert_eq!(cached, good_body);
+    }
+
+    #[cfg(feature = "remote-client")]
+    #[tokio::test]
+    async fn get_with_etag_rejects_bad_ref_transaction_cache_service_body() {
+        let server = start_malformed_object_server(b"bad transaction body", false).await;
+        let good_body = Bytes::from_static(br#"{"version":1,"edits":[]}"#);
+        let hash = blake3::hash(&good_body);
+        let path = Path::from(format!(
+            "org/repo/refs/journal/transactions/{}.json",
+            hash.to_hex()
+        ));
+        let origin = origin_store();
+        origin.put(&path, good_body.clone()).await.unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = Arc::new(LocalCache::new(tempdir.path().join("client-cache")));
+        let store = CachingStore::new_with_local_cache(
+            origin,
+            cache_service_config(server.addr),
+            Arc::clone(&cache),
+        )
+        .unwrap();
+
+        let (got, _) = store.get_with_etag(&path).await.unwrap();
+
+        assert_eq!(got, good_body);
+        let cached = cache
+            .get_or_fetch(&CacheKey::RefTransaction(hash), || async {
                 panic!("verified origin fallback should populate local cache")
             })
             .await
@@ -4454,6 +4521,38 @@ mod tests {
         let cs = CachingStore::new(origin, no_cache_config()).unwrap();
         let (got, _) = cs.get_with_etag(&path).await.unwrap();
         assert_eq!(got, body);
+    }
+
+    #[tokio::test]
+    async fn ref_transaction_is_hash_verified_and_reused_without_an_origin_read() {
+        let body = Bytes::from_static(br#"{"version":1,"edits":[]}"#);
+        let hash = blake3::hash(&body);
+        let path = Path::from(format!(
+            "repo/refs/journal/transactions/{}.json",
+            hash.to_hex()
+        ));
+        let inner = Arc::new(InMemory::new());
+        inner
+            .put(&path, PutPayload::from_bytes(body.clone()))
+            .await
+            .unwrap();
+        let counting_origin = Arc::new(CountingObjectStore::new(inner));
+        let origin = Store::new(Arc::clone(&counting_origin) as Arc<dyn ObjectStore>);
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = Arc::new(LocalCache::new(tempdir.path().join("cache")));
+        let store =
+            CachingStore::new_with_local_cache(origin, no_cache_config(), Arc::clone(&cache))
+                .unwrap();
+
+        assert_eq!(store.get_with_etag(&path).await.unwrap().0, body);
+        assert_eq!(store.get_with_etag(&path).await.unwrap().0, body);
+
+        assert_eq!(counting_origin.counts().body_requests(), 1);
+        assert!(
+            cache
+                .contains_verified(&CacheKey::RefTransaction(hash))
+                .await
+        );
     }
 
     #[tokio::test]

--- a/crates/crab-cache/src/catalog/removal.rs
+++ b/crates/crab-cache/src/catalog/removal.rs
@@ -30,6 +30,7 @@ pub(crate) struct PayloadRead {
     display_root: PathBuf,
     relative: PathBuf,
     original: std::fs::File,
+    modified: Option<std::time::SystemTime>,
 }
 
 impl PayloadRead {
@@ -39,10 +40,23 @@ impl PayloadRead {
         crate::private_fs::run_blocking(&tokio_util::sync::CancellationToken::new(), move |_| {
             let root = PinnedRoot::open(&display_root)?;
             let original = root.open_read(&relative)?;
+            let modified = original
+                .metadata()
+                .ok()
+                .and_then(|metadata| metadata.modified().ok());
             // Only this duplicate reads the shared cursor. The retained
             // descriptor pins identity until validation and repair finish.
             let reader = tokio::fs::File::from_std(original.try_clone()?);
-            Ok((Self { root, display_root, relative, original }, reader))
+            Ok((
+                Self {
+                    root,
+                    display_root,
+                    relative,
+                    original,
+                    modified,
+                },
+                reader,
+            ))
         })
         .await
         .inspect_err(|error| {
@@ -89,6 +103,20 @@ impl PayloadRead {
             self.original.set_modified(std::time::SystemTime::now())
         })
         .await;
+    }
+
+    pub(crate) async fn touch_if_stale(self, minimum_age: std::time::Duration) {
+        // Repeated coherent-snapshot reads may hit the same immutable object
+        // several times in one operation. Preserve LRU recency without turning
+        // each verified read into a filesystem metadata write.
+        if self
+            .modified
+            .and_then(|modified| modified.elapsed().ok())
+            .is_some_and(|age| age < minimum_age)
+        {
+            return;
+        }
+        self.touch().await;
     }
 
     pub(crate) async fn discard(self) -> Result<()> {

--- a/crates/crab-cache/src/clean.rs
+++ b/crates/crab-cache/src/clean.rs
@@ -83,7 +83,9 @@ pub(crate) fn entry_kind(relative: &Path) -> EntryKind {
 
 pub(crate) fn object_entry_kind(parts: &[&str]) -> EntryKind {
     match parts {
-        ["chunks" | "xorbs" | "shards" | "stages" | "manifests" | "hints"] => EntryKind::Directory,
+        ["chunks" | "xorbs" | "shards" | "ref-transactions" | "stages" | "manifests" | "hints"] => {
+            EntryKind::Directory
+        }
         ["hints", "clean-bloom.bin"] => EntryKind::Payload,
         ["manifests", name]
             if [".json", ".etag"].iter().any(|suffix| {
@@ -93,14 +95,15 @@ pub(crate) fn object_entry_kind(parts: &[&str]) -> EntryKind {
         {
             EntryKind::Payload
         }
-        ["chunks" | "xorbs" | "shards" | "stages", prefix] if hex(prefix, 2) => {
-            EntryKind::Directory
-        }
-        ["chunks" | "xorbs" | "shards" | "stages", prefix, hash]
-            if hex(prefix, 2) && hex(hash, 64) && hash.starts_with(prefix) =>
-        {
-            EntryKind::Payload
-        }
+        [
+            "chunks" | "xorbs" | "shards" | "ref-transactions" | "stages",
+            prefix,
+        ] if hex(prefix, 2) => EntryKind::Directory,
+        [
+            "chunks" | "xorbs" | "shards" | "ref-transactions" | "stages",
+            prefix,
+            hash,
+        ] if hex(prefix, 2) && hex(hash, 64) && hash.starts_with(prefix) => EntryKind::Payload,
         _ => EntryKind::Retain,
     }
 }
@@ -161,6 +164,7 @@ mod tests {
             format!("chunks/ab/{hash}"),
             format!("shards/ab/{hash}"),
             format!("xorbs/ab/{hash}"),
+            format!("ref-transactions/ab/{hash}"),
             format!("stages/ab/{hash}"),
             "manifests/repo.json".into(),
             "manifests/repo.etag".into(),
@@ -189,14 +193,14 @@ mod tests {
         let preview = clean_cache(&root, true, &CancellationToken::new())
             .await
             .unwrap();
-        assert_eq!((preview.files_removed, preview.bytes_reclaimed), (6, 42));
+        assert_eq!((preview.files_removed, preview.bytes_reclaimed), (7, 49));
         for path in &payloads {
             assert_eq!(std::fs::read(root.join(path)).unwrap(), b"fixture");
         }
         let report = clean_cache(&root, false, &CancellationToken::new())
             .await
             .unwrap();
-        assert_eq!((report.files_removed, report.bytes_reclaimed), (6, 42));
+        assert_eq!((report.files_removed, report.bytes_reclaimed), (7, 49));
         assert_eq!(report.retained_entries, retained.len() as u64);
         for path in retained {
             assert_eq!(

--- a/crates/crab-cache/src/key.rs
+++ b/crates/crab-cache/src/key.rs
@@ -12,6 +12,8 @@ pub enum CacheKey {
     Shard(MerkleHash),
     /// A content-addressed xorb.
     Xorb(MerkleHash),
+    /// An immutable ref-journal transaction identified by plain Blake3.
+    RefTransaction(blake3::Hash),
     /// A named manifest with an optional freshness token.
     Manifest { name: String, etag: Option<String> },
     /// A workflow stage cache entry.

--- a/crates/crab-cache/src/local_cache.rs
+++ b/crates/crab-cache/src/local_cache.rs
@@ -1,17 +1,19 @@
 //! Per-repo local cache with hash-verified reads and LRU eviction.
 //!
 //! Chunks and shards are stored under `{dir}/{hash[:2]}/{hash}` and
-//! verified via `compute_data_hash` on every read. A mismatch evicts
-//! the stale entry and refetches via the caller-supplied closure.
+//! verified via `compute_data_hash` on every read. Ref-journal transactions
+//! use the same layout but retain their native plain-Blake3 identity. A
+//! mismatch evicts the stale entry and refetches via the caller-supplied closure.
 //!
 //! Xorbs also use the two-level layout, but validate their aggregate xorb
 //! identity from serialized metadata instead of hashing the whole object.
 //!
 //! LRU eviction uses file modification time (mtime) as the access
-//! timestamp — object hits touch their retained file descriptor; manifest
-//! reads and metadata-only existence/size probes do not. Prune sorts
-//! by mtime ascending and removes the oldest entries until the cache
-//! fits within its configured byte budget.
+//! timestamp — object hits touch their retained file descriptor, with
+//! ref-transaction touches coalesced to avoid repeated snapshot write
+//! amplification. Manifest reads and metadata-only existence/size probes do
+//! not touch. Prune sorts by mtime ascending and removes the oldest entries
+//! until the cache fits within its configured byte budget.
 
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
@@ -49,6 +51,7 @@ const HASH_BYTES: usize = 32;
 const XORB_INDEX_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 const XORB_INDEX_OPEN_RETRY_DELAYS_MS: [u64; 4] = [5, 20, 50, 100];
 const CACHE_FILL_LOCK_STRIPES: usize = 256;
+const REF_TRANSACTION_TOUCH_INTERVAL: Duration = Duration::from_secs(60);
 pub const XORB_INDEX_SCHEMA_VERSION: i64 = 1;
 
 fn new_fill_locks() -> Box<[tokio::sync::Mutex<()>]> {
@@ -66,6 +69,8 @@ pub struct PruneStats {
     pub shards_evicted: u64,
     /// Number of xorb files evicted.
     pub xorbs_evicted: u64,
+    /// Number of immutable ref-journal transaction files evicted.
+    pub ref_transactions_evicted: u64,
     /// Total bytes freed across all evictions.
     pub bytes_freed: u64,
     /// Cache objects pruned or selected for pruning.
@@ -87,6 +92,7 @@ pub enum PruneObjectKind {
     Chunk,
     Shard,
     Xorb,
+    RefTransaction,
 }
 
 impl PruneObjectKind {
@@ -96,6 +102,7 @@ impl PruneObjectKind {
             Self::Chunk => "chunk",
             Self::Shard => "shard",
             Self::Xorb => "xorb",
+            Self::RefTransaction => "ref-transaction",
         }
     }
 }
@@ -112,7 +119,10 @@ impl PruneStats {
     /// Total object count pruned or selected for pruning.
     #[must_use]
     pub fn objects_evicted(&self) -> u64 {
-        self.chunks_evicted + self.shards_evicted + self.xorbs_evicted
+        self.chunks_evicted
+            + self.shards_evicted
+            + self.xorbs_evicted
+            + self.ref_transactions_evicted
     }
 }
 
@@ -142,6 +152,10 @@ pub struct CacheStats {
     pub xorb_bytes: u64,
     /// Number of cached xorb files.
     pub xorb_count: u64,
+    /// Total bytes used by immutable ref-journal transactions.
+    pub ref_transaction_bytes: u64,
+    /// Number of cached immutable ref-journal transactions.
+    pub ref_transaction_count: u64,
     /// Total bytes used by cached workflow stage entries.
     pub stage_bytes: u64,
     /// Number of cached workflow stage entries.
@@ -388,6 +402,10 @@ impl LocalCache {
                 self.try_read_verified_limited(&self.hash_path(key), hash, max_bytes)
                     .await
             }
+            CacheKey::RefTransaction(hash) => {
+                self.try_read_ref_transaction_limited(&self.hash_path(key), hash, max_bytes)
+                    .await
+            }
             CacheKey::Xorb(hash) => {
                 self.try_read_xorb_bytes_limited(&self.hash_path(key), hash, max_bytes)
                     .await
@@ -542,9 +560,11 @@ impl LocalCache {
     #[doc(hidden)]
     pub async fn put_unchecked_for_test(&self, key: &CacheKey, data: &[u8]) -> Result<()> {
         let path = match key {
-            CacheKey::Chunk(_) | CacheKey::Shard(_) | CacheKey::Xorb(_) | CacheKey::Stage(_) => {
-                self.hash_path(key)
-            }
+            CacheKey::Chunk(_)
+            | CacheKey::Shard(_)
+            | CacheKey::Xorb(_)
+            | CacheKey::RefTransaction(_)
+            | CacheKey::Stage(_) => self.hash_path(key),
             CacheKey::Manifest { name, .. } => self.manifest_data_path(name),
         };
         self.atomic_write(&path, data).await
@@ -558,6 +578,7 @@ impl LocalCache {
         enforce_key_size(key, data.len() as u64)?;
         match key {
             CacheKey::Chunk(hash) | CacheKey::Shard(hash) => verify_data_hash(data, hash),
+            CacheKey::RefTransaction(hash) => verify_blake3_hash(data, hash),
             CacheKey::Xorb(hash) => verify_xorb_payload(&Bytes::copy_from_slice(data), hash),
             CacheKey::Stage(_) | CacheKey::Manifest { .. } => Ok(()),
         }
@@ -568,6 +589,7 @@ impl LocalCache {
         enforce_key_size(key, data.len() as u64)?;
         match key {
             CacheKey::Chunk(hash) | CacheKey::Shard(hash) => verify_data_hash(data, hash),
+            CacheKey::RefTransaction(hash) => verify_blake3_hash(data, hash),
             CacheKey::Xorb(hash) => verify_xorb_payload(data, hash),
             CacheKey::Stage(_) | CacheKey::Manifest { .. } => Ok(()),
         }
@@ -576,9 +598,11 @@ impl LocalCache {
     /// Check if a key exists in cache (does not verify hash).
     pub async fn contains(&self, key: &CacheKey) -> bool {
         let path = match key {
-            CacheKey::Chunk(_) | CacheKey::Shard(_) | CacheKey::Xorb(_) | CacheKey::Stage(_) => {
-                self.hash_path(key)
-            }
+            CacheKey::Chunk(_)
+            | CacheKey::Shard(_)
+            | CacheKey::Xorb(_)
+            | CacheKey::RefTransaction(_)
+            | CacheKey::Stage(_) => self.hash_path(key),
             CacheKey::Manifest { name, .. } => self.manifest_data_path(name),
         };
         private_cache_file_metadata(&self.root, &path)
@@ -591,9 +615,11 @@ impl LocalCache {
     /// Return the size of an existing cache entry without reading its body.
     pub async fn cached_size(&self, key: &CacheKey) -> Result<Option<u64>> {
         let path = match key {
-            CacheKey::Chunk(_) | CacheKey::Shard(_) | CacheKey::Xorb(_) | CacheKey::Stage(_) => {
-                self.hash_path(key)
-            }
+            CacheKey::Chunk(_)
+            | CacheKey::Shard(_)
+            | CacheKey::Xorb(_)
+            | CacheKey::RefTransaction(_)
+            | CacheKey::Stage(_) => self.hash_path(key),
             CacheKey::Manifest { name, .. } => self.manifest_data_path(name),
         };
         Ok(private_cache_file_metadata(&self.root, &path)
@@ -620,6 +646,10 @@ impl LocalCache {
                 let path = self.hash_path(key);
                 self.try_verify_xorb_payload_file(&path, hash).await
             }
+            CacheKey::RefTransaction(hash) => self
+                .try_read_ref_transaction_limited(&self.hash_path(key), hash, None)
+                .await
+                .is_some(),
             CacheKey::Stage(_) | CacheKey::Manifest { .. } => self.contains(key).await,
         }
     }
@@ -724,9 +754,11 @@ impl LocalCache {
     /// Returns [`CacheError::Io`] when the entry exists but cannot be removed.
     pub async fn evict(&self, key: &CacheKey) -> Result<()> {
         let path = match key {
-            CacheKey::Chunk(_) | CacheKey::Shard(_) | CacheKey::Xorb(_) | CacheKey::Stage(_) => {
-                self.hash_path(key)
-            }
+            CacheKey::Chunk(_)
+            | CacheKey::Shard(_)
+            | CacheKey::Xorb(_)
+            | CacheKey::RefTransaction(_)
+            | CacheKey::Stage(_) => self.hash_path(key),
             CacheKey::Manifest { name, .. } => self.manifest_data_path(name),
         };
         crate::catalog::remove_file(&self.root, &path).await?;
@@ -843,6 +875,13 @@ impl LocalCache {
             CacheKey::Chunk(h) => self.merkle_path("chunks", h),
             CacheKey::Shard(h) => self.merkle_path("shards", h),
             CacheKey::Xorb(h) => self.merkle_path("xorbs", h),
+            CacheKey::RefTransaction(h) => {
+                let hex = h.to_hex();
+                self.root
+                    .join("ref-transactions")
+                    .join(&hex[..2])
+                    .join(hex.as_str())
+            }
             CacheKey::Stage(h) => {
                 let hex = h.as_hex();
                 self.root.join("stages").join(&hex[..2]).join(&hex)
@@ -882,6 +921,22 @@ impl LocalCache {
         .await
         .ok()??;
         entry.touch().await;
+        Some(data)
+    }
+
+    async fn try_read_ref_transaction_limited(
+        &self,
+        path: &Path,
+        expected: &blake3::Hash,
+        max_bytes: Option<u64>,
+    ) -> Option<Bytes> {
+        let limit = max_bytes.unwrap_or(u64::MAX);
+        let (data, entry) = read_file_bounded_result(&self.root, path, limit, |data| {
+            verify_blake3_hash(data, expected)
+        })
+        .await
+        .ok()??;
+        entry.touch_if_stale(REF_TRANSACTION_TOUCH_INTERVAL).await;
         Some(data)
     }
 
@@ -999,6 +1054,7 @@ fn cache_family_for_path(root: &Path, path: &Path) -> &'static str {
         Some("chunks") => "chunk",
         Some("xorbs") => "xorb",
         Some("shards") => "shard",
+        Some("ref-transactions") => "ref-transaction",
         Some("manifests") => "manifest",
         Some("stages") => "stage",
         _ => "other",
@@ -1045,6 +1101,7 @@ fn effective_read_limit(key: &CacheKey, requested: Option<u64>) -> Option<u64> {
         CacheKey::Shard(_) => Some(MAX_CACHE_SHARD_BYTES),
         CacheKey::Xorb(_) => Some(MAX_XORB_SIZE as u64),
         CacheKey::Chunk(_) => Some(MAX_CACHE_CHUNK_BYTES),
+        CacheKey::RefTransaction(_) => None,
         CacheKey::Stage(_) => Some(MAX_CACHE_STAGE_BYTES),
         CacheKey::Manifest { .. } => Some(MAX_CACHE_MANIFEST_BYTES),
     };
@@ -1121,6 +1178,17 @@ fn verify_data_hash(data: &[u8], expected: &MerkleHash) -> Result<()> {
     Err(CacheError::HashMismatch {
         requested: expected.hex(),
         actual: actual.hex(),
+    })
+}
+
+fn verify_blake3_hash(data: &[u8], expected: &blake3::Hash) -> Result<()> {
+    let actual = blake3::hash(data);
+    if actual == *expected {
+        return Ok(());
+    }
+    Err(CacheError::HashMismatch {
+        requested: expected.to_hex().to_string(),
+        actual: actual.to_hex().to_string(),
     })
 }
 
@@ -1755,6 +1823,44 @@ mod tests {
         .unwrap();
         assert_eq!(report.bytes_reclaimed, 4);
         assert!(reopened.read_clean_bloom().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn ref_transaction_hits_coalesce_recent_recency_writes() {
+        let (_dir, cache) = temp_cache();
+        let body: &[u8] = b"transaction";
+        let key = CacheKey::RefTransaction(blake3::hash(body));
+        cache.put(&key, body).await.unwrap();
+        let path = cache.hash_path(&key);
+        let recent = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+        assert_eq!(
+            cache
+                .get_or_fetch(&key, || async { unreachable!() })
+                .await
+                .unwrap(),
+            body
+        );
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            recent
+        );
+
+        let stale = std::time::UNIX_EPOCH + Duration::from_secs(1);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(stale)
+            .unwrap();
+        assert_eq!(
+            cache
+                .get_or_fetch(&key, || async { unreachable!() })
+                .await
+                .unwrap(),
+            body
+        );
+        assert!(std::fs::metadata(path).unwrap().modified().unwrap() > stale);
     }
 
     #[test]

--- a/crates/crab-cache/src/local_cache/maintenance.rs
+++ b/crates/crab-cache/src/local_cache/maintenance.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::clean::{EntryKind, object_entry_kind};
 use crate::private_fs::{FileStat, PinnedRoot, check_cancelled, with_pinned_root};
 
-const OBJECT_FAMILIES: &[&str] = &["chunks", "xorbs", "shards"];
+const OBJECT_FAMILIES: &[&str] = &["chunks", "xorbs", "shards", "ref-transactions"];
 const MAX_CACHE_LRU_ENTRIES: usize = 1_000_000;
 
 impl LocalCache {
@@ -97,15 +97,14 @@ impl LocalCache {
             move |root, cancel| {
                 let mut entries = collect_objects(root, cancel)?;
                 entries.sort_unstable_by(|a, b| {
-                    (a.kind == PruneObjectKind::Shard, a.modified, &a.path).cmp(&(
-                        b.kind == PruneObjectKind::Shard,
+                    (uses_shard_budget(a.kind), a.modified, &a.path).cmp(&(
+                        uses_shard_budget(b.kind),
                         b.modified,
                         &b.path,
                     ))
                 });
-                let boundary =
-                    entries.partition_point(|entry| entry.kind != PruneObjectKind::Shard);
-                let (large, shards) = entries.split_at(boundary);
+                let boundary = entries.partition_point(|entry| !uses_shard_budget(entry.kind));
+                let (large, metadata) = entries.split_at(boundary);
                 let mut removal =
                     crate::catalog::PayloadRemoval::open(Some(root), &root_path, options.dry_run)?;
                 let target = large_max.map_or(Ok(0), |max| {
@@ -121,19 +120,21 @@ impl LocalCache {
                     cancel,
                 )?;
                 if let Some(max) = shard_max {
-                    let target = total_bytes(shards)?.saturating_sub(max);
-                    let shard_stats = evict_oldest(
+                    let target = total_bytes(metadata)?.saturating_sub(max);
+                    let metadata_stats = evict_oldest(
                         root,
                         &mut removal,
                         &root_path,
-                        shards,
+                        metadata,
                         target,
                         options,
                         cancel,
                     )?;
-                    stats.shards_evicted = shard_stats.shards_evicted;
-                    stats.bytes_freed = stats.bytes_freed.saturating_add(shard_stats.bytes_freed);
-                    stats.entries.extend(shard_stats.entries);
+                    stats.shards_evicted = metadata_stats.shards_evicted;
+                    stats.ref_transactions_evicted = metadata_stats.ref_transactions_evicted;
+                    stats.bytes_freed =
+                        stats.bytes_freed.saturating_add(metadata_stats.bytes_freed);
+                    stats.entries.extend(metadata_stats.entries);
                 }
                 Ok(stats)
             },
@@ -194,13 +195,24 @@ impl LocalCache {
             let mut stats = CacheStats::default();
             visit_objects(
                 root,
-                &["chunks", "shards", "xorbs", "stages", "manifests"],
+                &[
+                    "chunks",
+                    "shards",
+                    "xorbs",
+                    "ref-transactions",
+                    "stages",
+                    "manifests",
+                ],
                 cancel,
                 &mut |path, metadata| {
                     let (bytes, count) = match family(path) {
                         Some("chunks") => (&mut stats.chunk_bytes, &mut stats.chunk_count),
                         Some("shards") => (&mut stats.shard_bytes, &mut stats.shard_count),
                         Some("xorbs") => (&mut stats.xorb_bytes, &mut stats.xorb_count),
+                        Some("ref-transactions") => (
+                            &mut stats.ref_transaction_bytes,
+                            &mut stats.ref_transaction_count,
+                        ),
                         Some("stages") => (&mut stats.stage_bytes, &mut stats.stage_count),
                         Some("manifests") => {
                             if path.extension().is_some_and(|ext| ext == "json") {
@@ -294,8 +306,16 @@ fn object_kind(path: &Path) -> Option<PruneObjectKind> {
         Some("chunks") => Some(PruneObjectKind::Chunk),
         Some("shards") => Some(PruneObjectKind::Shard),
         Some("xorbs") => Some(PruneObjectKind::Xorb),
+        Some("ref-transactions") => Some(PruneObjectKind::RefTransaction),
         _ => None,
     }
+}
+
+fn uses_shard_budget(kind: PruneObjectKind) -> bool {
+    matches!(
+        kind,
+        PruneObjectKind::Shard | PruneObjectKind::RefTransaction
+    )
 }
 
 fn object_hash(path: &Path) -> Result<MerkleHash> {
@@ -305,6 +325,16 @@ fn object_hash(path: &Path) -> Result<MerkleHash> {
         .ok_or_else(|| CacheError::UnsafeRoot {
             path: path.display().to_string(),
             reason: "object has no content-addressed filename".into(),
+        })
+}
+
+fn ref_transaction_hash(path: &Path) -> Result<blake3::Hash> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| blake3::Hash::from_hex(name).ok())
+        .ok_or_else(|| CacheError::UnsafeRoot {
+            path: path.display().to_string(),
+            reason: "ref transaction has no Blake3 filename".into(),
         })
 }
 
@@ -354,6 +384,7 @@ fn evict_oldest(
             PruneObjectKind::Chunk => stats.chunks_evicted += 1,
             PruneObjectKind::Shard => stats.shards_evicted += 1,
             PruneObjectKind::Xorb => stats.xorbs_evicted += 1,
+            PruneObjectKind::RefTransaction => stats.ref_transactions_evicted += 1,
         }
         stats.bytes_freed = stats.bytes_freed.saturating_add(bytes);
         if options.record_entries {
@@ -373,8 +404,29 @@ fn verify_file(
     kind: PruneObjectKind,
     cancel: &CancellationToken,
 ) -> Result<bool> {
-    let expected = object_hash(path)?;
     let bytes = file.metadata()?.len();
+    if kind == PruneObjectKind::RefTransaction {
+        let expected = ref_transaction_hash(path)?;
+        let mut actual = blake3::Hasher::new();
+        let mut buffer = vec![0; 64 * 1024];
+        let mut remaining = bytes;
+        loop {
+            check_cancelled(cancel)?;
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            let Some(rest) = remaining.checked_sub(read as u64) else {
+                return Ok(false);
+            };
+            remaining = rest;
+            actual.update(&buffer[..read]);
+        }
+        return Ok(remaining == 0
+            && file.metadata()?.len() == bytes
+            && actual.finalize() == expected);
+    }
+    let expected = object_hash(path)?;
     if kind == PruneObjectKind::Xorb {
         return match super::xorb_file::verify(file, path, bytes, &expected, cancel) {
             Ok(()) => Ok(true),
@@ -388,15 +440,20 @@ fn verify_file(
             Err(error) => Err(error),
         };
     }
-    let limit = if kind == PruneObjectKind::Chunk {
-        MAX_CACHE_CHUNK_BYTES
-    } else {
-        MAX_CACHE_SHARD_BYTES
+    let limit = match kind {
+        PruneObjectKind::Chunk => MAX_CACHE_CHUNK_BYTES,
+        PruneObjectKind::Shard => MAX_CACHE_SHARD_BYTES,
+        PruneObjectKind::RefTransaction => {
+            return Err(CacheError::Internal(
+                "ref transaction bypassed its native hash verifier".into(),
+            ));
+        }
+        PruneObjectKind::Xorb => MAX_XORB_SIZE as u64,
     };
     if bytes > limit {
         return Ok(false);
     }
-    let mut hashed = crab_xet::hash::HashedWrite::new(std::io::sink());
+    let mut data_hash = crab_xet::hash::HashedWrite::new(std::io::sink());
     let mut buffer = vec![0; 64 * 1024];
     let mut remaining = bytes;
     loop {
@@ -409,9 +466,9 @@ fn verify_file(
             return Ok(false);
         };
         remaining = rest;
-        hashed.write_all(&buffer[..read])?;
+        data_hash.write_all(&buffer[..read])?;
     }
-    Ok(remaining == 0 && file.metadata()?.len() == bytes && hashed.hash() == expected)
+    Ok(remaining == 0 && file.metadata()?.len() == bytes && data_hash.hash() == expected)
 }
 
 #[cfg(test)]
@@ -428,6 +485,7 @@ mod tests {
             PruneObjectKind::Chunk,
             PruneObjectKind::Shard,
             PruneObjectKind::Xorb,
+            PruneObjectKind::RefTransaction,
         ] {
             let mut file = File::options().write(true).open(&path)?;
             let result = verify_file(&mut file, &path, kind, &CancellationToken::new());

--- a/crates/crab-cache/src/local_cache/tests/maintenance.rs
+++ b/crates/crab-cache/src/local_cache/tests/maintenance.rs
@@ -9,7 +9,11 @@ async fn maintenance_retains_unknown_entries_and_stats_count_only_owned_payloads
     let data = b"data";
     let (xorb_hash, xorb_data) = test_xorb(data);
     let chunk = CacheKey::Chunk(compute_data_hash(data));
-    for key in [&chunk, &CacheKey::Shard(compute_data_hash(data))] {
+    for key in [
+        &chunk,
+        &CacheKey::Shard(compute_data_hash(data)),
+        &CacheKey::RefTransaction(blake3::hash(data)),
+    ] {
         cache.put(key, data).await.unwrap();
     }
     cache
@@ -55,21 +59,23 @@ async fn maintenance_retains_unknown_entries_and_stats_count_only_owned_payloads
             stats.chunk_count,
             stats.shard_count,
             stats.xorb_count,
+            stats.ref_transaction_count,
             stats.stage_count,
             stats.manifest_count
         ),
-        (1, 1, 1, 1, 1)
+        (1, 1, 1, 1, 1, 1)
     );
     assert_eq!(
         (
             stats.chunk_bytes,
             stats.shard_bytes,
             stats.xorb_bytes,
+            stats.ref_transaction_bytes,
             stats.stage_bytes
         ),
-        (4, 4, xorb_data.len() as u64, 4)
+        (4, 4, xorb_data.len() as u64, 4, 4)
     );
-    assert_eq!(cache.verify().await.unwrap().valid, 3);
+    assert_eq!(cache.verify().await.unwrap().valid, 4);
     let pruner = LocalCache::with_limits(cache.root.clone(), 0, Some(0));
     let preview = pruner
         .prune_with_options(PruneOptions {
@@ -81,9 +87,9 @@ async fn maintenance_retains_unknown_entries_and_stats_count_only_owned_payloads
     let applied = pruner.prune().await.unwrap();
     assert_eq!(
         (preview.objects_evicted(), applied.objects_evicted()),
-        (3, 3)
+        (4, 4)
     );
-    assert_eq!(applied.bytes_freed, 8 + xorb_data.len() as u64);
+    assert_eq!(applied.bytes_freed, 12 + xorb_data.len() as u64);
     let stats = cache.stats().await.unwrap();
     assert_eq!((stats.stage_count, stats.manifest_count), (1, 1));
     for path in retained {
@@ -101,6 +107,10 @@ async fn every_object_family_retains_active_readers_during_maintenance() {
         ),
         (
             CacheKey::Shard(compute_data_hash(b"data")),
+            b"data".as_slice(),
+        ),
+        (
+            CacheKey::RefTransaction(blake3::hash(b"data")),
             b"data".as_slice(),
         ),
         (CacheKey::Xorb(xorb_hash), xorb.as_ref()),

--- a/crates/crab-cache/src/path_class.rs
+++ b/crates/crab-cache/src/path_class.rs
@@ -26,6 +26,7 @@ pub enum CacheObjectKind {
     Pack,
     PackIndex,
     GeneratedPack,
+    RefTransaction,
     Metadata,
 }
 
@@ -69,6 +70,10 @@ pub fn cache_route_contract() -> CacheRouteContract {
             (
                 "generated_pack",
                 "{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json",
+            ),
+            (
+                "ref_transaction",
+                "{repo}/refs/journal/transactions/{hash}.json",
             ),
             ("metadata", "{repo}/file_index_db/compacted/*.sst"),
             ("metadata", "{repo}/file_index_db/manifest/*.manifest"),
@@ -130,20 +135,28 @@ pub fn parse_cache_object_path(path: &str) -> Option<CacheObjectPath<'_>> {
     parse_global_crab_object(path)
         .or_else(|| parse_pack_object(path))
         .or_else(|| parse_generated_pack_object(path))
+        .or_else(|| parse_ref_transaction(path))
         .or_else(|| parse_versioned_metadb_object(path))
 }
 
 /// Map a cache-service object path to the local disk cache key, when supported.
 ///
 /// Pack and metadata routes are immutable cache-service objects, but the local
-/// disk cache currently stores only xorb and shard object bodies by hash.
+/// disk cache stores only xorbs, shards, and ref transactions with native
+/// content identities.
 #[must_use]
 pub fn cache_key_for_path(path: &str) -> Option<CacheKey> {
     let parsed = parse_cache_object_path(path)?;
-    let hash = MerkleHash::from_hex(parsed.identity.as_ref()).ok()?;
     match parsed.kind {
-        CacheObjectKind::Xorb => Some(CacheKey::Xorb(hash)),
-        CacheObjectKind::Shard => Some(CacheKey::Shard(hash)),
+        CacheObjectKind::Xorb => Some(CacheKey::Xorb(
+            MerkleHash::from_hex(parsed.identity.as_ref()).ok()?,
+        )),
+        CacheObjectKind::Shard => Some(CacheKey::Shard(
+            MerkleHash::from_hex(parsed.identity.as_ref()).ok()?,
+        )),
+        CacheObjectKind::RefTransaction => Some(CacheKey::RefTransaction(
+            blake3::Hash::from_hex(parsed.identity.as_ref()).ok()?,
+        )),
         CacheObjectKind::Pack
         | CacheObjectKind::PackIndex
         | CacheObjectKind::GeneratedPack
@@ -214,6 +227,25 @@ fn parse_generated_pack_object(path: &str) -> Option<CacheObjectPath<'_>> {
         repo_path,
         kind: CacheObjectKind::GeneratedPack,
         identity: Cow::Owned(blake3::hash(path.as_bytes()).to_hex().to_string()),
+    })
+}
+
+fn parse_ref_transaction(path: &str) -> Option<CacheObjectPath<'_>> {
+    let marker = "/refs/journal/transactions/";
+    let marker_position = path.find(marker)?;
+    let repo_path = &path[..marker_position];
+    let filename = &path[marker_position + marker.len()..];
+    if repo_path.is_empty() || filename.contains('/') {
+        return None;
+    }
+    let identity = filename.strip_suffix(".json")?;
+    if !is_hash_hex(identity) {
+        return None;
+    }
+    Some(CacheObjectPath {
+        repo_path,
+        kind: CacheObjectKind::RefTransaction,
+        identity: Cow::Borrowed(identity),
     })
 }
 
@@ -345,6 +377,7 @@ mod tests {
         let xorb_hash = hex_hash('a');
         let shard_hash = hex_hash('b');
         let generated_hash = hex_hash('c');
+        let transaction_hash = hex_hash('d');
         vec![
             RouteContractCase {
                 name: "global xorb",
@@ -421,6 +454,17 @@ mod tests {
                     .to_string(),
                 }),
                 docs_token: "{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json",
+            },
+            RouteContractCase {
+                name: "ref journal transaction",
+                path: format!("/v1/org/repo/refs/journal/transactions/{transaction_hash}.json"),
+                class: PathClass::Immutable,
+                parsed: Some(ParsedRouteContract {
+                    repo_path: "org/repo",
+                    kind: CacheObjectKind::RefTransaction,
+                    identity: transaction_hash,
+                }),
+                docs_token: "{repo}/refs/journal/transactions/{hash}.json",
             },
             RouteContractCase {
                 name: "file index db sst",
@@ -539,6 +583,7 @@ mod tests {
             "{repo}/packs/pack-{id}.idx",
             "{repo}/generated-packs/v1/artifacts/{first-two-hex}/{hash}.pack",
             "{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json",
+            "{repo}/refs/journal/transactions/{hash}.json",
             "{repo}/file_index_db/manifest/*.manifest",
             ".crab/chunk_index_db/manifest/*.manifest",
         ] {
@@ -582,6 +627,7 @@ mod tests {
     fn local_cache_key_mapping_covers_hash_addressed_objects_only() {
         let xorb_hash = MerkleHash::from([9u64, 10, 11, 12]);
         let shard_hash = MerkleHash::from([1u64, 2, 3, 4]);
+        let transaction_hash = blake3::hash(b"transaction");
 
         let xorb_key = cache_key_for_path(&format!(
             ".crab/xorbs/{}/{}",
@@ -598,6 +644,15 @@ mod tests {
         ))
         .expect("shard path should map to local cache key");
         assert!(matches!(shard_key, CacheKey::Shard(hash) if hash == shard_hash));
+
+        let transaction_key = cache_key_for_path(&format!(
+            "org/repo/refs/journal/transactions/{}.json",
+            transaction_hash.to_hex()
+        ))
+        .expect("ref transaction should map to local cache key");
+        assert!(
+            matches!(transaction_key, CacheKey::RefTransaction(hash) if hash == transaction_hash)
+        );
 
         assert!(cache_key_for_path("org/repo/packs/pack-abc.pack").is_none());
         assert!(

--- a/crates/crab-metadata/src/manifest_store.rs
+++ b/crates/crab-metadata/src/manifest_store.rs
@@ -432,6 +432,33 @@ pub async fn read_repository_snapshot(
     ))
 }
 
+/// Reuse a verified snapshot when its complete mutable dependency set is unchanged.
+pub async fn read_repository_snapshot_reusing(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    previous: &RepositorySnapshot,
+) -> Result<RepositorySnapshot> {
+    // Capture markers before the manifest, matching the full snapshot's
+    // compaction-boundary ordering. Any mismatch falls back to that full path.
+    let active = list_active_transactions(store, router).await?;
+    let (manifest, manifest_etag) = read_manifest(store, router).await?;
+    let layout = read_canonical_layout(store, router).await?;
+    let transactions_unchanged = active.len() == previous.journal.transactions.len()
+        && previous
+            .journal
+            .transactions
+            .iter()
+            .all(|transaction| active.contains(transaction));
+    if manifest == previous.manifest
+        && manifest_etag == previous.manifest_etag
+        && layout == previous.layout
+        && transactions_unchanged
+    {
+        return Ok(previous.clone());
+    }
+    read_repository_snapshot(store, router).await
+}
+
 /// Fold committed journal transactions into one bounded manifest snapshot.
 ///
 /// Immutable indexes and the matching frontier are written before the

--- a/crates/crab-metadata/src/ref_journal.rs
+++ b/crates/crab-metadata/src/ref_journal.rs
@@ -626,7 +626,15 @@ pub async fn materialize_ref_journal(
         }
     }
 
-    let order = transaction_order(&transactions)?;
+    let mut order = transaction_order(&transactions)?;
+    if !ref_edits_match_base(base, &transactions, &order) && !compacted.is_empty() {
+        // Cleanup may retain an older marker after a transient failure. Walk
+        // immutable frontier ancestry only on mismatch to prove it was compacted.
+        let compacted_ancestors =
+            active_frontier_ancestors(store, router, &compacted, &transactions).await?;
+        transactions.retain(|transaction_id, _| !compacted_ancestors.contains(transaction_id));
+        order = transaction_order(&transactions)?;
+    }
     let mut refs = base.refs.clone();
     let mut peeled_refs = base.peeled_refs.clone();
     let mut head = base.head.clone();
@@ -713,6 +721,63 @@ pub async fn materialize_ref_journal(
         visible_heads,
         state_digest: hasher.finalize().to_hex().to_string(),
     })
+}
+
+fn ref_edits_match_base(
+    base: &Manifest,
+    transactions: &BTreeMap<String, RefJournalTransaction>,
+    order: &[String],
+) -> bool {
+    let mut refs = base.refs.clone();
+    for transaction_id in order {
+        let Some(transaction) = transactions.get(transaction_id) else {
+            return false;
+        };
+        for edit in &transaction.edits {
+            if refs.get(&edit.ref_name) != edit.old_oid.as_ref() {
+                return false;
+            }
+            match &edit.new_oid {
+                Some(oid) => {
+                    refs.insert(edit.ref_name.clone(), oid.clone());
+                }
+                None => {
+                    refs.remove(&edit.ref_name);
+                }
+            }
+        }
+    }
+    true
+}
+
+async fn active_frontier_ancestors(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    frontier_transactions: &BTreeSet<String>,
+    active_transactions: &BTreeMap<String, RefJournalTransaction>,
+) -> Result<BTreeSet<String>> {
+    let mut pending = frontier_transactions.clone();
+    let mut visited = BTreeSet::new();
+    let mut compacted = BTreeSet::new();
+    while let Some(transaction_id) = pending.pop_first() {
+        if !visited.insert(transaction_id.clone()) {
+            continue;
+        }
+        if visited.len() > MAX_REF_HEADS {
+            return Err(MetadataError::Internal(
+                "ref journal frontier ancestry limit exceeded".to_owned(),
+            ));
+        }
+        let transaction = match active_transactions.get(&transaction_id) {
+            Some(transaction) => transaction.clone(),
+            None => read_transaction(store, router, &transaction_id).await?,
+        };
+        if active_transactions.contains_key(&transaction_id) {
+            compacted.insert(transaction_id);
+        }
+        pending.extend(transaction.parents.into_values().flatten());
+    }
+    Ok(compacted)
 }
 
 pub(crate) async fn read_ref_journal_frontier(
@@ -1112,6 +1177,40 @@ mod tests {
             RefJournalTransaction::new(parents, edits, None, Vec::new(), Vec::new()).unwrap(),
             heads,
         )
+    }
+
+    async fn commit_main(
+        store: &Store,
+        layout: &StoreLayout<Store>,
+        old: Option<char>,
+        new: char,
+    ) -> String {
+        let head = read_ref_head(store, layout, "refs/heads/main")
+            .await
+            .unwrap();
+        let transaction = RefJournalTransaction::new(
+            BTreeMap::from([(
+                "refs/heads/main".to_owned(),
+                head.visible_transaction.clone(),
+            )]),
+            vec![RefJournalEdit {
+                ref_name: "refs/heads/main".to_owned(),
+                old_oid: old.map(|byte| byte.to_string().repeat(40)),
+                new_oid: Some(new.to_string().repeat(40)),
+                peeled_oid: None,
+                lock_holder: None,
+                visibility_evidence_hash: None,
+            }],
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let transaction_id = transaction.id().unwrap();
+        commit_ref_transaction(store, layout, &transaction, &[head], || false)
+            .await
+            .unwrap();
+        transaction_id
     }
 
     async fn materialize(
@@ -1649,6 +1748,66 @@ mod tests {
 
         assert!(after.transactions.is_empty());
         assert_eq!(after.refs["refs/heads/main"], "a".repeat(40));
+    }
+
+    #[tokio::test]
+    async fn compaction_frontier_stops_replaying_captured_ancestor_markers() {
+        let (store, layout) = fixture();
+        let base = Manifest::default_for_repo("refs/heads/main");
+        commit_main(&store, &layout, None, 'a').await;
+        let second_id = commit_main(&store, &layout, Some('a'), 'b').await;
+        let captured_active = list_active_transactions(&store, &layout).await.unwrap();
+        let snapshot = materialize(&store, &layout, &base).await;
+        let mut compacted = base;
+        compacted.generation = 1;
+        compacted.refs = snapshot.refs;
+        compacted.peeled_refs = snapshot.peeled_refs;
+        compacted.head = snapshot.head;
+        compacted.seal_git_validation();
+        write_ref_journal_frontier(&store, &layout, &compacted, &snapshot.visible_heads)
+            .await
+            .unwrap();
+
+        let after =
+            materialize_ref_journal(&store, &layout, &compacted, &[], &[], &captured_active)
+                .await
+                .unwrap();
+
+        assert!(after.transactions.is_empty());
+        assert_eq!(after.refs["refs/heads/main"], "b".repeat(40));
+
+        store
+            .delete(&layout.ref_journal_active_path(&second_id))
+            .await
+            .unwrap();
+        let retained_ancestor = list_active_transactions(&store, &layout).await.unwrap();
+        let after_partial_cleanup =
+            materialize_ref_journal(&store, &layout, &compacted, &[], &[], &retained_ancestor)
+                .await
+                .unwrap();
+
+        assert!(after_partial_cleanup.transactions.is_empty());
+        assert_eq!(
+            after_partial_cleanup.refs["refs/heads/main"],
+            "b".repeat(40)
+        );
+
+        let third_id = commit_main(&store, &layout, Some('b'), 'c').await;
+        let active_with_descendant = list_active_transactions(&store, &layout).await.unwrap();
+
+        let with_descendant = materialize_ref_journal(
+            &store,
+            &layout,
+            &compacted,
+            &[],
+            &[],
+            &active_with_descendant,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(with_descendant.transactions, [third_id]);
+        assert_eq!(with_descendant.refs["refs/heads/main"], "c".repeat(40));
     }
 
     #[tokio::test]

--- a/crates/crab-remote-git/src/pack.rs
+++ b/crates/crab-remote-git/src/pack.rs
@@ -421,12 +421,20 @@ impl RemoteGitRepository {
         visibility_catalog: crab_metadata::git_object_locator::GitObjectCatalogIdentity,
         visibility_validation_digest: &str,
         visible_objects: u64,
+        maximum_objects: u64,
     ) -> Result<bool> {
         if repository_catalog != Some(visibility_catalog)
             || repository_validation_digest != visibility_validation_digest
         {
             return Err(Error::RepositoryState {
                 reason: crate::RepositoryStateError::VisibilityProofMismatch,
+            });
+        }
+        if visible_objects > maximum_objects {
+            return Err(Error::LimitExceeded {
+                limit: "upload-pack planned objects",
+                actual: visible_objects,
+                maximum: maximum_objects,
             });
         }
         Ok(visible_objects == visibility_catalog.object_count)
@@ -458,6 +466,7 @@ impl RemoteGitRepository {
             catalog_identity,
             &visibility.git_validation_digest,
             visible_objects,
+            self.state.options.operation_limits().max_logical_objects,
         )?;
         let inventory = self.state.inventory.values().copied().collect::<Vec<_>>();
         let inventory_objects = inventory
@@ -3122,6 +3131,7 @@ mod tests {
                 catalog,
                 "validation",
                 catalog.object_count,
+                catalog.object_count,
             )
             .expect("matching complete catalog")
         );
@@ -3132,6 +3142,7 @@ mod tests {
                 catalog,
                 "validation",
                 catalog.object_count - 1,
+                catalog.object_count,
             )
             .expect("partial visibility")
         );
@@ -3147,6 +3158,7 @@ mod tests {
                 mismatched,
                 "validation",
                 mismatched.object_count,
+                mismatched.object_count,
             ),
             Err(Error::RepositoryState {
                 reason: crate::RepositoryStateError::VisibilityProofMismatch,
@@ -3159,10 +3171,26 @@ mod tests {
                 catalog,
                 "other-validation",
                 catalog.object_count,
+                catalog.object_count,
             ),
             Err(Error::RepositoryState {
                 reason: crate::RepositoryStateError::VisibilityProofMismatch,
             })
+        ));
+        assert!(matches!(
+            RemoteGitRepository::complete_catalog_is_visible(
+                Some(catalog),
+                "validation",
+                catalog,
+                "validation",
+                catalog.object_count,
+                catalog.object_count - 1,
+            ),
+            Err(Error::LimitExceeded {
+                limit: "upload-pack planned objects",
+                actual,
+                maximum,
+            }) if actual == catalog.object_count && maximum == catalog.object_count - 1
         ));
     }
 

--- a/packages/web/content/docs/cli/cache-service/architecture.mdx
+++ b/packages/web/content/docs/cli/cache-service/architecture.mdx
@@ -39,6 +39,7 @@ Before uploading new chunks, Crab can also ask the cache service which chunks ar
 | `{repo}/packs/pack-{id}.idx` | Yes |
 | `{repo}/generated-packs/v1/artifacts/{first-two-hex}/{hash}.pack` | Yes |
 | `{repo}/generated-packs/v1/requests/{first-two-hex}/{hash}.json` | Yes |
+| `{repo}/refs/journal/transactions/{hash}.json` | Yes |
 | `{repo}/file_index_db/compacted/*.sst` | Yes |
 | `{repo}/file_index_db/manifest/*.manifest` | Yes |
 | `{repo}/file_index_db/wal/*.sst` | Yes |
@@ -58,7 +59,7 @@ Before uploading new chunks, Crab can also ask the cache service which chunks ar
 | `.crab/chunk_index_db/manifest/current` | No |
 
 Mutable repository state is never cached. This prevents stale refs and stale metadata from breaking clone, fetch, and push behavior.
-Generated response bodies and request descriptors are immutable and content- or request-addressed. Production uses the existing mutable internal-lock namespace, which already bypasses the cache.
+Generated response bodies and request descriptors are immutable and content- or request-addressed. Ref-journal transaction bodies are immutable and verified against the plain BLAKE3 hash in their key; caching them avoids rereading the complete uncompacted journal from the origin on each push. Production uses the existing mutable internal-lock namespace, which already bypasses the cache.
 Only versioned SlateDB metadata objects are cached. Discovery pointers such as `manifest/current` stay mutable, and file-index lookups go through Crab's metadata databases rather than standalone file-index object routes.
 The same taxonomy is exposed from `/v1/capabilities.routes` so `crab doctor`
 and onboarding probes can verify that a client and cache server agree before


### PR DESCRIPTION
## Summary
- cache content-addressed ref-journal transaction bodies while keeping manifests, journal heads, markers, and conditional reads on the origin
- verify plain BLAKE3 identities at local-cache, cache-client, and cache-server boundaries; evict/refetch corrupt entries
- coalesce transaction recency timestamp writes and cover lifecycle accounting, pruning, route docs, and the RustFS qualification harness

## Correctness
- snapshot integration test proves mutable manifest reads still reach origin
- corrupt local and remote transaction bodies are rejected and repaired
- fresh clients reuse a cache-server transaction after one origin read
- retained under-lock coherent snapshot refresh; no ref-concurrency shortcuts

## Performance evidence
On the same local RustFS and Kubernetes 100-commit replay:
- before touch coalescing: late-20 avg 1346.7 ms, p95 1589 ms
- after: late-20 avg 1286.55 ms, p95 1368 ms
- early-20 median remained effectively unchanged (1141.5 ms vs 1131 ms)

## Verification
- cargo fmt --all --check
- cargo check -p crab-cache -p crab-cache-store -p crab-cache-server -p crab --locked
- cargo clippy -p crab-cache --all-features --all-targets --locked -- -D warnings
- cargo clippy -p crab-cache-store --all-features --all-targets --locked -- -D warnings
- cargo clippy -p crab-cache-server --all-targets --locked -- -D warnings
- cargo test -p crab-cache --all-features --locked
- cargo test -p crab-cache-store --all-features --locked
- cargo test -p crab-cache-server --locked
- cargo test -p crab snapshot_cache_repairs_transactions_and_rereads_mutable_state --locked
- python3 -m unittest crab.scripts.e2e.test_verify_large_repo_rustfs_report
- cargo build --release -p crab --locked

A combined fresh-bucket 2,000-commit Kubernetes/RustFS qualification with the clone optimization from #173 is running separately.