### PR TITLE
feat(repository): polish blame and shared UI

### DIFF
--- a/crates/crab-http-server/REFERENCE.md
+++ b/crates/crab-http-server/REFERENCE.md
@@ -273,6 +273,7 @@ Health probes accept the listener's loopback `Host` even when OIDC uses another 
 ## Repository browser and application APIs
 
 The browser and JavaScript Object Notation (JSON) API share the same authorization, snapshot, publication, and storage contracts. Browser links keep a selected branch for navigation and pin historical pages to a full commit OID.
+The blame view links commit OIDs and subjects to immutable commit details. Its attribution and source panes are separated by a pointer- and keyboard-resizable handle; arrow keys resize incrementally, Home and End select the supported bounds, and double-click restores the default.
 
 ### Scan the browser feature map
 

--- a/packages/repository/src/App.tsx
+++ b/packages/repository/src/App.tsx
@@ -320,8 +320,18 @@ export function App() {
           )}
         </main>
         <footer className="site-footer">
-          <span className="brand-small">Crab,</span>
-          <span>Git for any file at any scale</span>
+          <Link
+            className="footer-brand"
+            href="/"
+            aria-label="Crab repositories"
+          >
+            <span className="footer-brand-mark" aria-hidden="true" />
+            <strong>Crab</strong>
+          </Link>
+          <span className="footer-divider" aria-hidden="true">
+            ·
+          </span>
+          <span className="footer-tagline">Git for any file at any scale</span>
         </footer>
       </BaseStyles>
     </ThemeProvider>

