### PR TITLE
harden(s3): bound response stream idle time

### DIFF
--- a/.github/workflows/s3-gateway.yml
+++ b/.github/workflows/s3-gateway.yml
@@ -1308,6 +1308,8 @@ jobs:
           CRAB_S3_GATEWAY_IMAGE: crab-s3-gateway:test
           CRAB_S3_GATEWAY_MANAGEMENT_PORT: "18181"
           CRAB_S3_GATEWAY_PORT: "18180"
+          CRAB_S3_GATEWAY_STANDBY_MANAGEMENT_PORT: "18183"
+          CRAB_S3_GATEWAY_STANDBY_PORT: "18182"
           CRAB_S3_GATEWAY_SCRATCH_SIZE: 128m
           CRAB_S3_GATEWAY_SECRET_FILE: ${{ runner.temp }}/crab-s3-gateway/gateway-secret
           RUSTFS_PORT: "19100"
@@ -1335,24 +1337,33 @@ jobs:
             aws --endpoint-url http://127.0.0.1:19100 \
             s3api create-bucket --bucket crab-s3-gateway-qualification >/dev/null
           docker compose -f "${compose}" --profile initialize run --rm gateway-init
-          docker compose -f "${compose}" up --detach gateway
-          for attempt in $(seq 1 60); do
-            if docker compose -f "${compose}" exec --no-TTY gateway \
-              crab-s3-gateway --config /etc/crab/s3-gateway.toml --readiness-check; then
-              break
-            fi
-            if [[ "${attempt}" == 60 ]]; then
-              echo "Compose gateway did not become ready" >&2
-              exit 1
-            fi
-            sleep 1
+          docker compose -f "${compose}" up --detach gateway gateway-standby
+          for service in gateway gateway-standby; do
+            for attempt in $(seq 1 60); do
+              if docker compose -f "${compose}" exec --no-TTY "${service}" \
+                crab-s3-gateway --config /etc/crab/s3-gateway.toml --readiness-check; then
+                break
+              fi
+              if [[ "${attempt}" == 60 ]]; then
+                echo "Compose ${service} did not become ready" >&2
+                exit 1
+              fi
+              sleep 1
+            done
           done
           # JMESPath backticks are literals inside this single-quoted query.
           # shellcheck disable=SC2016
           AWS_ACCESS_KEY_ID="${GATEWAY_ACCESS_KEY}" \
             AWS_SECRET_ACCESS_KEY="${GATEWAY_SECRET_KEY}" \
-            AWS_DEFAULT_REGION=us-east-1 \
+          AWS_DEFAULT_REGION=us-east-1 \
             aws --endpoint-url http://127.0.0.1:18180 s3api list-buckets \
+              --query 'Buckets[?Name==`gateway-repository`].Name | [0]' \
+              --output text | grep -Fx gateway-repository
+          # shellcheck disable=SC2016
+          AWS_ACCESS_KEY_ID="${GATEWAY_ACCESS_KEY}" \
+            AWS_SECRET_ACCESS_KEY="${GATEWAY_SECRET_KEY}" \
+            AWS_DEFAULT_REGION=us-east-1 \
+            aws --endpoint-url http://127.0.0.1:18182 s3api list-buckets \
               --query 'Buckets[?Name==`gateway-repository`].Name | [0]' \
               --output text | grep -Fx gateway-repository
 
@@ -1361,6 +1372,7 @@ jobs:
           head -c 6291456 /dev/zero > "${compose_client}/part-1.bin"
           head -c 1048576 /dev/zero > "${compose_client}/part-2.bin"
           compose_endpoint=http://127.0.0.1:18180
+          compose_standby_endpoint=http://127.0.0.1:18182
           compose_bucket=gateway-repository
           compose_key=main/qualification/compose-restart.bin
           export AWS_ACCESS_KEY_ID="${GATEWAY_ACCESS_KEY}"
@@ -1386,19 +1398,19 @@ jobs:
             fi
             sleep 1
           done
