### PR TITLE
fix(staging): accept concurrent prepared xorb winners

### DIFF
--- a/crab/src/lfs/discovery/tests.rs
+++ b/crab/src/lfs/discovery/tests.rs
@@ -86,8 +86,7 @@ fn rev_list_parser_accepts_line_delimited_named_objects() {
 #[test]
 fn range_scan_does_not_fall_back_when_rev_list_fails() {
     let dir = tempfile::tempdir().unwrap();
-    let status = Command::new("git")
-        .current_dir(dir.path())
+    let status = git_command_in(dir.path(), GitObjectAccess::LocalOnly)
         .args(["init", "--quiet"])
         .status()
         .unwrap();
@@ -113,8 +112,7 @@ fn range_scan_streams_line_delimited_rev_list_and_cat_file_records() {
         vec!["config", "user.name", "Test"],
     ] {
         assert!(
-            Command::new("git")
-                .current_dir(dir.path())
+            git_command_in(dir.path(), GitObjectAccess::LocalOnly)
                 .args(args)
                 .status()
                 .unwrap()
@@ -135,24 +133,21 @@ fn range_scan_streams_line_delimited_rev_list_and_cat_file_records() {
     )
     .unwrap();
     assert!(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["add", "."])
             .status()
             .unwrap()
             .success()
     );
     assert!(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["commit", "--quiet", "-m", "fixture"])
             .status()
             .unwrap()
             .success()
     );
     let head = String::from_utf8(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["rev-parse", "HEAD"])
             .output()
             .unwrap()
@@ -179,8 +174,7 @@ fn range_scan_excludes_all_base_manifest_ref_tips() {
         vec!["config", "user.name", "Test"],
     ] {
         assert!(
-            Command::new("git")
-                .current_dir(dir.path())
+            git_command_in(dir.path(), GitObjectAccess::LocalOnly)
                 .args(args)
                 .status()
                 .unwrap()
@@ -196,24 +190,21 @@ fn range_scan_excludes_all_base_manifest_ref_tips() {
     };
     std::fs::write(dir.path().join("base.bin"), base_pointer.serialize()).unwrap();
     assert!(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["add", "base.bin"])
             .status()
             .unwrap()
             .success()
     );
     assert!(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["commit", "--quiet", "-m", "base"])
             .status()
             .unwrap()
             .success()
     );
     let base = String::from_utf8(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["rev-parse", "HEAD"])
             .output()
             .unwrap()
@@ -231,24 +222,21 @@ fn range_scan_excludes_all_base_manifest_ref_tips() {
     };
     std::fs::write(dir.path().join("new.bin"), new_pointer.serialize()).unwrap();
     assert!(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["add", "new.bin"])
             .status()
             .unwrap()
             .success()
     );
     assert!(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["commit", "--quiet", "-m", "new"])
             .status()
             .unwrap()
             .success()
     );
     let head = String::from_utf8(
-        Command::new("git")
-            .current_dir(dir.path())
+        git_command_in(dir.path(), GitObjectAccess::LocalOnly)
             .args(["rev-parse", "HEAD"])
             .output()
             .unwrap()

--- a/crates/crab-staging/src/push_plan.rs
+++ b/crates/crab-staging/src/push_plan.rs
@@ -490,7 +490,6 @@ async fn materialize_prepared_xorb_file(
     if prepared_xorb_file_matches_plan(&target, &xorb_hash, &xorb_hash, planned).await? {
         return Ok(true);
     }
-    fail_if_existing_prepared_xorb_is_corrupt(&target, &xorb_hash).await?;
 
     let parent = target
         .parent()
@@ -502,7 +501,13 @@ async fn materialize_prepared_xorb_file(
             Ok(true)
         }
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            prepared_xorb_file_matches_plan(&target, &xorb_hash, &xorb_hash, planned).await
+            if prepared_xorb_file_matches_plan(&target, &xorb_hash, &xorb_hash, planned).await? {
+                return Ok(true);
+            }
+            Err(StagingError::StagingCorrupt(format!(
+                "content-addressed prepared xorb {} already exists but fails plan validation",
+                xorb_hash.hex()
+            )))
         }
         Err(e)
             if matches!(
@@ -702,7 +707,6 @@ pub(crate) async fn write_prepared_xorb_with_payload_hash(
     if prepared_xorb_file_matches_identity(&path, xorb_hash, &payload_hash, byte_count).await? {
         return Ok(byte_count);
     }
-    fail_if_existing_prepared_xorb_is_corrupt(&path, xorb_hash).await?;
 
     let tmp = unique_prepared_xorb_temp_path(&path, "write");
     let mut tmp_guard = TempFileGuard::new(tmp.clone());
@@ -747,7 +751,6 @@ pub async fn move_prepared_xorb(
         tmp_guard.disarm();
         return Ok(bytes);
     }
-    fail_if_existing_prepared_xorb_is_corrupt(&path, xorb_hash).await?;
     let file = tokio::fs::OpenOptions::new().write(true).open(&tmp).await?;
     file.sync_all().await?;
     drop(file);
@@ -802,20 +805,6 @@ async fn install_prepared_xorb_temp(
     }
     tokio::fs::remove_file(temp).await?;
     sync_parent_directory(target).await
-}
-
-async fn fail_if_existing_prepared_xorb_is_corrupt(
-    path: &Path,
-    xorb_hash: &MerkleHash,
-) -> Result<()> {
-    match tokio::fs::metadata(path).await {
-        Ok(_) => Err(StagingError::StagingCorrupt(format!(
-            "content-addressed prepared xorb {} exists but fails identity validation",
-            xorb_hash.hex()
-        ))),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error.into()),
-    }
 }
 
 async fn prepared_xorb_file_matches_identity(


### PR DESCRIPTION
## Summary

Fixes the intermittent failure in `push_plan::tests::concurrent_identical_prepared_writes_create_one_immutable_body` seen in CI run https://github.com/crabbuild/crab/actions/runs/34662600907/job/103471184615.

Two writers could both observe the content-addressed target as absent. After one atomically published it with a hard link, the other hit the preflight `fail_if_existing_prepared_xorb_is_corrupt` check and incorrectly treated the valid winner as corruption. Publication now relies on the atomic hard-link race resolution and validates the winner; invalid existing targets still fail closed.

## Validation

- `cargo test -p crab-staging --lib` — 222 passed, 1 ignored
- `cargo clippy -p crab-staging --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Concurrent regression test repeated 200 times