--- a/packages/repository/src/content.tsx
+++ b/packages/repository/src/content.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useState, type CSSProperties } from "react";
+import {
+  useMemo,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+} from "react";
 import { File, MultiFileDiff } from "@pierre/diffs/react";
 import { IconButton, Label, SegmentedControl } from "@primer/react";
 import {
@@ -37,6 +43,16 @@ const diffColors = {
   "--diffs-deletion-color-override": "var(--button-danger-fgColor-rest)",
   "--diffs-modified-color-override": "var(--fgColor-accent)",
 } as CSSProperties;
+const DEFAULT_BLAME_PANE_WIDTH = 48;
+const MIN_BLAME_PANE_WIDTH = 25;
+const MAX_BLAME_PANE_WIDTH = 75;
+
+function clampBlamePaneWidth(width: number) {
+  return Math.min(
+    MAX_BLAME_PANE_WIDTH,
+    Math.max(MIN_BLAME_PANE_WIDTH, Math.round(width)),
+  );
+}
 
 function formatSize(bytes: number) {
   if (bytes < 1024) return `${bytes.toLocaleString()} bytes`;
@@ -48,6 +64,9 @@ export function FileView({ repo, rev, path, name, theme, write }: Props) {
     endpoint(repo, "file", { rev, path_hex: path }),
   );
   const [view, setView] = useState<"code" | "preview" | "blame">("code");
+  const [blamePaneWidth, setBlamePaneWidth] = useState(
+    DEFAULT_BLAME_PANE_WIDTH,
+  );
   const [copied, setCopied] = useState(false);
   const blame = useRequest<Blame>(
     view === "blame" ? endpoint(repo, "blame", { rev, path_hex: path }) : null,
@@ -209,8 +228,19 @@ export function FileView({ repo, rev, path, name, theme, write }: Props) {
                     </strong>
                   </span>
                 </div>
-                <div className="blame-view-grid">
-                  <div className="blame-rows" aria-label="Blame commits">
+                <div
+                  className="blame-view-grid"
+                  style={
+                    {
+                      "--blame-pane-width": `${blamePaneWidth}%`,
+                    } as CSSProperties
+                  }
+                >
+                  <div
+                    id="blame-commit-pane"
+                    className="blame-rows"
+                    aria-label="Blame commits"
+                  >
                     {blame.data.ranges.map((range) => (
                       <div
                         className="blame-row"
@@ -223,6 +253,7 @@ export function FileView({ repo, rev, path, name, theme, write }: Props) {
                           {range.start}–{range.start + range.lines - 1}
                         </code>
                         <Link
+                          className="blame-oid"
                           href={repoHref(repo, {
                             view: "commit",
                             rev: range.commit.oid,
@@ -233,17 +264,84 @@ export function FileView({ repo, rev, path, name, theme, write }: Props) {
                         <span className="blame-author">
                           {range.commit.author}
                         </span>
-                        <span className="blame-message">
+                        <Link
+                          className="blame-message"
+                          href={repoHref(repo, {
+                            view: "commit",
+                            rev: range.commit.oid,
+                          })}
+                        >
                           {range.commit.message.split("\n")[0]}
-                        </span>
+                        </Link>
                       </div>
                     ))}
                   </div>
-                  <div className="blame-source">
+                  <button
+                    type="button"
+                    className="blame-resizer"
+                    role="separator"
+                    aria-label="Resize blame pane"
+                    aria-controls="blame-commit-pane blame-source-pane"
+                    aria-orientation="vertical"
+                    aria-valuemin={MIN_BLAME_PANE_WIDTH}
+                    aria-valuemax={MAX_BLAME_PANE_WIDTH}
+                    aria-valuenow={blamePaneWidth}
+                    aria-valuetext={`${blamePaneWidth}% blame, ${100 - blamePaneWidth}% source`}
+                    title="Drag or use arrow keys to resize"
+                    onDoubleClick={() =>
+                      setBlamePaneWidth(DEFAULT_BLAME_PANE_WIDTH)
+                    }
+                    onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
+                      let width: number | undefined;
+                      if (event.key === "ArrowLeft") width = blamePaneWidth - 5;
+                      if (event.key === "ArrowRight")
+                        width = blamePaneWidth + 5;
+                      if (event.key === "Home") width = MIN_BLAME_PANE_WIDTH;
+                      if (event.key === "End") width = MAX_BLAME_PANE_WIDTH;
+                      if (width === undefined) return;
+                      event.preventDefault();
+                      setBlamePaneWidth(clampBlamePaneWidth(width));
+                    }}
+                    onPointerDown={(event: PointerEvent<HTMLButtonElement>) => {
+                      event.preventDefault();
+                      event.currentTarget.setPointerCapture(event.pointerId);
+                    }}
+                    onPointerMove={(event: PointerEvent<HTMLButtonElement>) => {
+                      if (
+                        !event.currentTarget.hasPointerCapture(event.pointerId)
+                      )
+                        return;
+                      const grid = event.currentTarget.parentElement;
+                      if (!grid) return;
+                      event.preventDefault();
+                      const bounds = grid.getBoundingClientRect();
+                      setBlamePaneWidth(
+                        clampBlamePaneWidth(
+                          ((event.clientX - bounds.left) / bounds.width) * 100,
+                        ),
+                      );
+                    }}
+                    onPointerUp={(event: PointerEvent<HTMLButtonElement>) => {
+                      event.currentTarget.releasePointerCapture(
+                        event.pointerId,
+                      );
+                    }}
+                  />
+                  <div
+                    id="blame-source-pane"
+                    className="blame-source"
+                    aria-label="File source"
+                    tabIndex={0}
+                  >
                     <File
                       file={file}
                       options={options}
-                      style={{ "--diffs-line-height": "20px" } as CSSProperties}
+                      style={
+                        {
+                          "--diffs-line-height": "20px",
+                          "--diffs-overflow-override": "visible",
+                        } as CSSProperties
+                      }
                     />
                   </div>
                 </div>

--- a/packages/repository/src/style.css
+++ b/packages/repository/src/style.css
@@ -544,12 +544,68 @@ main {
 }
 .blame-view-grid {
   display: grid;
-  grid-template-columns: minmax(360px, 1fr) minmax(420px, 1.15fr);
+  grid-template-columns:
+    minmax(0, var(--blame-pane-width, 48%)) 9px
+    minmax(0, 1fr);
   min-width: 780px;
 }
 .blame-rows {
   min-width: 0;
-  border-right: 1px solid var(--borderColor-muted);
+  overflow: hidden;
+  background: var(--bgColor-muted);
+}
+.blame-resizer {
+  position: relative;
+  width: 9px;
+  min-width: 9px;
+  margin: 0;
+  padding: 0;
+  touch-action: none;
+  cursor: col-resize;
+  background: var(--bgColor-default);
+  border: 0;
+  border-inline: 1px solid var(--borderColor-muted);
+}
+.blame-resizer::before {
+  position: absolute;
+  inset: 0 2px;
+  content: "";
+  background: var(--borderColor-muted);
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.blame-resizer::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3px;
+  height: 32px;
+  content: "";
+  background: var(--fgColor-muted);
+  border-radius: 999px;
+  opacity: 0.45;
+  transform: translate(-50%, -50%);
+  transition:
+    height 120ms ease,
+    opacity 120ms ease;
+}
+.blame-resizer:hover::before,
+.blame-resizer:focus-visible::before,
+.blame-resizer:active::before {
+  opacity: 1;
+  background: var(--bgColor-accent-muted);
+}
+.blame-resizer:hover::after,
+.blame-resizer:focus-visible::after,
+.blame-resizer:active::after {
+  height: 44px;
+  opacity: 1;
+  background: var(--fgColor-accent);
+}
+.blame-resizer:focus-visible {
+  z-index: 1;
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -2px;
 }
 .blame-row {
   position: relative;
@@ -574,12 +630,14 @@ main {
 }
 .blame-row > a {
   color: var(--fgColor-accent);
-  font-family: var(--fontStack-monospace);
-  font-weight: 600;
   text-decoration: none;
 }
 .blame-row > a:hover {
   text-decoration: underline;
+}
+.blame-oid {
+  font-family: var(--fontStack-monospace);
+  font-weight: 600;
 }
 .blame-row code,
 .blame-message {
@@ -593,10 +651,12 @@ main {
 }
 .blame-source {
   min-width: 0;
+  overflow-x: auto;
+  background: var(--bgColor-default);
 }
 .blame-source > diffs-file {
   display: block;
-  min-width: 0;
+  min-width: 100%;
   border: 0;
   border-radius: 0;
 }
@@ -641,14 +701,56 @@ main {
 }
 .site-footer {
   display: flex;
+  align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: 3px;
+  min-height: 64px;
+  padding: 16px 24px;
   color: var(--fgColor-muted);
+  background: linear-gradient(
+    180deg,
+    var(--bgColor-default),
+    color-mix(in srgb, var(--bgColor-muted) 55%, var(--bgColor-default))
+  );
+  border-top: 1px solid var(--borderColor-muted);
   font-size: 12px;
-  padding: 32px;
 }
-.brand-small {
+.footer-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fgColor-default);
+  text-decoration: none;
+}
+.footer-brand:hover {
+  color: var(--fgColor-accent);
+  text-decoration: none;
+}
+.footer-brand-mark {
+  display: block;
+  width: 22px;
+  height: 22px;
+  background: currentColor;
+  filter: drop-shadow(
+    0 1px 1px color-mix(in srgb, currentColor 22%, transparent)
+  );
+  mask: url("../../web/public/crab.optimized.svg") center / contain no-repeat;
+}
+.footer-brand strong {
   font-weight: 700;
+}
+.footer-divider {
+  color: var(--borderColor-emphasis);
+  font-weight: 700;
+}
+.footer-tagline {
+  letter-spacing: 0.01em;
+}
+@media (prefers-reduced-motion: reduce) {
+  .blame-resizer::before,
+  .blame-resizer::after {
+    transition: none;
+  }
 }
 .sr-only {
   position: absolute;
@@ -1997,10 +2099,13 @@ main {
   padding: 12px;
   font: inherit;
 }
-.discussion-compose input:focus,
-.discussion-editor textarea:focus {
+.discussion-compose input:focus {
   outline: 2px solid var(--focus-outlineColor);
   outline-offset: 0;
+}
+.discussion-editor textarea:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 1px var(--focus-outlineColor);
 }
 .discussion-compose input {
   margin-bottom: 16px;

--- a/packages/repository/tests/browser/discussion.e2e.ts
+++ b/packages/repository/tests/browser/discussion.e2e.ts
@@ -159,9 +159,20 @@ test("comment edits restore focus and Markdown preview posts reset to Write", as
   const card = page.locator("#comment-1");
   const edit = card.getByRole("button", { name: "Edit comment", exact: true });
   await edit.click();
-  await expect(
-    page.getByRole("textbox", { name: "Edit comment", exact: true }),
-  ).toBeFocused();
+  const editComment = page.getByRole("textbox", {
+    name: "Edit comment",
+    exact: true,
+  });
+  await expect(editComment).toBeFocused();
+  const focusBorder = await editComment.evaluate((textarea) => {
+    const style = getComputedStyle(textarea);
+    return {
+      boxShadow: style.boxShadow,
+      outlineWidth: style.outlineWidth,
+    };
+  });
+  expect(focusBorder.outlineWidth).toBe("0px");
+  expect(focusBorder.boxShadow).toMatch(/1px inset$/);
   await card.getByRole("button", { name: "Cancel edit", exact: true }).click();
   await expect(edit).toBeFocused();
   await edit.click();

--- a/packages/repository/tests/browser/repository.e2e.ts
+++ b/packages/repository/tests/browser/repository.e2e.ts
@@ -384,6 +384,37 @@ test.beforeEach(async ({ page }) => {
         },
       });
     }
+    if (url.pathname.endsWith("/blame"))
+      return route.fulfill({
+        json: {
+          ranges: [
+            {
+              start: 1,
+              lines: 2,
+              commit: {
+                oid: "1".repeat(40),
+                tree: "2".repeat(40),
+                parents: [],
+                author: "Alice",
+                author_seconds: 1_690_000_000,
+                message: "Start the project documentation",
+              },
+            },
+            {
+              start: 3,
+              lines: 3,
+              commit: {
+                oid: "3".repeat(40),
+                tree: "4".repeat(40),
+                parents: ["1".repeat(40)],
+                author: "Bob",
+                author_seconds: 1_700_000_000,
+                message: "Explain repository navigation",
+              },
+            },
+          ],
+        },
+      });
     if (url.pathname.endsWith("/issues"))
       return route.fulfill({
         json: {
@@ -606,6 +637,87 @@ test("Markdown files switch between source and a repository-aware preview", asyn
   );
   await page.getByRole("button", { name: "Code", exact: true }).click();
   await expect(preview).toHaveCount(0);
+});
+
+test("blame and source panes resize with pointer and keyboard controls", async ({
+  page,
+}) => {
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("README.md")}&kind=Blob`,
+  );
+  await page.getByRole("button", { name: "Blame", exact: true }).click();
+
+  const separator = page.getByRole("separator", {
+    name: "Resize blame pane",
+  });
+  const blamePane = page.getByLabel("Blame commits");
+  const sourcePane = page.getByLabel("File source");
+  await expect(separator).toHaveAttribute("aria-valuenow", "48");
+  await expect(blamePane).toBeVisible();
+  await expect(sourcePane).toBeVisible();
+  await expectNoAccessibilityViolations(page);
+
+  const initialWidth = (await blamePane.boundingBox())?.width ?? 0;
+  const handle = await separator.boundingBox();
+  if (!handle) throw new Error("Blame resize handle is not visible");
+  await page.mouse.move(handle.x + handle.width / 2, handle.y + 20);
+  await page.mouse.down();
+  await page.mouse.move(handle.x + handle.width / 2 + 120, handle.y + 20);
+  await page.mouse.up();
+  await expect
+    .poll(async () => (await blamePane.boundingBox())?.width ?? 0)
+    .toBeGreaterThan(initialWidth + 80);
+
+  await separator.press("Home");
+  await expect(separator).toHaveAttribute("aria-valuenow", "25");
+  await separator.press("ArrowRight");
+  await expect(separator).toHaveAttribute("aria-valuenow", "30");
+  await separator.dblclick();
+  await expect(separator).toHaveAttribute("aria-valuenow", "48");
+});
+
+test("blame commit messages open their commit details", async ({ page }) => {
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("README.md")}&kind=Blob`,
+  );
+  await page.getByRole("button", { name: "Blame", exact: true }).click();
+
+  const message = page.getByRole("link", {
+    name: "Start the project documentation",
+    exact: true,
+  });
+  await expect(message).toHaveAttribute(
+    "href",
+    `/team/project?view=commit&rev=${"1".repeat(40)}`,
+  );
+  await message.click();
+  await expect(
+    page.getByRole("heading", {
+      name: "Make the repository easier to browse",
+      exact: true,
+    }),
+  ).toBeVisible();
+});
+
+test("footer groups the Crab mark and tagline into one compact signature", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const footer = page.locator(".site-footer");
+  const brand = footer.getByRole("link", { name: "Crab repositories" });
+  const tagline = footer.getByText("Git for any file at any scale");
+  await expect(brand.locator(".footer-brand-mark")).toBeVisible();
+  await expect(tagline).toBeVisible();
+  const spacing = await footer.evaluate((node) => {
+    const brand = node.querySelector(".footer-brand")?.getBoundingClientRect();
+    const tagline = node
+      .querySelector(".footer-tagline")
+      ?.getBoundingClientRect();
+    return brand && tagline
+      ? tagline.left - brand.right
+      : Number.POSITIVE_INFINITY;
+  });
+  expect(spacing).toBeLessThanOrEqual(12);
 });
 
 test("Go to file finds a deep repository path before its directory is expanded", async ({


### PR DESCRIPTION
## Summary

- make blame attribution and source panes pointer- and keyboard-resizable
- link blame commit subjects to immutable commit details while preserving hash typography
- replace the plain footer with a compact Crab signature and icon
- render the discussion textarea focus border as a complete 1px inset accent
- document the blame interaction and add browser regression coverage

## Verification

- npm run format:check
- npm run typecheck
- npm test — 9 passed
- npm run test:browser — 33 passed
- npm run build
- cargo build -p crab-http-server --release --locked with the required external CARGO_TARGET_DIR
- live RustFS smoke against 7 real repositories: resized blame panes, followed a ripgrep blame subject to its commit, and verified the issue editor focus border