-          test "$(aws --endpoint-url "${compose_endpoint}" s3api list-parts \
+          test "$(aws --endpoint-url "${compose_standby_endpoint}" s3api list-parts \
             --bucket "${compose_bucket}" --key "${compose_key}" \
             --upload-id "${compose_upload_id}" --query 'length(Parts)' --output text)" = 1
-          aws --endpoint-url "${compose_endpoint}" s3api upload-part \
+          aws --endpoint-url "${compose_standby_endpoint}" s3api upload-part \
             --bucket "${compose_bucket}" --key "${compose_key}" \
             --upload-id "${compose_upload_id}" --part-number 2 \
             --body "${compose_client}/part-2.bin" >/dev/null
-          aws --endpoint-url "${compose_endpoint}" s3api list-parts \
+          aws --endpoint-url "${compose_standby_endpoint}" s3api list-parts \
             --bucket "${compose_bucket}" --key "${compose_key}" \
             --upload-id "${compose_upload_id}" \
             --query '{Parts: Parts[].{ETag: ETag, PartNumber: PartNumber}}' \
             > "${compose_client}/completion.json"
-          aws --endpoint-url "${compose_endpoint}" s3api complete-multipart-upload \
+          aws --endpoint-url "${compose_standby_endpoint}" s3api complete-multipart-upload \
             --bucket "${compose_bucket}" --key "${compose_key}" \
             --upload-id "${compose_upload_id}" \
             --multipart-upload "file://${compose_client}/completion.json" >/dev/null
@@ -1407,15 +1419,25 @@ jobs:
             "${compose_client}/result.bin" >/dev/null
           cmp <(cat "${compose_client}/part-1.bin" "${compose_client}/part-2.bin") \
             "${compose_client}/result.bin"
+          aws --endpoint-url "${compose_standby_endpoint}" s3api get-object \
+            --bucket "${compose_bucket}" --key "${compose_key}" \
+            "${compose_client}/standby-result.bin" >/dev/null
+          cmp "${compose_client}/result.bin" "${compose_client}/standby-result.bin"
           aws --endpoint-url "${compose_endpoint}" s3api delete-object \
             --bucket "${compose_bucket}" --key "${compose_key}" >/dev/null
-          docker compose -f "${compose}" stop gateway
+          docker compose -f "${compose}" stop gateway gateway-standby
 
       - name: Print service logs after failure
         if: failure()
+        env:
+          CRAB_S3_GATEWAY_CONFIG: ${{ github.workspace }}/crates/crab-s3-gateway/deploy/compose.gateway.toml
+          CRAB_S3_GATEWAY_IMAGE: crab-s3-gateway:test
+          CRAB_S3_GATEWAY_SECRET_FILE: ${{ runner.temp }}/crab-s3-gateway/gateway-secret
         run: |
           docker logs crab-s3-gateway 2>&1 || true
           docker logs crab-s3-gateway-rustfs 2>&1 || true
+          docker compose -f crates/crab-s3-gateway/deploy/compose.yaml \
+            logs --no-color gateway gateway-standby rustfs 2>&1 || true
 
       - name: Clean up services
         if: always()

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -452,4 +452,7 @@ byte-exact without Xet reconstruction scratch. The broader client/backend matrix
 remains a release gate, not an inferred claim from that local smoke test.
 The same packaged-image run uses pinned Boto3 to complete a deterministic 512 MiB
 multipart object and verify both a full read and a range crossing a persisted part
-boundary against the source digest.
+boundary against the source digest. Its Compose phase runs two gateway instances
+with independent caches against the same RustFS-backed Crab repository, then
+continues a multipart upload through the standby after replacing the primary and
+verifies reads through both instances.

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -406,9 +406,11 @@ memory/local/service and hit/miss/failure dimensions, verified hit bytes, local
 persistence failures, and aggregate catalog entry/byte accounting. Catalog
 gauges come from a coalesced read-only SQLite probe on each scrape; probe health
 and last-success time distinguish genuine zero usage from an unreadable
