### PR TITLE
perf(push): keep incremental latency flat under owner maintenance

### DIFF
--- a/crab/src/cmd/metadb.rs
+++ b/crab/src/cmd/metadb.rs
@@ -356,8 +356,10 @@ fn build_metadb(
     MetaDb::new(store, repo_prefix, metadb_config)
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct GenerationOwnerSample {
+    #[serde(skip)]
+    identity: GenerationOwnerIdentity,
     generation: u64,
     action: &'static str,
     maintenance_reason: &'static str,
@@ -378,6 +380,31 @@ struct GenerationOwnerSample {
     elapsed_ms: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GenerationOwnerIdentity {
+    generation: u64,
+    pack_index_hash: String,
+    git_validation_digest: String,
+    commit_graph_hash: Option<String>,
+}
+
+impl From<&crab_metadata::manifests::Manifest> for GenerationOwnerIdentity {
+    fn from(manifest: &crab_metadata::manifests::Manifest) -> Self {
+        Self {
+            generation: manifest.generation,
+            pack_index_hash: manifest.pack_index_hash.clone(),
+            git_validation_digest: manifest.git_validation_digest.clone(),
+            commit_graph_hash: manifest.commit_graph_hash.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CompletedGenerationOwnerWork {
+    sample: GenerationOwnerSample,
+    completed_at: std::time::Instant,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct CommitGraphMaintenance {
     action: &'static str,
@@ -390,6 +417,13 @@ struct CommitGraphMaintenance {
 const GENERATION_OWNER_GRAPH_REBUILD_MAX_BYTES: u64 = 32 * 1024 * 1024 * 1024;
 const GENERATION_OWNER_ONCE_RETRY_LIMIT: u32 = 3;
 const GENERATION_OWNER_ONCE_RETRY_INTERVAL_SECS: u64 = 2;
+const GENERATION_OWNER_MIN_QUIESCENCE: std::time::Duration = std::time::Duration::from_secs(5);
+const GENERATION_OWNER_STABLE_REVALIDATION: std::time::Duration =
+    std::time::Duration::from_mins(10);
+
+fn generation_owner_quiescence(interval_secs: u64) -> std::time::Duration {
+    std::time::Duration::from_secs(interval_secs).max(GENERATION_OWNER_MIN_QUIESCENCE)
+}
 
 async fn run_generation_owner(
     once: bool,
@@ -452,6 +486,11 @@ async fn generation_owner_loop(
 ) -> Result<()> {
     let mut consecutive_errors = 0_u32;
     let mut once_errors = 0_u32;
+    // Continuous owners require an elapsed quiet window before starting
+    // repository-sized derived work. One-shot runs remain explicitly eager.
+    let quiescence = generation_owner_quiescence(interval_secs);
+    let mut derived_work_after = (!once).then(|| std::time::Instant::now() + quiescence);
+    let mut completed_work = None;
     loop {
         if cancel.is_cancelled() {
             return Ok(());
@@ -462,6 +501,9 @@ async fn generation_owner_loop(
             lock_ttl,
             interval_secs,
             config,
+            once || derived_work_after
+                .is_none_or(|eligible_at| std::time::Instant::now() >= eligible_at),
+            completed_work.as_ref(),
             cancel,
         ))
         .await
@@ -476,7 +518,24 @@ async fn generation_owner_loop(
                 if once {
                     return Ok(());
                 }
-                if sample.superseded {
+                match sample.action {
+                    "ref_journal_compaction" => {
+                        derived_work_after = Some(std::time::Instant::now() + quiescence);
+                        completed_work = None;
+                    }
+                    "quiescence_wait" => {}
+                    "none" => {
+                        completed_work = Some(CompletedGenerationOwnerWork {
+                            sample: sample.clone(),
+                            completed_at: std::time::Instant::now(),
+                        });
+                    }
+                    "idle" => {}
+                    _ => completed_work = None,
+                }
+                // A compaction restarts the elapsed quiet window instead of
+                // immediately opening the large catalog/repack path.
+                if sample.superseded && sample.action != "ref_journal_compaction" {
                     continue;
                 }
             }
@@ -533,10 +592,13 @@ async fn generation_owner_sample(
     lock_ttl: std::time::Duration,
     interval_secs: u64,
     config: &Config,
+    derived_work_ready: bool,
+    completed_work: Option<&CompletedGenerationOwnerWork>,
     cancel: &CancellationToken,
 ) -> Result<GenerationOwnerSample> {
     let started = std::time::Instant::now();
     let (manifest, _) = crate::metadata::manifest::read_manifest(store, router).await?;
+    let identity = GenerationOwnerIdentity::from(&manifest);
     let generation = manifest.generation;
     if crate::git::push::compact_ref_journal_for_owner(
         store,
@@ -547,11 +609,30 @@ async fn generation_owner_sample(
     )
     .await?
     {
-        return Ok(superseded_owner_sample(
+        return Ok(empty_owner_sample(
+            identity,
             generation,
             "ref_journal_compaction",
+            interval_secs,
+            true,
             started,
         ));
+    }
+    if !derived_work_ready {
+        return Ok(empty_owner_sample(
+            identity,
+            generation,
+            "quiescence_wait",
+            interval_secs,
+            false,
+            started,
+        ));
+    }
+    if let Some(completed) = completed_work
+        && completed.sample.identity == identity
+        && completed.completed_at.elapsed() < GENERATION_OWNER_STABLE_REVALIDATION
+    {
+        return Ok(idle_owner_sample(completed, interval_secs, started));
     }
     let packs = if manifest.pack_index_hash.is_empty() {
         Vec::new()
@@ -582,7 +663,14 @@ async fn generation_owner_sample(
         sweep: locator_sweep,
     }) = maintenance
     else {
-        return Ok(superseded_owner_sample(generation, "superseded", started));
+        return Ok(empty_owner_sample(
+            identity,
+            generation,
+            "superseded",
+            0,
+            true,
+            started,
+        ));
     };
     // The owner is also the repair path for imports and Git-only pushes that
     // had no post-CAS MetaDb writer. Once locator coverage is current, publish
@@ -604,6 +692,7 @@ async fn generation_owner_sample(
     }
     if locator_advanced {
         return Ok(GenerationOwnerSample {
+            identity,
             generation,
             action: "catalog_advance",
             maintenance_reason: generation_owner_reason("catalog_advance"),
@@ -659,6 +748,7 @@ async fn generation_owner_sample(
             "visibility_repair"
         };
         return Ok(GenerationOwnerSample {
+            identity,
             generation,
             action,
             maintenance_reason: generation_owner_reason(action),
@@ -748,6 +838,7 @@ async fn generation_owner_sample(
         }
     }
     Ok(GenerationOwnerSample {
+        identity,
         generation,
         action: graph.action,
         maintenance_reason: generation_owner_reason(graph.action),
@@ -769,16 +860,38 @@ async fn generation_owner_sample(
     })
 }
 
-fn superseded_owner_sample(
+fn idle_owner_sample(
+    completed: &CompletedGenerationOwnerWork,
+    interval_secs: u64,
+    started: std::time::Instant,
+) -> GenerationOwnerSample {
+    let mut sample = completed.sample.clone();
+    sample.action = "idle";
+    sample.maintenance_reason = generation_owner_reason(sample.action);
+    sample.next_eligibility_secs = interval_secs;
+    sample.locator_advanced = false;
+    sample.locator_sweep = crab_metadata::git_object_locator::LocatorSweepStats::default();
+    sample.maintenance_bytes_read = 0;
+    sample.maintenance_bytes_written = 0;
+    sample.superseded = false;
+    sample.elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    sample
+}
+
+fn empty_owner_sample(
+    identity: GenerationOwnerIdentity,
     generation: u64,
     action: &'static str,
+    next_eligibility_secs: u64,
+    superseded: bool,
     started: std::time::Instant,
 ) -> GenerationOwnerSample {
     GenerationOwnerSample {
+        identity,
         generation,
         action,
         maintenance_reason: generation_owner_reason(action),
-        next_eligibility_secs: 0,
+        next_eligibility_secs,
         locator_advanced: false,
         visibility: "deferred",
         active_packs: 0,
@@ -786,12 +899,12 @@ fn superseded_owner_sample(
         geometric_repack_packs: 0,
         catalog_layers: 0,
         catalog_bytes: 0,
-        locator_sweep: Default::default(),
+        locator_sweep: crab_metadata::git_object_locator::LocatorSweepStats::default(),
         commit_graph_layers: 0,
         commit_graph_bytes: 0,
         maintenance_bytes_read: 0,
         maintenance_bytes_written: 0,
-        superseded: true,
+        superseded,
         elapsed_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
     }
 }
@@ -799,6 +912,8 @@ fn superseded_owner_sample(
 fn generation_owner_reason(action: &str) -> &'static str {
     match action {
         "ref_journal_compaction" => "active_ref_journal",
+        "quiescence_wait" => "repository_activity_quieting",
+        "idle" => "repository_identity_unchanged",
         "catalog_advance" => "catalog_coverage_stale",
         "catalog_visibility_handoff" => "catalog_proof_handoff",
         "visibility_repair" => "visibility_missing_or_stale",
@@ -3828,6 +3943,8 @@ mod tests {
     fn generation_owner_reason_is_stable_for_each_action() {
         let reasons = [
             ("ref_journal_compaction", "active_ref_journal"),
+            ("quiescence_wait", "repository_activity_quieting"),
+            ("idle", "repository_identity_unchanged"),
             ("catalog_advance", "catalog_coverage_stale"),
             ("visibility_repair", "visibility_missing_or_stale"),
             (
@@ -3847,6 +3964,27 @@ mod tests {
         for (action, reason) in reasons {
             assert_eq!(generation_owner_reason(action), reason);
         }
+    }
+
+    #[test]
+    fn generation_owner_identity_tracks_commit_graph_publication() {
+        let mut manifest = crab_metadata::manifests::Manifest::default_for_repo("refs/heads/main");
+        let before = GenerationOwnerIdentity::from(&manifest);
+        manifest.commit_graph_hash = Some("a".repeat(64));
+
+        assert_ne!(GenerationOwnerIdentity::from(&manifest), before);
+    }
+
+    #[test]
+    fn generation_owner_quiescence_has_a_real_time_floor() {
+        assert_eq!(
+            generation_owner_quiescence(1),
+            GENERATION_OWNER_MIN_QUIESCENCE
+        );
+        assert_eq!(
+            generation_owner_quiescence(30),
+            std::time::Duration::from_secs(30)
+        );
     }
 
     #[test]
@@ -3914,6 +4052,8 @@ mod tests {
             std::time::Duration::from_secs(60),
             60,
             &Config::default(),
+            true,
+            None,
             &CancellationToken::new(),
         )
         .await
@@ -3925,6 +4065,135 @@ mod tests {
         assert_eq!(sample.next_eligibility_secs, 60);
         assert!(!sample.locator_advanced);
         assert_eq!(sample.visibility, "published");
+        assert!(!sample.superseded);
+    }
+
+    #[tokio::test]
+    async fn continuous_owner_skips_completed_repository_identity() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = crate::storage::store::Store::new(inner);
+        let router = crate::storage::StoreLayout::new(store.clone(), "org/repo".to_owned());
+        crate::metadata::manifest::create_manifest_with_etag(
+            &store,
+            &router,
+            &crab_metadata::manifests::Manifest::default_for_repo("refs/heads/main"),
+        )
+        .await
+        .expect("create manifest");
+        let first = generation_owner_sample(
+            &store,
+            &router,
+            std::time::Duration::from_secs(60),
+            60,
+            &Config::default(),
+            true,
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("complete derived maintenance");
+        assert_eq!(first.action, "none");
+        let completed = CompletedGenerationOwnerWork {
+            sample: first,
+            completed_at: std::time::Instant::now(),
+        };
+
+        let idle = generation_owner_sample(
+            &store,
+            &router,
+            std::time::Duration::from_secs(60),
+            60,
+            &Config::default(),
+            true,
+            Some(&completed),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("skip unchanged derived maintenance");
+
+        assert_eq!(idle.action, "idle");
+        assert_eq!(idle.maintenance_reason, "repository_identity_unchanged");
+        assert_eq!(idle.visibility, "published");
+        assert!(!idle.superseded);
+    }
+
+    #[tokio::test]
+    async fn continuous_owner_revalidates_expired_repository_identity() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = crate::storage::store::Store::new(inner);
+        let router = crate::storage::StoreLayout::new(store.clone(), "org/repo".to_owned());
+        crate::metadata::manifest::create_manifest_with_etag(
+            &store,
+            &router,
+            &crab_metadata::manifests::Manifest::default_for_repo("refs/heads/main"),
+        )
+        .await
+        .expect("create manifest");
+        let first = generation_owner_sample(
+            &store,
+            &router,
+            std::time::Duration::from_secs(60),
+            60,
+            &Config::default(),
+            true,
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("complete derived maintenance");
+        let completed = CompletedGenerationOwnerWork {
+            sample: first,
+            completed_at: std::time::Instant::now()
+                .checked_sub(GENERATION_OWNER_STABLE_REVALIDATION)
+                .expect("revalidation interval fits monotonic clock"),
+        };
+
+        let revalidated = generation_owner_sample(
+            &store,
+            &router,
+            std::time::Duration::from_secs(60),
+            60,
+            &Config::default(),
+            true,
+            Some(&completed),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("revalidate expired derived maintenance");
+
+        assert_eq!(revalidated.action, "none");
+        assert_eq!(revalidated.maintenance_reason, "no_maintenance_due");
+    }
+
+    #[tokio::test]
+    async fn continuous_owner_requires_a_quiet_probe_before_derived_work() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = crate::storage::store::Store::new(inner);
+        let router = crate::storage::StoreLayout::new(store.clone(), "org/repo".to_owned());
+        crate::metadata::manifest::create_manifest_with_etag(
+            &store,
+            &router,
+            &crab_metadata::manifests::Manifest::default_for_repo("refs/heads/main"),
+        )
+        .await
+        .expect("create manifest");
+
+        let sample = generation_owner_sample(
+            &store,
+            &router,
+            std::time::Duration::from_secs(60),
+            60,
+            &Config::default(),
+            false,
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("owner should defer derived maintenance until a quiet probe");
+
+        assert_eq!(sample.action, "quiescence_wait");
+        assert_eq!(sample.maintenance_reason, "repository_activity_quieting");
+        assert_eq!(sample.next_eligibility_secs, 60);
         assert!(!sample.superseded);
     }
 
@@ -3980,6 +4249,8 @@ mod tests {
             std::time::Duration::from_secs(60),
             60,
             &Config::default(),
+            false,
+            None,
             &CancellationToken::new(),
         )
         .await
@@ -3987,7 +4258,7 @@ mod tests {
 
         assert_eq!(sample.action, "ref_journal_compaction");
         assert_eq!(sample.maintenance_reason, "active_ref_journal");
-        assert_eq!(sample.next_eligibility_secs, 0);
+        assert_eq!(sample.next_eligibility_secs, 60);
         assert!(sample.superseded);
         let snapshot = crate::metadata::manifest::read_repository_snapshot(&store, &router)
             .await

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6450,6 +6450,35 @@ pub struct PrePopulatedWalk {
     pub remote_alias: String,
 }
 
+/// Ref leases and read-only work captured while those leases were active.
+///
+/// `locked_base_snapshot` may only be set when the snapshot was read after
+/// `leases` were acquired. The pipeline still revalidates the complete mutable
+/// snapshot after classification because unrelated refs can advance under
+/// independent leases.
+pub(crate) struct LockedPushHandoff {
+    leases: PushLockLease,
+    prepopulated: Option<PrePopulatedWalk>,
+    locked_base_snapshot: Option<Arc<RepositorySnapshot>>,
+}
+
+impl LockedPushHandoff {
+    pub(crate) fn new(leases: PushLockLease, prepopulated: Option<PrePopulatedWalk>) -> Self {
+        Self {
+            leases,
+            prepopulated,
+            locked_base_snapshot: None,
+        }
+    }
+
+    /// Attach a snapshot captured after this handoff's ref leases were acquired.
+    #[must_use]
+    pub(crate) fn with_locked_base_snapshot(mut self, snapshot: Arc<RepositorySnapshot>) -> Self {
+        self.locked_base_snapshot = Some(snapshot);
+        self
+    }
+}
+
 impl PushPipeline {
     /// Create a new pipeline for the given push specs.
     #[must_use]
@@ -6932,6 +6961,11 @@ impl PushPipeline {
     async fn read_base_manifest(&self) -> Result<()> {
         if self.config.protected_push.is_some() {
             debug!("read_base_manifest: protected push uses service-owned source manifest reads");
+            return Ok(());
+        }
+
+        if self.base_snapshot.lock().await.is_some() {
+            debug!("read_base_manifest: reusing snapshot captured under push locks");
             return Ok(());
         }
 
@@ -13587,6 +13621,17 @@ impl PushPipeline {
         *self.lock_acquired_at.lock().await = Some(Instant::now());
     }
 
+    /// Install a coherent snapshot read while the supplied ref leases were active.
+    async fn install_locked_base_snapshot(&self, snapshot: Arc<RepositorySnapshot>) {
+        debug!(
+            generation = snapshot.manifest.generation,
+            refs = snapshot.journal.refs.len(),
+            "installing base snapshot captured under push locks"
+        );
+        *self.manifest_etag.lock().await = Some(snapshot.manifest_etag.clone());
+        *self.base_snapshot.lock().await = Some(snapshot);
+    }
+
     /// Install a pre-computed pointer walk produced by the native push
     /// orchestrator.
     ///
@@ -16565,9 +16610,13 @@ pub(crate) async fn run_push_batch_with_locks(
     metrics: Option<Arc<Metrics>>,
     cancel: CancellationToken,
     progress: Option<Arc<NativePushProgress>>,
-    leases: PushLockLease,
-    prepopulated: Option<PrePopulatedWalk>,
+    handoff: LockedPushHandoff,
 ) -> PushResult {
+    let LockedPushHandoff {
+        leases,
+        prepopulated,
+        locked_base_snapshot,
+    } = handoff;
     if specs.is_empty() {
         debug!("push batch is empty, releasing pre-acquired locks");
         release_push_lock_leases(leases).await;
@@ -16614,6 +16663,9 @@ pub(crate) async fn run_push_batch_with_locks(
         progress,
     );
     pipeline.install_locks(leases).await;
+    if let Some(snapshot) = locked_base_snapshot {
+        pipeline.install_locked_base_snapshot(snapshot).await;
+    }
     if let Some(pre) = prepopulated {
         pipeline.install_prepopulated_walk(pre).await;
     }
@@ -25105,8 +25157,7 @@ mod tests {
             None,
             CancellationToken::new(),
             None,
-            leases,
-            None,
+            LockedPushHandoff::new(leases, None),
         )
         .await;
 
@@ -35551,6 +35602,78 @@ mod tests {
         );
         assert!(pipeline.base_commit_graph.lock().await.is_none());
         assert!(!*pipeline.base_commit_graph_loaded.lock().await);
+    }
+
+    #[tokio::test]
+    async fn locked_base_snapshot_elides_pipeline_initial_read() {
+        let inner = Arc::new(object_store::memory::InMemory::new());
+        let reads = Arc::new(Mutex::new(Vec::new()));
+        let recording_store: Arc<dyn object_store::ObjectStore> = Arc::new(RecordingReadStore {
+            inner: Arc::clone(&inner),
+            reads: Arc::clone(&reads),
+        });
+        let store = Store::new(recording_store);
+        let router = StoreLayout::new(store.clone(), "locked-snapshot".to_owned());
+        initialize_test_repository(&store, &router).await;
+        let specs = vec![make_spec("refs/heads/main")];
+        let config = PushConfig::default();
+        let leases = acquire_push_lock_leases(
+            &store,
+            router.repo_prefix(),
+            &specs,
+            &config,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("acquire ref lease before snapshot");
+        let snapshot = Arc::new(
+            crate::metadata::manifest::read_repository_snapshot(&store, &router)
+                .await
+                .expect("read snapshot under ref lease"),
+        );
+        reads
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+
+        let pipeline = PushPipeline::new(
+            config,
+            specs,
+            Some(store),
+            None,
+            None,
+            router.repo_prefix().to_owned(),
+            router,
+            None,
+            CancellationToken::new(),
+            None,
+        );
+        pipeline.install_locks(leases).await;
+        pipeline
+            .install_locked_base_snapshot(Arc::clone(&snapshot))
+            .await;
+
+        pipeline
+            .read_base_manifest()
+            .await
+            .expect("reuse locked snapshot");
+
+        assert!(
+            reads
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty(),
+            "pipeline must not reread a snapshot captured under its active ref leases"
+        );
+        assert_eq!(
+            pipeline.base_snapshot.lock().await.as_deref(),
+            Some(snapshot.as_ref())
+        );
+        assert_eq!(
+            pipeline.manifest_etag.lock().await.as_deref(),
+            Some(snapshot.manifest_etag.as_str())
+        );
+        pipeline.stop_heartbeat_and_release_lock().await;
     }
 
     #[tokio::test]

--- a/crab/src/git/push.rs
+++ b/crab/src/git/push.rs
@@ -6964,11 +6964,6 @@ impl PushPipeline {
             return Ok(());
         }
 
-        if self.base_snapshot.lock().await.is_some() {
-            debug!("read_base_manifest: reusing snapshot captured under push locks");
-            return Ok(());
-        }
-
         let Some(store) = &self.store else {
             debug!("read_base_manifest: no store, skipping");
             return Ok(());
@@ -7000,6 +6995,15 @@ impl PushPipeline {
         }
 
         Ok(())
+    }
+
+    /// Establish the pipeline's initial base without rereading a locked snapshot.
+    async fn ensure_initial_base_manifest(&self) -> Result<()> {
+        if self.base_snapshot.lock().await.is_some() {
+            debug!("reusing initial snapshot captured under push locks");
+            return Ok(());
+        }
+        self.read_base_manifest().await
     }
 
     async fn base_manifest(&self) -> Option<Manifest> {
@@ -16047,7 +16051,7 @@ impl PushPipeline {
         // This establishes the base state for `build_manifest` later.
         self.at_stage(
             PushFailureStage::RemoteState,
-            self.read_base_manifest().await,
+            self.ensure_initial_base_manifest().await,
         )?;
 
         // Resolve policy and ref preconditions before dependency discovery or
@@ -35654,7 +35658,7 @@ mod tests {
             .await;
 
         pipeline
-            .read_base_manifest()
+            .ensure_initial_base_manifest()
             .await
             .expect("reuse locked snapshot");
 

--- a/crab/src/git/push_native.rs
+++ b/crab/src/git/push_native.rs
@@ -19,7 +19,7 @@ use crate::core::perf_phase::PerfPhaseSink;
 use crate::git::discover;
 use crate::git::progress::NativePushProgress;
 use crate::git::push::{
-    PrePopulatedWalk, PushConfig, PushFailureStage, PushLockLease, PushResult,
+    LockedPushHandoff, PrePopulatedWalk, PushConfig, PushFailureStage, PushLockLease, PushResult,
     acquire_push_lock_leases, duplicate_destination_result, release_push_lock_leases,
     run_push_batch_with_locks,
 };
@@ -365,6 +365,24 @@ async fn run_native_push_inner(
     // ── Phase 1: Discover ──────────────────────────────────────────
     release_native_locks_on_error(check_cancelled(&cancel), &mut pre_acquired_locks).await?;
     let phase_start = Instant::now();
+    if pre_acquired_locks.is_none() && !config.followtags && config.push.protected_push.is_none() {
+        match acquire_push_lock_leases(&store, router.repo_prefix(), specs, &config.push, &cancel)
+            .await
+        {
+            Ok(leases) => {
+                debug!(
+                    lock_count = leases.len(),
+                    "native push: acquired push locks before repository snapshot"
+                );
+                pre_acquired_locks = Some(leases);
+            }
+            Err(e) => {
+                warn!(error = %e, "native push: failed to acquire push lock before discovery");
+                return Ok(push_lock_rejection_result(specs, &e));
+            }
+        }
+    }
+    let mut locked_base_snapshot = None;
     let remote_refs_for_discovery = if let Some(session) = config.push.protected_push.as_ref() {
         // Prepare returns refs from the caller's filtered view. Those OIDs are
         // the only safe and locally resolvable frontier for a path-scoped
@@ -378,7 +396,14 @@ async fn run_native_push_inner(
         )
         .await
         {
-            Ok(snapshot) => Some(snapshot.journal.refs),
+            Ok(snapshot) => {
+                let snapshot = Arc::new(snapshot);
+                let refs = snapshot.journal.refs.clone();
+                if pre_acquired_locks.is_some() && !config.followtags {
+                    locked_base_snapshot = Some(snapshot);
+                }
+                Some(refs)
+            }
             Err(CrabError::NotFound { path })
                 if config.followtags && path == router.manifest_path().as_ref() =>
             {
@@ -394,23 +419,6 @@ async fn run_native_push_inner(
             }
         }
     };
-    if pre_acquired_locks.is_none() && !config.followtags && config.push.protected_push.is_none() {
-        match acquire_push_lock_leases(&store, router.repo_prefix(), specs, &config.push, &cancel)
-            .await
-        {
-            Ok(leases) => {
-                debug!(
-                    lock_count = leases.len(),
-                    "native push: acquired push locks before discovery"
-                );
-                pre_acquired_locks = Some(leases);
-            }
-            Err(e) => {
-                warn!(error = %e, "native push: failed to acquire push lock before discovery");
-                return Ok(push_lock_rejection_result(specs, &e));
-            }
-        }
-    }
     progress.begin_discovery();
     let discovery_ticker = progress.start_ticker();
     let discovery = if config.mirror_git_only {
@@ -611,6 +619,7 @@ async fn run_native_push_inner(
                     commit_entries.clone(),
                     sha_map.clone(),
                     remote_name,
+                    locked_base_snapshot.clone(),
                 )
                 .await
             }
@@ -640,6 +649,7 @@ async fn run_native_push_inner(
                             commit_entries.clone(),
                             sha_map.clone(),
                             remote_name,
+                            None,
                         )
                         .await
                     }
@@ -725,6 +735,7 @@ async fn run_native_push_with_locks(
     commit_entries: Vec<crab_metadata::commit_graph::CommitEntry>,
     sha_map: HashMap<String, String>,
     remote_name: &str,
+    locked_base_snapshot: Option<Arc<crate::metadata::manifest::RepositorySnapshot>>,
 ) -> PushResult {
     let prepopulated = PrePopulatedWalk {
         pointers,
@@ -732,6 +743,10 @@ async fn run_native_push_with_locks(
         resolved_shas: sha_map,
         remote_alias: remote_name.to_owned(),
     };
+    let mut handoff = LockedPushHandoff::new(leases, Some(prepopulated));
+    if let Some(snapshot) = locked_base_snapshot {
+        handoff = handoff.with_locked_base_snapshot(snapshot);
+    }
     Box::pin(run_push_batch_with_locks(
         specs,
         delegated_push,
@@ -742,8 +757,7 @@ async fn run_native_push_with_locks(
         metrics,
         cancel,
         Some(progress),
-        leases,
-        Some(prepopulated),
+        handoff,
     ))
     .await
 }
@@ -1358,6 +1372,101 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct GatedReadStore {
+        inner: Arc<object_store::memory::InMemory>,
+        target: object_store::path::Path,
+        started: Arc<tokio::sync::Semaphore>,
+        release: Arc<tokio::sync::Semaphore>,
+        gate_once: std::sync::atomic::AtomicBool,
+    }
+
+    impl std::fmt::Display for GatedReadStore {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("GatedReadStore")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl object_store::ObjectStore for GatedReadStore {
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            options: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, options).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            if !options.head
+                && location == &self.target
+                && self
+                    .gate_once
+                    .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                self.started.add_permits(1);
+                let permit =
+                    self.release
+                        .acquire()
+                        .await
+                        .map_err(|error| object_store::Error::Generic {
+                            store: "gated-read",
+                            source: Box::new(error),
+                        })?;
+                permit.forget();
+            }
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures_util::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures_util::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures_util::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
     struct TinyGitFixture {
         _git_env: crate::test::git_repo::CleanGitEnvGuard,
         _dir: tempfile::TempDir,
@@ -1754,6 +1863,81 @@ mod tests {
                 "{case}: cleanup must complete before returning to the caller"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_push_acquires_ref_lease_before_snapshot_read() {
+        let fixture = TinyGitFixture::new();
+        let tip = fixture.commit_text("readme.txt", "locked snapshot ordering");
+        let backing = Arc::new(object_store::memory::InMemory::new());
+        let setup_store = Store::new(backing.clone());
+        let prefix = "locked-snapshot-ordering";
+        let setup_router = StoreLayout::new(setup_store.clone(), prefix.to_owned());
+        crate::core::remote_layout::initialize(&setup_store, &setup_router)
+            .await
+            .unwrap();
+        crate::cmd::init::create_initial_manifest(&setup_store, &setup_router, "refs/heads/main")
+            .await
+            .unwrap();
+
+        let gated = Arc::new(GatedReadStore {
+            inner: backing,
+            target: setup_router.layout_descriptor_path(),
+            started: Arc::new(tokio::sync::Semaphore::new(0)),
+            release: Arc::new(tokio::sync::Semaphore::new(0)),
+            gate_once: std::sync::atomic::AtomicBool::new(true),
+        });
+        let store = Store::new(gated.clone());
+        let router = StoreLayout::new(store.clone(), prefix.to_owned());
+        let mut config = NativePushConfig::new(PushConfig {
+            git_dir: Some(fixture.git_dir.clone()),
+            ..PushConfig::default()
+        });
+        config.progress = false;
+        config.emit_summary = false;
+        let specs = vec![main_push_spec()];
+        let mut state = PushState::default();
+        let mut push = Box::pin(run_native_push(
+            &config,
+            &specs,
+            NativePushInputs::new(
+                Some(store),
+                None,
+                PushStaging::Missing,
+                router,
+                &mut state,
+                "origin",
+                "crab://bucket/locked-snapshot-ordering",
+                None,
+                CancellationToken::new(),
+            ),
+        ));
+
+        tokio::select! {
+            permit = gated.started.acquire() => permit.unwrap().forget(),
+            result = &mut push => panic!("push finished before its snapshot read was gated: {result:?}"),
+        }
+        assert!(
+            crab_coordination::PushLock::ref_lease_is_claimed(
+                setup_store.inner(),
+                prefix,
+                "refs/heads/main",
+            )
+            .await
+            .unwrap(),
+            "the destination-ref lease must precede the first snapshot read"
+        );
+
+        gated.release.add_permits(1);
+        let result = push
+            .await
+            .expect("native push after releasing snapshot read");
+        assert!(result.all_ok());
+        let snapshot =
+            crate::metadata::manifest::read_repository_snapshot(&setup_store, &setup_router)
+                .await
+                .unwrap();
+        assert_eq!(snapshot.journal.refs.get("refs/heads/main"), Some(&tip));
     }
 
     #[tokio::test]

--- a/crates/crab-http-server/WRITE-DESIGN.md
+++ b/crates/crab-http-server/WRITE-DESIGN.md
@@ -381,10 +381,10 @@ generation under the manifest owner lease. `crab-remote-git` deliberately return
 The CLI now uses `crab-write::journal::commit_edits`, which checks the whole batch
 against a snapshot captured under retained ref leases, obtains causal parents
 and commits through the same metadata marker. A failed marker write is confirmed
-only by bounded readback of the exact expected bytes. Otherwise the typed
-`RefJournalCommitUncertain` preserves the transaction ID and write/readback errors.
-An absent marker is not a rejected push: generation compaction removes committed
-markers. HTTP receive must reconcile this outcome or fail the transport without
+by bounded readback of the exact expected bytes or an immutable compaction
+frontier proving that every edited ref descends from the exact transaction.
+Otherwise the typed `RefJournalCommitUncertain` preserves the transaction ID and
+write/readback errors. HTTP receive must reconcile this outcome or fail the transport without
 inventing an unchanged-ref result; Git's [report-status contract](https://git-scm.com/docs/pack-protocol#_report_status)
 reports the actual outcome for each requested ref. Prepared heads are never
 rolled back after a marker write is attempted.

--- a/crates/crab-metadata/src/error.rs
+++ b/crates/crab-metadata/src/error.rs
@@ -76,7 +76,7 @@ pub enum MetadataError {
     )]
     PlanAlreadyAttempted { plan_id: String },
 
-    /// The commit marker write failed and its exact bytes could not be confirmed.
+    /// The commit marker write failed without exact marker or compaction-frontier proof.
     #[cfg(feature = "storage")]
     #[error(
         "ref journal transaction {transaction_id} may have committed; reconcile durable commit evidence before retrying; current refs alone cannot prove the outcome"

--- a/crates/crab-metadata/src/ref_journal.rs
+++ b/crates/crab-metadata/src/ref_journal.rs
@@ -209,9 +209,9 @@ pub async fn read_ref_head(
 ///
 /// Each head first points at invisible prepared state. The immutable commit
 /// marker makes every edit visible together; later head promotion is cleanup.
-/// A failed marker write is confirmed by bounded exact readback when possible.
-/// Otherwise `RefJournalCommitUncertain` retains its identity and both failures;
-/// missing markers cannot prove rejection because compaction removes them.
+/// A failed marker write is confirmed by bounded exact readback or by an exact
+/// immutable compaction-frontier ancestry proof. Otherwise
+/// `RefJournalCommitUncertain` retains its identity and both failures.
 /// Cancellation before the marker rolls back prepared heads; after attempting
 /// the marker, the operation finishes outcome recovery and returns its result.
 pub async fn commit_ref_transaction(
@@ -321,8 +321,9 @@ async fn commit_ref_transaction_inner(
         )
         .await
     {
-        // A lost write response is not a rejected transaction. Confirm only the
-        // exact marker; never roll back prepared heads after attempting commit.
+        // A lost write response is not a rejected transaction. Confirm only
+        // exact marker bytes or exact compacted ancestry; current refs are not
+        // proof. Never roll back prepared heads after attempting commit.
         let verification = match marker_store
             .get_with_etag_bounded_with_timeout(
                 &marker_path,
@@ -336,7 +337,20 @@ async fn commit_ref_transaction_inner(
                 path: marker_path.to_string(),
                 reason: "commit marker differs from the submitted transaction".to_owned(),
             })),
-            Err(StorageError::NotFound { .. }) => Err(None),
+            Err(StorageError::NotFound { .. }) => {
+                match transaction_is_compacted(store, router, &transaction_id, transaction).await {
+                    Ok(true) => Ok(()),
+                    Ok(false) => Err(None),
+                    Err(error) => {
+                        warn!(
+                            %transaction_id,
+                            %error,
+                            "could not verify ref transaction through the compaction frontier"
+                        );
+                        Err(None)
+                    }
+                }
+            }
             Err(error) => Err(Some(error)),
         };
         if let Err(verification) = verification {
@@ -496,6 +510,43 @@ pub async fn transaction_is_active(
         "ref journal active marker",
     )?;
     active_marker_exists(store, router, transaction_id).await
+}
+
+async fn transaction_is_compacted(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    transaction_id: &str,
+    transaction: &RefJournalTransaction,
+) -> Result<bool> {
+    let (manifest, _) = crate::manifest_store::read_manifest(store, router).await?;
+    let Some(frontier) = read_ref_journal_frontier(store, router, &manifest).await? else {
+        return Ok(false);
+    };
+    for edit in &transaction.edits {
+        let Some(mut current) = frontier.heads.get(&edit.ref_name).cloned() else {
+            return Ok(false);
+        };
+        let mut visited = BTreeSet::new();
+        loop {
+            if current == transaction_id {
+                break;
+            }
+            if !visited.insert(current.clone()) || visited.len() > MAX_REF_HEADS {
+                return Err(corrupt_object(
+                    router
+                        .ref_journal_frontier_path(&manifest.git_validation_digest)
+                        .as_ref(),
+                    "ref journal frontier ancestry is cyclic or exceeds its bound",
+                ));
+            }
+            let ancestor = read_transaction(store, router, &current).await?;
+            let Some(parent) = ancestor.parents.get(&edit.ref_name).cloned().flatten() else {
+                return Ok(false);
+            };
+            current = parent;
+        }
+    }
+    Ok(true)
 }
 
 /// Repair compacted head promotion before removing its visibility marker.

--- a/crates/crab-metadata/src/ref_journal/commit_tests.rs
+++ b/crates/crab-metadata/src/ref_journal/commit_tests.rs
@@ -298,18 +298,12 @@ async fn unconfirmed_marker_preserves_identity_and_typed_failure() {
 }
 
 #[tokio::test]
-async fn missing_marker_after_compaction_is_not_reported_as_rejection() {
+async fn missing_marker_after_compaction_is_confirmed_by_the_frontier() {
     let (store, layout, origin, transaction, heads) = fixture(Fault::CompactedBeforeRead).await;
-    let error = commit_ref_transaction(&store, &layout, &transaction, &heads, || false)
+    let committed = commit_ref_transaction(&store, &layout, &transaction, &heads, || false)
         .await
-        .unwrap_err();
-    assert!(matches!(
-        error,
-        MetadataError::RefJournalCommitUncertain {
-            verification: None,
-            ..
-        }
-    ));
+        .expect("compaction frontier proves the exact committed transaction");
+    assert_eq!(committed.transaction_id, transaction.id().unwrap());
     let (manifest, _) = manifest_store::read_manifest(&origin, &layout)
         .await
         .unwrap();
@@ -319,5 +313,77 @@ async fn missing_marker_after_compaction_is_not_reported_as_rejection() {
             ("refs/heads/dev".to_owned(), "a".repeat(40)),
             ("refs/heads/main".to_owned(), "a".repeat(40)),
         ])
+    );
+}
+
+#[tokio::test]
+async fn matching_compacted_ref_values_do_not_confirm_another_transaction() {
+    let (store, layout, origin, transaction, heads) = fixture(Fault::CompactedBeforeRead).await;
+    commit_ref_transaction(&store, &layout, &transaction, &heads, || false)
+        .await
+        .expect("committed transaction is compacted during marker recovery");
+    let lookalike = RefJournalTransaction::new(
+        transaction.parents.clone(),
+        transaction.edits.clone(),
+        Some("refs/heads/main".to_owned()),
+        vec![],
+        vec![],
+    )
+    .unwrap();
+    let lookalike_id = lookalike.id().unwrap();
+
+    assert_ne!(lookalike_id, transaction.id().unwrap());
+    assert!(
+        !transaction_is_compacted(&origin, &layout, &lookalike_id, &lookalike)
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn later_frontier_descendant_confirms_the_compacted_transaction() {
+    let (store, layout, origin, transaction, heads) = fixture(Fault::CompactedBeforeRead).await;
+    let committed = commit_ref_transaction(&store, &layout, &transaction, &heads, || false)
+        .await
+        .expect("first transaction is compacted during marker recovery");
+    let main = read_ref_head(&origin, &layout, "refs/heads/main")
+        .await
+        .unwrap();
+    let next = RefJournalTransaction::new(
+        BTreeMap::from([(
+            "refs/heads/main".to_owned(),
+            main.visible_transaction.clone(),
+        )]),
+        vec![RefJournalEdit {
+            ref_name: "refs/heads/main".to_owned(),
+            old_oid: Some("a".repeat(40)),
+            new_oid: Some("b".repeat(40)),
+            peeled_oid: None,
+            lock_holder: None,
+            visibility_evidence_hash: None,
+        }],
+        None,
+        vec![],
+        vec![],
+    )
+    .unwrap();
+    commit_ref_transaction(&origin, &layout, &next, &[main], || false)
+        .await
+        .unwrap();
+    manifest_store::compact_ref_journal(
+        &origin,
+        &layout,
+        "2026-09-04T00:00:01.000Z".to_owned(),
+        None,
+        "later-compactor".to_owned(),
+    )
+    .await
+    .unwrap()
+    .expect("later transaction compacted");
+
+    assert!(
+        transaction_is_compacted(&origin, &layout, &committed.transaction_id, &transaction)
+            .await
+            .unwrap()
     );
 }

--- a/crates/crab-write/README.md
+++ b/crates/crab-write/README.md
@@ -140,11 +140,12 @@ caller still owns the generation-owner election and any required GC fences.
 For journal commit, callers also own write authorization, individual ref-name/policy and
 graph/dependency validation, immutable uploads, visibility proof, and ref leases.
 After a failed marker write, the metadata journal attempts bounded exact readback.
-Matching marker bytes confirm commit and allow head cleanup to continue. If the
-marker is absent, different, oversized or unreadable, `RefJournalCommitUncertain`
-retains the transaction ID, original write error and any readback error. Absence
-does not prove rejection: a compactor may already have published the generation
-and removed the active marker. No prepared-head rollback follows a marker attempt.
+Matching marker bytes confirm commit and allow head cleanup to continue. An
+absent marker is confirmed only when every edited ref's immutable compaction
+frontier descends from the exact transaction ID. If neither proof succeeds, or
+the marker is different, oversized or unreadable, `RefJournalCommitUncertain`
+retains the transaction ID, original write error and any readback error. No
+prepared-head rollback follows a marker attempt.
 Callers must reconcile an uncertain outcome before reporting failure. Successful journal commit
 means refs are durable, not that the derived catalog is ready for reads.
 Current ref values alone cannot establish the historical transaction outcome;

--- a/crates/crab-write/README.md
+++ b/crates/crab-write/README.md
@@ -56,8 +56,13 @@ planning and again after closing the writer. A superseded sample returns `None`;
 a current sample returns advancement and catalog/sweep statistics. The CLI owner
 reports superseded samples before writing a generation receipt or running later
 maintenance. Its continuous loop retries immediately; a one-shot run reports the
-superseded sample and exits. The shared anchor parser also serves native push, repack and history
-recovery; malformed index hashes retain their source errors.
+superseded sample and exits. After ref-journal compaction, the CLI's continuous
+owner instead requires a clean elapsed quiet window of at least one polling interval
+and five seconds before it starts repository-sized derived maintenance. Once that
+work is complete, unchanged manifest identity uses
+the last verified maintenance snapshot until the periodic revalidation. The shared
+anchor parser also serves native push, repack and history recovery; malformed index
+hashes retain their source errors.
 
 `generation::maintain_commit_graph` derives a missing generation-bound split
 commit graph through bounded `crab-remote-git` batches after catalog readiness.

--- a/packages/web/content/docs/cli/diagnostics/metadata-database.mdx
+++ b/packages/web/content/docs/cli/diagnostics/metadata-database.mdx
@@ -64,9 +64,15 @@ crab metadb owner --interval 30 --jsonl
 
 It reuses one exclusive locator writer across generations and publishes
 immutable read checkpoints before visibility repair. Push clients only pay an
-owner-lease probe and do not each rebuild the shared locator. If the owner is
-between generations or unavailable, complete-pack fetch remains available and
-a client can resume the canonical repair path after the lease expires.
+owner-lease probe and do not each rebuild the shared locator. During sustained
+pushes, the owner drains ref-journal transactions before derived maintenance and
+requires an elapsed quiet window of at least one polling interval and five seconds
+before starting repository-sized catalog, commit-graph, or repack work. Once
+maintenance converges, unchanged manifest
+identity reports the last verified inventory snapshot without rescanning the
+repository on every poll. If the owner is between generations or unavailable,
+complete-pack fetch remains available and a client can resume the canonical
+repair path after the lease expires.
 
 ## Rebuilding from Shards
 

--- a/packages/web/content/docs/cli/reference/crab-metadb.mdx
+++ b/packages/web/content/docs/cli/reference/crab-metadb.mdx
@@ -56,7 +56,15 @@ crab metadb owner --interval 30 --jsonl
 ```
 
 Push clients then hand generation-bound Git locator publication to that owner.
+The continuous owner always drains committed ref-journal transactions first.
+After a drain, it observes an elapsed quiet window of at least one polling interval
+and five seconds before starting repository-sized catalog, commit-graph, or repack
+work. Sustained pushes
+therefore keep ref publication bounded instead of competing with background
+maintenance. `--once` remains eager for explicit operator maintenance.
 The default idle polling cost is 2,880 manifest reads per repository per day,
-plus two renewable object-store leases and a ten-minute visibility-evidence
-revalidation. Increase `--interval` when storage request cost matters more than
-the delay before protocol-v2 fetch becomes available for a new generation.
+plus two renewable object-store leases and a ten-minute derived-state
+revalidation. Between revalidations, an unchanged manifest identity reports the
+last verified maintenance snapshot without reopening the repository catalog.
+Increase `--interval` when storage request cost matters more than the delay
+before protocol-v2 fetch becomes available for a new generation.


### PR DESCRIPTION
## Summary

- acquire destination-ref leases before the native push snapshot and hand the verified snapshot into the pipeline, removing a duplicate repository read while preserving the post-classification mutable-dependency refresh
- make the continuous metadata owner drain ref-journal work first, defer derived catalog/visibility/graph maintenance until a real quiet period, and avoid repeating unchanged generation scans
- recover a lost marker reply after concurrent compaction only when the manifest-bound immutable frontier proves every edited ref descends from the exact transaction ID

## Why this is the right boundary

The ref leases are the authority that stabilizes push inputs, so the reusable snapshot is captured under those leases and remains subject to the existing complete dependency refresh before commit. Maintenance policy belongs to the generation owner rather than every pusher. Commit recovery remains fail-closed: matching current refs are insufficient, and the new adversarial test proves a different transaction with identical ref values is not accepted.

## Qualification

Fresh local RustFS instance using a new bucket and the requested CrabData volume:

- exact k8s Crab clone: 12.80 s
- GitHub direct clone: 56.65 s
- speedup: 4.43x
- source and Crab clone inventories: exactly 1,646,244 objects each
- git fsck --full: passed
- real k8s replay: 2,000/2,000 commits pushed; exact final tip verified
- exact-current synthetic continuation: 2,000/2,000 pushes succeeded; 873.4 ms mean, 883 ms median, 4.418 s max, zero pushes over 5 s
- steady-state pushes 501-2000: 885.2 ms mean, 903 ms median, regression slope -0.004 ms/push
- owner performed journal compaction during the stream and deferred catalog/visibility work until the repository was quiet

## Validation

- cargo fmt --all -- --check
- cargo check -p crab --locked
- cargo test -p crab-metadata --features storage --locked
- cargo test -p crab-write --locked
- cargo test -p crab-remote --features publication --locked
- cargo test -p crab --locked cmd::metadb::tests
- cargo test -p crab --locked git::push_native::tests
- cargo test -p crab-remote-git --locked complete_inventory_requires_matching_fully_visible_catalog
- cargo test -p crab-git --locked concatenate_complete_pack_inventory_preserves_pack_objects
- npm run check:links