-catalog. No series includes a repository, ref, path, endpoint, principal, or
-credential label. Origin transport metrics remain the authority for fallback
-cost and provider failures.
+catalog. Response-body failures after headers are exposed separately from
+request status outcomes; `crab_s3_gateway_http_response_body_timeouts_total`
+identifies the bounded response-idle-timeout subset. No series includes a
+repository, ref, path, endpoint, principal, or credential label. Origin
+transport metrics remain the authority for fallback cost and provider failures.
 
 The canonical Helm chart can optionally install a release-scoped PodMonitor and
 PrometheusRule. Both are opt-in because their CRDs belong to the Prometheus

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -352,8 +352,12 @@ abort with `RequestTimeout` after 60 seconds without an incoming body frame; thi
 is an idle timeout, not a total-transfer deadline, so large clients may continue
 for as long as they keep sending data. XML operations that `s3s` buffers,
 including multipart completion, use the same 60-second body-idle bound; streamed
-multipart form uploads remain on their streaming path. Content spools, Xet range reconstruction,
-and generated Git packs share one atomic process-local gate. It retains 10% of
+multipart form uploads remain on their streaming path. Response streams use the
+same 60-second per-frame idle bound, releasing read admission and dropping the
+underlying provider or Xet stream on timeout; this is not a total-transfer
+deadline, so large downloads may continue while bytes keep arriving. Content
+spools, Xet range reconstruction, and generated Git packs share one atomic
+process-local gate. It retains 10% of
 visible capacity outside reservations, bounded to a 64 MiB minimum and 1 GiB
 maximum. A failed capacity probe fails closed, and reservation pressure returns
 `SlowDown` without publishing partial state.

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -225,8 +225,9 @@ immutable view with bounded four-repository concurrency; it returns `503
 Service Unavailable` with `Retry-After: 5` when any repository is unsafe to
 serve. `GET /metrics` returns Prometheus 0.0.4 text
 for bounded HTTP method/outcome counts, full response-stream duration and
-in-flight requests, response-body errors/aborts, and control/read/transfer
-admission capacity, queue pressure, and outcomes. It also reports aggregate
+in-flight requests, response-body errors/aborts, and the bounded response-idle
+timeout subset, plus control/read/transfer admission capacity, queue pressure,
+and outcomes. It also reports aggregate
 multipart-maintenance cycles, completed lifecycle actions, failure reasons,
 cycle duration, and the last cycle in which every configured repository was
 healthy. Per-slot failures make that cycle degraded instead of disappearing

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -313,10 +313,14 @@ a range that crosses a persisted part boundary against the source SHA-256.
 Multipart registration is measured with equal one-part upload counts at 8 MiB
 and 64 MiB: the durable control records must remain within 64 KiB, differ by no
 more than 64 bytes, and leave no staged payload after abort.
-The packaged-image gate also kills the gateway with live, frozen, and eligible
-orphaned multipart payloads on RustFS. A restarted process must reclaim only the
-orphan within two completed scans, release its capacity slot, preserve the live
-and frozen payloads, and leave no fixture payloads after explicit cleanup.
+The packaged-image gate also runs two Compose gateway instances with independent
+caches against one RustFS-backed repository. It replaces the primary during a
+multipart upload, continues and completes that upload through the standby, and
+verifies the completed bytes through both instances. It then kills a gateway with
+live, frozen, and eligible orphaned multipart payloads on RustFS. A restarted
+process must reclaim only the orphan within two completed scans, release its
+capacity slot, preserve the live and frozen payloads, and leave no fixture
+payloads after explicit cleanup.
 Stale, dirty, incomplete, skipped, unmeasured, or identity-bearing reports fail
 the evidence gate.
 The statically validated Kubernetes workload and EKS values are in

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -159,7 +159,10 @@ deadline; HTTP/2 is limited to 64 concurrent streams and a 128 KiB header list,
 with a 30-second keep-alive ping and a 10-second acknowledgement deadline. Each
 XML operation that `s3s` buffers, including multipart completion, is also bounded
 by the 60-second request-body idle timeout; streamed object and part uploads keep
-their existing body timeout and backpressure path.
+their existing body timeout and backpressure path. Object response streams also
+use a 60-second per-frame idle timeout: a stalled provider or Xet reconstruction
+releases read admission and is dropped, while a continuously producing large
+download has no total-transfer deadline.
 PutObject, UploadPart, and copied source range uses a request-local temporary
 file. Large multipart completion rereads durable parts instead of creating an
 additional full-object spool, so its local scratch does not scale with the

--- a/crates/crab-s3-gateway/deploy/README.md
+++ b/crates/crab-s3-gateway/deploy/README.md
@@ -1,11 +1,12 @@
 # Docker Compose qualification
 
 This stack is an isolated local smoke environment, not a production credential
-or storage configuration. It runs the packaged gateway with a non-root user,
-read-only root filesystem, dropped capabilities, bounded scratch, private
-management port, a process-bounded persistent gateway cache, and a persistent
-RustFS data volume. The cache is disposable and survives gateway-container
-replacement; it is never authoritative repository state.
+or storage configuration. It defines two independently runnable packaged
+gateway instances with non-root users, read-only root filesystems, dropped
+capabilities, bounded scratch, private management ports, process-bounded
+persistent gateway caches, and a persistent RustFS data volume. The caches are
+disposable and survive gateway-container replacement; they are never
+authoritative repository state.
 
 The checked ECS Fargate deployment profile is in [`ecs/`](ecs/), with the
 CloudFormation template, parameter example, static lint contract, and live-
@@ -62,6 +63,12 @@ Use any unchanged S3 client at `http://127.0.0.1:18080` with access key
 `us-east-1`, and path-style addressing. The management listener is bound only
 to `127.0.0.1:18081`.
 
+To exercise the two-instance path locally, start `gateway-standby` alongside
+`gateway`, use `http://127.0.0.1:18082` and its management listener at
+`127.0.0.1:18083`, and continue an upload through either endpoint. Each
+instance has its own disposable cache; RustFS-backed Crab metadata and staged
+multipart parts are the shared recovery boundary.
+
 Verify the private Prometheus endpoint after generating traffic:
 
 ```sh
@@ -84,13 +91,15 @@ Keep that runbook and the PrometheusRule from the same source revision.
 Provider-internal retries still require provider or load-balancer telemetry
 because gateway metrics count complete logical object-store operations.
 
-The checked CI qualification also creates a multipart session, uploads a valid
-non-final part, force-recreates the gateway container, verifies the replacement
-process can list the durable part, uploads the final part, completes the object,
-and compares every assembled byte. RustFS retains the shared upload catalog and
-repository data; the gateway's scratch filesystem remains disposable. The
-named `gateway-cache` volume may warm the replacement process but is not needed
-for correctness or recovery.
+The checked CI qualification starts both gateway instances, creates a multipart
+session through the primary, uploads a valid non-final part, force-recreates the
+primary while the standby remains live, verifies the standby can list the
+durable part, uploads the final part and completes the object through the
+standby, then reads it through both instances and compares every assembled byte.
+RustFS retains the shared upload catalog and repository data; each gateway's
+scratch filesystem remains disposable. The `gateway-cache` and
+`gateway-cache-standby` volumes may warm their respective replacement
+processes but are not needed for correctness or recovery.
 It also sends a multi-chunk HMAC-signed SigV4 `PutObject`, verifies the decoded
 bytes and S3-compatible `Content-Encoding` metadata, then corrupts a chunk
 signature and proves no object was published.
@@ -128,7 +137,7 @@ docker compose -f crates/crab-s3-gateway/deploy/compose.yaml down
 ```
 
 Only the explicit isolated-smoke teardown removes the RustFS and disposable
-gateway-cache volumes:
+`gateway-cache` and `gateway-cache-standby` volumes:
 
 ```sh
 docker compose -f crates/crab-s3-gateway/deploy/compose.yaml down --volumes

--- a/crates/crab-s3-gateway/deploy/compose.yaml
+++ b/crates/crab-s3-gateway/deploy/compose.yaml
@@ -53,6 +53,27 @@ services:
       - "127.0.0.1:${CRAB_S3_GATEWAY_MANAGEMENT_PORT:-18081}:8081"
     volumes: *gateway-mounts
 
+  gateway-standby:
+    image: ${CRAB_S3_GATEWAY_IMAGE:-crab-s3-gateway:local}
+    depends_on:
+      rustfs:
+        condition: service_started
+    environment: *backend-environment
+    read_only: true
+    tmpfs:
+      - /var/lib/crab/tmp:rw,noexec,nosuid,nodev,size=${CRAB_S3_GATEWAY_SCRATCH_SIZE:-512m},uid=10001,gid=10001,mode=0700
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    stop_grace_period: 35s
+    ports:
+      - "127.0.0.1:${CRAB_S3_GATEWAY_STANDBY_PORT:-18082}:8080"
+      - "127.0.0.1:${CRAB_S3_GATEWAY_STANDBY_MANAGEMENT_PORT:-18083}:8081"
+    volumes:
+      - ${CRAB_S3_GATEWAY_CONFIG:?set CRAB_S3_GATEWAY_CONFIG}:/etc/crab/s3-gateway.toml:ro
+      - ${CRAB_S3_GATEWAY_SECRET_FILE:?set CRAB_S3_GATEWAY_SECRET_FILE}:/run/secrets/crab-s3-secret:ro
+      - gateway-cache-standby:/var/lib/crab/cache-volume
+
 volumes:
   rustfs-data:
   gateway-cache:
+  gateway-cache-standby:

--- a/crates/crab-s3-gateway/deploy/operations.md
+++ b/crates/crab-s3-gateway/deploy/operations.md
@@ -304,7 +304,8 @@ For Kubernetes, use `helm upgrade --atomic`, wait for rollout, and observe
 readiness, maintenance health, admission pressure, and signed range reads under
 active traffic. Preserve `maxUnavailable: 0`, the disruption budget, and
 topology spreading. For Docker, recreate only the gateway container and retain
-the backend and cache volumes; Compose remains single-host and cannot provide
+the backend and cache volumes; the Compose smoke can exercise two instances
+against the shared backend, but it remains single-host and cannot provide
 failure-domain availability.
 
 Rollback only to a revision explicitly documented as compatible with every

--- a/crates/crab-s3-gateway/deploy/operations.md
+++ b/crates/crab-s3-gateway/deploy/operations.md
@@ -65,10 +65,11 @@ kubectl get events --namespace "$gateway_namespace" \
 ```
 
 Use a temporary port-forward to inspect `/readyz` and `/metrics` on one pod.
-Compare maintenance failure reasons, backend outcomes, response-body errors,
-scratch health, and admission queues for the same pod and time window. A body
-error can occur after a client has received `200`; verify the complete object
-length and digest before treating that request as successful.
+Compare maintenance failure reasons, backend outcomes, response-body errors and
+the `crab_s3_gateway_http_response_body_timeouts_total` timeout subset, scratch
+health, and admission queues for the same pod and time window. A body error can
+occur after a client has received `200`; verify the complete object length and
+digest before treating that request as successful.
 
 Safe action:
 

--- a/crates/crab-s3-gateway/src/content.rs
+++ b/crates/crab-s3-gateway/src/content.rs
@@ -17,6 +17,7 @@ pub(crate) const MAX_MULTIPART_OBJECT_BYTES: u64 = 50_000_000_000_000;
 pub(crate) const MAX_MULTIPART_PART_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 pub(crate) const INLINE_GIT_BLOB_BYTES: u64 = 64 * 1024 * 1024;
 pub(crate) const BODY_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const RESPONSE_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub(crate) fn max_multipart_object_bytes(provider: crab_storage::StorageProviderKind) -> u64 {
     MAX_MULTIPART_OBJECT_BYTES.min(crab_storage::multipart::upload_limits(provider).max_object_size)

--- a/crates/crab-s3-gateway/src/content.rs
+++ b/crates/crab-s3-gateway/src/content.rs
@@ -19,6 +19,17 @@ pub(crate) const INLINE_GIT_BLOB_BYTES: u64 = 64 * 1024 * 1024;
 pub(crate) const BODY_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 pub(crate) const RESPONSE_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
+#[derive(Debug)]
+pub(crate) struct ResponseIdleTimeout;
+
+impl std::fmt::Display for ResponseIdleTimeout {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("response body was idle for too long")
+    }
+}
+
+impl std::error::Error for ResponseIdleTimeout {}
+
 pub(crate) fn max_multipart_object_bytes(provider: crab_storage::StorageProviderKind) -> u64 {
     MAX_MULTIPART_OBJECT_BYTES.min(crab_storage::multipart::upload_limits(provider).max_object_size)
 }

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -188,10 +188,7 @@ fn hold_permit_with_timeout(
                 Ok(None) => None,
                 Err(_) => {
                     drop(permit);
-                    let error: s3s::StdError = Box::new(std::io::Error::new(
-                        std::io::ErrorKind::TimedOut,
-                        "response body was idle for too long",
-                    ));
+                    let error: s3s::StdError = Box::new(crate::content::ResponseIdleTimeout);
                     Some((Err(error), None))
                 }
             }

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -24,6 +24,7 @@ use crate::{
     Config, RepositoryAccess, RepositoryConfig,
     admission::{Admission, RequestClass, RequestPermit},
     auth::GatewayAuth,
+    content::RESPONSE_IDLE_TIMEOUT,
     metrics::{MaintenanceCycleOutcome, MaintenanceFailure, Metrics},
     mutation, namespace,
 };
@@ -166,10 +167,34 @@ type ContentStream =
     Pin<Box<dyn futures_util::Stream<Item = Result<Bytes, s3s::StdError>> + Send + 'static>>;
 
 fn hold_permit(stream: ContentStream, permit: RequestPermit) -> ContentStream {
+    hold_permit_with_timeout(stream, permit, RESPONSE_IDLE_TIMEOUT)
+}
+
+fn hold_permit_with_timeout(
+    stream: ContentStream,
+    permit: RequestPermit,
+    idle_timeout: Duration,
+) -> ContentStream {
     Box::pin(futures_util::stream::unfold(
-        (stream, permit),
-        |(mut stream, permit)| async move {
-            stream.next().await.map(|result| (result, (stream, permit)))
+        Some((stream, permit)),
+        move |state| async move {
+            let (mut stream, permit) = state?;
+            match tokio::time::timeout(idle_timeout, stream.next()).await {
+                Ok(Some(Ok(bytes))) => Some((Ok(bytes), Some((stream, permit)))),
+                Ok(Some(Err(error))) => {
+                    drop(permit);
+                    Some((Err(error), None))
+                }
+                Ok(None) => None,
+                Err(_) => {
+                    drop(permit);
+                    let error: s3s::StdError = Box::new(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "response body was idle for too long",
+                    ));
+                    Some((Err(error), None))
+                }
+            }
         },
     ))
 }
@@ -4846,6 +4871,21 @@ mod tests {
         );
 
         drop(response);
+        admission.acquire(RequestClass::Read).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stalled_response_releases_read_capacity_with_timeout_error() {
+        let admission = Admission::new(8, CancellationToken::new(), Metrics::new().unwrap());
+        let permit = admission.acquire(RequestClass::Read).await.unwrap();
+        let _second = admission.acquire(RequestClass::Read).await.unwrap();
+        let _third = admission.acquire(RequestClass::Read).await.unwrap();
+        let _fourth = admission.acquire(RequestClass::Read).await.unwrap();
+        let source: ContentStream = Box::pin(futures_util::stream::pending());
+        let mut response = hold_permit_with_timeout(source, permit, Duration::from_millis(1));
+
+        let error = response.next().await.unwrap().unwrap_err();
+        assert_eq!(error.to_string(), "response body was idle for too long");
         admission.acquire(RequestClass::Read).await.unwrap();
     }
 

--- a/crates/crab-s3-gateway/src/metrics.rs
+++ b/crates/crab-s3-gateway/src/metrics.rs
@@ -84,6 +84,7 @@ struct MethodMetrics {
     in_flight: Gauge,
     duration: Histogram,
     body_errors: Counter,
+    body_timeouts: Counter,
     body_aborts: Counter,
 }
 
@@ -335,6 +336,13 @@ impl MethodMetrics {
                 ),
                 &METADATA,
             ),
+            body_timeouts: recorder.register_counter(
+                &key(
+                    "crab_s3_gateway_http_response_body_timeouts_total",
+                    &[("method", method)],
+                ),
+                &METADATA,
+            ),
             body_aborts: recorder.register_counter(
                 &key(
                     "crab_s3_gateway_http_response_body_aborts_total",
@@ -453,6 +461,13 @@ impl RequestObservation {
         self.finish();
     }
 
+    fn body_timeout(&mut self) {
+        self.metrics.inner.methods[self.method]
+            .body_timeouts
+            .increment(1);
+        self.body_error();
+    }
+
     fn body_abort(&mut self) {
         self.metrics.inner.methods[self.method]
             .body_aborts
@@ -523,7 +538,14 @@ impl http_body::Body for ObservedBody {
             }
             Poll::Ready(Some(Err(error))) => {
                 if let Some(mut observation) = this.observation.take() {
-                    observation.body_error();
+                    if error
+                        .downcast_ref::<crate::content::ResponseIdleTimeout>()
+                        .is_some()
+                    {
+                        observation.body_timeout();
+                    } else {
+                        observation.body_error();
+                    }
                 }
                 Poll::Ready(Some(Err(error)))
             }
@@ -572,6 +594,11 @@ fn describe_metrics(recorder: &impl Recorder) {
         recorder,
         "crab_s3_gateway_http_response_body_errors_total",
         "Response streams that failed after headers were produced.",
+    );
+    describe_counter(
+        recorder,
+        "crab_s3_gateway_http_response_body_timeouts_total",
+        "Response streams terminated by the bounded idle timeout.",
     );
     describe_counter(
         recorder,

--- a/crates/crab-s3-gateway/src/metrics/tests.rs
+++ b/crates/crab-s3-gateway/src/metrics/tests.rs
@@ -97,7 +97,27 @@ async fn failed_response_body_records_stream_error() {
     assert!(body.frame().await.unwrap().is_err());
     let rendered = metrics.render(&admission);
     assert!(rendered.contains("crab_s3_gateway_http_response_body_errors_total{method=\"get\"} 1"));
+    assert!(
+        rendered.contains("crab_s3_gateway_http_response_body_timeouts_total{method=\"get\"} 0")
+    );
     assert!(rendered.contains("crab_s3_gateway_http_in_flight_requests{method=\"get\"} 0"));
+}
+
+#[tokio::test]
+async fn timed_out_response_body_records_a_timeout_subclass() {
+    let (admission, metrics) = setup();
+    let observation = metrics.start_request(&Method::GET).response(StatusCode::OK);
+    let stream =
+        futures_util::stream::iter([Err::<Frame<Bytes>, _>(crate::content::ResponseIdleTimeout)]);
+    let source = http_body_util::StreamBody::new(stream);
+    let mut body = ObservedBody::new(s3s::Body::http_body_unsync(source), observation);
+
+    assert!(body.frame().await.unwrap().is_err());
+    let rendered = metrics.render(&admission);
+    assert!(rendered.contains("crab_s3_gateway_http_response_body_errors_total{method=\"get\"} 1"));
+    assert!(
+        rendered.contains("crab_s3_gateway_http_response_body_timeouts_total{method=\"get\"} 1")
+    );
 }
 
 #[test]

--- a/crates/crab-s3-gateway/src/server.rs
+++ b/crates/crab-s3-gateway/src/server.rs
@@ -15,6 +15,7 @@ use hyper_util::{
     server::{conn::auto::Builder as ConnectionBuilder, graceful::GracefulShutdown},
 };
 use s3s::{
+    config::{S3Config, StaticConfigProvider},
     host::SingleDomain,
     service::{S3Service, S3ServiceBuilder},
 };
@@ -36,6 +37,11 @@ const MAX_HTTP1_HEADERS: usize = 128;
 const MAX_HTTP1_BUFFER_BYTES: usize = 128 * 1024;
 const MAX_HTTP2_HEADER_LIST_BYTES: u32 = 128 * 1024;
 const MAX_HTTP2_STREAMS_PER_CONNECTION: u32 = 64;
+const S3_XML_MAX_BODY_BYTES: usize = 20 * 1024 * 1024;
+const S3_FORM_MAX_FIELD_BYTES: usize = 1024 * 1024;
+const S3_FORM_MAX_FIELDS_BYTES: usize = 20 * 1024 * 1024;
+const S3_FORM_MAX_PARTS: usize = 1000;
+const S3_PRESIGNED_MAX_SKEW_SECONDS: u32 = 900;
 
 #[derive(Clone)]
 pub(crate) struct RequestBodyDigest {
@@ -86,6 +92,9 @@ pub async fn serve(config: Config) -> Result<()> {
     let auth = gateway.auth();
     builder.set_auth(auth.clone());
     builder.set_access(auth);
+    builder.set_config(Arc::new(StaticConfigProvider::new(Arc::new(
+        gateway_s3_config(),
+    ))));
     if let Some(domain) = endpoint_domain {
         builder.set_host(SingleDomain::new(&domain)?);
     }
@@ -189,6 +198,18 @@ fn connection_capacity(max_in_flight_requests: usize) -> usize {
     max_in_flight_requests
         .saturating_mul(CONNECTIONS_PER_REQUEST)
         .max(MANAGEMENT_CONNECTIONS)
+}
+
+fn gateway_s3_config() -> S3Config {
+    let mut config = S3Config::default();
+    config.xml_max_body_size = S3_XML_MAX_BODY_BYTES;
+    config.post_object_max_file_size = crate::content::MAX_PUT_OBJECT_BYTES;
+    config.form_max_field_size = S3_FORM_MAX_FIELD_BYTES;
+    config.form_max_fields_size = S3_FORM_MAX_FIELDS_BYTES;
+    config.form_max_parts = S3_FORM_MAX_PARTS;
+    config.presigned_url_max_skew_time_secs = S3_PRESIGNED_MAX_SKEW_SECONDS;
+    config.normalize_forward_slash_path = false;
+    config
 }
 
 /// Check the running process without accessing repository storage.
@@ -485,6 +506,25 @@ mod tests {
     fn connection_capacity_scales_without_exceeding_the_request_budget_multiplier() {
         assert_eq!(connection_capacity(8), 32);
         assert_eq!(connection_capacity(4096), 16_384);
+    }
+
+    #[test]
+    fn s3_protocol_limits_are_pinned_to_the_gateway_contract() {
+        let config = gateway_s3_config();
+
+        assert_eq!(config.xml_max_body_size, S3_XML_MAX_BODY_BYTES);
+        assert_eq!(
+            config.post_object_max_file_size,
+            crate::content::MAX_PUT_OBJECT_BYTES
+        );
+        assert_eq!(config.form_max_field_size, S3_FORM_MAX_FIELD_BYTES);
+        assert_eq!(config.form_max_fields_size, S3_FORM_MAX_FIELDS_BYTES);
+        assert_eq!(config.form_max_parts, S3_FORM_MAX_PARTS);
+        assert_eq!(
+            config.presigned_url_max_skew_time_secs,
+            S3_PRESIGNED_MAX_SKEW_SECONDS
+        );
+        assert!(!config.normalize_forward_slash_path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- bound every S3 response stream to a 60-second per-frame idle timeout
- release the read admission permit and drop provider/Xet streams on timeout or stream error
- expose response-body timeout diagnostics through `crab_s3_gateway_http_response_body_timeouts_total`
- preserve unlimited total duration for continuously producing large downloads
- pin the upstream `s3s` XML/form/parser limits and signed-path normalization
- qualify two independent Compose gateway instances with separate caches, shared RustFS-backed state, and multipart continuation across primary replacement/standby
- document both hardening contracts, observability, deployment failover qualification, and add stalled-stream/parser-limit regression tests

This follows the merged S3 gateway implementation in #175 and targets the `S3 Gateway Production Readiness` milestone.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p crab-s3-gateway --locked`
- `cargo test -p crab-s3-gateway --locked` (146 library tests, 1 binary test)
- `cargo clippy -p crab-s3-gateway --locked --all-targets -- -D warnings`
- `python3 -B -m unittest crab/scripts/e2e/test_s3_gateway_qualification_report.py crab/scripts/e2e/test_s3_gateway_workload.py`
- Docker Compose config expansion, workflow Bash syntax, and actionlint/ShellCheck
- `git diff --check`
