### PR TITLE
perf(s3): bound sustained gateway amplification

### DIFF
--- a/crab/docs/architecture/crab-s3-gateway.md
+++ b/crab/docs/architecture/crab-s3-gateway.md
@@ -761,18 +761,53 @@ recheck object conditions on the new destination view. Never resolve contention
 with a blind forced branch update or replacement of an entire stale tree.
 
 The implemented mutation owner admits same-ref requests through a bounded FIFO
-queue. It resolves only the target's ancestor trees, writes one path-local
-attribute delta, prepares the pack, and uploads the pack sidecars, visibility
-evidence, and attribute delta concurrently before acquiring the ref lease. Under
-the lease it captures a new repository snapshot, revalidates the parent, and
-either publishes the journal edit or releases and reprepares. Journal success is
-the acknowledgement point; catalog compaction and commit-graph maintenance run
-asynchronously because the repository read view consumes committed journal
-transactions directly. A new foreground write cancels an in-flight maintenance
-pass so derived catalog work releases its fences and yields to S3 mutation
-traffic. The gateway schedules maintenance again after the local write burst is
-idle and prevents overlapping compaction waves from advancing ahead of visibility
-proof publication.
+queue. After a 10 ms collection window it drains at most 32 compatible requests
+or 32 MiB of Git mutation payload; a larger request proceeds alone and multipart
+completion is always isolated with its durable publication plan. The owner loads
+one immutable starting view, evaluates conditions sequentially against an
+in-memory evolving tree and attribute manifest, and builds one commit per
+successful state change. It deduplicates the generated objects into one pack,
+spools those trusted objects once before producing the canonical pack and
+verified sidecars, and uploads them with every commit-bound attribute delta and
+one visibility proof, then acquires the ref lease. Under the lease it captures a
+bounded ref-journal head and parent transaction for warm existing-ref updates;
+cold creation and namespace-changing paths still capture a coherent repository
+snapshot. It revalidates the original parent and either advances the ref directly
+to the final commit with one journal transaction or releases and rebuilds the
+bounded batch. Journal success is the acknowledgement point;
+catalog compaction and commit-graph maintenance run asynchronously because the
+repository read view consumes committed journal transactions directly. The
+object-store ref journal, immutable active marker, and lease are authoritative;
+SlateDB remains a rebuildable derived index and is not part of admission or
+acknowledgement. At most 256 warm branch queues may retain a materialized
+Git directory state and attribute manifest between batches under a shared
+128 MiB process budget. A warm batch prepares optimistically, then revalidates
+its cached parent under the object-store ref lease before publication; a
+competing writer forces a cold rebuild. Idle-branch eviction, capacity pressure,
+or restart also falls back to immutable repository objects. Cold reconstruction
+prepares a full, commit-identified attribute checkpoint; warm state does the same
+after each 64 publication batches. After validating the parent under the ref
+lease, publication commits the journal and then replaces one bounded checkpoint
+slot for that branch before acknowledging the batch when the checkpoint PUT
+succeeds. A crash or checkpoint-write failure leaves a missing or stale slot,
+which readers ignore while replaying
+immutable deltas. Only the journal winner writes the checkpoint. The final
+version-2 delta carries optional checkpoint and slot fields, so existing deltas
+require neither migration nor a schema-version bump. A manifest above the existing
+32 MiB bound keeps its authoritative delta chain and retries checkpointing after
+another 64 publication batches instead of failing the write. Drained batches run
+under gateway ownership so disconnecting the caller
+that acquired local admission cannot abandon peer requests. A new foreground
+write cancels an in-flight maintenance pass so
+derived catalog work releases its fences and yields to S3 mutation traffic. The
+gateway schedules maintenance again after the local write burst is idle and
+prevents overlapping maintenance waves from advancing ahead of visibility proof
+publication. Sustained traffic additionally claims one catalog-maintenance pass
+every 64 local publication epochs. The elected worker compacts durable journal
+entries and advances exact-object catalog coverage under the generation-owner and
+GC-writer fences. This keeps both the mutable journal and clean-read object lookup
+bounded without waiting for an idle window; commit-graph maintenance still
+requires a five-second quiet window.
 
 ### 4.2 PUT and DELETE execution rules
 
@@ -825,11 +860,11 @@ processing entries. Preserve per-entry result association, including duplicate
 keys and quiet-mode behavior specified by the protocol. Authorize each target;
 an authorized sibling must not grant access to another key/ref.
 
-Use bounded canonical per-key mutations initially. Each admitted deletion owns
-its durable outcome; aggregate only proven successes/errors into the XML result.
-A later optimization may batch compatible authorized edits, but must preserve
-the same per-key contract and map publication rejection accurately. Do not promise
-cross-ref atomicity. If the response is lost after partial progress, a client
+Use bounded canonical per-key mutations. Each admitted deletion owns its durable
+outcome; aggregate only proven successes/errors into the XML result. The
+same-branch mutation owner may group compatible edits into one publication while
+retaining one FIFO commit and result per successful state change. Do not promise
+cross-ref or whole-request atomicity. If the response is lost after partial progress, a client
 retry re-evaluates missing-key semantics; it does not reverse prior deletions.
 Unknown per-key publication outcomes must not be labeled definite rejection.
 [S3 multi-delete contract](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html)

--- a/crab/docs/architecture/crab-s3-gateway.md
+++ b/crab/docs/architecture/crab-s3-gateway.md
@@ -820,7 +820,8 @@ pack inventory is a proven subset of its snapshot, then searches only the
 remaining pack tail. This remains valid while manifest compaction and catalog
 publication briefly differ and keeps common object lookup bounded without waiting
 for an idle window; a complete pack scan remains the fallback when no catalog
-inventory can be proven as a subset. Commit-graph maintenance still requires a
+inventory can be proven as a subset or the derived catalog cannot open.
+Commit-graph maintenance still requires a
 five-second quiet window.
 
 ### 4.2 PUT and DELETE execution rules

--- a/crab/docs/architecture/crab-s3-gateway.md
+++ b/crab/docs/architecture/crab-s3-gateway.md
@@ -783,15 +783,16 @@ acknowledgement. At most 256 warm branch queues may retain a materialized
 Git directory state and attribute manifest between batches under a shared
 128 MiB process budget. A warm batch prepares optimistically, then revalidates
 its cached parent under the object-store ref lease before publication; a
-competing writer forces a cold rebuild. Idle-branch eviction, capacity pressure,
-or restart also falls back to immutable repository objects. Cold reconstruction
-prepares a full, commit-identified attribute checkpoint; warm state does the same
-after each 64 publication batches. After validating the parent under the ref
-lease, publication commits the journal and then replaces one bounded checkpoint
-slot for that branch before acknowledging the batch when the checkpoint PUT
-succeeds. A crash or checkpoint-write failure leaves a missing or stale slot,
-which readers ignore while replaying
-immutable deltas. Only the journal winner writes the checkpoint. The final
+competing writer forces a cold rebuild. Idle states remain reusable until memory
+pressure requires eviction; capacity pressure or restart falls back to immutable
+repository objects. An unborn branch bypasses the object catalog because it has
+no starting Git tree, while publication still rechecks absence under its ref
+lease. Cold reconstruction prepares a full, commit-identified attribute
+checkpoint; warm state does the same after each 64 publication batches. After
+validating the parent under the ref lease, publication commits the journal and
+then attempts to replace one bounded checkpoint slot for that branch. A crash or
+checkpoint-write failure leaves a missing or stale slot, which readers ignore
+while replaying immutable deltas. Only the journal winner writes the checkpoint. The final
 version-2 delta carries optional checkpoint and slot fields, so existing deltas
 require neither migration nor a schema-version bump. A manifest above the existing
 32 MiB bound keeps its authoritative delta chain and retries checkpointing after
@@ -805,9 +806,22 @@ prevents overlapping maintenance waves from advancing ahead of visibility proof
 publication. Sustained traffic additionally claims one catalog-maintenance pass
 every 64 local publication epochs. The elected worker compacts durable journal
 entries and advances exact-object catalog coverage under the generation-owner and
-GC-writer fences. This keeps both the mutable journal and clean-read object lookup
-bounded without waiting for an idle window; commit-graph maintenance still
-requires a five-second quiet window.
+GC-writer fences.
+
+When an attribute delta ancestry proves that a branch began empty and every
+commit came from the gateway, its checkpoint is also a complete materialized S3
+namespace index. `ListObjects` binds that index to the current journal-projected
+ref and pages the sorted checkpoint plus the per-commit deltas from at most 63
+newer publication batches under normal checkpoint publication, without opening
+SlateDB or walking Git trees. A missing delta, legacy checkpoint, or Git-authored
+ancestor removes the coverage proof and routes the request through canonical Git
+traversal. For that fallback, each read binds the newest catalog whose immutable
+pack inventory is a proven subset of its snapshot, then searches only the
+remaining pack tail. This remains valid while manifest compaction and catalog
+publication briefly differ and keeps common object lookup bounded without waiting
+for an idle window; a complete pack scan remains the fallback when no catalog
+inventory can be proven as a subset. Commit-graph maintenance still requires a
+five-second quiet window.
 
 ### 4.2 PUT and DELETE execution rules
 

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -7,10 +7,13 @@ tracked by the gateway crate and its test reports, not by this document.
 ## Release model
 
 The gateway exposes existing Crab repositories through the S3 REST protocol.
-Each successful `PutObject`, `CopyObject`, `DeleteObject`, or completed multipart
-upload publishes one commit immediately to the addressed branch. `DeleteObjects`
-performs ordered, individually reported mutations and is not atomic across keys.
-A delete of a missing key succeeds without advancing the branch.
+Each successful state-changing `PutObject`, `CopyObject`, `DeleteObject`, or
+completed multipart upload owns one commit on the addressed branch. Compatible
+same-branch mutations may share one bounded publication transaction, but their
+commits form a FIFO parent chain and no success is returned before that
+transaction is durable. `DeleteObjects` performs ordered, individually reported
+mutations and is not atomic across keys. A delete of a missing key succeeds
+without advancing the branch.
 
 Repository history is the only version model. The gateway does not
 implement AWS bucket versioning, delete markers, or version-ID parameters. A
@@ -376,6 +379,46 @@ verified reconstruction through a single bounded backpressure slot and cancels
 reconstruction when the response is dropped; a complete GET withholds its
 terminal chunk until the whole-file hash and declared size verify. Successful
 writes are returned only after their committed outcome is durable and read-ready.
+Each process collects compatible same-branch mutations for at most 10 ms and
+drains at most 32 requests or 32 MiB of Git mutation payload per batch. A single
+larger mutation proceeds alone. The batch evaluates conditions in FIFO order,
+builds one commit per successful state change, uploads one deduplicated Git pack,
+routing trusted generated objects directly through one bounded decoded spool and
+canonical pack preparation rather than an artificial pack inflate cycle. It
+advances the ref from the original parent to the final commit with one active
+journal marker. Failed conditions publish no commit. Multipart completion always
+runs alone because its durable plan receipt owns an independent exactly-once
+outcome. A competing process is serialized by the object-store ref lease; the
+losing bounded batch is rebuilt against the winning tip.
+The process retains at most 256 warm branch queues and may reuse materialized
+Git directory state and the S3 attribute manifest optimistically. Publication
+revalidates the cached parent while holding the object-store ref lease; a tip
+mismatch discards the preparation and rebuilds against the winning snapshot.
+Warm state has a shared 128 MiB process budget; an idle branch yields its state
+when another branch becomes active. Capacity pressure or restart reconstructs
+the tree and manifest from immutable repository objects. To bound normal cold
+attribute replay, the first cold publication and every 64 later publication
+batches replace one full, commit-identified manifest checkpoint in a bounded
+per-branch object-store slot. The final commit delta records that slot. Under the
+same ref lease, the gateway revalidates the parent, publishes the final journal
+transaction, and then attempts to replace the slot before acknowledging the
+batch. Only the journal winner writes the checkpoint. A crash or checkpoint-write failure leaves
+a missing or stale slot, so readers replay immutable deltas. A superseded slot has
+the same fallback; malformed checkpoint content fails closed. A manifest
+above the existing 32 MiB manifest bound skips checkpointing without failing the
+mutation, and another checkpoint attempt follows after 64 publication batches.
+Deltas and the ref journal stay
+authoritative. The process cache and any SlateDB-derived catalog are neither
+authoritative nor required for recovery. Once a batch is drained, its worker is
+owned by the gateway rather than the HTTP request that won local admission, so
+one disconnected caller cannot cancel the remaining accepted mutations.
+Every 64 local publication epochs, one coalesced background worker folds active
+ref-journal transactions into the object-store manifest and advances exact-object
+catalog coverage under the generation-owner and GC-writer fences, even when writes
+remain continuous. Clean read views use that catalog instead of scanning every
+pack index. Full commit-graph work still waits for a five-second quiet window.
+Maintenance failure never changes an already acknowledged mutation and the next
+cadence retries from durable journal state.
 
 The temporary-storage requirement is proportional to each in-progress request
 body, copied range, or non-streaming source assembly, not to a Crab/Xet GET or a
@@ -403,8 +446,9 @@ bounded while avoiding serial startup latency. It returns unavailable when any
 refresh fails or the ten-second probe deadline expires; `/livez` remains a
 storage-free process check.
 
-The private metrics listener reports cache attempts by the fixed
-memory/local/service and hit/miss/failure dimensions, verified hit bytes, local
+The private metrics listener reports mutation batch, request, commit, Git input
+byte, execution-duration, and queue-wait measurements. It also reports cache
+attempts by the fixed memory/local/service and hit/miss/failure dimensions, verified hit bytes, local
 persistence failures, and aggregate catalog entry/byte accounting. Catalog
 gauges come from a coalesced read-only SQLite probe on each scrape; probe health
 and last-success time distinguish genuine zero usage from an unreadable

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -394,9 +394,11 @@ The process retains at most 256 warm branch queues and may reuse materialized
 Git directory state and the S3 attribute manifest optimistically. Publication
 revalidates the cached parent while holding the object-store ref lease; a tip
 mismatch discards the preparation and rebuilds against the winning snapshot.
-Warm state has a shared 128 MiB process budget; an idle branch yields its state
-when another branch becomes active. Capacity pressure or restart reconstructs
-the tree and manifest from immutable repository objects. To bound normal cold
+Warm state has a shared 128 MiB process budget. Idle branches remain reusable
+below the eviction watermark and yield state under memory pressure. Capacity
+pressure or restart reconstructs the tree and manifest from immutable repository
+objects. An unborn branch skips catalog access and begins from the empty Git tree;
+publication rechecks that absence under its ref lease. To bound normal cold
 attribute replay, the first cold publication and every 64 later publication
 batches replace one full, commit-identified manifest checkpoint in a bounded
 per-branch object-store slot. The final commit delta records that slot. Under the
@@ -409,14 +411,23 @@ above the existing 32 MiB manifest bound skips checkpointing without failing the
 mutation, and another checkpoint attempt follows after 64 publication batches.
 Deltas and the ref journal stay
 authoritative. The process cache and any SlateDB-derived catalog are neither
-authoritative nor required for recovery. Once a batch is drained, its worker is
+authoritative nor required for recovery. If the complete delta ancestry proves
+that the branch began empty and every commit came from the gateway, the
+checkpoint also forms a sorted S3 namespace index. `ListObjects` binds it to the
+current journal-projected ref and pages it without opening the Git catalog. Any
+missing delta, legacy checkpoint, or Git-authored ancestor removes that proof and
+requires canonical Git-tree listing. Once a batch is drained, its worker is
 owned by the gateway rather than the HTTP request that won local admission, so
 one disconnected caller cannot cancel the remaining accepted mutations.
 Every 64 local publication epochs, one coalesced background worker folds active
 ref-journal transactions into the object-store manifest and advances exact-object
 catalog coverage under the generation-owner and GC-writer fences, even when writes
-remain continuous. Clean read views use that catalog instead of scanning every
-pack index. Full commit-graph work still waits for a five-second quiet window.
+remain continuous. Read views bind the newest catalog whose immutable pack
+inventory is proven to be a subset of their pinned snapshot and search the
+remaining pack tail for newer objects. Their combined coverage is exhaustive, so
+a combined miss is definitive; complete pack-index scans remain only when no
+catalog inventory can be proven as a subset. Full commit-graph work still waits
+for a five-second quiet window.
 Maintenance failure never changes an already acknowledged mutation and the next
 cadence retries from durable journal state.
 

--- a/crab/docs/architecture/s3-gateway-contract.md
+++ b/crab/docs/architecture/s3-gateway-contract.md
@@ -391,8 +391,9 @@ runs alone because its durable plan receipt owns an independent exactly-once
 outcome. A competing process is serialized by the object-store ref lease; the
 losing bounded batch is rebuilt against the winning tip.
 The process retains at most 256 warm branch queues and may reuse materialized
-Git directory state and the S3 attribute manifest optimistically. Publication
-revalidates the cached parent while holding the object-store ref lease; a tip
+Git directory state and the S3 attribute manifest optimistically. The owner
+revalidates the cached parent while holding the object-store ref lease before
+publishing a commit or returning a prepared no-op or precondition result; a tip
 mismatch discards the preparation and rebuilds against the winning snapshot.
 Warm state has a shared 128 MiB process budget. Idle branches remain reusable
 below the eviction watermark and yield state under memory pressure. Capacity
@@ -426,7 +427,8 @@ remain continuous. Read views bind the newest catalog whose immutable pack
 inventory is proven to be a subset of their pinned snapshot and search the
 remaining pack tail for newer objects. Their combined coverage is exhaustive, so
 a combined miss is definitive; complete pack-index scans remain only when no
-catalog inventory can be proven as a subset. Full commit-graph work still waits
+catalog inventory can be proven as a subset or the derived catalog cannot open.
+Full commit-graph work still waits
 for a five-second quiet window.
 Maintenance failure never changes an already acknowledged mutation and the next
 cadence retries from durable journal state.

--- a/crates/crab-git/README.md
+++ b/crates/crab-git/README.md
@@ -159,6 +159,10 @@ on a blocking worker. Input reads and base lookups need caller-owned deadlines;
 base lookup must authorize access before returning bounded object bytes. The
 returned `IncomingPack` retains decoded objects in a private spool, exposes exact
 object IDs/kinds/bytes, and removes its files when dropped.
+`IncomingPack::from_generated_objects` gives trusted in-process Git object
+builders the same bounded identity spool without first compressing and then
+inflating an artificial wire pack. `prepare` remains mandatory and produces the
+same independently readable canonical pack and verified sidecars.
 
 This is an integrity boundary, not a Git publisher. It validates the complete pack
 checksum, compressed streams, entry framing and delta reconstruction. Callers

--- a/crates/crab-git/src/incoming_pack.rs
+++ b/crates/crab-git/src/incoming_pack.rs
@@ -94,6 +94,70 @@ impl IncomingPack {
         })
     }
 
+    /// Spool trusted generated objects directly for canonical pack preparation.
+    ///
+    /// Object identities, count, individual size, aggregate decoded bytes, and
+    /// cancellation are checked while writing the private spool. The caller must
+    /// still call [`IncomingPack::prepare`] to enforce the encoded-pack limit and
+    /// build verified index sidecars. This path is for objects constructed by the
+    /// caller, not untrusted Git pack input.
+    pub fn from_generated_objects<C>(
+        objects: impl IntoIterator<Item = (Kind, Vec<u8>)>,
+        directory: &Path,
+        limits: ReceiveLimits,
+        cancelled: C,
+    ) -> Result<Self>
+    where
+        C: Fn() -> bool,
+    {
+        let directory = tempfile::Builder::new()
+            .prefix("crab-generated-")
+            .tempdir_in(directory)?;
+        let mut decoded = File::options()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(directory.path().join("objects"))?;
+        let mut stored = BTreeMap::new();
+        let mut decoded_bytes = 0_u64;
+        for (kind, data) in objects {
+            check(&cancelled)?;
+            if data.len() > limits.max_object_bytes {
+                return Err(IncomingPackError::Limit("object size"));
+            }
+            let oid = object_id(kind, &data);
+            if stored.contains_key(&oid) {
+                continue;
+            }
+            if stored.len() >= limits.max_objects as usize {
+                return Err(IncomingPackError::Limit("object count"));
+            }
+            decoded_bytes = decoded_bytes
+                .checked_add(data.len() as u64)
+                .filter(|bytes| *bytes <= limits.max_inflated_bytes)
+                .ok_or(IncomingPackError::Limit("inflated bytes"))?;
+            let offset = decoded.stream_position()?;
+            decoded.write_all(&data)?;
+            stored.insert(
+                oid,
+                IncomingObject {
+                    oid,
+                    kind,
+                    size: data.len(),
+                    offset,
+                },
+            );
+        }
+        decoded.flush()?;
+        let received_objects =
+            u32::try_from(stored.len()).map_err(|_| IncomingPackError::Limit("object count"))?;
+        Ok(Self {
+            directory,
+            objects: stored,
+            received_objects,
+        })
+    }
+
     /// Returns all unique objects, including any verified external thin-pack bases.
     pub fn objects(&self) -> impl Iterator<Item = &IncomingObject> {
         self.objects.values()

--- a/crates/crab-git/src/incoming_pack/tests.rs
+++ b/crates/crab-git/src/incoming_pack/tests.rs
@@ -37,6 +37,50 @@ fn no_base(
 }
 
 #[test]
+fn generated_objects_spool_once_with_identity_and_resource_bounds() {
+    let temp = tempfile::tempdir().unwrap();
+    let generated = IncomingPack::from_generated_objects(
+        [
+            (Kind::Blob, b"first".to_vec()),
+            (Kind::Blob, b"second".to_vec()),
+            (Kind::Blob, b"first".to_vec()),
+        ],
+        temp.path(),
+        limits(),
+        || false,
+    )
+    .unwrap();
+
+    assert_eq!(generated.received_objects(), 2);
+    assert_eq!(
+        generated
+            .read_object(&object_id(Kind::Blob, b"second"))
+            .unwrap()
+            .unwrap()
+            .data,
+        b"second"
+    );
+    assert!(matches!(
+        IncomingPack::from_generated_objects(
+            [(Kind::Blob, vec![0; 1024 * 1024 + 1])],
+            temp.path(),
+            limits(),
+            || false,
+        ),
+        Err(IncomingPackError::Limit("object size"))
+    ));
+    assert!(matches!(
+        IncomingPack::from_generated_objects(
+            [(Kind::Blob, Vec::new())],
+            temp.path(),
+            limits(),
+            || true,
+        ),
+        Err(IncomingPackError::Cancelled)
+    ));
+}
+
+#[test]
 fn resolves_forward_ref_deltas_and_cleans_private_spools() {
     let temp = tempfile::tempdir().unwrap();
     let oid = object_id(Kind::Blob, b"abc");

--- a/crates/crab-metadata/README.md
+++ b/crates/crab-metadata/README.md
@@ -89,6 +89,17 @@ freshness revalidation and protection against concurrent GC. This path scans
 the captured shard inventory, so it is not an acceleration-index performance
 claim.
 
+### Git object catalog checkpoints
+
+Each published Git object catalog checkpoint has a small identity marker written
+after SlateDB makes the checkpoint durable.
+`GitObjectLocatorSession::latest_published_identity` reads that marker without
+opening the large catalog.
+Callers may use the identity only after proving its immutable pack inventory is
+covered by their pinned repository snapshot, then open the named checkpoint for
+the actual lookup. A missing marker means publication is incomplete; malformed
+or name-mismatched marker content fails closed.
+
 ### Snapshot identity
 
 `RepositorySnapshot` also captures the validated canonical layout descriptor.

--- a/crates/crab-metadata/src/git_object_locator/mod.rs
+++ b/crates/crab-metadata/src/git_object_locator/mod.rs
@@ -40,6 +40,16 @@ impl CatalogCheckpointMarker {
             && self.object_count == identity.object_count
             && self.catalog_digest == identity.catalog_digest.to_string()
     }
+
+    pub(crate) fn identity(&self) -> Option<GitObjectCatalogIdentity> {
+        (self.version == CATALOG_CHECKPOINT_MARKER_VERSION).then_some(())?;
+        Some(GitObjectCatalogIdentity {
+            generation: self.generation,
+            pack_index_hash: MerkleHash::from_hex(&self.pack_index_hash).ok()?,
+            object_count: self.object_count,
+            catalog_digest: MerkleHash::from_hex(&self.catalog_digest).ok()?,
+        })
+    }
 }
 
 use crab_xet::hash::MerkleHash;

--- a/crates/crab-metadata/src/git_object_locator/reader.rs
+++ b/crates/crab-metadata/src/git_object_locator/reader.rs
@@ -142,6 +142,55 @@ impl GitObjectLocatorSession {
         Self::open_with_published_checkpoint(store, repo_prefix, options).await
     }
 
+    /// Read the latest published catalog identity without opening its SlateDB checkpoint.
+    ///
+    /// The post-checkpoint marker is authoritative for this discovery step. A
+    /// missing marker means publication is still in progress; malformed or
+    /// mismatched marker content fails closed.
+    pub async fn latest_published_identity(
+        store: Arc<dyn ObjectStore>,
+        repo_prefix: &str,
+    ) -> Result<Option<GitObjectCatalogIdentity>> {
+        let path = git_object_locator_path(repo_prefix);
+        let Some(checkpoint) = reader_checkpoint_id(Arc::clone(&store), &path, None).await? else {
+            return Ok(None);
+        };
+        let Some(name) = checkpoint.name.as_deref() else {
+            return Ok(None);
+        };
+        let Some(digest) = name.strip_prefix(super::READER_CHECKPOINT_PREFIX) else {
+            return Ok(None);
+        };
+        let digest = crab_xet::hash::MerkleHash::from_hex(digest)
+            .map_err(|_| corrupt("checkpoint", "invalid published checkpoint name"))?;
+        let marker_path =
+            ObjectPath::from(super::catalog_checkpoint_marker_path(repo_prefix, digest));
+        let storage = crab_storage::Store::new(Arc::clone(&store));
+        let body = match storage.get_with_etag(&marker_path).await {
+            Ok((body, _)) => body,
+            Err(crab_storage::StorageError::NotFound { .. }) => return Ok(None),
+            Err(source) => return Err(MetadataError::Storage { source }),
+        };
+        let marker: super::CatalogCheckpointMarker =
+            serde_json::from_slice(&body).map_err(|error| MetadataError::CorruptObject {
+                path: marker_path.to_string(),
+                reason: format!("invalid catalog checkpoint marker JSON: {error}"),
+            })?;
+        let identity = marker
+            .identity()
+            .ok_or_else(|| MetadataError::CorruptObject {
+                path: marker_path.to_string(),
+                reason: "invalid catalog checkpoint marker identity".to_owned(),
+            })?;
+        if identity.catalog_digest != digest || !marker.matches_identity(identity) {
+            return Err(MetadataError::CorruptObject {
+                path: marker_path.to_string(),
+                reason: "catalog checkpoint marker does not match its name".to_owned(),
+            });
+        }
+        Ok(Some(identity))
+    }
+
     async fn open_with_published_checkpoint(
         store: Arc<dyn ObjectStore>,
         repo_prefix: &str,
@@ -1402,6 +1451,65 @@ mod tests {
             pack_size: pack.pack_size,
         };
         (object_ids, HashMap::from([(pack.pack_id, inventory)]))
+    }
+
+    #[tokio::test]
+    async fn latest_published_identity_comes_from_checkpoint_marker() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let pack = pack(1);
+        let coverage = GitLocatorCoverage {
+            generation: 7,
+            pack_index_hash: pack.pack_index_hash,
+        };
+        publish(Arc::clone(&store), pack, [3; 20], Some(coverage)).await;
+
+        let identity = GitObjectLocatorSession::latest_published_identity(store, "org/repo")
+            .await
+            .expect("discover identity")
+            .expect("published identity");
+
+        assert_eq!(
+            (
+                identity.generation,
+                identity.pack_index_hash,
+                identity.object_count
+            ),
+            (7, coverage.pack_index_hash, 1)
+        );
+    }
+
+    #[tokio::test]
+    async fn latest_published_identity_rejects_malformed_marker() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let pack = pack(1);
+        publish(
+            Arc::clone(&store),
+            pack,
+            [3; 20],
+            Some(GitLocatorCoverage {
+                generation: 7,
+                pack_index_hash: pack.pack_index_hash,
+            }),
+        )
+        .await;
+        let identity =
+            GitObjectLocatorSession::latest_published_identity(Arc::clone(&store), "org/repo")
+                .await
+                .expect("discover identity")
+                .expect("published identity");
+        let marker = ObjectPath::from(super::super::catalog_checkpoint_marker_path(
+            "org/repo",
+            identity.catalog_digest,
+        ));
+        store
+            .put(&marker, bytes::Bytes::from_static(b"{").into())
+            .await
+            .expect("corrupt marker");
+
+        assert!(matches!(
+            GitObjectLocatorSession::latest_published_identity(store, "org/repo").await,
+            Err(MetadataError::CorruptObject { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/crab-remote-git/README.md
+++ b/crates/crab-remote-git/README.md
@@ -13,6 +13,8 @@ Caller: authorize and resolve physical placement
        manifest generation + pack inventory + locator coverage
      or RemoteGitRepository::from_snapshot
        validated manifest + committed journal overlay
+     or RemoteGitRepository::from_snapshot_with_catalog_tail
+       compacted-base catalog + bounded journal-pack overlay
   -> OperationContext: shared budgets and cancellation
        snapshot -> tree / blob / history / diff
   -> OperationContext::finish: result + locator close
@@ -30,6 +32,7 @@ open, but selecting a snapshot returns `EmptyRepository`.
 | Shared admission and caches | `RemoteGitRuntime` | Process-wide; shut down after active contexts finish or drop |
 | Open a repository | `RemoteGitRepository::open` | Caller supplies authorized physical placement identity |
 | Open a committed journal view | `RemoteGitRepository::from_snapshot` | Caller supplies a validated snapshot, retention, and freshness policy; no catalog required |
+| Accelerate a committed snapshot | `RemoteGitRepository::from_snapshot_with_catalog_tail` | Any catalog whose immutable pack inventory is a subset of the snapshot combines with the remaining pack tail; a combined miss is definitive |
 | Reuse a handle | `is_current` | Checks manifest identity; journal freshness can require reopening |
 | Select a revision | `refs`, `resolve`, `snapshot` | Selection stays within pinned visible refs |
 | Browse content | `entry`, `list_directory`, `list_tree_blobs`, `list_tree_recursive`, `read_blob` | Paths are opaque `GitPath` bytes; bounded blob pages seek by prefix/continuation without reading bodies |

--- a/crates/crab-remote-git/README.md
+++ b/crates/crab-remote-git/README.md
@@ -32,7 +32,7 @@ open, but selecting a snapshot returns `EmptyRepository`.
 | Shared admission and caches | `RemoteGitRuntime` | Process-wide; shut down after active contexts finish or drop |
 | Open a repository | `RemoteGitRepository::open` | Caller supplies authorized physical placement identity |
 | Open a committed journal view | `RemoteGitRepository::from_snapshot` | Caller supplies a validated snapshot, retention, and freshness policy; no catalog required |
-| Accelerate a committed snapshot | `RemoteGitRepository::from_snapshot_with_catalog_tail` | Any catalog whose immutable pack inventory is a subset of the snapshot combines with the remaining pack tail; a combined miss is definitive |
+| Accelerate a committed snapshot | `RemoteGitRepository::from_snapshot_with_catalog_tail` | Any available catalog whose immutable pack inventory is a subset of the snapshot combines with the remaining pack tail; unavailable or unproven catalogs fall back to all pinned pack indexes |
 | Reuse a handle | `is_current` | Checks manifest identity; journal freshness can require reopening |
 | Select a revision | `refs`, `resolve`, `snapshot` | Selection stays within pinned visible refs |
 | Browse content | `entry`, `list_directory`, `list_tree_blobs`, `list_tree_recursive`, `read_blob` | Paths are opaque `GitPath` bytes; bounded blob pages seek by prefix/continuation without reading bodies |

--- a/crates/crab-remote-git/REFERENCE.md
+++ b/crates/crab-remote-git/REFERENCE.md
@@ -132,8 +132,9 @@ in place. High-throughput services may use `from_snapshot_with_catalog_tail`. It
 reads the immutable pack inventory named by the latest catalog checkpoint and
 proves that inventory is a subset of the pinned snapshot. Object lookups use that
 catalog and search only the remaining pack tail on a miss. If no checkpoint can
-be proven as a subset, the canonical complete pack-index path remains; a miss in
-both the proven catalog and complete tail is definitive.
+be proven as a subset or the derived catalog cannot open, the canonical complete
+pack-index path remains; a miss in both the proven catalog and complete tail is
+definitive.
 
 ### Generated response packs
 

--- a/crates/crab-remote-git/REFERENCE.md
+++ b/crates/crab-remote-git/REFERENCE.md
@@ -33,6 +33,8 @@ The supported entry points are:
 - `RemoteGitRepository::open`: generation-consistent repository open;
 - `RemoteGitRepository::from_snapshot`: immutable committed-journal repository
   view without locator publication, for callers that own retention and freshness;
+- `RemoteGitRepository::from_snapshot_with_catalog_tail`: the same immutable
+  view with opportunistic exact base-catalog lookup and journal-pack-first misses;
 - `RemoteGitRepository::is_current`: metadata-only manifest identity check for
   safely reusing a pinned immutable handle;
 - `RemoteGitRepository::operation`: one typed operation kind,
@@ -126,7 +128,12 @@ Services may keep a bounded cache of cloned immutable repository handles.
 uncompacted commits capture a validated repository snapshot and open it through
 `from_snapshot`; its snapshot digest isolates journal-specific cache entries. A
 changed snapshot requires a new immutable handle; cached state is never refreshed
-in place.
+in place. High-throughput services may use `from_snapshot_with_catalog_tail`. It
+reads the immutable pack inventory named by the latest catalog checkpoint and
+proves that inventory is a subset of the pinned snapshot. Object lookups use that
+catalog and search only the remaining pack tail on a miss. If no checkpoint can
+be proven as a subset, the canonical complete pack-index path remains; a miss in
+both the proven catalog and complete tail is definitive.
 
 ### Generated response packs
 

--- a/crates/crab-remote-git/src/operation.rs
+++ b/crates/crab-remote-git/src/operation.rs
@@ -230,7 +230,7 @@ impl OperationContext {
         let span = operation_span(correlation_id, kind);
         check_cancelled(cancellation)?;
         check_cancelled(&runtime_cancellation)?;
-        let session = if open_catalog && let Some(catalog) = state.catalog_identity {
+        let session = if open_catalog && let Some(catalog) = state.lookup_catalog_identity {
             // Keep catalog acquisition and later page reads on the same budget.
             // The pinned repository store remains reusable by other operations.
             let store = state
@@ -1394,6 +1394,12 @@ mod tests {
             manifest_etag: "etag".to_owned(),
             shard_index_hash: Arc::from("shards"),
             catalog_identity: Some(GitObjectCatalogIdentity {
+                generation: 1,
+                pack_index_hash: MerkleHash::from([1; 32]),
+                object_count: 1,
+                catalog_digest: MerkleHash::from([2; 32]),
+            }),
+            lookup_catalog_identity: Some(GitObjectCatalogIdentity {
                 generation: 1,
                 pack_index_hash: MerkleHash::from([1; 32]),
                 object_count: 1,

--- a/crates/crab-remote-git/src/operation.rs
+++ b/crates/crab-remote-git/src/operation.rs
@@ -251,7 +251,15 @@ impl OperationContext {
                     ),
                 ) => session.map_err(|_| Error::Timeout {
                     operation: "open locator",
-                })??,
+                })?,
+            };
+            let session = match session {
+                Ok(session) => session,
+                Err(error) if state.catalog_identity.is_none() => {
+                    tracing::warn!(%error, "snapshot lookup catalog unavailable; using immutable pack indexes");
+                    GitObjectLocatorSession::without_catalog()
+                }
+                Err(error) => return Err(error.into()),
             };
             let session = TrackedLocatorSession::new(session, Arc::clone(&state.runtime));
             // A handle pins the immutable catalog opened with its refs. Using
@@ -1436,6 +1444,50 @@ mod tests {
             transfer.finish::<()>(Err(Error::Cancelled)).await,
             Err(Error::Cancelled)
         ));
+    }
+
+    #[tokio::test]
+    async fn snapshot_accelerator_falls_back_when_its_catalog_cannot_open() {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let store = Store::new(object_store);
+        let runtime = Arc::new(crate::RemoteGitRuntime::default());
+        let state = Arc::new(crate::state::RepositoryState {
+            store: store.clone(),
+            layout: StoreLayout::new(store, "org/repo".to_owned()),
+            runtime: Arc::clone(&runtime),
+            identity: crate::RepositoryIdentity::new("memory", "org/repo", 1)
+                .expect("repository identity"),
+            options: crate::RepositoryOptions::default(),
+            generation: 1,
+            git_validation_digest: Arc::from("validation"),
+            manifest_etag: "etag".to_owned(),
+            shard_index_hash: Arc::from("shards"),
+            catalog_identity: None,
+            lookup_catalog_identity: Some(GitObjectCatalogIdentity {
+                generation: 1,
+                pack_index_hash: MerkleHash::from([1; 32]),
+                object_count: 1,
+                catalog_digest: MerkleHash::from([2; 32]),
+            }),
+            inventory: HashMap::new(),
+            refs: crate::RepositoryRefs::default(),
+            reader: None,
+            commit_graph: None,
+            shallow_closure: None,
+        });
+
+        let cancellation = CancellationToken::new();
+        let operation = OperationContext::open(
+            state,
+            OperationKind::Snapshot,
+            &cancellation,
+            crate::OperationLimits::default(),
+        )
+        .await
+        .expect("canonical pack-index fallback");
+
+        operation.finish(Ok(())).await.expect("close operation");
+        runtime.shutdown().await;
     }
 
     #[derive(Clone, Default)]

--- a/crates/crab-remote-git/src/reader.rs
+++ b/crates/crab-remote-git/src/reader.rs
@@ -134,6 +134,7 @@ pub(crate) struct RemoteGitReader {
     store: Store,
     repo_prefix: String,
     inventory: HashMap<MerkleHash, GitPackInventoryEntry>,
+    preferred_pack_indexes: Option<HashMap<MerkleHash, GitPackInventoryEntry>>,
     limits: ReaderLimits,
     runtime: Arc<RemoteGitRuntime>,
     identity: RepositoryIdentity,
@@ -150,6 +151,28 @@ impl RemoteGitReader {
         identity: RepositoryIdentity,
         generation: u64,
     ) -> Result<Self> {
+        Self::from_pinned_with_preferred_pack_indexes(
+            store,
+            repo_prefix,
+            inventory,
+            None::<[GitPackInventoryEntry; 0]>,
+            limits,
+            runtime,
+            identity,
+            generation,
+        )
+    }
+
+    pub(crate) fn from_pinned_with_preferred_pack_indexes(
+        store: Store,
+        repo_prefix: impl Into<String>,
+        inventory: impl IntoIterator<Item = GitPackInventoryEntry>,
+        preferred_pack_indexes: Option<impl IntoIterator<Item = GitPackInventoryEntry>>,
+        limits: ReaderLimits,
+        runtime: Arc<RemoteGitRuntime>,
+        identity: RepositoryIdentity,
+        generation: u64,
+    ) -> Result<Self> {
         let limits = limits.validate()?;
         let mut canonical = HashMap::new();
         for pack in inventory {
@@ -159,10 +182,26 @@ impl RemoteGitReader {
                 });
             }
         }
+        let preferred_pack_indexes = if let Some(packs) = preferred_pack_indexes {
+            let mut preferred = HashMap::new();
+            for pack in packs {
+                if canonical.get(&pack.pack_id) != Some(&pack)
+                    || preferred.insert(pack.pack_id, pack).is_some()
+                {
+                    return Err(Error::RepositoryState {
+                        reason: RepositoryStateError::InconsistentGeneration,
+                    });
+                }
+            }
+            (!preferred.is_empty()).then_some(preferred)
+        } else {
+            None
+        };
         Ok(Self {
             store,
             repo_prefix: repo_prefix.into(),
             inventory: canonical,
+            preferred_pack_indexes,
             limits,
             runtime,
             identity,
@@ -326,12 +365,6 @@ impl RemoteGitReader {
                 .lookup_batch_from_pack_indexes(requested, budget, cancellation)
                 .await;
         }
-        if requested.len() < PACK_INDEX_LOOKUP_MIN_OBJECTS || self.inventory.is_empty() {
-            return self
-                .lookup_batch_from_catalog(session, requested, cancellation)
-                .await;
-        }
-
         if session.coverage().is_some() {
             // A generation-bound catalog already contains the OID-to-pack
             // join. The operation layer has checked that coverage against its
@@ -341,24 +374,36 @@ impl RemoteGitReader {
             let mut lookups = self
                 .lookup_batch_from_catalog(session, requested, cancellation)
                 .await?;
-            let missing = lookups
+            if !lookups
                 .iter()
-                .enumerate()
-                .filter_map(|(index, lookup)| {
-                    matches!(lookup, GitObjectLookup::Miss).then_some((index, requested[index]))
-                })
-                .collect::<Vec<_>>();
-            if missing.is_empty() {
+                .any(|lookup| matches!(lookup, GitObjectLookup::Miss))
+            {
                 return Ok(lookups);
             }
-
-            let missing_ids = missing.iter().map(|(_, oid)| *oid).collect::<Vec<_>>();
-            let fallback = self
-                .lookup_batch_from_pack_indexes(&missing_ids, budget, cancellation)
+            if let Some(preferred) = &self.preferred_pack_indexes {
+                self.fill_pack_index_misses(
+                    &mut lookups,
+                    requested,
+                    preferred,
+                    budget,
+                    cancellation,
+                )
                 .await?;
-            for ((index, _), lookup) in missing.into_iter().zip(fallback) {
-                lookups[index] = lookup;
+                // Exact base coverage plus the complete journal-added tail is
+                // exhaustive. A remaining miss is definitive; scanning the
+                // historical base indexes would only duplicate the catalog.
+                return Ok(lookups);
+            } else if requested.len() < PACK_INDEX_LOOKUP_MIN_OBJECTS || self.inventory.is_empty() {
+                return Ok(lookups);
             }
+            self.fill_pack_index_misses(
+                &mut lookups,
+                requested,
+                &self.inventory,
+                budget,
+                cancellation,
+            )
+            .await?;
             return Ok(lookups);
         }
 
@@ -464,7 +509,48 @@ impl RemoteGitReader {
         budget: &OperationBudget,
         cancellation: &CancellationToken,
     ) -> Result<Vec<GitObjectLookup>> {
-        let mut pack_ids = self.inventory.keys().copied().collect::<Vec<_>>();
+        self.lookup_batch_from_selected_pack_indexes(
+            requested,
+            &self.inventory,
+            budget,
+            cancellation,
+        )
+        .await
+    }
+
+    async fn fill_pack_index_misses(
+        &self,
+        lookups: &mut [GitObjectLookup],
+        requested: &[[u8; 20]],
+        inventory: &HashMap<MerkleHash, GitPackInventoryEntry>,
+        budget: &OperationBudget,
+        cancellation: &CancellationToken,
+    ) -> Result<()> {
+        let missing = lookups
+            .iter()
+            .enumerate()
+            .filter_map(|(index, lookup)| {
+                matches!(lookup, GitObjectLookup::Miss).then_some((index, requested[index]))
+            })
+            .collect::<Vec<_>>();
+        let missing_ids = missing.iter().map(|(_, oid)| *oid).collect::<Vec<_>>();
+        let fallback = self
+            .lookup_batch_from_selected_pack_indexes(&missing_ids, inventory, budget, cancellation)
+            .await?;
+        for ((index, _), lookup) in missing.into_iter().zip(fallback) {
+            lookups[index] = lookup;
+        }
+        Ok(())
+    }
+
+    async fn lookup_batch_from_selected_pack_indexes(
+        &self,
+        requested: &[[u8; 20]],
+        inventory: &HashMap<MerkleHash, GitPackInventoryEntry>,
+        budget: &OperationBudget,
+        cancellation: &CancellationToken,
+    ) -> Result<Vec<GitObjectLookup>> {
+        let mut pack_ids = inventory.keys().copied().collect::<Vec<_>>();
         pack_ids.sort_unstable();
         let pack_count = pack_ids.len();
         // Do not retain every index for a repository-wide batch: pack count is
@@ -3150,6 +3236,91 @@ mod tests {
                 .all(|lookup| matches!(lookup, GitObjectLookup::Hit(_)))
         );
         session.close().await.expect("close catalog reader");
+    }
+
+    #[tokio::test]
+    async fn journal_overlay_miss_searches_the_bounded_pack_tail_first() {
+        let store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let base_pack_id = MerkleHash::from_hex(&"11".repeat(32)).expect("base pack hash");
+        let tail_pack_id = MerkleHash::from_hex(&"33".repeat(32)).expect("tail pack hash");
+        let pack_index_hash = MerkleHash::from_hex(&"22".repeat(32)).expect("index hash");
+        let base_pack = GitPackLocatorRecord {
+            pack_id: base_pack_id,
+            committed_generation: 1,
+            pack_index_hash,
+            object_count: 1,
+            pack_size: 220,
+        };
+        let mut writer = GitObjectLocatorWriter::open(Arc::clone(&store), "org/repo")
+            .await
+            .expect("open catalog writer");
+        writer.bind_packs(&[base_pack]).await.expect("bind pack");
+        writer
+            .set_coverage(GitLocatorCoverage {
+                generation: 1,
+                pack_index_hash,
+            })
+            .await
+            .expect("publish catalog coverage");
+        writer.close().await.expect("close catalog writer");
+        let session = GitObjectLocatorSession::open(Arc::clone(&store), "org/repo")
+            .await
+            .expect("open catalog reader");
+
+        let runtime = Arc::new(RemoteGitRuntime::default());
+        let identity = RepositoryIdentity::new("provider", "repository", 1).expect("identity");
+        runtime
+            .insert_pack_index(
+                crate::runtime::PackIndexCacheKey::new(&identity, tail_pack_id),
+                Arc::new(PackIndex {
+                    object_ids: vec![gix_hash::ObjectId::from([2; 20])],
+                    pack_offsets: vec![100],
+                    crc32: vec![11],
+                    offset_order: vec![0],
+                    pack_data_end: 200,
+                    pack_checksum: [0; 20],
+                    source_bytes: 1,
+                }),
+            )
+            .await;
+        let base_inventory = GitPackInventoryEntry {
+            pack_id: base_pack_id,
+            object_count: 1,
+            pack_size: 220,
+        };
+        let tail_inventory = GitPackInventoryEntry {
+            pack_id: tail_pack_id,
+            object_count: 1,
+            pack_size: 220,
+        };
+        let reader = RemoteGitReader::from_pinned_with_preferred_pack_indexes(
+            Store::new(Arc::clone(&store)),
+            "org/repo",
+            [base_inventory, tail_inventory],
+            Some([tail_inventory]),
+            ReaderLimits::default(),
+            Arc::clone(&runtime),
+            identity,
+            1,
+        )
+        .expect("reader");
+        let budget = OperationBudget::new(crate::OperationLimits::default(), Arc::clone(&runtime));
+        let lookups = reader
+            .lookup_batch_for_read(&session, &[[2; 20]], &budget, &CancellationToken::new())
+            .await
+            .expect("tail lookup");
+
+        assert!(matches!(
+            lookups.as_slice(),
+            [GitObjectLookup::Hit(GitObjectLocator { pack_id, .. })] if *pack_id == tail_pack_id
+        ));
+        let misses = reader
+            .lookup_batch_for_read(&session, &[[4; 20]], &budget, &CancellationToken::new())
+            .await
+            .expect("catalog and tail miss");
+        assert!(matches!(misses.as_slice(), [GitObjectLookup::Miss]));
+        session.close().await.expect("close catalog reader");
+        runtime.shutdown().await;
     }
 
     #[test]

--- a/crates/crab-remote-git/src/reader.rs
+++ b/crates/crab-remote-git/src/reader.rs
@@ -193,7 +193,7 @@ impl RemoteGitReader {
                     });
                 }
             }
-            (!preferred.is_empty()).then_some(preferred)
+            Some(preferred)
         } else {
             None
         };
@@ -3300,7 +3300,7 @@ mod tests {
             Some([tail_inventory]),
             ReaderLimits::default(),
             Arc::clone(&runtime),
-            identity,
+            identity.clone(),
             1,
         )
         .expect("reader");
@@ -3319,6 +3319,32 @@ mod tests {
             .await
             .expect("catalog and tail miss");
         assert!(matches!(misses.as_slice(), [GitObjectLookup::Miss]));
+
+        let exact_reader = RemoteGitReader::from_pinned_with_preferred_pack_indexes(
+            Store::new(Arc::clone(&store)),
+            "org/repo",
+            [base_inventory],
+            Some([]),
+            ReaderLimits::default(),
+            Arc::clone(&runtime),
+            identity,
+            1,
+        )
+        .expect("exact catalog reader");
+        let exact_misses = exact_reader
+            .lookup_batch_for_read(
+                &session,
+                &vec![[4; 20]; PACK_INDEX_LOOKUP_MIN_OBJECTS],
+                &budget,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("exact catalog miss");
+        assert!(
+            exact_misses
+                .iter()
+                .all(|lookup| matches!(lookup, GitObjectLookup::Miss))
+        );
         session.close().await.expect("close catalog reader");
         runtime.shutdown().await;
     }

--- a/crates/crab-remote-git/src/repository.rs
+++ b/crates/crab-remote-git/src/repository.rs
@@ -6,7 +6,9 @@ use crab_metadata::git_object_locator::{
     GitLocatorCoverage, GitObjectCatalogIdentity, GitObjectLocatorSession, GitObjectLookup,
     GitPackInventoryEntry,
 };
-use crab_metadata::manifest_store::{read_bulk_pack_list, read_manifest};
+use crab_metadata::manifest_store::{
+    read_bulk_pack_list, read_bulk_pack_list_with_limit, read_manifest,
+};
 use crab_metadata::ref_journal::{list_active_transactions, materialize_ref_journal};
 use crab_storage::{Store, StoreLayout};
 use crab_xet::hash::MerkleHash;
@@ -1313,13 +1315,31 @@ async fn snapshot_catalog_tail(
             return Ok(None);
         }
     };
-    let base = read_bulk_pack_list(
-        layout.store(),
-        layout,
-        &identity.pack_index_hash.to_string(),
-    )
-    .await?;
-    let base = parse_inventory(&base)?;
+    let maximum_base_packs = u64::try_from(complete.len()).unwrap_or(u64::MAX);
+    let catalog_pack_index_hash = identity.pack_index_hash.to_string();
+    let base = tokio::select! {
+        biased;
+        () = cancellation.cancelled() => return Err(Error::Cancelled),
+        result = read_bulk_pack_list_with_limit(
+            layout.store(),
+            layout,
+            &catalog_pack_index_hash,
+            maximum_base_packs,
+        ) => match result {
+            Ok(base) => base,
+            Err(error) => {
+                tracing::warn!(%error, "snapshot lookup catalog inventory unavailable; using immutable pack indexes");
+                return Ok(None);
+            }
+        }
+    };
+    let base = match parse_inventory(&base) {
+        Ok(base) => base,
+        Err(error) => {
+            tracing::warn!(%error, "snapshot lookup catalog inventory is invalid; using immutable pack indexes");
+            return Ok(None);
+        }
+    };
     if base
         .iter()
         .any(|(pack_id, entry)| complete.get(pack_id) != Some(entry))
@@ -2097,6 +2117,44 @@ mod tests {
         .expect("snapshot");
         snapshot.journal.packs[0].pack_id = "44".repeat(32);
         snapshot.journal.packs[0].content_hash = "44".repeat(32);
+        let runtime = Arc::new(RemoteGitRuntime::default());
+
+        let repository = RemoteGitRepository::from_snapshot_with_catalog_tail(
+            fixture.layout.clone(),
+            &snapshot,
+            RepositoryIdentity::new("memory", fixture.layout.repo_prefix(), 1).expect("identity"),
+            Arc::clone(&runtime),
+            RepositoryOptions::default(),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("canonical snapshot fallback");
+
+        assert!(repository.state.lookup_catalog_identity.is_none());
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn snapshot_overlay_falls_back_when_catalog_inventory_is_unavailable() {
+        let fixture = open_fixture(1, Some(1)).await;
+        crab_metadata::layout_descriptor::ensure_canonical_layout(&fixture.store, &fixture.layout)
+            .await
+            .expect("layout");
+        let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+            &fixture.store,
+            &fixture.layout,
+        )
+        .await
+        .expect("snapshot");
+        let catalog_inventory = fixture.layout.repo_path(&format!(
+            "metadata/pack/indexes/{}.json",
+            fixture.manifest.pack_index_hash
+        ));
+        fixture
+            .backend
+            .delete(&catalog_inventory)
+            .await
+            .expect("remove catalog inventory");
         let runtime = Arc::new(RemoteGitRuntime::default());
 
         let repository = RemoteGitRepository::from_snapshot_with_catalog_tail(

--- a/crates/crab-remote-git/src/repository.rs
+++ b/crates/crab-remote-git/src/repository.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crab_metadata::git_object_locator::{
-    GitLocatorCoverage, GitObjectLocatorSession, GitObjectLookup, GitPackInventoryEntry,
+    GitLocatorCoverage, GitObjectCatalogIdentity, GitObjectLocatorSession, GitObjectLookup,
+    GitPackInventoryEntry,
 };
 use crab_metadata::manifest_store::{read_bulk_pack_list, read_manifest};
 use crab_metadata::ref_journal::{list_active_transactions, materialize_ref_journal};
@@ -321,10 +322,57 @@ impl RemoteGitRepository {
     pub async fn from_snapshot(
         layout: StoreLayout<Store>,
         snapshot: &crab_metadata::manifest_store::RepositorySnapshot,
+        identity: RepositoryIdentity,
+        runtime: Arc<RemoteGitRuntime>,
+        options: RepositoryOptions,
+        cancellation: &CancellationToken,
+    ) -> Result<Self> {
+        Self::from_snapshot_parts(
+            layout,
+            snapshot,
+            identity,
+            runtime,
+            options,
+            cancellation,
+            None,
+        )
+    }
+
+    /// Open a snapshot using a proven base catalog plus its complete pack tail.
+    ///
+    /// If catalog coverage cannot be proven as a subset of the snapshot, this retains
+    /// the canonical pack-index path. Catalog coverage and the remaining immutable
+    /// packs form an exhaustive object lookup view, so a combined miss is definitive.
+    pub async fn from_snapshot_with_catalog_tail(
+        layout: StoreLayout<Store>,
+        snapshot: &crab_metadata::manifest_store::RepositorySnapshot,
+        identity: RepositoryIdentity,
+        runtime: Arc<RemoteGitRuntime>,
+        options: RepositoryOptions,
+        cancellation: &CancellationToken,
+    ) -> Result<Self> {
+        check_cancelled(cancellation)?;
+        check_cancelled(&runtime.background_cancellation())?;
+        let catalog_tail = snapshot_catalog_tail(&layout, snapshot, cancellation).await?;
+        Self::from_snapshot_parts(
+            layout,
+            snapshot,
+            identity,
+            runtime,
+            options,
+            cancellation,
+            catalog_tail,
+        )
+    }
+
+    fn from_snapshot_parts(
+        layout: StoreLayout<Store>,
+        snapshot: &crab_metadata::manifest_store::RepositorySnapshot,
         mut identity: RepositoryIdentity,
         runtime: Arc<RemoteGitRuntime>,
         options: RepositoryOptions,
         cancellation: &CancellationToken,
+        catalog_tail: Option<(GitObjectCatalogIdentity, Vec<GitPackInventoryEntry>)>,
     ) -> Result<Self> {
         RepositoryOptions::new(options.object_limits(), options.operation_limits())?;
         check_cancelled(cancellation)?;
@@ -347,10 +395,15 @@ impl RemoteGitRepository {
         let manifest = snapshot.materialized_manifest();
         let refs = RepositoryRefs::try_from(&manifest)?;
         let inventory = parse_inventory(&snapshot.journal.packs)?;
-        let reader = Arc::new(RemoteGitReader::from_pinned(
+        let (lookup_catalog_identity, preferred_pack_indexes) = match catalog_tail {
+            Some((identity, packs)) => (Some(identity), Some(packs)),
+            None => (None, None),
+        };
+        let reader = Arc::new(RemoteGitReader::from_pinned_with_preferred_pack_indexes(
             layout.store().clone(),
             layout.repo_prefix(),
             inventory.values().copied(),
+            preferred_pack_indexes,
             ReaderLimits::from_options(options),
             Arc::clone(&runtime),
             identity.clone(),
@@ -368,6 +421,7 @@ impl RemoteGitRepository {
                 shard_index_hash: Arc::from(manifest.shard_index_hash.as_str()),
                 manifest_etag: snapshot.manifest_etag.clone(),
                 catalog_identity: None,
+                lookup_catalog_identity,
                 inventory,
                 refs,
                 reader: Some(reader),
@@ -504,6 +558,7 @@ impl RemoteGitRepository {
                     shard_index_hash: Arc::from(manifest.shard_index_hash.as_str()),
                     manifest_etag,
                     catalog_identity: None,
+                    lookup_catalog_identity: None,
                     inventory: std::collections::HashMap::new(),
                     refs,
                     reader: None,
@@ -641,6 +696,7 @@ impl RemoteGitRepository {
                     shard_index_hash: Arc::from(manifest.shard_index_hash.as_str()),
                     manifest_etag,
                     catalog_identity: Some(catalog_identity),
+                    lookup_catalog_identity: Some(catalog_identity),
                     inventory,
                     refs,
                     reader: Some(Arc::new(reader)),
@@ -1229,6 +1285,54 @@ async fn finish_locator_validation<T>(
     operation: Result<T>,
 ) -> Result<T> {
     finish_with_close(operation, session.close().await)
+}
+
+async fn snapshot_catalog_tail(
+    layout: &StoreLayout<Store>,
+    snapshot: &crab_metadata::manifest_store::RepositorySnapshot,
+    cancellation: &CancellationToken,
+) -> Result<Option<(GitObjectCatalogIdentity, Vec<GitPackInventoryEntry>)>> {
+    if snapshot.journal.packs.is_empty() {
+        return Ok(None);
+    }
+    check_cancelled(cancellation)?;
+    let complete = parse_inventory(&snapshot.journal.packs)?;
+    let identity = match GitObjectLocatorSession::latest_published_identity(
+        Arc::clone(layout.store().inner()),
+        layout.repo_prefix(),
+    )
+    .await
+    {
+        Ok(Some(identity)) => identity,
+        Ok(None) => return Ok(None),
+        Err(error @ crab_metadata::error::MetadataError::CorruptObject { .. }) => {
+            return Err(Error::Metadata(error));
+        }
+        Err(error) => {
+            tracing::warn!(%error, "snapshot lookup catalog unavailable; using immutable pack indexes");
+            return Ok(None);
+        }
+    };
+    let base = read_bulk_pack_list(
+        layout.store(),
+        layout,
+        &identity.pack_index_hash.to_string(),
+    )
+    .await?;
+    let base = parse_inventory(&base)?;
+    if base
+        .iter()
+        .any(|(pack_id, entry)| complete.get(pack_id) != Some(entry))
+    {
+        return Ok(None);
+    }
+    let tail = complete
+        .values()
+        .filter(|pack| !base.contains_key(&pack.pack_id))
+        .copied()
+        .collect::<Vec<_>>();
+    check_cancelled(cancellation)?;
+    Ok(Some((identity, tail)))
 }
 
 /// Parse references from a validated manifest without opening object storage.
@@ -1941,6 +2045,73 @@ mod tests {
                 .await
                 .expect("missing visibility proof")
         );
+    }
+
+    #[tokio::test]
+    async fn snapshot_overlay_accepts_older_catalog_with_complete_pack_subset() {
+        let fixture = open_fixture(2, Some(1)).await;
+        crab_metadata::layout_descriptor::ensure_canonical_layout(&fixture.store, &fixture.layout)
+            .await
+            .expect("layout");
+        let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+            &fixture.store,
+            &fixture.layout,
+        )
+        .await
+        .expect("snapshot");
+        let runtime = Arc::new(RemoteGitRuntime::default());
+
+        let repository = RemoteGitRepository::from_snapshot_with_catalog_tail(
+            fixture.layout.clone(),
+            &snapshot,
+            RepositoryIdentity::new("memory", fixture.layout.repo_prefix(), 1).expect("identity"),
+            Arc::clone(&runtime),
+            RepositoryOptions::default(),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("catalog-tail snapshot");
+
+        assert_eq!(
+            repository
+                .state
+                .lookup_catalog_identity
+                .map(|identity| identity.generation),
+            Some(1)
+        );
+        assert!(repository.state.catalog_identity.is_none());
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn snapshot_overlay_rejects_catalog_whose_pack_inventory_is_not_a_subset() {
+        let fixture = open_fixture(1, Some(1)).await;
+        crab_metadata::layout_descriptor::ensure_canonical_layout(&fixture.store, &fixture.layout)
+            .await
+            .expect("layout");
+        let mut snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+            &fixture.store,
+            &fixture.layout,
+        )
+        .await
+        .expect("snapshot");
+        snapshot.journal.packs[0].pack_id = "44".repeat(32);
+        snapshot.journal.packs[0].content_hash = "44".repeat(32);
+        let runtime = Arc::new(RemoteGitRuntime::default());
+
+        let repository = RemoteGitRepository::from_snapshot_with_catalog_tail(
+            fixture.layout.clone(),
+            &snapshot,
+            RepositoryIdentity::new("memory", fixture.layout.repo_prefix(), 1).expect("identity"),
+            Arc::clone(&runtime),
+            RepositoryOptions::default(),
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("canonical snapshot fallback");
+
+        assert!(repository.state.lookup_catalog_identity.is_none());
+        runtime.shutdown().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/crab-remote-git/src/state.rs
+++ b/crates/crab-remote-git/src/state.rs
@@ -23,7 +23,10 @@ pub(crate) struct RepositoryState {
     pub(crate) git_validation_digest: Arc<str>,
     pub(crate) manifest_etag: String,
     pub(crate) shard_index_hash: Arc<str>,
+    /// Catalog for exact-generation APIs such as visibility and complete-pack transfer.
     pub(crate) catalog_identity: Option<GitObjectCatalogIdentity>,
+    /// Catalog usable for object lookup, including beneath a bounded journal overlay.
+    pub(crate) lookup_catalog_identity: Option<GitObjectCatalogIdentity>,
     pub(crate) inventory: HashMap<MerkleHash, GitPackInventoryEntry>,
     pub(crate) refs: RepositoryRefs,
     pub(crate) reader: Option<Arc<RemoteGitReader>>,

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -169,7 +169,8 @@ Multi-delete retains one result and commit per successful entry; grouping never
 makes the whole request atomic. A process-local, 128 MiB warm-state budget may
 retain the exact-tip Git directories and S3 attribute manifest between batches.
 The cached parent is revalidated while holding the object-store ref lease before
-publication. It is discarded on a tip mismatch, restart, or memory-pressure
+publishing a commit or returning a prepared no-op or precondition result. It is
+discarded on a tip mismatch, restart, or memory-pressure
 eviction; idle branch state remains reusable below the shared watermark. Object
 storage remains the authority and a cold request reconstructs the same state from
 immutable repository objects. Unborn branches skip catalog access and recheck

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -169,9 +169,11 @@ Multi-delete retains one result and commit per successful entry; grouping never
 makes the whole request atomic. A process-local, 128 MiB warm-state budget may
 retain the exact-tip Git directories and S3 attribute manifest between batches.
 The cached parent is revalidated while holding the object-store ref lease before
-publication. It is discarded on a tip mismatch, idle-branch eviction, restart,
-or capacity pressure; object storage remains the authority and a cold request
-reconstructs the same state from immutable repository objects. The first cold
+publication. It is discarded on a tip mismatch, restart, or memory-pressure
+eviction; idle branch state remains reusable below the shared watermark. Object
+storage remains the authority and a cold request reconstructs the same state from
+immutable repository objects. Unborn branches skip catalog access and recheck
+absence under their ref lease before publication. The first cold
 publication and every 64 subsequent publication batches write a commit-identified
 attribute checkpoint into one bounded object-store slot per branch while holding
 the same ref lease. The final commit delta records the slot; a missing or
@@ -179,13 +181,22 @@ superseded slot falls back to the immutable delta chain. Checkpoint markers rema
 optional in the existing version-2 delta format. If the full manifest exceeds the
 existing 32 MiB manifest bound, publication keeps the delta chain authoritative
 and skips the checkpoint, so the optimization cannot reject an otherwise valid
-mutation. SlateDB is not required by this write path; its object catalog remains
+mutation. When the delta ancestry proves that the branch began empty and every
+commit came from the gateway, the checkpoint is also a complete sorted S3
+namespace index. `ListObjects` binds it to the current durable ref and pages it
+with only the newer per-commit deltas since the last successful checkpoint,
+without opening SlateDB or walking Git trees. A missing delta, legacy checkpoint,
+or Git-authored ancestor keeps canonical Git tree listing, so the accelerator
+cannot hide Git-written objects. SlateDB is not required by this write path; its
+object catalog remains
 a rebuildable derived index. During sustained writes, one background worker every
 64 local publication epochs folds the active ref journal into the object-store
 manifest and advances catalog coverage under the generation-owner and GC-writer
-fences. Clean read views then use exact catalog lookup instead of scanning every
-immutable pack index. Full commit-graph maintenance still waits for a five-second
-quiet window.
+fences. Read views use the newest catalog whose immutable pack inventory is a
+proven subset of their snapshot, then inspect only the remaining pack tail. This
+also covers the interval between manifest compaction and matching catalog
+publication without scanning every historical pack. Full commit-graph
+maintenance still waits for a five-second quiet window.
 
 Keys must be valid UTF-8 paths that Git trees can represent without loss. The
 gateway rejects ambiguous or unsafe components such as empty segments, `.`,

--- a/crates/crab-s3-gateway/README.md
+++ b/crates/crab-s3-gateway/README.md
@@ -154,9 +154,38 @@ The first key component selects a ref:
 | `<40-hex-commit>/path/file` | Exact Git commit | No |
 
 An empty listing prefix returns the authorized branch prefixes. Reads pin one
-commit for a consistent view. Each successful PUT, COPY, single DELETE, or
-completed multipart upload publishes one commit. Multi-delete reports and
-publishes its entries individually.
+commit for a consistent view. Each successful state-changing PUT, COPY, single
+DELETE, or completed multipart upload owns one commit. Compatible same-branch
+requests wait up to 10 ms for a bounded batch of at most 32 requests or 32 MiB
+of Git payload. Their conditions are evaluated in FIFO order, their commits form
+one parent chain, and their Git objects share one pack and ref-journal
+publication. Trusted generated objects enter one bounded decoded spool before
+canonical pack and sidecar preparation; they are not compressed and reinflated
+as synthetic wire input. A single larger request runs alone. Multipart completion also runs
+alone so its durable exactly-once receipt cannot be coupled to another request.
+Once drained, a gateway-owned worker retains the batch even if an originating
+HTTP connection closes; one disconnected client cannot cancel peer mutations.
+Multi-delete retains one result and commit per successful entry; grouping never
+makes the whole request atomic. A process-local, 128 MiB warm-state budget may
+retain the exact-tip Git directories and S3 attribute manifest between batches.
+The cached parent is revalidated while holding the object-store ref lease before
+publication. It is discarded on a tip mismatch, idle-branch eviction, restart,
+or capacity pressure; object storage remains the authority and a cold request
+reconstructs the same state from immutable repository objects. The first cold
+publication and every 64 subsequent publication batches write a commit-identified
+attribute checkpoint into one bounded object-store slot per branch while holding
+the same ref lease. The final commit delta records the slot; a missing or
+superseded slot falls back to the immutable delta chain. Checkpoint markers remain
+optional in the existing version-2 delta format. If the full manifest exceeds the
+existing 32 MiB manifest bound, publication keeps the delta chain authoritative
+and skips the checkpoint, so the optimization cannot reject an otherwise valid
+mutation. SlateDB is not required by this write path; its object catalog remains
+a rebuildable derived index. During sustained writes, one background worker every
+64 local publication epochs folds the active ref journal into the object-store
+manifest and advances catalog coverage under the generation-owner and GC-writer
+fences. Clean read views then use exact catalog lookup instead of scanning every
+immutable pack index. Full commit-graph maintenance still waits for a five-second
+quiet window.
 
 Keys must be valid UTF-8 paths that Git trees can represent without loss. The
 gateway rejects ambiguous or unsafe components such as empty segments, `.`,
@@ -296,7 +325,7 @@ private.
 | --- | --- |
 | `GET /livez` or `--healthcheck` | Process can accept requests |
 | `GET /readyz` or `--readiness-check` | Every configured repository has a fresh, safe read view |
-| `GET /metrics` | Prometheus request, admission, multipart, backend, cache, and scratch metrics |
+| `GET /metrics` | Prometheus request, admission, mutation-batch, multipart, backend, cache, and scratch metrics |
 
 Readiness returns `503 Service Unavailable` with `Retry-After: 5` when any
 repository cannot be served safely. Metric labels never contain repository
@@ -308,6 +337,16 @@ pool waits for bounded capacity, then returns S3 `SlowDown` with
 clients should use exponential backoff with jitter. Scratch capacity is also
 reserved before work begins so overload fails predictably instead of filling
 the filesystem.
+
+For write-efficiency diagnosis, compare
+`crab_s3_gateway_mutation_batch_requests_total` and
+`crab_s3_gateway_mutation_batch_commits_total` with
+`crab_s3_gateway_mutation_batches_total`. The first ratio is requests drained
+per local execution and the second is commits amortized over each durable pack.
+`crab_s3_gateway_mutation_queue_wait_seconds` and
+`crab_s3_gateway_mutation_batch_duration_seconds` separate collection/admission
+delay from object-store publication latency. These metrics use no repository,
+ref, key, principal, or credential labels.
 
 Operational alerts, capacity guidance, credential rotation, maintenance,
 backup/restore, upgrades, and rollback are documented in the

--- a/crates/crab-s3-gateway/deploy/operations.md
+++ b/crates/crab-s3-gateway/deploy/operations.md
@@ -150,6 +150,35 @@ and queued requests with pending scratch bytes, filesystem available bytes,
 gateway RSS/CPU, node ephemeral-storage usage, and backend in-flight calls.
 Inspect the pod for eviction or volume errors. Do not infer the `emptyDir`
 policy cap from `statvfs` when the node runtime does not expose it as a quota.
+For same-branch writes, divide
+`rate(crab_s3_gateway_mutation_batch_requests_total[5m])` and
+`rate(crab_s3_gateway_mutation_batch_commits_total[5m])` by
+`rate(crab_s3_gateway_mutation_batches_total[5m])`. Ratios near one under
+concurrent load mean requests are not overlapping inside the 10 ms collection
+window; a healthy overlapping burst should amortize multiple commits over one
+pack. Rising `crab_s3_gateway_mutation_queue_wait_seconds` with stable batch
+duration identifies local admission pressure. Rising
+`crab_s3_gateway_mutation_batch_duration_seconds` with backend latency identifies
+publication pressure instead. A growing batch duration accompanied by a large
+increase in backend range and HEAD calls indicates cold Git-state discovery.
+Confirm the process is not restarting and that another active branch is not
+evicting the shared 128 MiB exact-tip warm state before increasing client
+fanout; eviction changes performance, never correctness. A healthy repository
+maintains at most one commit-identified attribute-checkpoint slot per written
+branch, refreshed on the first cold publication and every 64 subsequent
+publication batches while its full manifest remains within 32 MiB. Repeated long
+attribute-delta replays after successful writes indicate that checkpoint PUTs are
+failing, the slot is unreadable or superseded, or the manifest is above that bound.
+Check backend errors first; never repair this by forcing a ref update or treating
+SlateDB as authoritative.
+The gateway also attempts one catalog-maintenance pass every 64 local publication
+epochs during continuous traffic. The elected worker folds the active ref journal
+into the object-store manifest and advances exact-object catalog coverage while
+holding the generation-owner and GC-writer fences. A growing active-journal
+backlog or stale catalog despite that cadence indicates owner/manifest-lock
+contention or backend failures; inspect `S3 bounded catalog maintenance failed`
+warnings. Commit-graph maintenance intentionally waits for a five-second quiet
+window or may be run by `crab metadb owner`.
 
 Safe action:
 

--- a/crates/crab-s3-gateway/src/attributes.rs
+++ b/crates/crab-s3-gateway/src/attributes.rs
@@ -521,8 +521,7 @@ pub(crate) async fn save_delta(
     repository: &Repository,
     commit: ObjectId,
     parent: Option<ObjectId>,
-    path: String,
-    attributes: Option<ObjectAttributes>,
+    changes: BTreeMap<String, Option<ObjectAttributes>>,
     checkpoint: bool,
     checkpoint_slot: Option<String>,
 ) -> crate::Result<()> {
@@ -534,7 +533,7 @@ pub(crate) async fn save_delta(
         checkpoint,
         checkpoint_slot,
         parent: parent.map(|oid| oid.to_string()),
-        changes: BTreeMap::from([(path, attributes)]),
+        changes,
     })
     .map_err(|source| crate::Error::Attributes { source })?;
     if bytes.len() as u64 > MAX_MANIFEST_BYTES {

--- a/crates/crab-s3-gateway/src/attributes.rs
+++ b/crates/crab-s3-gateway/src/attributes.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, str::FromStr as _};
+use std::{
+    collections::BTreeMap,
+    ops::Bound::{Excluded, Included, Unbounded},
+    str::FromStr as _,
+};
 
 use bytes::Bytes;
 use gix_hash::ObjectId;
@@ -167,6 +171,7 @@ impl Checksums {
 pub(crate) struct Manifest {
     objects: BTreeMap<String, ObjectAttributes>,
     estimated_bytes: usize,
+    complete: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -180,6 +185,7 @@ struct LegacyManifest {
 struct CheckpointPayload<'a> {
     version: u32,
     commit: String,
+    complete: bool,
     objects: &'a BTreeMap<String, ObjectAttributes>,
 }
 
@@ -188,7 +194,24 @@ struct CheckpointPayload<'a> {
 struct StoredCheckpoint {
     version: u32,
     commit: String,
+    #[serde(default)]
+    complete: bool,
     objects: BTreeMap<String, ObjectAttributes>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ManifestListingItem {
+    Object {
+        path: String,
+        attributes: ListingAttributes,
+    },
+    CommonPrefix(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ManifestListingPage {
+    pub(crate) items: Vec<ManifestListingItem>,
+    pub(crate) has_more: bool,
 }
 
 pub(crate) struct PreparedCheckpoint {
@@ -216,13 +239,21 @@ struct Delta {
 }
 
 impl Manifest {
-    fn from_objects(objects: BTreeMap<String, ObjectAttributes>) -> Self {
+    fn from_objects(objects: BTreeMap<String, ObjectAttributes>, complete: bool) -> Self {
         let estimated_bytes = objects.iter().fold(0usize, |total, (path, attributes)| {
             total.saturating_add(estimated_object_bytes(path, attributes))
         });
         Self {
             objects,
             estimated_bytes,
+            complete,
+        }
+    }
+
+    pub(crate) fn empty_complete() -> Self {
+        Self {
+            complete: true,
+            ..Self::default()
         }
     }
 
@@ -251,6 +282,64 @@ impl Manifest {
 
     pub(crate) fn estimated_bytes(&self) -> usize {
         self.estimated_bytes
+    }
+
+    pub(crate) fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    /// Page the durable S3 namespace only when it covers the complete Git tree.
+    pub(crate) fn complete_listing(
+        &self,
+        prefix: &str,
+        after: Option<&str>,
+        delimiter: Option<u8>,
+        limit: usize,
+    ) -> Option<ManifestListingPage> {
+        if !self.complete {
+            return None;
+        }
+        let bounds = match after {
+            Some(after) => (Excluded(after.to_owned()), Unbounded),
+            None => (Included(prefix.to_owned()), Unbounded),
+        };
+        let mut items = Vec::with_capacity(limit.saturating_add(1));
+        let mut last_prefix = None;
+        for (path, attributes) in self.objects.range(bounds) {
+            if !path.starts_with(prefix) {
+                if path.as_str() > prefix {
+                    break;
+                }
+                continue;
+            }
+            if !crate::namespace::listable_path(path.as_bytes()) {
+                continue;
+            }
+            if delimiter == Some(b'/')
+                && let Some(offset) = path[prefix.len()..].find('/')
+            {
+                let common = &path[..prefix.len() + offset + 1];
+                if after.is_some_and(|after| common <= after)
+                    || last_prefix.as_deref() == Some(common)
+                {
+                    continue;
+                }
+                last_prefix = Some(common.to_owned());
+                items.push(ManifestListingItem::CommonPrefix(common.to_owned()));
+            } else {
+                last_prefix = None;
+                items.push(ManifestListingItem::Object {
+                    path: path.clone(),
+                    attributes: attributes.into(),
+                });
+            }
+            if items.len() > limit {
+                break;
+            }
+        }
+        let has_more = items.len() > limit;
+        items.truncate(limit);
+        Some(ManifestListingPage { items, has_more })
     }
 
     fn apply(&mut self, changes: BTreeMap<String, Option<ObjectAttributes>>) {
@@ -295,7 +384,7 @@ pub(crate) async fn load(repository: &Repository, commit: ObjectId) -> crate::Re
         match load_stored(repository, commit).await? {
             None => break,
             Some(Stored::Legacy(legacy)) => {
-                manifest = Manifest::from_objects(legacy.objects);
+                manifest = Manifest::from_objects(legacy.objects, false);
                 break;
             }
             Some(Stored::Delta(delta)) => {
@@ -311,6 +400,9 @@ pub(crate) async fn load(repository: &Repository, commit: ObjectId) -> crate::Re
                 retain_newest_changes(&mut changes, delta.changes);
             }
         }
+    }
+    if current.is_none() {
+        manifest.complete = true;
     }
     manifest.apply(changes);
     Ok(manifest)
@@ -464,8 +556,9 @@ pub(crate) fn prepare_checkpoint(
         return Ok(None);
     }
     let bytes = serde_json::to_vec(&CheckpointPayload {
-        version: LEGACY_VERSION,
+        version: VERSION,
         commit: commit.to_string(),
+        complete: manifest.complete,
         objects: &manifest.objects,
     })
     .map_err(|source| crate::Error::Attributes { source })?;
@@ -514,7 +607,7 @@ async fn load_checkpoint(
         Some(_) => {
             let stored = serde_json::from_slice::<StoredCheckpoint>(&bytes)
                 .map_err(|source| crate::Error::Attributes { source })?;
-            if stored.version != LEGACY_VERSION {
+            if !matches!(stored.version, LEGACY_VERSION | VERSION) {
                 return Err(crate::Error::Config(
                     "unsupported S3 attribute checkpoint version",
                 ));
@@ -522,7 +615,10 @@ async fn load_checkpoint(
             if stored.commit != commit.to_string() {
                 return Ok(None);
             }
-            stored.objects
+            return Ok(Some(Manifest::from_objects(
+                stored.objects,
+                stored.version == VERSION && stored.complete,
+            )));
         }
         None => {
             let stored = serde_json::from_slice::<LegacyManifest>(&bytes)
@@ -535,7 +631,7 @@ async fn load_checkpoint(
             stored.objects
         }
     };
-    Ok(Some(Manifest::from_objects(objects)))
+    Ok(Some(Manifest::from_objects(objects, false)))
 }
 
 fn checkpoint_slot_path(
@@ -671,7 +767,7 @@ mod tests {
         let mut manifest = Manifest::default();
         manifest.update("object".to_owned(), Some(attributes("first")));
         manifest.update("object".to_owned(), Some(attributes("replacement")));
-        let rebuilt = Manifest::from_objects(manifest.objects.clone());
+        let rebuilt = Manifest::from_objects(manifest.objects.clone(), false);
         assert_eq!(manifest.estimated_bytes(), rebuilt.estimated_bytes());
 
         manifest.update("object".to_owned(), None);
@@ -683,6 +779,7 @@ mod tests {
         let manifest = Manifest {
             objects: BTreeMap::new(),
             estimated_bytes: MAX_MANIFEST_BYTES as usize + 1,
+            complete: false,
         };
 
         assert!(
@@ -694,5 +791,86 @@ mod tests {
             .unwrap()
             .is_none()
         );
+    }
+
+    #[test]
+    fn complete_listing_pages_objects_and_prefixes_without_git_traversal() {
+        let mut manifest = Manifest::empty_complete();
+        for path in [
+            "prefix/a-1",
+            "prefix/a/item",
+            "prefix/a0",
+            "prefix/b/item",
+            "prefix/c",
+            "prefix/.git/hidden",
+        ] {
+            manifest.update(path.to_owned(), Some(attributes(path)));
+        }
+
+        let first = manifest
+            .complete_listing("prefix/", None, Some(b'/'), 2)
+            .unwrap();
+        assert_eq!(
+            first,
+            ManifestListingPage {
+                items: vec![
+                    ManifestListingItem::Object {
+                        path: "prefix/a-1".to_owned(),
+                        attributes: ListingAttributes {
+                            etag: "prefix/a-1".to_owned(),
+                            size: 0,
+                            modified_seconds: 0,
+                        },
+                    },
+                    ManifestListingItem::CommonPrefix("prefix/a/".to_owned()),
+                ],
+                has_more: true,
+            }
+        );
+        let second = manifest
+            .complete_listing("prefix/", Some("prefix/a/"), Some(b'/'), 2)
+            .unwrap();
+        assert_eq!(
+            second.items,
+            vec![
+                ManifestListingItem::Object {
+                    path: "prefix/a0".to_owned(),
+                    attributes: ListingAttributes {
+                        etag: "prefix/a0".to_owned(),
+                        size: 0,
+                        modified_seconds: 0,
+                    },
+                },
+                ManifestListingItem::CommonPrefix("prefix/b/".to_owned()),
+            ]
+        );
+        assert!(second.has_more);
+    }
+
+    #[test]
+    fn incomplete_manifest_cannot_replace_git_tree_listing() {
+        let mut manifest = Manifest::default();
+        manifest.update("known".to_owned(), Some(attributes("known")));
+
+        assert!(manifest.complete_listing("", None, None, 1000).is_none());
+    }
+
+    #[test]
+    fn checkpoint_persists_complete_namespace_proof() {
+        let commit = ObjectId::empty_tree(gix_hash::Kind::Sha1);
+        let complete = prepare_checkpoint("refs/heads/main", commit, &Manifest::empty_complete())
+            .unwrap()
+            .unwrap();
+        let stored: StoredCheckpoint = serde_json::from_slice(&complete.bytes).unwrap();
+
+        assert_eq!(stored.version, VERSION);
+        assert_eq!(stored.commit, commit.to_string());
+        assert!(stored.complete);
+
+        let legacy: StoredCheckpoint = serde_json::from_str(&format!(
+            r#"{{"version":1,"commit":"{commit}","objects":{{}}}}"#
+        ))
+        .unwrap();
+        assert!(!legacy.complete);
     }
 }

--- a/crates/crab-s3-gateway/src/attributes.rs
+++ b/crates/crab-s3-gateway/src/attributes.rs
@@ -166,43 +166,120 @@ impl Checksums {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Manifest {
     objects: BTreeMap<String, ObjectAttributes>,
+    estimated_bytes: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct LegacyManifest {
     version: u32,
     objects: BTreeMap<String, ObjectAttributes>,
 }
 
+#[derive(Serialize)]
+struct CheckpointPayload<'a> {
+    version: u32,
+    commit: String,
+    objects: &'a BTreeMap<String, ObjectAttributes>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredCheckpoint {
+    version: u32,
+    commit: String,
+    objects: BTreeMap<String, ObjectAttributes>,
+}
+
+pub(crate) struct PreparedCheckpoint {
+    slot: String,
+    bytes: Bytes,
+}
+
+impl PreparedCheckpoint {
+    pub(crate) fn slot(&self) -> &str {
+        &self.slot
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Delta {
     version: u32,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    checkpoint: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    checkpoint_slot: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     parent: Option<String>,
     changes: BTreeMap<String, Option<ObjectAttributes>>,
 }
 
 impl Manifest {
+    fn from_objects(objects: BTreeMap<String, ObjectAttributes>) -> Self {
+        let estimated_bytes = objects.iter().fold(0usize, |total, (path, attributes)| {
+            total.saturating_add(estimated_object_bytes(path, attributes))
+        });
+        Self {
+            objects,
+            estimated_bytes,
+        }
+    }
+
     pub(crate) fn object(&self, path: &str, oid: ObjectId) -> Option<&ObjectAttributes> {
         self.objects
             .get(path)
             .filter(|attributes| attributes.blob_oid == oid.to_string())
     }
 
+    pub(crate) fn update(&mut self, path: String, attributes: Option<ObjectAttributes>) {
+        self.apply(BTreeMap::from([(path, attributes)]));
+    }
+
+    pub(crate) fn listing(
+        &self,
+        objects: &[(String, ObjectId)],
+    ) -> BTreeMap<String, ListingAttributes> {
+        objects
+            .iter()
+            .filter_map(|(path, oid)| {
+                self.object(path, *oid)
+                    .map(|attributes| (path.clone(), attributes.into()))
+            })
+            .collect()
+    }
+
+    pub(crate) fn estimated_bytes(&self) -> usize {
+        self.estimated_bytes
+    }
+
     fn apply(&mut self, changes: BTreeMap<String, Option<ObjectAttributes>>) {
         for (path, attributes) in changes {
             match attributes {
                 Some(attributes) => {
-                    self.objects.insert(path, attributes);
+                    let added = estimated_object_bytes(&path, &attributes);
+                    if let Some(previous) = self.objects.insert(path.clone(), attributes) {
+                        self.estimated_bytes = self
+                            .estimated_bytes
+                            .saturating_sub(estimated_object_bytes(&path, &previous));
+                    }
+                    self.estimated_bytes = self.estimated_bytes.saturating_add(added);
                 }
                 None => {
-                    self.objects.remove(&path);
+                    if let Some(previous) = self.objects.remove(&path) {
+                        self.estimated_bytes = self
+                            .estimated_bytes
+                            .saturating_sub(estimated_object_bytes(&path, &previous));
+                    }
                 }
             }
         }
     }
+}
+
+fn estimated_object_bytes(path: &str, attributes: &ObjectAttributes) -> usize {
+    path.len()
+        .saturating_add(serde_json::to_vec(attributes).map_or(usize::MAX, |bytes| bytes.len()))
 }
 
 pub(crate) async fn load(repository: &Repository, commit: ObjectId) -> crate::Result<Manifest> {
@@ -218,10 +295,18 @@ pub(crate) async fn load(repository: &Repository, commit: ObjectId) -> crate::Re
         match load_stored(repository, commit).await? {
             None => break,
             Some(Stored::Legacy(legacy)) => {
-                manifest.objects = legacy.objects;
+                manifest = Manifest::from_objects(legacy.objects);
                 break;
             }
             Some(Stored::Delta(delta)) => {
+                if delta.checkpoint
+                    && let Some(checkpoint) =
+                        load_checkpoint(repository, commit, delta.checkpoint_slot.as_deref())
+                            .await?
+                {
+                    manifest = checkpoint;
+                    break;
+                }
                 current = parse_parent(delta.parent.as_deref())?;
                 retain_newest_changes(&mut changes, delta.changes);
             }
@@ -261,6 +346,13 @@ pub(crate) async fn load_object(
                     .cloned());
             }
             Some(Stored::Delta(delta)) => {
+                if delta.checkpoint
+                    && let Some(checkpoint) =
+                        load_checkpoint(repository, commit, delta.checkpoint_slot.as_deref())
+                            .await?
+                {
+                    return Ok(checkpoint.object(path, oid).cloned());
+                }
                 if let Some(attributes) = delta.changes.get(path) {
                     return Ok(attributes
                         .as_ref()
@@ -304,7 +396,6 @@ pub(crate) async fn load_objects(
                 return Ok(resolved);
             }
             Some(Stored::Delta(delta)) => {
-                current = parse_parent(delta.parent.as_deref())?;
                 for (path, attributes) in delta.changes {
                     let Some(oid) = unresolved.remove(&path) else {
                         continue;
@@ -315,6 +406,19 @@ pub(crate) async fn load_objects(
                         resolved.insert(path, (&attributes).into());
                     }
                 }
+                if delta.checkpoint
+                    && let Some(manifest) =
+                        load_checkpoint(repository, commit, delta.checkpoint_slot.as_deref())
+                            .await?
+                {
+                    for (path, oid) in unresolved {
+                        if let Some(attributes) = manifest.object(&path, oid) {
+                            resolved.insert(path, attributes.into());
+                        }
+                    }
+                    return Ok(resolved);
+                }
+                current = parse_parent(delta.parent.as_deref())?;
             }
         }
     }
@@ -327,12 +431,16 @@ pub(crate) async fn save_delta(
     parent: Option<ObjectId>,
     path: String,
     attributes: Option<ObjectAttributes>,
+    checkpoint: bool,
+    checkpoint_slot: Option<String>,
 ) -> crate::Result<()> {
     let target = repository
         .layout
         .repo_path(&format!("s3/attributes/{commit}.json"));
     let bytes = serde_json::to_vec(&Delta {
         version: VERSION,
+        checkpoint,
+        checkpoint_slot,
         parent: parent.map(|oid| oid.to_string()),
         changes: BTreeMap::from([(path, attributes)]),
     })
@@ -345,6 +453,113 @@ pub(crate) async fn save_delta(
         .put_exact(&target, Bytes::from(bytes))
         .await?;
     Ok(())
+}
+
+pub(crate) fn prepare_checkpoint(
+    branch: &str,
+    commit: ObjectId,
+    manifest: &Manifest,
+) -> crate::Result<Option<PreparedCheckpoint>> {
+    if u64::try_from(manifest.estimated_bytes()).unwrap_or(u64::MAX) > MAX_MANIFEST_BYTES {
+        return Ok(None);
+    }
+    let bytes = serde_json::to_vec(&CheckpointPayload {
+        version: LEGACY_VERSION,
+        commit: commit.to_string(),
+        objects: &manifest.objects,
+    })
+    .map_err(|source| crate::Error::Attributes { source })?;
+    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        return Ok(None);
+    }
+    Ok(Some(PreparedCheckpoint {
+        slot: blake3::hash(branch.as_bytes()).to_hex().to_string(),
+        bytes: Bytes::from(bytes),
+    }))
+}
+
+pub(crate) async fn publish_checkpoint(
+    repository: &Repository,
+    checkpoint: &PreparedCheckpoint,
+) -> crate::Result<()> {
+    repository
+        .store
+        .put_overwrite(
+            &checkpoint_slot_path(repository, &checkpoint.slot)?,
+            checkpoint.bytes.clone(),
+        )
+        .await?;
+    Ok(())
+}
+
+async fn load_checkpoint(
+    repository: &Repository,
+    commit: ObjectId,
+    slot: Option<&str>,
+) -> crate::Result<Option<Manifest>> {
+    let path = match slot {
+        Some(slot) => checkpoint_slot_path(repository, slot)?,
+        None => legacy_checkpoint_path(repository, commit),
+    };
+    let bytes = match repository
+        .store
+        .get_with_etag_bounded(&path, MAX_MANIFEST_BYTES)
+        .await
+    {
+        Ok((bytes, _)) => bytes,
+        Err(crab_storage::StorageError::NotFound { .. }) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let objects = match slot {
+        Some(_) => {
+            let stored = serde_json::from_slice::<StoredCheckpoint>(&bytes)
+                .map_err(|source| crate::Error::Attributes { source })?;
+            if stored.version != LEGACY_VERSION {
+                return Err(crate::Error::Config(
+                    "unsupported S3 attribute checkpoint version",
+                ));
+            }
+            if stored.commit != commit.to_string() {
+                return Ok(None);
+            }
+            stored.objects
+        }
+        None => {
+            let stored = serde_json::from_slice::<LegacyManifest>(&bytes)
+                .map_err(|source| crate::Error::Attributes { source })?;
+            if stored.version != LEGACY_VERSION {
+                return Err(crate::Error::Config(
+                    "unsupported S3 attribute checkpoint version",
+                ));
+            }
+            stored.objects
+        }
+    };
+    Ok(Some(Manifest::from_objects(objects)))
+}
+
+fn checkpoint_slot_path(
+    repository: &Repository,
+    slot: &str,
+) -> crate::Result<object_store::path::Path> {
+    if slot.len() != blake3::OUT_LEN * 2
+        || !slot
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(crate::Error::Config(
+            "S3 attribute checkpoint slot is corrupt",
+        ));
+    }
+    Ok(repository
+        .layout
+        .repo_path(&format!("s3/attribute-checkpoints/branches/{slot}.json")))
+}
+
+fn legacy_checkpoint_path(repository: &Repository, commit: ObjectId) -> object_store::path::Path {
+    repository
+        .layout
+        .repo_path(&format!("s3/attribute-checkpoints/{commit}.json"))
 }
 
 enum Stored {
@@ -441,6 +656,43 @@ mod tests {
         assert_eq!(
             selected["older"].as_ref().map(|value| value.etag.as_str()),
             Some("old")
+        );
+    }
+
+    #[test]
+    fn version_two_delta_without_checkpoint_marker_remains_compatible() {
+        let delta: Delta = serde_json::from_str(r#"{"version":2,"changes":{}}"#).unwrap();
+
+        assert!(!delta.checkpoint);
+    }
+
+    #[test]
+    fn manifest_memory_estimate_tracks_replacement_and_removal() {
+        let mut manifest = Manifest::default();
+        manifest.update("object".to_owned(), Some(attributes("first")));
+        manifest.update("object".to_owned(), Some(attributes("replacement")));
+        let rebuilt = Manifest::from_objects(manifest.objects.clone());
+        assert_eq!(manifest.estimated_bytes(), rebuilt.estimated_bytes());
+
+        manifest.update("object".to_owned(), None);
+        assert_eq!(manifest.estimated_bytes(), 0);
+    }
+
+    #[test]
+    fn oversized_manifest_skips_checkpoint_before_serialization() {
+        let manifest = Manifest {
+            objects: BTreeMap::new(),
+            estimated_bytes: MAX_MANIFEST_BYTES as usize + 1,
+        };
+
+        assert!(
+            prepare_checkpoint(
+                "refs/heads/main",
+                ObjectId::empty_tree(gix_hash::Kind::Sha1),
+                &manifest,
+            )
+            .unwrap()
+            .is_none()
         );
     }
 }

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -4938,6 +4938,32 @@ mod tests {
                 .await
                 .unwrap();
         }
+        let lfs_pointer = crab_git::LfsPointer {
+            oid: [7; 32],
+            size: 10 * 1024 * 1024,
+            extensions: Vec::new(),
+        }
+        .serialize();
+        gateway
+            .mutations
+            .apply(
+                repository,
+                "refs/heads/main",
+                &crab_remote_git::GitPath::new(b"lfs/model.bin".to_vec()).unwrap(),
+                mutation::Change::Put {
+                    bytes: Bytes::from(lfs_pointer),
+                    track_lfs: true,
+                    attributes: Box::new(crate::attributes::PutAttributes {
+                        logical_size: Some(10 * 1024 * 1024),
+                        ..Default::default()
+                    }),
+                    condition: mutation::PutCondition::None,
+                },
+                "user",
+                &gateway.cancellation,
+            )
+            .await
+            .unwrap();
 
         // A fresh gateway has no branch actor or remote-Git caches. The
         // durable attribute chain must still prove and serve the complete S3
@@ -5053,6 +5079,23 @@ mod tests {
                 last.next_continuation_token,
             ),
             (Some("main/prefix/c".to_owned()), Some(1), Some(false), None)
+        );
+        let lfs = listing_gateway
+            .list_objects_v2(list_request(ListObjectsV2Input {
+                bucket: "repo".to_owned(),
+                prefix: Some("main/lfs/".to_owned()),
+                ..Default::default()
+            }))
+            .await
+            .unwrap()
+            .output;
+        assert_eq!(
+            lfs.contents
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|object| object.key)
+                .collect::<Vec<_>>(),
+            ["main/lfs/.gitattributes", "main/lfs/model.bin"]
         );
         listing_gateway.shutdown().await;
         gateway.shutdown().await;

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -32,15 +32,16 @@ use crate::{
 const MAX_BUCKETS_PER_PAGE: usize = 10_000;
 const READINESS_CONCURRENCY: usize = 4;
 
+#[derive(Clone)]
 pub(crate) struct Repository {
     pub(crate) config: RepositoryConfig,
     pub(crate) store: Store,
     pub(crate) layout: StoreLayout<Store>,
     pub(crate) identity: RepositoryIdentity,
-    pub(crate) read_views: crate::repository::ReadViewCache,
+    pub(crate) read_views: Arc<crate::repository::ReadViewCache>,
     pub(crate) maintenance: Arc<crate::repository::WriteMaintenance>,
-    hydrator: crab_read::ShardHydrator,
-    lfs: crab_lfs::LfsObjectStore,
+    hydrator: Arc<crab_read::ShardHydrator>,
+    lfs: Arc<crab_lfs::LfsObjectStore>,
 }
 
 impl Repository {
@@ -85,14 +86,19 @@ impl Repository {
             layout.global_prefix().to_owned(),
         );
         Ok(Self {
-            hydrator: crab_read::ReadRuntimeBuilder::new(caching, read_layout, 16).build()?,
-            lfs: crab_lfs::LfsObjectStore::new(store.clone(), layout.repo_prefix()),
+            hydrator: Arc::new(
+                crab_read::ReadRuntimeBuilder::new(caching, read_layout, 16).build()?,
+            ),
+            lfs: Arc::new(crab_lfs::LfsObjectStore::new(
+                store.clone(),
+                layout.repo_prefix(),
+            )),
             identity: RepositoryIdentity::new(
                 format!("{}:{}", provider_name(config.provider), config.bucket),
                 config.prefix.clone(),
                 1,
             )?,
-            read_views: crate::repository::ReadViewCache::new(),
+            read_views: Arc::new(crate::repository::ReadViewCache::new()),
             maintenance: Arc::new(crate::repository::WriteMaintenance::new()),
             config,
             store,
@@ -813,10 +819,17 @@ impl Gateway {
             if blob.metadata.kind != EntryKind::Blob {
                 return Err(s3_error!(InvalidObjectState));
             }
-            let manifest = repo
-                .attributes(repository, snapshot.commit_oid())
-                .await
-                .map_err(gateway_error)?;
+            let manifest = match self.mutations.manifest(
+                &repository.config.name,
+                &address.reference,
+                snapshot.commit_oid(),
+            ) {
+                Some(manifest) => manifest,
+                None => repo
+                    .attributes(repository, snapshot.commit_oid())
+                    .await
+                    .map_err(gateway_error)?,
+            };
             let path = std::str::from_utf8(address.path.as_bytes())
                 .map_err(|_| s3_error!(InvalidObjectState))?;
             let attributes = manifest.object(path, blob.metadata.oid).cloned();
@@ -869,10 +882,17 @@ impl Gateway {
             }
             let path = std::str::from_utf8(address.path.as_bytes())
                 .map_err(|_| s3_error!(InvalidObjectState))?;
-            let attributes = view
-                .object_attributes(repository, snapshot.commit_oid(), path, entry.oid)
-                .await
-                .map_err(gateway_error)?;
+            let attributes = match self.mutations.manifest(
+                &repository.config.name,
+                &address.reference,
+                snapshot.commit_oid(),
+            ) {
+                Some(manifest) => manifest.object(path, entry.oid).cloned(),
+                None => view
+                    .object_attributes(repository, snapshot.commit_oid(), path, entry.oid)
+                    .await
+                    .map_err(gateway_error)?,
+            };
             if let Some(attributes) = attributes {
                 return Ok(ReadObjectMetadata {
                     blob_oid: entry.oid,
@@ -934,9 +954,17 @@ impl Gateway {
             }
             let path = std::str::from_utf8(address.path.as_bytes())
                 .map_err(|_| s3_error!(InvalidObjectState))?;
-            view.object_attributes(repository, snapshot.commit_oid(), path, entry.oid)
-                .await
-                .map_err(gateway_error)
+            match self.mutations.manifest(
+                &repository.config.name,
+                &address.reference,
+                snapshot.commit_oid(),
+            ) {
+                Some(manifest) => Ok(manifest.object(path, entry.oid).cloned()),
+                None => view
+                    .object_attributes(repository, snapshot.commit_oid(), path, entry.oid)
+                    .await
+                    .map_err(gateway_error),
+            }
         }
         .await;
         finish(operation, result).await
@@ -2946,10 +2974,20 @@ impl S3 for Gateway {
                     crab_remote_git::TreeListingItem::CommonPrefix(_) => None,
                 })
                 .collect::<Vec<_>>();
-            let page_attributes =
-                crate::attributes::load_objects(repository, snapshot.commit_oid(), &page_objects)
-                    .await
-                    .map_err(gateway_error)?;
+            let page_attributes = match self.mutations.manifest(
+                &repository.config.name,
+                &reference,
+                snapshot.commit_oid(),
+            ) {
+                Some(manifest) => manifest.listing(&page_objects),
+                None => crate::attributes::load_objects(
+                    repository,
+                    snapshot.commit_oid(),
+                    &page_objects,
+                )
+                .await
+                .map_err(gateway_error)?,
+            };
             let mut contents = Vec::new();
             let mut common_prefixes = Vec::new();
             let mut next = None;
@@ -4256,6 +4294,7 @@ fn object_entry_error(kind: EntryKind) -> s3s::S3Error {
 
 fn mutation_error(error: mutation::Error) -> s3s::S3Error {
     match error {
+        mutation::Error::Batch(error) => shared_mutation_error(error),
         mutation::Error::NotDirectory
         | mutation::Error::IsDirectory
         | mutation::Error::InvalidAttributes => {
@@ -4288,6 +4327,35 @@ fn mutation_error(error: mutation::Error) -> s3s::S3Error {
         ),
         error => {
             tracing::error!(error = ?error, "S3 repository mutation failed");
+            s3_error!(InternalError)
+        }
+    }
+}
+
+fn shared_mutation_error(error: Arc<mutation::Error>) -> s3s::S3Error {
+    match error.as_ref() {
+        mutation::Error::Cancelled
+        | mutation::Error::Publication(crab_remote::publication::Error::Cancelled) => {
+            s3_error!(RequestTimeout)
+        }
+        mutation::Error::Overloaded
+        | mutation::Error::AdmissionTimeout
+        | mutation::Error::Capacity(_) => slow_down_error(),
+        mutation::Error::Write(crab_write::WriteError::RefChanged { .. }) => s3_error!(
+            OperationAborted,
+            "A conflicting branch write won; retry the request"
+        ),
+        mutation::Error::Coordination(crab_coordination::CoordinationError::PushLockHeld {
+            ..
+        })
+        | mutation::Error::Publication(crab_remote::publication::Error::Coordination(
+            crab_coordination::CoordinationError::PushLockHeld { .. },
+        )) => s3_error!(
+            OperationAborted,
+            "The write outcome is being reconciled; retry the request"
+        ),
+        _ => {
+            tracing::error!(error = ?error, "S3 repository mutation batch failed");
             s3_error!(InternalError)
         }
     }

--- a/crates/crab-s3-gateway/src/gateway.rs
+++ b/crates/crab-s3-gateway/src/gateway.rs
@@ -2903,11 +2903,52 @@ impl S3 for Gateway {
         }
         let max_keys = max_keys.min(1000);
         let limit = usize::try_from(max_keys).map_err(|_| s3_error!(InvalidArgument))?;
-        let repo = self.open(repository).await?;
-        if repo.remote().refs().find(&reference).is_none() {
+        if limit == 0 {
             return empty_list_objects_response(&req, url_encode);
         }
-        if limit == 0 {
+        let encoded_ref = prefix
+            .split_once('/')
+            .map(|(value, _)| value)
+            .unwrap_or_default();
+        let ref_prefix = format!("{encoded_ref}/");
+        let after = req
+            .input
+            .continuation_token
+            .as_deref()
+            .or(req.input.start_after.as_deref());
+        let after = match after {
+            Some(after) => match after.strip_prefix(&ref_prefix) {
+                Some(path) => Some(path),
+                None if after < ref_prefix.as_str() => None,
+                None => return empty_list_objects_response(&req, url_encode),
+            },
+            None => None,
+        };
+        if let Some(page) = self
+            .complete_attribute_listing(
+                repository,
+                &reference,
+                &path_prefix,
+                after,
+                req.input
+                    .delimiter
+                    .as_deref()
+                    .filter(|delimiter| !delimiter.is_empty())
+                    .map(|_| b'/'),
+                limit,
+            )
+            .await?
+        {
+            return complete_attribute_listing_response(
+                &req,
+                encoded_ref,
+                page,
+                max_keys,
+                url_encode,
+            );
+        }
+        let repo = self.open(repository).await?;
+        if repo.remote().refs().find(&reference).is_none() {
             return empty_list_objects_response(&req, url_encode);
         }
         let operation = repo
@@ -2922,28 +2963,10 @@ impl S3 for Gateway {
                 .map_err(gateway_error)?;
             let commit = snapshot.commit(&operation).await.map_err(remote_error)?;
             let commit_modified = timestamp(commit.committer.seconds)?;
-            let encoded_ref = prefix
-                .split_once('/')
-                .map(|(value, _)| value)
-                .unwrap_or_default();
-            let ref_prefix = format!("{encoded_ref}/");
-            let after = req
-                .input
-                .continuation_token
-                .as_deref()
-                .or(req.input.start_after.as_deref());
-            let after = match after {
-                Some(after) => match after.strip_prefix(&ref_prefix) {
-                    Some(path) => Some(Bytes::copy_from_slice(path.as_bytes())),
-                    None if after < ref_prefix.as_str() => None,
-                    None => return empty_list_objects_response(&req, url_encode),
-                },
-                None => None,
-            };
             let listing = list_visible_tree_blobs(
                 &snapshot,
                 Bytes::copy_from_slice(path_prefix.as_bytes()),
-                after,
+                after.map(|path| Bytes::copy_from_slice(path.as_bytes())),
                 req.input
                     .delimiter
                     .as_deref()
@@ -3059,6 +3082,66 @@ impl S3 for Gateway {
         .await;
         finish(operation, result).await
     }
+}
+
+fn complete_attribute_listing_response(
+    req: &S3Request<ListObjectsV2Input>,
+    encoded_ref: &str,
+    page: crate::attributes::ManifestListingPage,
+    max_keys: i32,
+    url_encode: bool,
+) -> S3Result<S3Response<ListObjectsV2Output>> {
+    let mut contents = Vec::new();
+    let mut common_prefixes = Vec::new();
+    let mut next = None;
+    for item in page.items {
+        match item {
+            crate::attributes::ManifestListingItem::Object { path, attributes } => {
+                let key = format!("{encoded_ref}/{path}");
+                next = Some(key.clone());
+                contents.push(Object {
+                    key: Some(key),
+                    e_tag: Some(ETag::Strong(attributes.etag)),
+                    last_modified: Some(timestamp(
+                        i64::try_from(attributes.modified_seconds)
+                            .map_err(|_| s3_error!(InternalError))?,
+                    )?),
+                    size: i64::try_from(attributes.size).ok(),
+                    storage_class: Some(ObjectStorageClass::from_static("STANDARD")),
+                    ..Default::default()
+                });
+            }
+            crate::attributes::ManifestListingItem::CommonPrefix(path) => {
+                let key = format!("{encoded_ref}/{path}");
+                next = Some(key.clone());
+                common_prefixes.push(CommonPrefix { prefix: Some(key) });
+            }
+        }
+    }
+    if url_encode {
+        for object in &mut contents {
+            object.key = encode_list_option(object.key.take(), true);
+        }
+        for group in &mut common_prefixes {
+            group.prefix = encode_list_option(group.prefix.take(), true);
+        }
+    }
+    let key_count = contents.len().saturating_add(common_prefixes.len());
+    Ok(S3Response::new(ListObjectsV2Output {
+        name: Some(req.input.bucket.clone()),
+        prefix: encode_list_option(req.input.prefix.clone(), url_encode),
+        max_keys: Some(max_keys),
+        key_count: Some(i32::try_from(key_count).map_err(|_| s3_error!(InternalError))?),
+        continuation_token: req.input.continuation_token.clone(),
+        next_continuation_token: page.has_more.then_some(next).flatten(),
+        is_truncated: Some(page.has_more),
+        contents: (!contents.is_empty()).then_some(contents),
+        common_prefixes: (!common_prefixes.is_empty()).then_some(common_prefixes),
+        delimiter: encode_list_option(req.input.delimiter.clone(), url_encode),
+        encoding_type: req.input.encoding_type.clone(),
+        start_after: encode_list_option(req.input.start_after.clone(), url_encode),
+        ..Default::default()
+    }))
 }
 
 async fn list_visible_tree_blobs(
@@ -4061,6 +4144,37 @@ fn stored_to_pending(
 }
 
 impl Gateway {
+    async fn complete_attribute_listing(
+        &self,
+        repository: &Repository,
+        reference: &str,
+        prefix: &str,
+        after: Option<&str>,
+        delimiter: Option<u8>,
+        limit: usize,
+    ) -> S3Result<Option<crate::attributes::ManifestListingPage>> {
+        let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+            &repository.store,
+            &repository.layout,
+        )
+        .await
+        .map_err(|error| gateway_error(error.into()))?;
+        let Some(tip) = snapshot.journal.refs.get(reference) else {
+            return Ok(None);
+        };
+        let tip = gix_hash::ObjectId::from_hex(tip.as_bytes())
+            .map_err(|_| s3_error!(InvalidObjectState))?;
+        let Some(manifest) = self
+            .mutations
+            .complete_manifest(repository, reference, tip)
+            .await
+            .map_err(gateway_error)?
+        else {
+            return Ok(None);
+        };
+        Ok(manifest.complete_listing(prefix, after, delimiter, limit))
+    }
+
     async fn list_refs(
         &self,
         req: &S3Request<ListObjectsV2Input>,
@@ -4771,8 +4885,8 @@ mod tests {
             auth,
             region: Arc::from("us-east-1"),
             admission: Admission::new(8, cancellation.clone(), metrics.clone()),
-            metrics,
-            local_cache,
+            metrics: metrics.clone(),
+            local_cache: Arc::clone(&local_cache),
             cancellation,
         };
         let repository = &gateway.repositories["repo"];
@@ -4825,7 +4939,29 @@ mod tests {
                 .unwrap();
         }
 
-        let first = gateway
+        // A fresh gateway has no branch actor or remote-Git caches. The
+        // durable attribute chain must still prove and serve the complete S3
+        // namespace without opening the repository-wide object catalog.
+        let listing_cancellation = CancellationToken::new();
+        let listing_runtime = Arc::new(RemoteGitRuntime::default());
+        let listing_gateway = Gateway {
+            repositories: Arc::clone(&gateway.repositories),
+            mutations: Arc::new(mutation::Coordinator::new(
+                Arc::clone(&listing_runtime),
+                options,
+                metrics.clone(),
+            )),
+            runtime: listing_runtime,
+            options,
+            auth: gateway.auth.clone(),
+            region: Arc::clone(&gateway.region),
+            admission: Admission::new(8, listing_cancellation.clone(), metrics.clone()),
+            metrics,
+            local_cache: Arc::clone(&local_cache),
+            cancellation: listing_cancellation,
+        };
+
+        let first = listing_gateway
             .list_objects_v2(list_request(ListObjectsV2Input {
                 bucket: "repo".to_owned(),
                 prefix: Some("main/prefix/".to_owned()),
@@ -4864,7 +5000,7 @@ mod tests {
                 Some(true),
             )
         );
-        let second = gateway
+        let second = listing_gateway
             .list_objects_v2(list_request(ListObjectsV2Input {
                 bucket: "repo".to_owned(),
                 prefix: Some("main/prefix/".to_owned()),
@@ -4896,7 +5032,7 @@ mod tests {
                 Some("main/prefix/b/"),
             )
         );
-        let last = gateway
+        let last = listing_gateway
             .list_objects_v2(list_request(ListObjectsV2Input {
                 bucket: "repo".to_owned(),
                 prefix: Some("main/prefix/".to_owned()),
@@ -4918,6 +5054,7 @@ mod tests {
             ),
             (Some("main/prefix/c".to_owned()), Some(1), Some(false), None)
         );
+        listing_gateway.shutdown().await;
         gateway.shutdown().await;
     }
 

--- a/crates/crab-s3-gateway/src/metrics.rs
+++ b/crates/crab-s3-gateway/src/metrics.rs
@@ -73,6 +73,7 @@ struct MetricsInner {
     methods: [MethodMetrics; METHOD_COUNT],
     admission: [AdmissionMetrics; RequestClass::ALL.len()],
     multipart_maintenance: MultipartMaintenanceMetrics,
+    mutations: MutationMetrics,
     backend: backend::BackendMetrics,
     cache: cache::CacheMetrics,
     filesystem: filesystem::FilesystemMetrics,
@@ -102,6 +103,15 @@ struct MultipartMaintenanceMetrics {
     failures: [Counter; MAINTENANCE_FAILURES.len()],
     duration: Histogram,
     last_success: Gauge,
+}
+
+struct MutationMetrics {
+    batches: Counter,
+    requests: Counter,
+    commits: Counter,
+    input_bytes: Counter,
+    duration: Histogram,
+    queue_wait: Histogram,
 }
 
 #[derive(Clone, Copy)]
@@ -150,6 +160,7 @@ impl Metrics {
         let admission =
             RequestClass::ALL.map(|class| AdmissionMetrics::new(&recorder, class.label()));
         let multipart_maintenance = MultipartMaintenanceMetrics::new(&recorder);
+        let mutations = MutationMetrics::new(&recorder);
         let backend = backend::BackendMetrics::new(&recorder);
         let cache = cache::CacheMetrics::new(&recorder);
         let filesystem = filesystem::FilesystemMetrics::new(&recorder, scratch_path);
@@ -160,6 +171,7 @@ impl Metrics {
                 methods,
                 admission,
                 multipart_maintenance,
+                mutations,
                 backend,
                 cache,
                 filesystem,
@@ -194,6 +206,37 @@ impl Metrics {
 
     pub(crate) fn record_admission(&self, class: RequestClass, outcome: AdmissionOutcome) {
         self.inner.admission[class.index()].events[outcome.index()].increment(1);
+    }
+
+    pub(crate) fn start_mutation_batch(
+        &self,
+        requests: usize,
+        input_bytes: usize,
+    ) -> MutationBatchObservation {
+        self.inner.mutations.batches.increment(1);
+        self.inner
+            .mutations
+            .requests
+            .increment(saturating_u64(requests));
+        self.inner
+            .mutations
+            .input_bytes
+            .increment(saturating_u64(input_bytes));
+        MutationBatchObservation {
+            metrics: self.clone(),
+            started: Instant::now(),
+        }
+    }
+
+    pub(crate) fn record_mutation_queue_wait(&self, seconds: f64) {
+        self.inner.mutations.queue_wait.record(seconds);
+    }
+
+    pub(crate) fn record_mutation_commits(&self, commits: usize) {
+        self.inner
+            .mutations
+            .commits
+            .increment(saturating_u64(commits));
     }
 
     pub(crate) fn record_maintenance_failure(&self, failure: MaintenanceFailure, count: usize) {
@@ -432,6 +475,52 @@ impl MultipartMaintenanceMetrics {
     }
 }
 
+impl MutationMetrics {
+    fn new(recorder: &impl Recorder) -> Self {
+        Self {
+            batches: recorder.register_counter(
+                &Key::from_static_name("crab_s3_gateway_mutation_batches_total"),
+                &METADATA,
+            ),
+            requests: recorder.register_counter(
+                &Key::from_static_name("crab_s3_gateway_mutation_batch_requests_total"),
+                &METADATA,
+            ),
+            commits: recorder.register_counter(
+                &Key::from_static_name("crab_s3_gateway_mutation_batch_commits_total"),
+                &METADATA,
+            ),
+            input_bytes: recorder.register_counter(
+                &Key::from_static_name("crab_s3_gateway_mutation_batch_input_bytes_total"),
+                &METADATA,
+            ),
+            duration: recorder.register_histogram(
+                &Key::from_static_name("crab_s3_gateway_mutation_batch_duration_seconds"),
+                &METADATA,
+            ),
+            queue_wait: recorder.register_histogram(
+                &Key::from_static_name("crab_s3_gateway_mutation_queue_wait_seconds"),
+                &METADATA,
+            ),
+        }
+    }
+}
+
+pub(crate) struct MutationBatchObservation {
+    metrics: Metrics,
+    started: Instant,
+}
+
+impl Drop for MutationBatchObservation {
+    fn drop(&mut self) {
+        self.metrics
+            .inner
+            .mutations
+            .duration
+            .record(self.started.elapsed().as_secs_f64());
+    }
+}
+
 pub(crate) struct RequestObservation {
     metrics: Metrics,
     method: usize,
@@ -629,6 +718,36 @@ fn describe_metrics(recorder: &impl Recorder) {
         recorder,
         "crab_s3_gateway_admission_events_total",
         "Admission decisions by request class and bounded outcome.",
+    );
+    describe_counter(
+        recorder,
+        "crab_s3_gateway_mutation_batches_total",
+        "Bounded same-ref mutation batches executed by this process.",
+    );
+    describe_counter(
+        recorder,
+        "crab_s3_gateway_mutation_batch_requests_total",
+        "S3 mutations admitted into bounded same-ref batches.",
+    );
+    describe_counter(
+        recorder,
+        "crab_s3_gateway_mutation_batch_commits_total",
+        "Git commits durably published by bounded same-ref batches.",
+    );
+    describe_counter(
+        recorder,
+        "crab_s3_gateway_mutation_batch_input_bytes_total",
+        "Logical mutation bytes admitted into bounded same-ref batches.",
+    );
+    recorder.describe_histogram(
+        KeyName::from_const_str("crab_s3_gateway_mutation_batch_duration_seconds"),
+        Some(Unit::Seconds),
+        "Full bounded same-ref batch execution duration.".into(),
+    );
+    recorder.describe_histogram(
+        KeyName::from_const_str("crab_s3_gateway_mutation_queue_wait_seconds"),
+        Some(Unit::Seconds),
+        "Per-request wait before a same-ref mutation batch starts.".into(),
     );
     describe_counter(
         recorder,

--- a/crates/crab-s3-gateway/src/metrics/tests.rs
+++ b/crates/crab-s3-gateway/src/metrics/tests.rs
@@ -135,6 +135,23 @@ fn renderer_emits_the_configured_cumulative_histogram() {
 }
 
 #[test]
+fn mutation_batch_metrics_expose_amortization_and_wait() {
+    let (admission, metrics) = setup();
+    let observation = metrics.start_mutation_batch(8, 4096);
+    metrics.record_mutation_queue_wait(0.01);
+    metrics.record_mutation_commits(7);
+    drop(observation);
+
+    let body = metrics.render(&admission);
+    assert!(body.contains("crab_s3_gateway_mutation_batches_total 1"));
+    assert!(body.contains("crab_s3_gateway_mutation_batch_requests_total 8"));
+    assert!(body.contains("crab_s3_gateway_mutation_batch_commits_total 7"));
+    assert!(body.contains("crab_s3_gateway_mutation_batch_input_bytes_total 4096"));
+    assert!(body.contains("crab_s3_gateway_mutation_batch_duration_seconds_count 1"));
+    assert!(body.contains("crab_s3_gateway_mutation_queue_wait_seconds_count 1"));
+}
+
+#[test]
 fn renderer_exports_current_scratch_filesystem_capacity() {
     let scratch = tempfile::tempdir().unwrap();
     let metrics = Metrics::new_with_scratch_path(scratch.path().to_owned()).unwrap();

--- a/crates/crab-s3-gateway/src/mutation.rs
+++ b/crates/crab-s3-gateway/src/mutation.rs
@@ -32,6 +32,7 @@ const PACK_SCRATCH_BASE_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_QUEUED_WRITES_PER_REF: usize = 64;
 const MAX_TRACKED_REFS: usize = 256;
 const MAX_WARM_BRANCH_STATE_BYTES: usize = 128 * 1024 * 1024;
+const WARM_BRANCH_STATE_EVICTION_BYTES: usize = MAX_WARM_BRANCH_STATE_BYTES * 3 / 4;
 const ATTRIBUTE_CHECKPOINT_BATCHES: usize = 64;
 const WRITE_QUEUE_TIMEOUT: Duration = Duration::from_secs(60);
 const BATCH_COLLECTION_DELAY: Duration = Duration::from_millis(10);
@@ -257,6 +258,37 @@ impl Coordinator {
         self.admission.manifest(repository, branch, Some(tip))
     }
 
+    pub(crate) async fn complete_manifest(
+        &self,
+        repository: &Repository,
+        branch: &str,
+        tip: ObjectId,
+    ) -> crate::Result<Option<Arc<attributes::Manifest>>> {
+        if let Some(manifest) = self.manifest(&repository.config.name, branch, tip)
+            && manifest.is_complete()
+        {
+            return Ok(Some(manifest));
+        }
+        if let Some(manifest) =
+            self.admission
+                .complete_manifest(&repository.config.name, branch, tip)
+        {
+            return Ok(Some(manifest));
+        }
+        let manifest = attributes::load(repository, tip).await?;
+        if !manifest.is_complete() {
+            return Ok(None);
+        }
+        let manifest = Arc::new(manifest);
+        self.admission.store_complete_manifest(
+            &repository.config.name,
+            branch,
+            tip,
+            Arc::clone(&manifest),
+        );
+        Ok(Some(manifest))
+    }
+
     async fn apply_batch(
         repository: &Repository,
         runtime: Arc<crab_remote_git::RemoteGitRuntime>,
@@ -360,7 +392,14 @@ async fn apply(
 #[derive(Default)]
 struct WriteAdmission {
     refs: std::sync::Mutex<HashMap<String, Arc<RefQueue>>>,
+    complete_manifests: std::sync::Mutex<HashMap<String, CachedCompleteManifest>>,
     warm_bytes: Arc<AtomicUsize>,
+}
+
+struct CachedCompleteManifest {
+    tip: ObjectId,
+    manifest: Arc<attributes::Manifest>,
+    bytes: usize,
 }
 
 struct RefQueue {
@@ -575,6 +614,90 @@ impl RefQueue {
 }
 
 impl WriteAdmission {
+    fn complete_manifest(
+        &self,
+        repository: &str,
+        branch: &str,
+        tip: ObjectId,
+    ) -> Option<Arc<attributes::Manifest>> {
+        self.complete_manifests
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&format!("{repository}\0{branch}"))
+            .filter(|cached| cached.tip == tip)
+            .map(|cached| Arc::clone(&cached.manifest))
+    }
+
+    fn store_complete_manifest(
+        &self,
+        repository: &str,
+        branch: &str,
+        tip: ObjectId,
+        manifest: Arc<attributes::Manifest>,
+    ) {
+        let key = format!("{repository}\0{branch}");
+        let mut cached = self
+            .complete_manifests
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(previous) = cached.remove(&key) {
+            self.warm_bytes.fetch_sub(previous.bytes, Ordering::AcqRel);
+        }
+        let bytes = manifest.estimated_bytes();
+        if cached.len() >= MAX_TRACKED_REFS
+            || self
+                .warm_bytes
+                .load(Ordering::Acquire)
+                .saturating_add(bytes)
+                > MAX_WARM_BRANCH_STATE_BYTES
+        {
+            let removed = cached.drain().fold(0usize, |total, (_, entry)| {
+                total.saturating_add(entry.bytes)
+            });
+            self.warm_bytes.fetch_sub(removed, Ordering::AcqRel);
+        }
+        if self
+            .warm_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |used| {
+                used.checked_add(bytes)
+                    .filter(|next| *next <= MAX_WARM_BRANCH_STATE_BYTES)
+            })
+            .is_ok()
+        {
+            cached.insert(
+                key,
+                CachedCompleteManifest {
+                    tip,
+                    manifest,
+                    bytes,
+                },
+            );
+        }
+    }
+
+    fn clear_complete_manifest(&self, key: &str) {
+        let removed = self
+            .complete_manifests
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(key);
+        if let Some(removed) = removed {
+            self.warm_bytes.fetch_sub(removed.bytes, Ordering::AcqRel);
+        }
+    }
+
+    fn clear_complete_manifests(&self) {
+        let removed = self
+            .complete_manifests
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .drain()
+            .fold(0usize, |total, (_, entry)| {
+                total.saturating_add(entry.bytes)
+            });
+        self.warm_bytes.fetch_sub(removed, Ordering::AcqRel);
+    }
+
     fn manifest(
         &self,
         repository: &str,
@@ -596,11 +719,20 @@ impl WriteAdmission {
         mutation: Mutation,
     ) -> Result<QueuedMutation> {
         let key = format!("{repository}\0{branch}");
+        self.clear_complete_manifest(&key);
+        if self.warm_bytes.load(Ordering::Acquire) > WARM_BRANCH_STATE_EVICTION_BYTES {
+            self.clear_complete_manifests();
+        }
         let queue = {
             let mut refs = self.refs.lock().map_err(|_| Error::AdmissionState)?;
-            for (candidate, queue) in refs.iter() {
-                if candidate != &key && queue.admitted.load(Ordering::Acquire) == 0 {
-                    queue.state.clear();
+            if self.warm_bytes.load(Ordering::Acquire) > WARM_BRANCH_STATE_EVICTION_BYTES {
+                for (candidate, queue) in refs.iter() {
+                    if self.warm_bytes.load(Ordering::Acquire) <= WARM_BRANCH_STATE_EVICTION_BYTES {
+                        break;
+                    }
+                    if candidate != &key && queue.admitted.load(Ordering::Acquire) == 0 {
+                        queue.state.clear();
+                    }
                 }
             }
             match refs.get(&key) {
@@ -1025,6 +1157,35 @@ async fn prepare_and_upload_batch(
             Err(Error::WarmStateMiss) => {}
             Err(error) => return Err(error),
         }
+    }
+    let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+        &repository.store,
+        &repository.layout,
+    )
+    .await?;
+    if !snapshot.journal.refs.contains_key(request.branch) {
+        // An unborn branch has no Git objects to reconstruct. Publication
+        // rechecks absence under the ref lease, so avoid opening the
+        // repository-wide locator merely to prove the empty starting tree.
+        let batch = build_batch(
+            None,
+            None,
+            None,
+            attributes::Manifest::empty_complete(),
+            None,
+            ATTRIBUTE_CHECKPOINT_BATCHES,
+            mutations,
+        )
+        .await?;
+        return upload_batch(
+            repository,
+            request.branch,
+            batch,
+            None,
+            cancel,
+            request.metrics,
+        )
+        .await;
     }
     let view = repository
         .read_views
@@ -2224,6 +2385,22 @@ mod tests {
     use gix_object::WriteTo as _;
     use std::collections::BTreeMap;
 
+    fn mutation(path: &[u8], upload_id: Option<&str>) -> Mutation {
+        Mutation {
+            path: crab_remote_git::GitPath::new(path.to_vec()).unwrap(),
+            change: Change::Put {
+                bytes: Bytes::from_static(b"content"),
+                track_lfs: false,
+                attributes: Box::new(attributes::PutAttributes {
+                    completion_upload_id: upload_id.map(str::to_owned),
+                    ..Default::default()
+                }),
+                condition: PutCondition::None,
+            },
+            principal: "user".to_owned(),
+        }
+    }
+
     #[test]
     fn generated_pack_reservation_covers_peak_temporary_copies() {
         let objects = vec![
@@ -2293,19 +2470,6 @@ mod tests {
     #[test]
     fn multipart_completion_stays_outside_ordinary_batches() {
         let admission = WriteAdmission::default();
-        let mutation = |path: &[u8], upload_id: Option<&str>| Mutation {
-            path: crab_remote_git::GitPath::new(path.to_vec()).unwrap(),
-            change: Change::Put {
-                bytes: Bytes::from_static(b"content"),
-                track_lfs: false,
-                attributes: Box::new(attributes::PutAttributes {
-                    completion_upload_id: upload_id.map(str::to_owned),
-                    ..Default::default()
-                }),
-                condition: PutCondition::None,
-            },
-            principal: "user".to_owned(),
-        };
         let first = admission
             .enqueue("repo", "refs/heads/main", mutation(b"first", None))
             .unwrap();
@@ -2368,6 +2532,31 @@ mod tests {
             0,
         );
         assert!(cache.take(None).is_none());
+    }
+
+    #[test]
+    fn idle_branch_state_is_retained_below_memory_pressure() {
+        let admission = WriteAdmission::default();
+        let first = admission
+            .enqueue("repo", "refs/heads/first", mutation(b"first", None))
+            .unwrap();
+        let first_queue = Arc::clone(&first.queue);
+        drop(first);
+        let tip = ObjectId::empty_tree(gix_hash::Kind::Sha1);
+        first_queue.state.store(
+            Some(tip),
+            None,
+            attributes::Manifest::default(),
+            WarmTree::default(),
+            0,
+        );
+
+        let second = admission
+            .enqueue("repo", "refs/heads/second", mutation(b"second", None))
+            .unwrap();
+
+        assert!(first_queue.state.take(Some(tip)).is_some());
+        drop(second);
     }
 
     async fn fixture() -> (

--- a/crates/crab-s3-gateway/src/mutation.rs
+++ b/crates/crab-s3-gateway/src/mutation.rs
@@ -360,8 +360,13 @@ impl Coordinator {
                 }
             }
         }
-        if let Some((epoch, maintenance_cancel)) = repository.maintenance.finish(cancel) {
-            crate::repository::schedule_catalog_maintenance(repository, cancel, epoch);
+        let idle_maintenance = repository.maintenance.finish(cancel);
+        crate::repository::schedule_catalog_maintenance(
+            repository,
+            cancel,
+            repository.maintenance.current_epoch(),
+        );
+        if let Some((epoch, maintenance_cancel)) = idle_maintenance {
             crate::repository::schedule_readability(
                 repository,
                 runtime,
@@ -1035,6 +1040,21 @@ async fn apply_with_fences(
         )
         .await?;
         let Some(publication) = prepared.publication.as_ref() else {
+            if prepared.requires_revalidation {
+                let lease = RefLease::acquire(repository, request.branch, cancel).await?;
+                let current = prepared_parent_is_current(
+                    repository,
+                    request.branch,
+                    prepared.tip,
+                    prepared.transaction.as_deref(),
+                )
+                .await;
+                lease.release().await;
+                if !current? {
+                    repository.read_views.invalidate().await;
+                    continue;
+                }
+            }
             if let Some(state) = request.state {
                 state.store(
                     prepared.tip,
@@ -1104,6 +1124,7 @@ struct PreparedBatch {
     attributes: attributes::Manifest,
     tree: WarmTree,
     batches_since_checkpoint: usize,
+    requires_revalidation: bool,
 }
 
 struct BuiltBatch {
@@ -1149,6 +1170,7 @@ async fn prepare_and_upload_batch(
                     request.branch,
                     batch,
                     cached.transaction,
+                    true,
                     cancel,
                     request.metrics,
                 )
@@ -1182,6 +1204,7 @@ async fn prepare_and_upload_batch(
             request.branch,
             batch,
             None,
+            false,
             cancel,
             request.metrics,
         )
@@ -1230,6 +1253,7 @@ async fn prepare_and_upload_batch(
         request.branch,
         batch,
         None,
+        false,
         cancel,
         request.metrics,
     )
@@ -1300,6 +1324,7 @@ async fn upload_batch(
     branch: &str,
     batch: BuiltBatch,
     expected_transaction: Option<String>,
+    requires_revalidation: bool,
     cancel: &CancellationToken,
     metrics: &Metrics,
 ) -> Result<PreparedBatch> {
@@ -1322,6 +1347,7 @@ async fn upload_batch(
             attributes,
             tree,
             batches_since_checkpoint,
+            requires_revalidation,
         });
     };
     let commit_count = commits.len();
@@ -1355,7 +1381,38 @@ async fn upload_batch(
         attributes,
         tree,
         batches_since_checkpoint,
+        requires_revalidation,
     })
+}
+
+async fn prepared_parent_is_current(
+    repository: &Repository,
+    branch: &str,
+    expected_tip: Option<ObjectId>,
+    expected_transaction: Option<&str>,
+) -> Result<bool> {
+    if let Some(expected_transaction) = expected_transaction {
+        let head = crab_metadata::ref_journal::read_ref_head(
+            &repository.store,
+            &repository.layout,
+            branch,
+        )
+        .await?;
+        return Ok(head.visible_transaction.as_deref() == Some(expected_transaction));
+    }
+    let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+        &repository.store,
+        &repository.layout,
+    )
+    .await?;
+    let current = snapshot
+        .journal
+        .refs
+        .get(branch)
+        .map(|oid| oid.parse::<ObjectId>())
+        .transpose()
+        .map_err(|_| std::io::Error::other("repository ref contains an invalid object ID"))?;
+    Ok(current == expected_tip)
 }
 
 async fn upload_built_batch(
@@ -1382,8 +1439,7 @@ async fn upload_built_batch(
             (
                 built.commit,
                 built.parent,
-                built.path.clone(),
-                built.attributes.clone(),
+                built.attribute_changes.clone(),
                 built.commit == final_commit && checkpoint_slot.is_some(),
                 (built.commit == final_commit)
                     .then(|| checkpoint_slot.clone())
@@ -1468,13 +1524,12 @@ async fn upload_built_batch(
     };
     let attributes_upload = async {
         futures_util::future::try_join_all(attribute_deltas.into_iter().map(
-            |(commit, parent, path, attributes, checkpoint, checkpoint_slot)| {
+            |(commit, parent, changes, checkpoint, checkpoint_slot)| {
                 attributes::save_delta(
                     repository,
                     commit,
                     parent,
-                    path,
-                    attributes,
+                    changes,
                     checkpoint,
                     checkpoint_slot,
                 )
@@ -1619,8 +1674,7 @@ struct BuiltCommit {
     commit: ObjectId,
     etag: Option<String>,
     objects: Vec<(Kind, Vec<u8>)>,
-    path: String,
-    attributes: Option<attributes::ObjectAttributes>,
+    attribute_changes: std::collections::BTreeMap<String, Option<attributes::ObjectAttributes>>,
 }
 
 enum Build {
@@ -1993,11 +2047,24 @@ async fn build_commit(
             (None, None, None)
         }
     };
+    let seconds = now_seconds()?;
     let mut objects = Vec::new();
+    let mut attribute_changes = std::collections::BTreeMap::new();
     if let Some(bytes) = changed {
         objects.push((Kind::Blob, bytes));
     }
     if let Some(attributes) = lfs_attributes {
+        let attributes_path = push_component(&directory_path, b".gitattributes")?;
+        let attributes_path = std::str::from_utf8(attributes_path.as_bytes())
+            .map_err(|_| std::io::Error::other("S3 attribute path is not UTF-8"))?
+            .to_owned();
+        let generated_attributes = attributes::ObjectAttributes::new(
+            attributes.oid,
+            crate::gateway::md5_hex(&attributes.bytes),
+            attributes.bytes.len() as u64,
+            seconds,
+            attributes::PutAttributes::default(),
+        );
         replace_entry(
             leaf_entries,
             b".gitattributes",
@@ -2007,6 +2074,7 @@ async fn build_commit(
                 oid: attributes.oid,
             }),
         );
+        attribute_changes.insert(attributes_path, Some(generated_attributes));
         objects.push((Kind::Blob, attributes.bytes));
     }
     let mut tree_oid = None;
@@ -2033,7 +2101,6 @@ async fn build_commit(
         replace_entry(&mut frames[depth - 1].entries, directory_name, entry);
     }
     let tree = tree_oid.ok_or_else(|| std::io::Error::other("root tree was not encoded"))?;
-    let seconds = now_seconds()?;
     let object_attributes = pending_attributes.map(|(oid, pending, size)| {
         attributes::ObjectAttributes::new(
             oid,
@@ -2043,25 +2110,23 @@ async fn build_commit(
             *pending,
         )
     });
-    let attribute_identity = serde_json::to_vec(&(
-        path_string,
-        parent.map(|oid| oid.to_string()),
-        &object_attributes,
-    ))
-    .map_err(|source| Error::Attributes(Box::new(crate::Error::Attributes { source })))?;
+    attribute_changes.insert(path_string.to_owned(), object_attributes.clone());
+    let attribute_identity = serde_json::to_vec(&attribute_changes)
+        .map_err(|source| Error::Attributes(Box::new(crate::Error::Attributes { source })))?;
     let attribute_digest = blake3::hash(&attribute_identity).to_hex();
     let commit_bytes = commit_bytes(tree, parent, principal, seconds, attribute_digest.as_str());
     let commit = object_id(Kind::Commit, &commit_bytes)?;
     objects.push((Kind::Commit, commit_bytes));
     tree_state.commit(frames, &objects)?;
-    manifest.update(path_string.to_owned(), object_attributes.clone());
+    for (path, attributes) in &attribute_changes {
+        manifest.update(path.clone(), attributes.clone());
+    }
     Ok(Build::Commit(Box::new(BuiltCommit {
         parent,
         commit,
         etag,
         objects,
-        path: path_string.to_owned(),
-        attributes: object_attributes,
+        attribute_changes,
     })))
 }
 
@@ -2968,18 +3033,30 @@ mod tests {
         .await
         .unwrap();
 
+        let stored_attributes = read(
+            &repository,
+            Arc::clone(&runtime),
+            &cancel,
+            "nested/.gitattributes",
+        )
+        .await;
         assert_eq!(
-            read(
-                &repository,
-                Arc::clone(&runtime),
-                &cancel,
-                "nested/.gitattributes",
-            )
-            .await,
+            stored_attributes,
             format!(
                 "README.md text\n{}\n",
                 lfs_attributes_line(filename.as_bytes())
             )
+        );
+        let commit = tip(&repository, Arc::clone(&runtime), &cancel).await;
+        let manifest = attributes::load(&repository, commit).await.unwrap();
+        let attributes_oid = object_id(Kind::Blob, &stored_attributes).unwrap();
+        let attributes_etag = crate::gateway::md5_hex(&stored_attributes);
+        assert!(manifest.is_complete());
+        assert_eq!(
+            manifest
+                .object("nested/.gitattributes", attributes_oid)
+                .map(|attributes| attributes.etag.as_str()),
+            Some(attributes_etag.as_str())
         );
         assert_eq!(
             read(
@@ -3730,6 +3807,59 @@ mod tests {
         assert_eq!(
             read(&repository, Arc::clone(&runtime), &cancel, "second.txt").await,
             "second"
+        );
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn warm_precondition_failure_revalidates_the_object_store_ref() {
+        let (repository, runtime, cancel) = fixture().await;
+        let local = Coordinator::new(
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            Metrics::new().unwrap(),
+        );
+        let competing = Coordinator::new(
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            Metrics::new().unwrap(),
+        );
+        coordinated_put(&local, &repository, &cancel, "seed.txt", b"seed").await;
+        coordinated_put(
+            &competing,
+            &repository,
+            &cancel,
+            "created-elsewhere.txt",
+            b"winner",
+        )
+        .await;
+
+        let result = local
+            .apply(
+                &repository,
+                "refs/heads/main",
+                &crab_remote_git::GitPath::new(b"created-elsewhere.txt".to_vec()).unwrap(),
+                Change::Put {
+                    bytes: Bytes::from_static(b"loser"),
+                    track_lfs: false,
+                    attributes: Box::new(attributes::PutAttributes::default()),
+                    condition: PutCondition::IfNoneMatchAny,
+                },
+                "user",
+                &cancel,
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::PreconditionFailed)));
+        assert_eq!(
+            read(
+                &repository,
+                Arc::clone(&runtime),
+                &cancel,
+                "created-elsewhere.txt",
+            )
+            .await,
+            "winner"
         );
         runtime.shutdown().await;
     }

--- a/crates/crab-s3-gateway/src/mutation.rs
+++ b/crates/crab-s3-gateway/src/mutation.rs
@@ -1,21 +1,22 @@
 use std::{
-    collections::HashMap,
-    io::Write as _,
+    collections::{HashMap, VecDeque},
     sync::{
-        Arc, Weak,
+        Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use bytes::Bytes;
 use crab_coordination::{GcFenceHeartbeat, GcFenceLease, PushLock};
 use crab_metadata::{git_visibility, manifests::PackManifestEntry, ref_journal::RefJournalEdit};
-use crab_remote_git::{EntryKind, EntryMode, OperationKind, RemoteGitRepository, Revision};
+#[cfg(test)]
+use crab_remote_git::RemoteGitRepository;
+use crab_remote_git::{EntryMode, OperationKind};
 use gix_hash::ObjectId;
-use gix_object::{Kind, WriteTo as _, bstr::BString, tree};
+use gix_object::{Kind, bstr::BString, tree};
 use md5::Digest as _;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Semaphore, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -25,10 +26,17 @@ use crate::{
 };
 
 const LOCK_TTL: Duration = Duration::from_secs(300);
+const REF_LOCK_TTL: Duration = Duration::from_secs(30);
 const MAX_GENERATED_PACK_BYTES: u64 = 512 * 1024 * 1024;
 const PACK_SCRATCH_BASE_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_QUEUED_WRITES_PER_REF: usize = 64;
+const MAX_TRACKED_REFS: usize = 256;
+const MAX_WARM_BRANCH_STATE_BYTES: usize = 128 * 1024 * 1024;
+const ATTRIBUTE_CHECKPOINT_BATCHES: usize = 64;
 const WRITE_QUEUE_TIMEOUT: Duration = Duration::from_secs(60);
+const BATCH_COLLECTION_DELAY: Duration = Duration::from_millis(10);
+const MAX_MUTATIONS_PER_BATCH: usize = 32;
+const MAX_MUTATION_BATCH_BYTES: usize = 32 * 1024 * 1024;
 const MAX_REPREPARE_ATTEMPTS: usize = 8;
 const TREE_PAGE_SIZE: usize = 4_096;
 
@@ -52,6 +60,10 @@ pub(crate) enum Error {
     AdmissionTimeout,
     #[error("repository write admission state is unavailable")]
     AdmissionState,
+    #[error("warm branch state does not cover the requested Git path")]
+    WarmStateMiss,
+    #[error("batched repository mutation failed")]
+    Batch(#[source] Arc<Error>),
     #[error("system clock is before the Unix epoch")]
     Clock(#[from] std::time::SystemTimeError),
     #[error("repository read failed")]
@@ -169,39 +181,163 @@ impl Coordinator {
         principal: &str,
         cancel: &CancellationToken,
     ) -> Result<Outcome> {
-        repository.maintenance.begin();
-        let result = async {
-            let _admitted = self
-                .admission
-                .acquire(&repository.config.name, branch, cancel)
-                .await?;
-            apply_admitted(
-                repository,
-                Arc::clone(&self.runtime),
-                self.options,
+        async {
+            let mutation = Mutation {
+                path: path.clone(),
                 change,
+                principal: principal.to_owned(),
+            };
+            let mut queued = self
+                .admission
+                .enqueue(&repository.config.name, branch, mutation)?;
+            let deadline = tokio::time::Instant::now() + WRITE_QUEUE_TIMEOUT;
+            loop {
+                let permit = tokio::select! {
+                    result = &mut queued.result => {
+                        break result.map_err(|_| Error::AdmissionState)?;
+                    }
+                    () = cancel.cancelled() => break Err(Error::Cancelled),
+                    () = tokio::time::sleep_until(deadline) => break Err(Error::AdmissionTimeout),
+                    permit = Arc::clone(&queued.queue.gate).acquire_owned() => {
+                        permit.map_err(|_| Error::AdmissionState)?
+                    }
+                };
+                match queued.result.try_recv() {
+                    Ok(result) => break result,
+                    Err(oneshot::error::TryRecvError::Closed) => {
+                        break Err(Error::AdmissionState);
+                    }
+                    Err(oneshot::error::TryRecvError::Empty) => {}
+                }
+                tokio::select! {
+                    () = cancel.cancelled() => break Err(Error::Cancelled),
+                    () = tokio::time::sleep_until(deadline) => break Err(Error::AdmissionTimeout),
+                    () = tokio::time::sleep(BATCH_COLLECTION_DELAY) => {}
+                }
+                let batch = queued.queue.take_batch()?;
+                if batch.is_empty() {
+                    drop(permit);
+                    continue;
+                }
+                let repository = Repository::clone(repository);
+                repository.maintenance.begin();
+                let runtime = Arc::clone(&self.runtime);
+                let options = self.options;
+                let metrics = self.metrics.clone();
+                let branch = branch.to_owned();
+                let queue = Arc::clone(&queued.queue);
+                let worker_cancel = cancel.clone();
+                // A drained batch owns every accepted mutation. Detaching it
+                // prevents one disconnected HTTP caller from cancelling peers.
+                tokio::spawn(async move {
+                    Self::apply_batch(
+                        &repository,
+                        runtime,
+                        options,
+                        &metrics,
+                        &branch,
+                        &queue,
+                        batch,
+                        &worker_cancel,
+                    )
+                    .await;
+                    drop(permit);
+                });
+            }
+        }
+        .await
+    }
+
+    pub(crate) fn manifest(
+        &self,
+        repository: &str,
+        branch: &str,
+        tip: ObjectId,
+    ) -> Option<Arc<attributes::Manifest>> {
+        self.admission.manifest(repository, branch, Some(tip))
+    }
+
+    async fn apply_batch(
+        repository: &Repository,
+        runtime: Arc<crab_remote_git::RemoteGitRuntime>,
+        options: crab_remote_git::RepositoryOptions,
+        metrics: &Metrics,
+        branch: &str,
+        queue: &RefQueue,
+        batch: Vec<PendingMutation>,
+        cancel: &CancellationToken,
+    ) {
+        let input_bytes = batch.iter().fold(0usize, |total, pending| {
+            total.saturating_add(pending.mutation.estimated_bytes())
+        });
+        for pending in &batch {
+            metrics.record_mutation_queue_wait(pending.queued_at.elapsed().as_secs_f64());
+        }
+        let _observation = metrics.start_mutation_batch(batch.len(), input_bytes);
+        let mutations = batch
+            .iter()
+            .map(|pending| pending.mutation.clone())
+            .collect::<Vec<_>>();
+        let planned = mutations.len() == 1 && mutations[0].is_planned();
+        let results = if planned {
+            match mutations.into_iter().next() {
+                Some(mutation) => Ok(vec![
+                    apply_admitted(
+                        repository,
+                        Arc::clone(&runtime),
+                        options,
+                        mutation,
+                        ApplyRequest {
+                            branch,
+                            plan_id: None,
+                            metrics,
+                            state: Some(&queue.state),
+                        },
+                        cancel,
+                    )
+                    .await,
+                ]),
+                None => Err(std::io::Error::other("planned mutation batch is empty").into()),
+            }
+        } else {
+            apply_batch_admitted(
+                repository,
+                Arc::clone(&runtime),
+                options,
+                mutations,
                 ApplyRequest {
                     branch,
-                    path,
-                    principal,
                     plan_id: None,
-                    metrics: &self.metrics,
+                    metrics,
+                    state: Some(&queue.state),
                 },
                 cancel,
             )
             .await
+        };
+        match results {
+            Ok(results) => {
+                for (pending, result) in batch.into_iter().zip(results) {
+                    let _ = pending.result.send(result);
+                }
+            }
+            Err(error) => {
+                let error = Arc::new(error);
+                for pending in batch {
+                    let _ = pending.result.send(Err(Error::Batch(Arc::clone(&error))));
+                }
+            }
         }
-        .await;
         if let Some((epoch, maintenance_cancel)) = repository.maintenance.finish(cancel) {
+            crate::repository::schedule_catalog_maintenance(repository, cancel, epoch);
             crate::repository::schedule_readability(
                 repository,
-                Arc::clone(&self.runtime),
-                self.options,
+                runtime,
+                options,
                 maintenance_cancel,
                 epoch,
             );
         }
-        result
     }
 }
 
@@ -223,45 +359,268 @@ async fn apply(
 
 #[derive(Default)]
 struct WriteAdmission {
-    refs: std::sync::Mutex<HashMap<String, Weak<RefQueue>>>,
+    refs: std::sync::Mutex<HashMap<String, Arc<RefQueue>>>,
+    warm_bytes: Arc<AtomicUsize>,
 }
 
 struct RefQueue {
     gate: Arc<Semaphore>,
     admitted: AtomicUsize,
+    pending: std::sync::Mutex<VecDeque<PendingMutation>>,
+    state: BranchState,
 }
 
-struct WritePermit {
+struct CachedBranchState {
+    tip: Option<ObjectId>,
+    transaction: Option<String>,
+    manifest: Arc<attributes::Manifest>,
+    tree: WarmTree,
+    bytes: usize,
+    batches_since_checkpoint: usize,
+}
+
+struct BranchState {
+    cached: std::sync::Mutex<Option<CachedBranchState>>,
+    warm_bytes: Arc<AtomicUsize>,
+}
+
+impl BranchState {
+    fn new(warm_bytes: Arc<AtomicUsize>) -> Self {
+        Self {
+            cached: std::sync::Mutex::new(None),
+            warm_bytes,
+        }
+    }
+
+    #[cfg(test)]
+    fn take(&self, tip: Option<ObjectId>) -> Option<CachedBranchState> {
+        self.take_latest().filter(|state| state.tip == tip)
+    }
+
+    fn take_latest(&self) -> Option<CachedBranchState> {
+        let mut cached = self
+            .cached
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let state = cached.take();
+        if let Some(state) = &state {
+            self.warm_bytes.fetch_sub(state.bytes, Ordering::AcqRel);
+        }
+        state
+    }
+
+    fn store(
+        &self,
+        tip: Option<ObjectId>,
+        transaction: Option<String>,
+        manifest: attributes::Manifest,
+        tree: WarmTree,
+        batches_since_checkpoint: usize,
+    ) {
+        self.clear();
+        let bytes = manifest
+            .estimated_bytes()
+            .saturating_add(tree.estimated_bytes());
+        if self
+            .warm_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |used| {
+                used.checked_add(bytes)
+                    .filter(|next| *next <= MAX_WARM_BRANCH_STATE_BYTES)
+            })
+            .is_err()
+        {
+            return;
+        }
+        let state = CachedBranchState {
+            tip,
+            transaction,
+            manifest: Arc::new(manifest),
+            tree,
+            bytes,
+            batches_since_checkpoint,
+        };
+        *self
+            .cached
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(state);
+    }
+
+    fn manifest(&self, tip: Option<ObjectId>) -> Option<Arc<attributes::Manifest>> {
+        self.cached
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .filter(|state| state.tip == tip)
+            .map(|state| Arc::clone(&state.manifest))
+    }
+
+    fn clear(&self) {
+        let state = self
+            .cached
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(state) = state {
+            self.warm_bytes.fetch_sub(state.bytes, Ordering::AcqRel);
+        }
+    }
+}
+
+impl Drop for BranchState {
+    fn drop(&mut self) {
+        let state = self
+            .cached
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(state) = state {
+            self.warm_bytes.fetch_sub(state.bytes, Ordering::AcqRel);
+        }
+    }
+}
+
+struct QueuedMutation {
     queue: Arc<RefQueue>,
-    _permit: OwnedSemaphorePermit,
+    result: oneshot::Receiver<Result<Outcome>>,
 }
 
-impl Drop for WritePermit {
+impl Drop for QueuedMutation {
     fn drop(&mut self) {
         self.queue.admitted.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
+struct PendingMutation {
+    mutation: Mutation,
+    result: oneshot::Sender<Result<Outcome>>,
+    queued_at: Instant,
+}
+
+#[derive(Clone)]
+struct Mutation {
+    path: crab_remote_git::GitPath,
+    change: Change,
+    principal: String,
+}
+
+impl Mutation {
+    fn is_planned(&self) -> bool {
+        matches!(
+            &self.change,
+            Change::Put { attributes, .. } if attributes.completion_upload_id.is_some()
+        )
+    }
+
+    fn completion_plan(&self) -> Option<CompletionPlan> {
+        match &self.change {
+            Change::Put { attributes, .. } => {
+                attributes
+                    .completion_upload_id
+                    .as_deref()
+                    .map(|id| CompletionPlan {
+                        id: crate::multipart::publication_plan_id(id),
+                        etag: attributes.etag_override.clone(),
+                    })
+            }
+            Change::Attributes { .. } | Change::Delete { .. } => None,
+        }
+    }
+
+    fn estimated_bytes(&self) -> usize {
+        match &self.change {
+            Change::Put { bytes, .. } => bytes.len(),
+            Change::Attributes { .. } | Change::Delete { .. } => 0,
+        }
+    }
+}
+
+impl RefQueue {
+    fn take_batch(&self) -> Result<Vec<PendingMutation>> {
+        let mut pending = self.pending.lock().map_err(|_| Error::AdmissionState)?;
+        while pending.front().is_some_and(|item| item.result.is_closed()) {
+            pending.pop_front();
+        }
+        let planned = pending
+            .front()
+            .is_some_and(|item| item.mutation.is_planned());
+        let mut batch = Vec::new();
+        let mut bytes = 0usize;
+        while batch.len() < MAX_MUTATIONS_PER_BATCH {
+            let Some(next) = pending.front() else {
+                break;
+            };
+            if next.result.is_closed() {
+                pending.pop_front();
+                continue;
+            }
+            if !batch.is_empty()
+                && (planned
+                    || next.mutation.is_planned()
+                    || bytes.saturating_add(next.mutation.estimated_bytes())
+                        > MAX_MUTATION_BATCH_BYTES)
+            {
+                break;
+            }
+            let next = pending
+                .pop_front()
+                .ok_or_else(|| std::io::Error::other("write queue front disappeared"))?;
+            bytes = bytes.saturating_add(next.mutation.estimated_bytes());
+            batch.push(next);
+            if planned {
+                break;
+            }
+        }
+        Ok(batch)
+    }
+}
+
 impl WriteAdmission {
-    async fn acquire(
+    fn manifest(
         &self,
         repository: &str,
         branch: &str,
-        cancel: &CancellationToken,
-    ) -> Result<WritePermit> {
-        check_cancelled(cancel)?;
+        tip: Option<ObjectId>,
+    ) -> Option<Arc<attributes::Manifest>> {
+        let key = format!("{repository}\0{branch}");
+        self.refs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&key)
+            .and_then(|queue| queue.state.manifest(tip))
+    }
+
+    fn enqueue(
+        &self,
+        repository: &str,
+        branch: &str,
+        mutation: Mutation,
+    ) -> Result<QueuedMutation> {
         let key = format!("{repository}\0{branch}");
         let queue = {
             let mut refs = self.refs.lock().map_err(|_| Error::AdmissionState)?;
-            refs.retain(|_, queue| queue.strong_count() > 0);
-            match refs.get(&key).and_then(Weak::upgrade) {
-                Some(queue) => queue,
+            for (candidate, queue) in refs.iter() {
+                if candidate != &key && queue.admitted.load(Ordering::Acquire) == 0 {
+                    queue.state.clear();
+                }
+            }
+            match refs.get(&key) {
+                Some(queue) => Arc::clone(queue),
                 None => {
+                    if refs.len() >= MAX_TRACKED_REFS {
+                        // The map is only a warm scheduling cache. Retain active
+                        // queues and discard every idle derived manifest at once.
+                        refs.retain(|_, queue| Arc::strong_count(queue) > 1);
+                    }
+                    if refs.len() >= MAX_TRACKED_REFS {
+                        return Err(Error::Overloaded);
+                    }
                     let queue = Arc::new(RefQueue {
                         gate: Arc::new(Semaphore::new(1)),
                         admitted: AtomicUsize::new(0),
+                        pending: std::sync::Mutex::new(VecDeque::new()),
+                        state: BranchState::new(Arc::clone(&self.warm_bytes)),
                     });
-                    refs.insert(key, Arc::downgrade(&queue));
+                    refs.insert(key, Arc::clone(&queue));
                     queue
                 }
             }
@@ -272,26 +631,26 @@ impl WriteAdmission {
                 (value < MAX_QUEUED_WRITES_PER_REF).then_some(value + 1)
             })
             .map_err(|_| Error::Overloaded)?;
-        let acquired = tokio::select! {
-            () = cancel.cancelled() => Err(Error::Cancelled),
-            result = tokio::time::timeout(WRITE_QUEUE_TIMEOUT, Arc::clone(&queue.gate).acquire_owned()) => {
-                match result {
-                    Ok(Ok(permit)) => Ok(permit),
-                    Ok(Err(_)) => Err(Error::AdmissionState),
-                    Err(_) => Err(Error::AdmissionTimeout),
-                }
-            }
-        };
-        match acquired {
-            Ok(permit) => Ok(WritePermit {
-                queue,
-                _permit: permit,
-            }),
-            Err(error) => {
-                queue.admitted.fetch_sub(1, Ordering::AcqRel);
-                Err(error)
-            }
+        let (result, receiver) = oneshot::channel();
+        let pushed = queue
+            .pending
+            .lock()
+            .map(|mut pending| {
+                pending.push_back(PendingMutation {
+                    mutation,
+                    result,
+                    queued_at: Instant::now(),
+                })
+            })
+            .map_err(|_| Error::AdmissionState);
+        if let Err(error) = pushed {
+            queue.admitted.fetch_sub(1, Ordering::AcqRel);
+            return Err(error);
         }
+        Ok(QueuedMutation {
+            queue,
+            result: receiver,
+        })
     }
 }
 
@@ -315,7 +674,7 @@ impl RefLease {
                 repository.store.inner(),
                 repository.layout.repo_prefix(),
                 branch,
-                LOCK_TTL,
+                REF_LOCK_TTL,
             )
             .await
             {
@@ -368,34 +727,32 @@ impl RefLease {
 #[derive(Clone, Copy)]
 struct ApplyRequest<'a> {
     branch: &'a str,
-    path: &'a crab_remote_git::GitPath,
-    principal: &'a str,
     plan_id: Option<&'a str>,
     metrics: &'a Metrics,
+    state: Option<&'a BranchState>,
 }
 
 async fn apply_admitted(
     repository: &Repository,
     runtime: Arc<crab_remote_git::RemoteGitRuntime>,
     options: crab_remote_git::RepositoryOptions,
-    change: Change,
+    mutation: Mutation,
     request: ApplyRequest<'_>,
     cancel: &CancellationToken,
 ) -> Result<Outcome> {
-    let completion_plan = match &change {
-        Change::Put { attributes, .. } => {
-            attributes
-                .completion_upload_id
-                .as_deref()
-                .map(|id| CompletionPlan {
-                    id: crate::multipart::publication_plan_id(id),
-                    etag: attributes.etag_override.clone(),
-                })
-        }
-        Change::Attributes { .. } | Change::Delete { .. } => None,
-    };
+    let completion_plan = mutation.completion_plan();
     let Some(completion_plan) = completion_plan else {
-        return apply_with_gc_fences(repository, runtime, options, change, request, cancel).await;
+        return take_single_result(
+            apply_with_gc_fences(
+                repository,
+                runtime,
+                options,
+                vec![mutation],
+                request,
+                cancel,
+            )
+            .await?,
+        );
     };
     if let Some(outcome) = resolved_completion_plan(repository, &completion_plan).await? {
         return Ok(outcome);
@@ -412,7 +769,7 @@ async fn apply_admitted(
                 repository,
                 runtime,
                 options,
-                change,
+                vec![mutation],
                 ApplyRequest {
                     plan_id: Some(&executing_plan_id),
                     ..request
@@ -420,6 +777,7 @@ async fn apply_admitted(
                 &scoped,
             )
             .await
+            .and_then(take_single_result)
         },
     )
     .await;
@@ -433,6 +791,30 @@ async fn apply_admitted(
             .ok_or(error),
         result => result,
     }
+}
+
+async fn apply_batch_admitted(
+    repository: &Repository,
+    runtime: Arc<crab_remote_git::RemoteGitRuntime>,
+    options: crab_remote_git::RepositoryOptions,
+    mutations: Vec<Mutation>,
+    request: ApplyRequest<'_>,
+    cancel: &CancellationToken,
+) -> Result<Vec<Result<Outcome>>> {
+    apply_with_gc_fences(repository, runtime, options, mutations, request, cancel).await
+}
+
+fn take_single_result(mut results: Vec<Result<Outcome>>) -> Result<Outcome> {
+    if results.len() != 1 {
+        return Err(
+            std::io::Error::other("singleton mutation returned the wrong result count").into(),
+        );
+    }
+    results.pop().ok_or_else(|| {
+        Error::Io(std::io::Error::other(
+            "singleton mutation result disappeared",
+        ))
+    })?
 }
 
 struct CompletionPlan {
@@ -462,10 +844,10 @@ async fn apply_with_gc_fences(
     repository: &Repository,
     runtime: Arc<crab_remote_git::RemoteGitRuntime>,
     options: crab_remote_git::RepositoryOptions,
-    change: Change,
+    mutations: Vec<Mutation>,
     request: ApplyRequest<'_>,
     cancel: &CancellationToken,
-) -> Result<Outcome> {
+) -> Result<Vec<Result<Outcome>>> {
     let mut fences = Vec::new();
     let result = async {
         for domain in [
@@ -482,7 +864,7 @@ async fn apply_with_gc_fences(
             repository,
             Arc::clone(&runtime),
             options,
-            change,
+            mutations,
             request,
             cancel,
         ))
@@ -505,41 +887,62 @@ async fn apply_with_fences(
     repository: &Repository,
     runtime: Arc<crab_remote_git::RemoteGitRuntime>,
     options: crab_remote_git::RepositoryOptions,
-    change: Change,
+    mutations: Vec<Mutation>,
     request: ApplyRequest<'_>,
     cancel: &CancellationToken,
-) -> Result<Outcome> {
+) -> Result<Vec<Result<Outcome>>> {
     for _ in 0..MAX_REPREPARE_ATTEMPTS {
         check_cancelled(cancel)?;
-        let prepared = prepare_and_upload(
+        let prepared = prepare_and_upload_batch(
             repository,
             Arc::clone(&runtime),
             options,
-            change.clone(),
+            &mutations,
             request,
             cancel,
         )
         .await?;
-        let prepared = match prepared {
-            Prepared::Noop(outcome) => return Ok(outcome),
-            Prepared::Commit(prepared) => prepared,
+        let Some(publication) = prepared.publication.as_ref() else {
+            if let Some(state) = request.state {
+                state.store(
+                    prepared.tip,
+                    prepared.transaction,
+                    prepared.attributes,
+                    prepared.tree,
+                    prepared.batches_since_checkpoint,
+                );
+            }
+            request
+                .metrics
+                .record_mutation_commits(prepared.commit_count);
+            return Ok(prepared.outcomes);
         };
         let lease = RefLease::acquire(repository, request.branch, cancel).await?;
         let published = publish_prepared(
             repository,
             request.branch,
             &lease.holder,
-            &prepared,
+            publication,
             request.plan_id,
             cancel,
         )
         .await;
         lease.release().await;
         match published? {
-            Publish::Committed => {
-                return Ok(Outcome {
-                    etag: prepared.etag,
-                });
+            Publish::Committed(transaction) => {
+                if let Some(state) = request.state {
+                    state.store(
+                        prepared.tip,
+                        Some(transaction),
+                        prepared.attributes,
+                        prepared.tree,
+                        prepared.batches_since_checkpoint,
+                    );
+                }
+                request
+                    .metrics
+                    .record_mutation_commits(prepared.commit_count);
+                return Ok(prepared.outcomes);
             }
             Publish::Reprepare => repository.read_views.invalidate().await,
         }
@@ -553,35 +956,81 @@ async fn apply_with_fences(
 
 struct UploadedMutation {
     parent: Option<ObjectId>,
+    expected_transaction: Option<String>,
     commit: ObjectId,
-    etag: Option<String>,
     pack: PackManifestEntry,
     evidence_hash: String,
+    checkpoint: Option<attributes::PreparedCheckpoint>,
 }
 
-enum Prepared {
-    Noop(Outcome),
-    Commit(UploadedMutation),
+struct PreparedBatch {
+    outcomes: Vec<Result<Outcome>>,
+    publication: Option<UploadedMutation>,
+    commit_count: usize,
+    tip: Option<ObjectId>,
+    transaction: Option<String>,
+    attributes: attributes::Manifest,
+    tree: WarmTree,
+    batches_since_checkpoint: usize,
+}
+
+struct BuiltBatch {
+    outcomes: Vec<Result<Outcome>>,
+    commits: Vec<BuiltCommit>,
+    tip: Option<ObjectId>,
+    attributes: attributes::Manifest,
+    tree: WarmTree,
+    batches_since_checkpoint: usize,
+    checkpoint: bool,
 }
 
 enum Publish {
-    Committed,
+    Committed(String),
     Reprepare,
 }
 
-async fn prepare_and_upload(
+async fn prepare_and_upload_batch(
     repository: &Repository,
     runtime: Arc<crab_remote_git::RemoteGitRuntime>,
     options: crab_remote_git::RepositoryOptions,
-    change: Change,
+    mutations: &[Mutation],
     request: ApplyRequest<'_>,
     cancel: &CancellationToken,
-) -> Result<Prepared> {
+) -> Result<PreparedBatch> {
+    if let Some(cached) = request.state.and_then(BranchState::take_latest) {
+        // The ref lease revalidates this optimistic parent before publication;
+        // a competing process forces a cold rebuild against object-store state.
+        match build_batch(
+            None,
+            None,
+            cached.tip,
+            Arc::try_unwrap(cached.manifest).unwrap_or_else(|manifest| (*manifest).clone()),
+            Some(cached.tree),
+            cached.batches_since_checkpoint,
+            mutations,
+        )
+        .await
+        {
+            Ok(batch) => {
+                return upload_batch(
+                    repository,
+                    request.branch,
+                    batch,
+                    cached.transaction,
+                    cancel,
+                    request.metrics,
+                )
+                .await;
+            }
+            Err(Error::WarmStateMiss) => {}
+            Err(error) => return Err(error),
+        }
+    }
     let view = repository
         .read_views
         .current(repository, runtime, options, cancel)
         .await?;
-    let parent = view
+    let original_parent = view
         .remote()
         .refs()
         .find(request.branch)
@@ -590,65 +1039,214 @@ async fn prepare_and_upload(
         .remote()
         .operation(OperationKind::Repository, cancel)
         .await?;
-    let built = async {
-        let snapshot = match parent {
+    let batch = async {
+        let snapshot = match original_parent {
             Some(parent) => Some(view.snapshot(&parent.to_string(), &operation).await?),
             None => None,
         };
-        let path_string = std::str::from_utf8(request.path.as_bytes())
-            .map_err(|_| std::io::Error::other("S3 object path is not UTF-8"))?;
-        let current_attributes = match &snapshot {
-            Some(snapshot) => match snapshot.entry(request.path, &operation).await? {
-                Some(entry) if entry.kind == EntryKind::Blob => {
-                    view.object_attributes(
-                        repository,
-                        snapshot.commit_oid(),
-                        path_string,
-                        entry.oid,
-                    )
-                    .await?
-                }
-                Some(_) | None => None,
-            },
-            None => None,
+        let manifest = match original_parent {
+            Some(parent) => (*view.attributes(repository, parent).await?).clone(),
+            None => attributes::Manifest::default(),
         };
-        build_commit(
-            view.remote(),
-            &operation,
-            parent,
-            request.path,
-            change,
-            request.principal,
-            current_attributes.as_ref(),
+        build_batch(
+            snapshot,
+            Some(&operation),
+            original_parent,
+            manifest,
+            None,
+            ATTRIBUTE_CHECKPOINT_BATCHES,
+            mutations,
         )
         .await
     }
     .await;
-    let built = match operation.finish(Ok(())).await {
-        Ok(()) => built?,
+    let batch = match operation.finish(Ok(())).await {
+        Ok(()) => batch?,
         Err(error) => return Err(error.into()),
     };
-    let built = match built {
-        Build::Noop(outcome) => return Ok(Prepared::Noop(outcome)),
-        Build::Commit(built) => *built,
-    };
-    upload_built(repository, parent, built, cancel, request.metrics)
-        .await
-        .map(Prepared::Commit)
+    upload_batch(
+        repository,
+        request.branch,
+        batch,
+        None,
+        cancel,
+        request.metrics,
+    )
+    .await
 }
 
-async fn upload_built(
+async fn build_batch(
+    snapshot: Option<crab_remote_git::RemoteGitSnapshot>,
+    operation: Option<&crab_remote_git::OperationContext>,
+    original_parent: Option<ObjectId>,
+    mut manifest: attributes::Manifest,
+    warm_tree: Option<WarmTree>,
+    batches_since_checkpoint: usize,
+    mutations: &[Mutation],
+) -> Result<BuiltBatch> {
+    let mut tree_state = MutableTree::new(snapshot, warm_tree);
+    let mut parent = original_parent;
+    let mut outcomes = Vec::with_capacity(mutations.len());
+    let mut commits = Vec::with_capacity(mutations.len());
+    for mutation in mutations {
+        match build_commit(
+            &mut tree_state,
+            operation,
+            parent,
+            &mutation.path,
+            mutation.change.clone(),
+            &mutation.principal,
+            &mut manifest,
+        )
+        .await
+        {
+            Ok(Build::Noop(outcome)) => outcomes.push(Ok(outcome)),
+            Ok(Build::Commit(mut built)) => {
+                built.parent = parent;
+                parent = Some(built.commit);
+                outcomes.push(Ok(Outcome {
+                    etag: built.etag.clone(),
+                }));
+                commits.push(*built);
+            }
+            Err(Error::WarmStateMiss) => return Err(Error::WarmStateMiss),
+            Err(error) => outcomes.push(Err(error)),
+        }
+    }
+    let next_checkpoint = batches_since_checkpoint.saturating_add(1);
+    let has_commits = !commits.is_empty();
+    let checkpoint = has_commits && next_checkpoint >= ATTRIBUTE_CHECKPOINT_BATCHES;
+    let batches_since_checkpoint = if !has_commits {
+        batches_since_checkpoint
+    } else if checkpoint {
+        0
+    } else {
+        next_checkpoint
+    };
+    Ok(BuiltBatch {
+        outcomes,
+        commits,
+        tip: parent,
+        attributes: manifest,
+        tree: tree_state.into_warm(),
+        batches_since_checkpoint,
+        checkpoint,
+    })
+}
+
+async fn upload_batch(
+    repository: &Repository,
+    branch: &str,
+    batch: BuiltBatch,
+    expected_transaction: Option<String>,
+    cancel: &CancellationToken,
+    metrics: &Metrics,
+) -> Result<PreparedBatch> {
+    let BuiltBatch {
+        outcomes,
+        commits,
+        tip,
+        attributes,
+        tree,
+        batches_since_checkpoint,
+        checkpoint,
+    } = batch;
+    if commits.is_empty() {
+        return Ok(PreparedBatch {
+            outcomes,
+            publication: None,
+            commit_count: 0,
+            tip,
+            transaction: expected_transaction,
+            attributes,
+            tree,
+            batches_since_checkpoint,
+        });
+    };
+    let commit_count = commits.len();
+    let parent = commits.first().and_then(|commit| commit.parent);
+    let final_commit = commits
+        .last()
+        .map(|commit| commit.commit)
+        .ok_or_else(|| std::io::Error::other("mutation batch has no commit"))?;
+    let checkpoint = if checkpoint {
+        check_cancelled(cancel)?;
+        attributes::prepare_checkpoint(branch, final_commit, &attributes)?
+    } else {
+        None
+    };
+    let publication = upload_built_batch(
+        repository,
+        parent,
+        commits,
+        expected_transaction.clone(),
+        checkpoint,
+        cancel,
+        metrics,
+    )
+    .await?;
+    Ok(PreparedBatch {
+        outcomes,
+        publication: Some(publication),
+        commit_count,
+        tip,
+        transaction: expected_transaction,
+        attributes,
+        tree,
+        batches_since_checkpoint,
+    })
+}
+
+async fn upload_built_batch(
     repository: &Repository,
     parent: Option<ObjectId>,
-    built: BuiltCommit,
+    commits: Vec<BuiltCommit>,
+    expected_transaction: Option<String>,
+    checkpoint: Option<attributes::PreparedCheckpoint>,
     cancel: &CancellationToken,
     metrics: &Metrics,
 ) -> Result<UploadedMutation> {
-    let scratch_bytes = pack_scratch_reservation(&built.objects);
+    let mut objects = Vec::new();
+    let mut seen = HashMap::new();
+    let final_commit = commits
+        .last()
+        .map(|built| built.commit)
+        .ok_or_else(|| std::io::Error::other("mutation batch has no commit"))?;
+    let checkpoint_slot = checkpoint
+        .as_ref()
+        .map(|checkpoint| checkpoint.slot().to_owned());
+    let attribute_deltas = commits
+        .iter()
+        .map(|built| {
+            (
+                built.commit,
+                built.parent,
+                built.path.clone(),
+                built.attributes.clone(),
+                built.commit == final_commit && checkpoint_slot.is_some(),
+                (built.commit == final_commit)
+                    .then(|| checkpoint_slot.clone())
+                    .flatten(),
+            )
+        })
+        .collect::<Vec<_>>();
+    for built in commits {
+        for (kind, bytes) in built.objects {
+            let oid = object_id(kind, &bytes)?;
+            if seen.insert(oid, ()).is_none() {
+                objects.push((kind, bytes));
+            }
+        }
+    }
+    let scratch_bytes = pack_scratch_reservation(&objects);
     let capacity = metrics.reserve_scratch(scratch_bytes)?;
     let mut scratch = metrics.start_scratch(ScratchPurpose::GitPack);
     scratch.reserve(scratch_bytes);
-    let prepared = prepare_pack(built.objects.clone(), cancel).await;
+    let visible_objects = objects
+        .iter()
+        .map(|(kind, bytes)| object_id(*kind, bytes).map(|oid| oid.to_string()))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let prepared = prepare_pack(objects, cancel).await;
     if matches!(
         &prepared,
         Err(Error::Io(_)
@@ -663,21 +1261,16 @@ async fn upload_built(
     drop(capacity);
     check_cancelled(cancel)?;
     let pack_id = pack.content_hash().to_hex().to_string();
-    let visible_objects = built
-        .objects
-        .iter()
-        .map(|(kind, bytes)| object_id(*kind, bytes).map(|oid| oid.to_string()))
-        .collect::<std::result::Result<Vec<_>, _>>()?;
     let evidence = match parent {
         Some(parent) => git_visibility::GitVisibilityEdit::from_delta_objects(
             Some(parent.to_string()),
-            built.commit.to_string(),
+            final_commit.to_string(),
             visible_objects,
             vec![],
         ),
         None => git_visibility::GitVisibilityEdit::from_replacement_objects(
             None,
-            built.commit.to_string(),
+            final_commit.to_string(),
             visible_objects,
         ),
     };
@@ -713,14 +1306,21 @@ async fn upload_built(
             .map_err(Error::from)
     };
     let attributes_upload = async {
-        attributes::save_delta(
-            repository,
-            built.commit,
-            parent,
-            built.path.clone(),
-            built.attributes.clone(),
-        )
+        futures_util::future::try_join_all(attribute_deltas.into_iter().map(
+            |(commit, parent, path, attributes, checkpoint, checkpoint_slot)| {
+                attributes::save_delta(
+                    repository,
+                    commit,
+                    parent,
+                    path,
+                    attributes,
+                    checkpoint,
+                    checkpoint_slot,
+                )
+            },
+        ))
         .await
+        .map(|_| ())
         .map_err(Error::from)
     };
     let (_, _, _, _, evidence_hash, _) = tokio::try_join!(
@@ -743,16 +1343,17 @@ async fn upload_built(
     check_cancelled(cancel)?;
     let uploaded = UploadedMutation {
         parent,
-        commit: built.commit,
-        etag: built.etag,
+        expected_transaction,
+        commit: final_commit,
         pack: PackManifestEntry {
             pack_id: pack_id.clone(),
             content_hash: pack_id,
             size: pack.size(),
             object_count: pack.object_count().into(),
-            ref_tips: vec![built.commit.to_string()],
+            ref_tips: vec![final_commit.to_string()],
         },
         evidence_hash,
+        checkpoint,
     };
     drop(pack);
     drop(pack_owner);
@@ -765,11 +1366,11 @@ fn pack_scratch_reservation(objects: &[(Kind, Vec<u8>)]) -> u64 {
         total.saturating_add(object.len() as u64)
     });
     let sidecars = (objects.len() as u64).saturating_mul(64);
-    // Generated-pack preparation retains its source, quarantine pack,
-    // inflated/decoded spools, and two normalized packs at peak. The extra
-    // quarter plus fixed allowance covers zlib and index-sidecar overhead.
+    // Direct generated-pack preparation retains one decoded spool and two
+    // normalized packs at peak. The fourth copy, extra quarter, and fixed
+    // allowance conservatively cover indexing and sidecar overhead.
     bytes
-        .saturating_mul(6)
+        .saturating_mul(4)
         .saturating_add(bytes / 4)
         .saturating_add(sidecars)
         .saturating_add(PACK_SCRATCH_BASE_BYTES)
@@ -784,48 +1385,76 @@ async fn publish_prepared(
     cancel: &CancellationToken,
 ) -> Result<Publish> {
     check_cancelled(cancel)?;
-    let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
-        &repository.store,
-        &repository.layout,
-    )
-    .await?;
-    let current = snapshot
-        .journal
-        .refs
-        .get(branch)
-        .map(|oid| oid.parse::<ObjectId>())
-        .transpose()
-        .map_err(|_| std::io::Error::other("repository ref contains an invalid object ID"))?;
-    if current != prepared.parent {
-        return Ok(Publish::Reprepare);
-    }
     let options = crab_write::journal::CommitOptions::new(LOCK_TTL, cancel);
     let options = match plan_id {
         Some(plan_id) => options.with_plan(plan_id),
         None => options,
     };
-    crab_write::journal::commit_edits(
-        &repository.store,
-        &repository.layout,
-        &snapshot,
-        vec![RefJournalEdit {
-            ref_name: branch.to_owned(),
-            old_oid: prepared.parent.map(|oid| oid.to_string()),
-            new_oid: Some(prepared.commit.to_string()),
-            peeled_oid: None,
-            lock_holder: Some(holder.to_owned()),
-            visibility_evidence_hash: Some(prepared.evidence_hash.clone()),
-        }],
-        prepared.parent.is_none().then(|| branch.to_owned()),
-        vec![prepared.pack.clone()],
-        vec![],
-        options,
-    )
-    .await?;
-    Ok(Publish::Committed)
+    let edit = RefJournalEdit {
+        ref_name: branch.to_owned(),
+        old_oid: prepared.parent.map(|oid| oid.to_string()),
+        new_oid: Some(prepared.commit.to_string()),
+        peeled_oid: None,
+        lock_holder: Some(holder.to_owned()),
+        visibility_evidence_hash: Some(prepared.evidence_hash.clone()),
+    };
+    let committed = if let (Some(expected), Some(_)) =
+        (prepared.expected_transaction.as_deref(), prepared.parent)
+    {
+        crab_write::journal::commit_existing_ref_edit(
+            &repository.store,
+            &repository.layout,
+            expected,
+            edit,
+            vec![prepared.pack.clone()],
+            options,
+        )
+        .await
+    } else {
+        let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+            &repository.store,
+            &repository.layout,
+        )
+        .await?;
+        let current = snapshot
+            .journal
+            .refs
+            .get(branch)
+            .map(|oid| oid.parse::<ObjectId>())
+            .transpose()
+            .map_err(|_| std::io::Error::other("repository ref contains an invalid object ID"))?;
+        if current != prepared.parent {
+            return Ok(Publish::Reprepare);
+        }
+        crab_write::journal::commit_edits(
+            &repository.store,
+            &repository.layout,
+            &snapshot,
+            vec![edit],
+            prepared.parent.is_none().then(|| branch.to_owned()),
+            vec![prepared.pack.clone()],
+            vec![],
+            options,
+        )
+        .await
+    };
+    let committed = match committed {
+        Ok(committed) => committed,
+        Err(crab_write::WriteError::RefChanged { .. }) => return Ok(Publish::Reprepare),
+        Err(error) => return Err(error.into()),
+    };
+    if let Some(checkpoint) = &prepared.checkpoint
+        && let Err(error) = attributes::publish_checkpoint(repository, checkpoint).await
+    {
+        // The journal is already authoritative. A missing checkpoint falls
+        // back to immutable deltas, so retrying this mutation would duplicate it.
+        tracing::warn!(%error, "S3 attribute checkpoint publication failed");
+    }
+    Ok(Publish::Committed(committed.transaction_id))
 }
 
 struct BuiltCommit {
+    parent: Option<ObjectId>,
     commit: ObjectId,
     etag: Option<String>,
     objects: Vec<(Kind, Vec<u8>)>,
@@ -839,55 +1468,258 @@ enum Build {
 }
 
 struct TreeFrame {
+    path: Vec<u8>,
     old_oid: Option<ObjectId>,
+    new_oid: Option<ObjectId>,
     entries: Vec<tree::Entry>,
 }
 
+#[derive(Clone)]
+struct DirectoryState {
+    oid: Option<ObjectId>,
+    entries: Vec<tree::Entry>,
+}
+
+struct GeneratedAttributeBlob {
+    oid: ObjectId,
+    bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+struct WarmTree {
+    root_oid: Option<ObjectId>,
+    directories: HashMap<Vec<u8>, DirectoryState>,
+    generated_attribute_blobs: HashMap<Vec<u8>, GeneratedAttributeBlob>,
+    estimated_bytes: usize,
+}
+
+impl WarmTree {
+    fn estimated_bytes(&self) -> usize {
+        self.estimated_bytes
+    }
+}
+
+struct MutableTree {
+    snapshot: Option<crab_remote_git::RemoteGitSnapshot>,
+    root_oid: Option<ObjectId>,
+    directories: HashMap<Vec<u8>, DirectoryState>,
+    generated_attribute_blobs: HashMap<Vec<u8>, GeneratedAttributeBlob>,
+    estimated_bytes: usize,
+}
+
+impl MutableTree {
+    fn new(snapshot: Option<crab_remote_git::RemoteGitSnapshot>, warm: Option<WarmTree>) -> Self {
+        let snapshot_root = snapshot.as_ref().map(|value| value.root_tree_oid());
+        let warm = warm.filter(|warm| snapshot_root.is_none() || warm.root_oid == snapshot_root);
+        let (root_oid, directories, generated_attribute_blobs, estimated_bytes) = match warm {
+            Some(warm) => (
+                warm.root_oid,
+                warm.directories,
+                warm.generated_attribute_blobs,
+                warm.estimated_bytes,
+            ),
+            None => (snapshot_root, HashMap::new(), HashMap::new(), 0),
+        };
+        Self {
+            snapshot,
+            root_oid,
+            directories,
+            generated_attribute_blobs,
+            estimated_bytes,
+        }
+    }
+
+    fn into_warm(self) -> WarmTree {
+        WarmTree {
+            root_oid: self.root_oid,
+            directories: self.directories,
+            generated_attribute_blobs: self.generated_attribute_blobs,
+            estimated_bytes: self.estimated_bytes,
+        }
+    }
+
+    async fn frames(
+        &mut self,
+        directories: &[Vec<u8>],
+        operation: Option<&crab_remote_git::OperationContext>,
+    ) -> Result<Vec<TreeFrame>> {
+        let mut frames = Vec::with_capacity(directories.len() + 1);
+        let mut directory_path = crab_remote_git::GitPath::root();
+        let mut directory_oid = self.root_oid;
+        for depth in 0..=directories.len() {
+            let key = directory_path.as_bytes().to_vec();
+            if !self.directories.contains_key(&key) {
+                let entries = match (self.snapshot.as_ref(), directory_oid) {
+                    (Some(snapshot), Some(_)) => {
+                        load_directory(
+                            snapshot,
+                            &directory_path,
+                            operation.ok_or(Error::WarmStateMiss)?,
+                        )
+                        .await?
+                    }
+                    (None, None) | (Some(_), None) => Vec::new(),
+                    (None, Some(_)) => return Err(Error::WarmStateMiss),
+                };
+                let state = DirectoryState {
+                    oid: directory_oid,
+                    entries,
+                };
+                self.estimated_bytes = self
+                    .estimated_bytes
+                    .saturating_add(estimated_directory_bytes(&key, &state));
+                self.directories.insert(key.clone(), state);
+            }
+            let state = self
+                .directories
+                .get(&key)
+                .ok_or_else(|| std::io::Error::other("mutation directory state disappeared"))?;
+            if state.oid != directory_oid {
+                return Err(std::io::Error::other("mutation directory state diverged").into());
+            }
+            frames.push(TreeFrame {
+                path: key,
+                old_oid: state.oid,
+                new_oid: state.oid,
+                entries: state.entries.clone(),
+            });
+            if depth == directories.len() {
+                break;
+            }
+            let component = &directories[depth];
+            directory_oid = match find_entry(&state.entries, component) {
+                Some(entry) if entry.mode == tree::EntryKind::Tree.into() => Some(entry.oid),
+                Some(_) => return Err(Error::NotDirectory),
+                None => None,
+            };
+            directory_path = push_component(&directory_path, component)?;
+        }
+        Ok(frames)
+    }
+
+    fn commit(&mut self, frames: Vec<TreeFrame>, objects: &[(Kind, Vec<u8>)]) -> Result<()> {
+        for frame in &frames {
+            let attributes = find_entry(&frame.entries, b".gitattributes");
+            match attributes {
+                Some(attributes) => {
+                    let mut generated = None;
+                    for (kind, bytes) in objects {
+                        if *kind == Kind::Blob && object_id(*kind, bytes)? == attributes.oid {
+                            generated = Some(bytes);
+                            break;
+                        }
+                    }
+                    if let Some(bytes) = generated {
+                        self.replace_generated_attributes(
+                            frame.path.clone(),
+                            Some(GeneratedAttributeBlob {
+                                oid: attributes.oid,
+                                bytes: bytes.clone(),
+                            }),
+                        );
+                    } else if self
+                        .generated_attribute_blobs
+                        .get(&frame.path)
+                        .is_some_and(|blob| blob.oid != attributes.oid)
+                    {
+                        self.replace_generated_attributes(frame.path.clone(), None);
+                    }
+                }
+                None => self.replace_generated_attributes(frame.path.clone(), None),
+            }
+        }
+        for frame in frames {
+            if frame.path.is_empty() {
+                self.root_oid = frame.new_oid;
+            }
+            let state = DirectoryState {
+                oid: frame.new_oid,
+                entries: frame.entries,
+            };
+            let next_bytes = estimated_directory_bytes(&frame.path, &state);
+            if let Some(previous) = self.directories.insert(frame.path.clone(), state) {
+                self.estimated_bytes = self
+                    .estimated_bytes
+                    .saturating_sub(estimated_directory_bytes(&frame.path, &previous));
+            }
+            self.estimated_bytes = self.estimated_bytes.saturating_add(next_bytes);
+        }
+        Ok(())
+    }
+
+    fn replace_generated_attributes(
+        &mut self,
+        path: Vec<u8>,
+        replacement: Option<GeneratedAttributeBlob>,
+    ) {
+        if let Some(previous) = self.generated_attribute_blobs.remove(&path) {
+            self.estimated_bytes = self
+                .estimated_bytes
+                .saturating_sub(estimated_attribute_blob_bytes(&path, &previous));
+        }
+        if let Some(replacement) = replacement {
+            self.estimated_bytes = self
+                .estimated_bytes
+                .saturating_add(estimated_attribute_blob_bytes(&path, &replacement));
+            self.generated_attribute_blobs.insert(path, replacement);
+        }
+    }
+
+    async fn blob(
+        &self,
+        path: &crab_remote_git::GitPath,
+        oid: ObjectId,
+        operation: Option<&crab_remote_git::OperationContext>,
+    ) -> Result<Vec<u8>> {
+        let directory = path
+            .as_bytes()
+            .strip_suffix(b"/.gitattributes")
+            .or_else(|| (path.as_bytes() == b".gitattributes").then_some(b"".as_slice()))
+            .ok_or(Error::WarmStateMiss)?;
+        if let Some(blob) = self.generated_attribute_blobs.get(directory)
+            && blob.oid == oid
+        {
+            return Ok(blob.bytes.clone());
+        }
+        let snapshot = self.snapshot.as_ref().ok_or(Error::WarmStateMiss)?;
+        let blob = snapshot
+            .read_blob(path, operation.ok_or(Error::WarmStateMiss)?)
+            .await?;
+        if blob.metadata.oid != oid {
+            return Err(std::io::Error::other("mutation blob identity diverged").into());
+        }
+        Ok(blob.bytes.to_vec())
+    }
+}
+
+fn estimated_directory_bytes(path: &[u8], directory: &DirectoryState) -> usize {
+    directory.entries.iter().fold(path.len(), |total, entry| {
+        total
+            .saturating_add(std::mem::size_of::<tree::Entry>())
+            .saturating_add(entry.filename.len())
+    })
+}
+
+fn estimated_attribute_blob_bytes(path: &[u8], blob: &GeneratedAttributeBlob) -> usize {
+    path.len()
+        .saturating_add(std::mem::size_of::<ObjectId>())
+        .saturating_add(blob.bytes.len())
+}
+
 async fn build_commit(
-    remote: &RemoteGitRepository,
-    operation: &crab_remote_git::OperationContext,
+    tree_state: &mut MutableTree,
+    operation: Option<&crab_remote_git::OperationContext>,
     parent: Option<ObjectId>,
     path: &crab_remote_git::GitPath,
     change: Change,
     principal: &str,
-    current_attributes: Option<&attributes::ObjectAttributes>,
+    manifest: &mut attributes::Manifest,
 ) -> Result<Build> {
     let components = path.components().map(<[u8]>::to_vec).collect::<Vec<_>>();
     let (name, directories) = components.split_last().ok_or(Error::IsDirectory)?;
-    let snapshot = match parent {
-        Some(parent) => Some(
-            remote
-                .snapshot(&Revision::Commit(parent), operation)
-                .await?,
-        ),
-        None => None,
-    };
-    let mut frames = Vec::with_capacity(directories.len() + 1);
+    let mut frames = tree_state.frames(directories, operation).await?;
     let mut directory_path = crab_remote_git::GitPath::root();
-    let mut directory_oid = snapshot.as_ref().map(|value| value.root_tree_oid());
-    for depth in 0..=directories.len() {
-        let entries = match (&snapshot, directory_oid) {
-            (Some(snapshot), Some(_)) => {
-                load_directory(snapshot, &directory_path, operation).await?
-            }
-            (None, None) | (Some(_), None) => Vec::new(),
-            (None, Some(_)) => {
-                return Err(std::io::Error::other("empty repository has a root tree").into());
-            }
-        };
-        frames.push(TreeFrame {
-            old_oid: directory_oid,
-            entries,
-        });
-        if depth == directories.len() {
-            break;
-        }
-        let component = &directories[depth];
-        directory_oid = match find_entry(&frames[depth].entries, component) {
-            Some(entry) if entry.mode == tree::EntryKind::Tree.into() => Some(entry.oid),
-            Some(_) => return Err(Error::NotDirectory),
-            None => None,
-        };
+    for component in directories {
         directory_path = push_component(&directory_path, component)?;
     }
     let leaf_entries = &mut frames
@@ -903,6 +1735,9 @@ async fn build_commit(
     };
     let path_string = std::str::from_utf8(path.as_bytes())
         .map_err(|_| std::io::Error::other("S3 object path is not UTF-8"))?;
+    let current_attributes = old
+        .as_ref()
+        .and_then(|(oid, _)| manifest.object(path_string, *oid));
     let lfs_attributes = match &change {
         Change::Put {
             track_lfs: true, ..
@@ -910,14 +1745,8 @@ async fn build_commit(
         Change::Put {
             track_lfs: true, ..
         } => {
-            prepare_lfs_attributes(
-                snapshot.as_ref(),
-                &directory_path,
-                leaf_entries,
-                name,
-                operation,
-            )
-            .await?
+            prepare_lfs_attributes(tree_state, &directory_path, leaf_entries, name, operation)
+                .await?
         }
         Change::Put { .. } | Change::Attributes { .. } | Change::Delete { .. } => None,
     };
@@ -1026,12 +1855,10 @@ async fn build_commit(
         let oid = if depth > 0 && empty {
             None
         } else {
-            Some(encode_tree(
-                frame.old_oid,
-                std::mem::take(&mut frame.entries),
-                &mut objects,
-            )?)
+            let oid = encode_tree(frame.old_oid, &frame.entries, &mut objects)?;
+            Some(oid)
         };
+        frame.new_oid = oid;
         if depth == 0 {
             tree_oid = oid;
             break;
@@ -1065,7 +1892,10 @@ async fn build_commit(
     let commit_bytes = commit_bytes(tree, parent, principal, seconds, attribute_digest.as_str());
     let commit = object_id(Kind::Commit, &commit_bytes)?;
     objects.push((Kind::Commit, commit_bytes));
+    tree_state.commit(frames, &objects)?;
+    manifest.update(path_string.to_owned(), object_attributes.clone());
     Ok(Build::Commit(Box::new(BuiltCommit {
+        parent,
         commit,
         etag,
         objects,
@@ -1104,35 +1934,30 @@ struct LfsAttributesChange {
 }
 
 async fn prepare_lfs_attributes(
-    snapshot: Option<&crab_remote_git::RemoteGitSnapshot>,
+    tree_state: &MutableTree,
     directory: &crab_remote_git::GitPath,
     entries: &[tree::Entry],
     filename: &[u8],
-    operation: &crab_remote_git::OperationContext,
+    operation: Option<&crab_remote_git::OperationContext>,
 ) -> Result<Option<LfsAttributesChange>> {
     let attributes_entry = find_entry(entries, b".gitattributes");
-    let (mut bytes, mode, old_oid) = match (snapshot, attributes_entry) {
-        (Some(snapshot), Some(entry)) => {
+    let (mut bytes, mode, old_oid) = match attributes_entry {
+        Some(entry) => {
             let mode = entry_mode(entry.mode)?;
             if !matches!(mode, EntryMode::Regular | EntryMode::Executable) {
                 return Err(Error::InvalidAttributes);
             }
             let path = push_component(directory, b".gitattributes")?;
-            let blob = snapshot.read_blob(&path, operation).await?;
+            let bytes = tree_state.blob(&path, entry.oid, operation).await?;
             if !matches!(
-                crab_git::classify(&blob.bytes),
+                crab_git::classify(&bytes),
                 crab_git::PointerKind::NotAPointer
             ) {
                 return Err(Error::InvalidAttributes);
             }
-            (blob.bytes.to_vec(), entry.mode, Some(entry.oid))
+            (bytes, entry.mode, Some(entry.oid))
         }
-        (_, None) => (Vec::new(), tree::EntryKind::Blob.into(), None),
-        (None, Some(_)) => {
-            return Err(
-                std::io::Error::other("empty repository contains a .gitattributes entry").into(),
-            );
-        }
+        None => (Vec::new(), tree::EntryKind::Blob.into(), None),
     };
     let line = lfs_attributes_line(filename);
     if bytes
@@ -1210,6 +2035,7 @@ async fn load_directory(
         };
         cursor = Some(next);
     }
+    entries.sort();
     Ok(entries)
 }
 
@@ -1249,16 +2075,33 @@ fn git_entry_mode(mode: EntryMode) -> gix_object::tree::EntryMode {
 }
 
 fn find_entry<'a>(entries: &'a [tree::Entry], name: &[u8]) -> Option<&'a tree::Entry> {
-    entries
-        .iter()
-        .find(|entry| <BString as AsRef<[u8]>>::as_ref(&entry.filename) == name)
+    entry_index(entries, name).map(|index| &entries[index])
 }
 
 fn replace_entry(entries: &mut Vec<tree::Entry>, name: &[u8], replacement: Option<tree::Entry>) {
-    entries.retain(|entry| <BString as AsRef<[u8]>>::as_ref(&entry.filename) != name);
-    if let Some(replacement) = replacement {
-        entries.push(replacement);
+    if let Some(index) = entry_index(entries, name) {
+        entries.remove(index);
     }
+    if let Some(replacement) = replacement {
+        let index = entries
+            .binary_search(&replacement)
+            .unwrap_or_else(|index| index);
+        entries.insert(index, replacement);
+    }
+}
+
+fn entry_index(entries: &[tree::Entry], name: &[u8]) -> Option<usize> {
+    [tree::EntryKind::Blob, tree::EntryKind::Tree]
+        .into_iter()
+        .find_map(|kind| {
+            entries
+                .binary_search(&tree::Entry {
+                    mode: kind.into(),
+                    filename: BString::from(name),
+                    oid: ObjectId::empty_blob(gix_hash::Kind::Sha1),
+                })
+                .ok()
+        })
 }
 
 fn push_component(
@@ -1275,12 +2118,18 @@ fn push_component(
 
 fn encode_tree(
     old_oid: Option<ObjectId>,
-    mut entries: Vec<tree::Entry>,
+    entries: &[tree::Entry],
     objects: &mut Vec<(Kind, Vec<u8>)>,
 ) -> Result<ObjectId> {
-    entries.sort();
     let mut bytes = Vec::new();
-    gix_object::Tree { entries }.write_to(&mut bytes)?;
+    let mut mode = [0; 6];
+    for entry in entries {
+        bytes.extend_from_slice(entry.mode.as_bytes(&mut mode));
+        bytes.push(b' ');
+        bytes.extend_from_slice(&entry.filename);
+        bytes.push(0);
+        bytes.extend_from_slice(entry.oid.as_bytes());
+    }
     let oid = object_id(Kind::Tree, &bytes)?;
     if old_oid != Some(oid) {
         objects.push((Kind::Tree, bytes));
@@ -1333,10 +2182,8 @@ async fn prepare_pack(
     let worker_flag = Arc::clone(&cancelled);
     let result = tokio::task::spawn_blocking(move || {
         let owner = tempfile::tempdir()?;
-        let input = owner.path().join("generated.pack");
-        write_pack(&input, &objects)?;
-        let incoming = crab_git::incoming_pack::quarantine(
-            std::io::BufReader::new(std::fs::File::open(&input)?),
+        let incoming = crab_git::incoming_pack::IncomingPack::from_generated_objects(
+            objects,
             owner.path(),
             crab_git::incoming_pack::ReceiveLimits {
                 max_pack_bytes: MAX_GENERATED_PACK_BYTES,
@@ -1346,7 +2193,6 @@ async fn prepare_pack(
                 max_delta_depth: 1,
             },
             || worker_flag.load(Ordering::Acquire),
-            |_| Ok(None),
         )?;
         let prepared = incoming
             .prepare(owner.path(), MAX_GENERATED_PACK_BYTES, &worker_flag)?
@@ -1356,42 +2202,6 @@ async fn prepare_pack(
     .await?;
     watcher.abort();
     result
-}
-
-fn write_pack(path: &std::path::Path, objects: &[(Kind, Vec<u8>)]) -> Result<()> {
-    let count = u32::try_from(objects.len())
-        .map_err(|_| std::io::Error::other("too many generated Git objects"))?;
-    let mut bytes = b"PACK\0\0\0\x02".to_vec();
-    bytes.extend_from_slice(&count.to_be_bytes());
-    for (kind, data) in objects {
-        pack_header(*kind, data.len(), &mut bytes);
-        let mut encoder =
-            flate2::write::ZlibEncoder::new(&mut bytes, flate2::Compression::default());
-        encoder.write_all(data)?;
-        encoder.finish()?;
-    }
-    let mut hasher = gix_hash::hasher(gix_hash::Kind::Sha1);
-    hasher.update(&bytes);
-    bytes.extend_from_slice(hasher.try_finalize()?.as_bytes());
-    std::fs::write(path, bytes)?;
-    Ok(())
-}
-
-fn pack_header(kind: Kind, size: usize, output: &mut Vec<u8>) {
-    let kind = match kind {
-        Kind::Commit => 1,
-        Kind::Tree => 2,
-        Kind::Blob => 3,
-        Kind::Tag => 4,
-    };
-    let mut remaining = size >> 4;
-    let mut byte = (kind << 4) | (size as u8 & 0x0f);
-    while remaining != 0 {
-        output.push(byte | 0x80);
-        byte = (remaining as u8) & 0x7f;
-        remaining >>= 7;
-    }
-    output.push(byte);
 }
 
 fn now_seconds() -> Result<u64> {
@@ -1411,6 +2221,7 @@ mod tests {
     use super::*;
     use crate::{RepositoryAccess, RepositoryConfig};
     use crab_coordination::GIT_OBJECT_LOCATOR_RESOURCE;
+    use gix_object::WriteTo as _;
     use std::collections::BTreeMap;
 
     #[test]
@@ -1423,8 +2234,140 @@ mod tests {
 
         assert_eq!(
             pack_scratch_reservation(&objects),
-            bytes * 6 + bytes / 4 + 2 * 64 + PACK_SCRATCH_BASE_BYTES
+            bytes * 4 + bytes / 4 + 2 * 64 + PACK_SCRATCH_BASE_BYTES
         );
+    }
+
+    #[test]
+    fn tree_encoder_matches_the_canonical_git_encoding() {
+        let mut entries = vec![
+            tree::Entry {
+                mode: tree::EntryKind::Blob.into(),
+                filename: BString::from("z.txt"),
+                oid: ObjectId::empty_blob(gix_hash::Kind::Sha1),
+            },
+            tree::Entry {
+                mode: tree::EntryKind::Tree.into(),
+                filename: BString::from("a"),
+                oid: ObjectId::empty_tree(gix_hash::Kind::Sha1),
+            },
+        ];
+        entries.sort();
+        let mut expected = Vec::new();
+        gix_object::Tree {
+            entries: entries.clone(),
+        }
+        .write_to(&mut expected)
+        .unwrap();
+        let mut objects = Vec::new();
+
+        let oid = encode_tree(None, &entries, &mut objects).unwrap();
+
+        assert_eq!(oid, object_id(Kind::Tree, &expected).unwrap());
+        assert_eq!(objects, vec![(Kind::Tree, expected)]);
+    }
+
+    #[test]
+    fn entry_lookup_preserves_git_tree_order_around_directories() {
+        let mut entries = vec![
+            tree::Entry {
+                mode: tree::EntryKind::Tree.into(),
+                filename: BString::from("name"),
+                oid: ObjectId::empty_tree(gix_hash::Kind::Sha1),
+            },
+            tree::Entry {
+                mode: tree::EntryKind::Blob.into(),
+                filename: BString::from("name.ext"),
+                oid: ObjectId::empty_blob(gix_hash::Kind::Sha1),
+            },
+        ];
+        entries.sort();
+
+        assert_eq!(
+            find_entry(&entries, b"name").map(|entry| entry.mode.kind()),
+            Some(tree::EntryKind::Tree)
+        );
+        assert!(find_entry(&entries, b"missing").is_none());
+    }
+
+    #[test]
+    fn multipart_completion_stays_outside_ordinary_batches() {
+        let admission = WriteAdmission::default();
+        let mutation = |path: &[u8], upload_id: Option<&str>| Mutation {
+            path: crab_remote_git::GitPath::new(path.to_vec()).unwrap(),
+            change: Change::Put {
+                bytes: Bytes::from_static(b"content"),
+                track_lfs: false,
+                attributes: Box::new(attributes::PutAttributes {
+                    completion_upload_id: upload_id.map(str::to_owned),
+                    ..Default::default()
+                }),
+                condition: PutCondition::None,
+            },
+            principal: "user".to_owned(),
+        };
+        let first = admission
+            .enqueue("repo", "refs/heads/main", mutation(b"first", None))
+            .unwrap();
+        let planned = admission
+            .enqueue(
+                "repo",
+                "refs/heads/main",
+                mutation(b"planned", Some("upload")),
+            )
+            .unwrap();
+        let last = admission
+            .enqueue("repo", "refs/heads/main", mutation(b"last", None))
+            .unwrap();
+        assert!(Arc::ptr_eq(&first.queue, &planned.queue));
+        assert!(Arc::ptr_eq(&first.queue, &last.queue));
+
+        let ordinary = first.queue.take_batch().unwrap();
+        assert_eq!(ordinary.len(), 1);
+        assert!(ordinary[0].mutation.completion_plan().is_none());
+        let completion = first.queue.take_batch().unwrap();
+        assert_eq!(completion.len(), 1);
+        assert!(completion[0].mutation.completion_plan().is_some());
+        let trailing = first.queue.take_batch().unwrap();
+        assert_eq!(trailing.len(), 1);
+        assert!(trailing[0].mutation.completion_plan().is_none());
+    }
+
+    #[test]
+    fn warm_branch_state_is_reused_only_for_the_exact_tip() {
+        let cache = BranchState::new(Arc::new(AtomicUsize::new(0)));
+        let tip = ObjectId::empty_tree(gix_hash::Kind::Sha1);
+        let blob = ObjectId::empty_blob(gix_hash::Kind::Sha1);
+        let mut manifest = attributes::Manifest::default();
+        manifest.update(
+            "object".to_owned(),
+            Some(attributes::ObjectAttributes::new(
+                blob,
+                "etag".to_owned(),
+                0,
+                0,
+                attributes::PutAttributes::default(),
+            )),
+        );
+        cache.store(Some(tip), None, manifest, WarmTree::default(), 0);
+
+        assert!(
+            cache
+                .manifest(Some(tip))
+                .unwrap()
+                .object("object", blob)
+                .is_some()
+        );
+        let state = cache.take(Some(tip)).unwrap();
+        assert!(state.manifest.object("object", blob).is_some());
+        cache.store(
+            Some(tip),
+            state.transaction,
+            Arc::try_unwrap(state.manifest).unwrap(),
+            state.tree,
+            0,
+        );
+        assert!(cache.take(None).is_none());
     }
 
     async fn fixture() -> (
@@ -1544,6 +2487,135 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sustained_write_maintenance_bounds_the_journal_and_advances_catalog() {
+        let (repository, runtime, cancel) = fixture().await;
+        let coordinator = Coordinator::new(
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            Metrics::new().unwrap(),
+        );
+        coordinated_put(&coordinator, &repository, &cancel, "object", b"value").await;
+        let before = crab_metadata::manifest_store::read_repository_snapshot(
+            &repository.store,
+            &repository.layout,
+        )
+        .await
+        .unwrap();
+        assert_eq!(before.journal.transactions.len(), 1);
+
+        crate::repository::schedule_catalog_maintenance(&repository, &cancel, 64);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+                    &repository.store,
+                    &repository.layout,
+                )
+                .await
+                .unwrap();
+                if snapshot.journal.transactions.is_empty()
+                    && !repository.maintenance.catalog_maintenance_is_running()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        let read_view = repository
+            .read_views
+            .current(
+                &repository,
+                Arc::clone(&runtime),
+                crab_remote_git::RepositoryOptions::default(),
+                &cancel,
+            )
+            .await
+            .unwrap();
+        assert!(
+            read_view
+                .remote()
+                .catalog_visibility_available(&cancel)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "object").await,
+            Bytes::from_static(b"value")
+        );
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn warm_existing_ref_publication_does_not_scan_repository_manifest() {
+        let (repository, runtime, cancel) = fixture().await;
+        let coordinator = Coordinator::new(
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            Metrics::new().unwrap(),
+        );
+        let manifest_lock = PushLock::acquire_internal(
+            repository.store.inner(),
+            repository.layout.repo_prefix(),
+            crab_coordination::GIT_MANIFEST_RESOURCE,
+            LOCK_TTL,
+        )
+        .await
+        .unwrap();
+        coordinated_put(&coordinator, &repository, &cancel, "first.txt", b"first").await;
+        let first = crab_metadata::ref_journal::read_ref_head(
+            &repository.store,
+            &repository.layout,
+            "refs/heads/main",
+        )
+        .await
+        .unwrap()
+        .visible_transaction
+        .unwrap();
+        let manifest_path = repository.layout.manifest_path();
+        let (manifest, _) = repository
+            .store
+            .get_with_etag(&manifest_path)
+            .await
+            .unwrap();
+        repository
+            .store
+            .put_overwrite(&manifest_path, Bytes::from_static(b"{"))
+            .await
+            .unwrap();
+
+        coordinated_put(&coordinator, &repository, &cancel, "second.txt", b"second").await;
+        let second = crab_metadata::ref_journal::read_ref_head(
+            &repository.store,
+            &repository.layout,
+            "refs/heads/main",
+        )
+        .await
+        .unwrap()
+        .visible_transaction
+        .unwrap();
+        let transaction = crab_metadata::ref_journal::read_transaction(
+            &repository.store,
+            &repository.layout,
+            &second,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            transaction.parents.get("refs/heads/main"),
+            Some(&Some(first))
+        );
+        repository
+            .store
+            .put_overwrite(&manifest_path, manifest)
+            .await
+            .unwrap();
+        manifest_lock.release().await.unwrap();
+        runtime.shutdown().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1729,6 +2801,65 @@ mod tests {
             )
             .await,
             pointer
+        );
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn batched_lfs_puts_extend_the_generated_attribute_blob() {
+        let (repository, runtime, cancel) = fixture().await;
+        let metrics = Metrics::new().unwrap();
+        let mutation = |name: &str, marker: u8| Mutation {
+            path: crab_remote_git::GitPath::new(format!("nested/{name}").into_bytes()).unwrap(),
+            change: Change::Put {
+                bytes: Bytes::from(
+                    crab_git::LfsPointer {
+                        oid: [marker; 32],
+                        size: 10 * 1024 * 1024,
+                        extensions: Vec::new(),
+                    }
+                    .serialize(),
+                ),
+                track_lfs: true,
+                attributes: Box::new(attributes::PutAttributes {
+                    logical_size: Some(10 * 1024 * 1024),
+                    ..Default::default()
+                }),
+                condition: PutCondition::None,
+            },
+            principal: "user".to_owned(),
+        };
+        let results = apply_batch_admitted(
+            &repository,
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            vec![mutation("first.bin", 1), mutation("second.bin", 2)],
+            ApplyRequest {
+                branch: "refs/heads/main",
+                plan_id: None,
+                metrics: &metrics,
+                state: None,
+            },
+            &cancel,
+        )
+        .await
+        .unwrap();
+        assert!(results.iter().all(Result::is_ok));
+
+        let stored = read(
+            &repository,
+            Arc::clone(&runtime),
+            &cancel,
+            "nested/.gitattributes",
+        )
+        .await;
+        assert_eq!(
+            stored,
+            format!(
+                "{}\n{}\n",
+                lfs_attributes_line(b"first.bin"),
+                lfs_attributes_line(b"second.bin")
+            )
         );
         runtime.shutdown().await;
     }
@@ -1982,6 +3113,63 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn batch_conditions_observe_prior_successes_in_fifo_order() {
+        let (repository, runtime, cancel) = fixture().await;
+        let path = crab_remote_git::GitPath::new(b"manifest".to_vec()).unwrap();
+        let mutation = |bytes, condition| Mutation {
+            path: path.clone(),
+            change: Change::Put {
+                bytes,
+                track_lfs: false,
+                attributes: Box::new(attributes::PutAttributes::default()),
+                condition,
+            },
+            principal: "user".to_owned(),
+        };
+        let first = object_id(Kind::Blob, b"first").unwrap();
+        let metrics = Metrics::new().unwrap();
+        let results = apply_batch_admitted(
+            &repository,
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            vec![
+                mutation(Bytes::from_static(b"first"), PutCondition::IfNoneMatchAny),
+                mutation(
+                    Bytes::from_static(b"rejected"),
+                    PutCondition::IfNoneMatchAny,
+                ),
+                mutation(Bytes::from_static(b"third"), PutCondition::IfMatch(first)),
+            ],
+            ApplyRequest {
+                branch: "refs/heads/main",
+                plan_id: None,
+                metrics: &metrics,
+                state: None,
+            },
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        assert!(results[0].is_ok());
+        assert!(matches!(&results[1], Err(Error::PreconditionFailed)));
+        assert!(results[2].is_ok());
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "manifest").await,
+            "third"
+        );
+        let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+            &repository.store,
+            &repository.layout,
+        )
+        .await
+        .unwrap();
+        assert_eq!(snapshot.journal.transactions.len(), 1);
+        assert_eq!(snapshot.journal.packs.len(), 1);
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn conditional_delete_rejects_a_missing_object() {
         let (repository, runtime, cancel) = fixture().await;
         let path = crab_remote_git::GitPath::new(b"missing".to_vec()).unwrap();
@@ -2092,20 +3280,31 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn same_ref_writes_queue_and_all_commit() {
+    async fn same_ref_writes_share_one_pack_and_keep_one_commit_each() {
         let (repository, runtime, cancel) = fixture().await;
         let repository = Arc::new(repository);
+        let blocker = PushLock::acquire_internal(
+            repository.store.inner(),
+            repository.layout.repo_prefix(),
+            GIT_OBJECT_LOCATOR_RESOURCE,
+            LOCK_TTL,
+        )
+        .await
+        .unwrap();
         let coordinator = Arc::new(Coordinator::new(
             Arc::clone(&runtime),
             crab_remote_git::RepositoryOptions::default(),
             Metrics::new().unwrap(),
         ));
+        let start = Arc::new(tokio::sync::Barrier::new(9));
         let mut writes = tokio::task::JoinSet::new();
         for index in 0..8 {
             let repository = Arc::clone(&repository);
             let coordinator = Arc::clone(&coordinator);
             let cancel = cancel.clone();
+            let start = Arc::clone(&start);
             writes.spawn(async move {
+                start.wait().await;
                 let path = format!("queued/{index}.txt");
                 coordinator
                     .apply(
@@ -2124,11 +3323,64 @@ mod tests {
                     .await
             });
         }
+        start.wait().await;
         while let Some(result) = writes.join_next().await {
             result.unwrap().unwrap();
         }
+        let journal = crab_metadata::manifest_store::read_repository_snapshot(
+            &repository.store,
+            &repository.layout,
+        )
+        .await
+        .unwrap()
+        .journal;
+        assert_eq!(journal.transactions.len(), 1);
+        assert_eq!(journal.packs.len(), 1);
+        let transaction = crab_metadata::ref_journal::read_transaction(
+            &repository.store,
+            &repository.layout,
+            &journal.transactions[0],
+        )
+        .await
+        .unwrap();
+        assert_eq!(transaction.edits.len(), 1);
+        assert_eq!(transaction.packs.len(), 1);
+
+        let view = repository
+            .read_views
+            .current(
+                &repository,
+                Arc::clone(&runtime),
+                crab_remote_git::RepositoryOptions::default(),
+                &cancel,
+            )
+            .await
+            .unwrap();
+        let tip = view.remote().refs().find("refs/heads/main").unwrap().target;
+        let operation = view
+            .remote()
+            .operation(OperationKind::Repository, &cancel)
+            .await
+            .unwrap();
+        let snapshot = view
+            .remote()
+            .snapshot(&crab_remote_git::Revision::Commit(tip), &operation)
+            .await
+            .unwrap();
+        let history = snapshot
+            .history(
+                crab_remote_git::HistoryTraversal::FirstParent,
+                &crab_remote_git::PageRequest::new(16, None).unwrap(),
+                &operation,
+            )
+            .await
+            .unwrap();
+        assert_eq!(history.items.len(), 8);
+        operation.finish(Ok(())).await.unwrap();
+        blocker.release().await.unwrap();
+
         let mut canonical = None;
-        for _ in 0..100 {
+        for _ in 0..700 {
             let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
                 &repository.store,
                 &repository.layout,
@@ -2166,6 +3418,130 @@ mod tests {
                 format!("value-{index}")
             );
         }
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn admitted_batch_survives_all_callers_being_dropped() {
+        let (repository, runtime, cancel) = fixture().await;
+        let repository = Arc::new(repository);
+        let lock = PushLock::acquire_ref(
+            repository.store.inner(),
+            repository.layout.repo_prefix(),
+            "refs/heads/main",
+            LOCK_TTL,
+        )
+        .await
+        .unwrap();
+        let coordinator = Arc::new(Coordinator::new(
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            Metrics::new().unwrap(),
+        ));
+        let mut callers = Vec::new();
+        for index in 0..2 {
+            let repository = Arc::clone(&repository);
+            let coordinator = Arc::clone(&coordinator);
+            let cancel = cancel.clone();
+            callers.push(tokio::spawn(async move {
+                coordinated_put(
+                    &coordinator,
+                    &repository,
+                    &cancel,
+                    &format!("detached/{index}.txt"),
+                    b"durable",
+                )
+                .await;
+            }));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        for caller in callers {
+            caller.abort();
+        }
+        lock.release().await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+                    &repository.store,
+                    &repository.layout,
+                )
+                .await
+                .unwrap();
+                if snapshot.journal.transactions.len() == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "detached/0.txt").await,
+            "durable"
+        );
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "detached/1.txt").await,
+            "durable"
+        );
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn independent_coordinators_reprepare_against_the_winning_tip() {
+        let (repository, runtime, cancel) = fixture().await;
+        let repository = Arc::new(repository);
+        let first = Arc::new(Coordinator::new(
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            Metrics::new().unwrap(),
+        ));
+        let second = Arc::new(Coordinator::new(
+            Arc::clone(&runtime),
+            crab_remote_git::RepositoryOptions::default(),
+            Metrics::new().unwrap(),
+        ));
+        let start = Arc::new(tokio::sync::Barrier::new(3));
+        let mut writes = tokio::task::JoinSet::new();
+        for (coordinator, path, bytes) in [
+            (first, "first.txt", Bytes::from_static(b"first")),
+            (second, "second.txt", Bytes::from_static(b"second")),
+        ] {
+            let repository = Arc::clone(&repository);
+            let cancel = cancel.clone();
+            let start = Arc::clone(&start);
+            writes.spawn(async move {
+                start.wait().await;
+                coordinator
+                    .apply(
+                        &repository,
+                        "refs/heads/main",
+                        &crab_remote_git::GitPath::new(path.as_bytes().to_vec()).unwrap(),
+                        Change::Put {
+                            bytes,
+                            track_lfs: false,
+                            attributes: Box::new(attributes::PutAttributes::default()),
+                            condition: PutCondition::None,
+                        },
+                        "user",
+                        &cancel,
+                    )
+                    .await
+            });
+        }
+        start.wait().await;
+        while let Some(result) = writes.join_next().await {
+            result.unwrap().unwrap();
+        }
+
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "first.txt").await,
+            "first"
+        );
+        assert_eq!(
+            read(&repository, Arc::clone(&runtime), &cancel, "second.txt").await,
+            "second"
+        );
         runtime.shutdown().await;
     }
 
@@ -2281,9 +3657,44 @@ mod tests {
         let (bytes, _) = repository.store.get_with_etag(&path).await.unwrap();
         let stored: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(stored["version"], 2);
+        assert_eq!(stored["checkpoint"], true);
         assert!(stored.get("objects").is_none());
         assert_eq!(stored["changes"].as_object().unwrap().len(), 1);
         assert!(stored["changes"].get("second.txt").is_some());
+        let checkpoint_slot = stored["checkpoint_slot"].as_str().unwrap();
+        let checkpoint = repository.layout.repo_path(&format!(
+            "s3/attribute-checkpoints/branches/{checkpoint_slot}.json"
+        ));
+        repository.store.head(&checkpoint).await.unwrap();
+
+        let manifest = attributes::load(&repository, commit).await.unwrap();
+        let stale = attributes::prepare_checkpoint(
+            "refs/heads/main",
+            ObjectId::empty_tree(gix_hash::Kind::Sha1),
+            &manifest,
+        )
+        .unwrap()
+        .unwrap();
+        attributes::publish_checkpoint(&repository, &stale)
+            .await
+            .unwrap();
+        let fallback = attributes::load(&repository, commit).await.unwrap();
+        for path in ["first.txt", "second.txt"] {
+            let oid = object_id(Kind::Blob, path.as_bytes()).unwrap();
+            assert!(fallback.object(path, oid).is_some());
+        }
+        let current = attributes::prepare_checkpoint("refs/heads/main", commit, &manifest)
+            .unwrap()
+            .unwrap();
+        attributes::publish_checkpoint(&repository, &current)
+            .await
+            .unwrap();
+
+        let parent = stored["parent"].as_str().unwrap();
+        let parent_delta = repository
+            .layout
+            .repo_path(&format!("s3/attributes/{parent}.json"));
+        repository.store.delete(&parent_delta).await.unwrap();
 
         let manifest = attributes::load(&repository, commit).await.unwrap();
         for path in ["first.txt", "second.txt"] {

--- a/crates/crab-s3-gateway/src/repository.rs
+++ b/crates/crab-s3-gateway/src/repository.rs
@@ -19,6 +19,8 @@ use tokio_util::sync::CancellationToken;
 use crate::gateway::Repository;
 
 const MAINTENANCE_TTL: Duration = Duration::from_secs(60);
+const FULL_MAINTENANCE_IDLE_DELAY: Duration = Duration::from_secs(5);
+const CATALOG_MAINTENANCE_EPOCHS: u64 = 64;
 const MAX_CACHED_SNAPSHOTS: usize = 64;
 const MAX_CACHED_MANIFESTS: usize = 16;
 const MAX_CACHED_OBJECT_ATTRIBUTES: usize = 256;
@@ -134,6 +136,7 @@ pub(crate) struct ReadViewCache {
 pub(crate) struct WriteMaintenance {
     epoch: AtomicU64,
     active: AtomicUsize,
+    catalog_maintenance_running: std::sync::atomic::AtomicBool,
     state: StdMutex<MaintenanceState>,
 }
 
@@ -147,6 +150,7 @@ impl WriteMaintenance {
         Self {
             epoch: AtomicU64::new(0),
             active: AtomicUsize::new(0),
+            catalog_maintenance_running: std::sync::atomic::AtomicBool::new(false),
             state: StdMutex::new(MaintenanceState {
                 scheduled: CancellationToken::new(),
                 running: false,
@@ -199,6 +203,24 @@ impl WriteMaintenance {
         self.state().running = false;
     }
 
+    fn claim_catalog_maintenance(&self, epoch: u64) -> bool {
+        epoch.is_multiple_of(CATALOG_MAINTENANCE_EPOCHS)
+            && self
+                .catalog_maintenance_running
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+    }
+
+    fn finish_catalog_maintenance(&self) {
+        self.catalog_maintenance_running
+            .store(false, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn catalog_maintenance_is_running(&self) -> bool {
+        self.catalog_maintenance_running.load(Ordering::Acquire)
+    }
+
     fn is_idle_at(&self, epoch: u64) -> bool {
         self.active.load(Ordering::Acquire) == 0 && self.epoch.load(Ordering::Acquire) == epoch
     }
@@ -209,6 +231,35 @@ impl WriteMaintenance {
             Err(poisoned) => poisoned.into_inner(),
         }
     }
+}
+
+pub(crate) fn schedule_catalog_maintenance(
+    repository: &Repository,
+    cancel: &CancellationToken,
+    epoch: u64,
+) {
+    if !repository.maintenance.claim_catalog_maintenance(epoch) {
+        return;
+    }
+    let store = repository.store.clone();
+    let layout = repository.layout.clone();
+    let maintenance = Arc::clone(&repository.maintenance);
+    let cancel = cancel.child_token();
+    tokio::spawn(async move {
+        let result = crab_write::generation::ensure_catalog_readable(
+            &store,
+            &layout,
+            MAINTENANCE_TTL,
+            &cancel,
+        )
+        .await;
+        maintenance.finish_catalog_maintenance();
+        match result {
+            Ok(_) => {}
+            Err(crab_write::WriteError::Cancelled) if cancel.is_cancelled() => {}
+            Err(error) => tracing::warn!(%error, "S3 bounded catalog maintenance failed"),
+        }
+    });
 }
 
 impl ReadViewCache {
@@ -250,21 +301,51 @@ impl ReadViewCache {
             .map(|cached| Arc::clone(&cached.view));
         let view = match existing {
             Some(view) => view,
-            None => Arc::new(ReadView {
-                key,
-                remote: RemoteGitRepository::from_snapshot(
-                    repository.layout.clone(),
-                    &snapshot,
-                    repository.identity.clone(),
-                    runtime,
-                    options,
-                    cancel,
-                )
-                .await?,
-                snapshots: Mutex::new(HashMap::new()),
-                manifests: Mutex::new(HashMap::new()),
-                objects: Mutex::new(HashMap::new()),
-            }),
+            None => {
+                let remote = if snapshot.journal.transactions.is_empty() {
+                    match RemoteGitRepository::open(
+                        repository.store.clone(),
+                        repository.layout.clone(),
+                        repository.identity.clone(),
+                        Arc::clone(&runtime),
+                        options,
+                        cancel,
+                    )
+                    .await
+                    {
+                        Ok(remote) => remote,
+                        Err(crab_remote_git::Error::RepositoryIndexing { .. }) => {
+                            RemoteGitRepository::from_snapshot(
+                                repository.layout.clone(),
+                                &snapshot,
+                                repository.identity.clone(),
+                                runtime,
+                                options,
+                                cancel,
+                            )
+                            .await?
+                        }
+                        Err(error) => return Err(error.into()),
+                    }
+                } else {
+                    RemoteGitRepository::from_snapshot(
+                        repository.layout.clone(),
+                        &snapshot,
+                        repository.identity.clone(),
+                        runtime,
+                        options,
+                        cancel,
+                    )
+                    .await?
+                };
+                Arc::new(ReadView {
+                    key,
+                    remote,
+                    snapshots: Mutex::new(HashMap::new()),
+                    manifests: Mutex::new(HashMap::new()),
+                    objects: Mutex::new(HashMap::new()),
+                })
+            }
         };
         *self.cached.write().await = Some(CachedReadView {
             observed_at,
@@ -352,7 +433,7 @@ async fn wait_for_idle(
     // compact it, instead of racing every acknowledgement with maintenance.
     tokio::select! {
         () = cancel.cancelled() => false,
-        () = tokio::time::sleep(Duration::from_millis(100)) => maintenance.is_idle_at(epoch),
+        () = tokio::time::sleep(FULL_MAINTENANCE_IDLE_DELAY) => maintenance.is_idle_at(epoch),
     }
 }
 
@@ -388,6 +469,17 @@ mod tests {
 
         parent.cancel();
         assert!(second.is_cancelled());
+    }
+
+    #[test]
+    fn sustained_writes_claim_one_periodic_catalog_maintenance() {
+        let maintenance = WriteMaintenance::new();
+
+        assert!(!maintenance.claim_catalog_maintenance(63));
+        assert!(maintenance.claim_catalog_maintenance(64));
+        assert!(!maintenance.claim_catalog_maintenance(128));
+        maintenance.finish_catalog_maintenance();
+        assert!(maintenance.claim_catalog_maintenance(128));
     }
 
     #[test]

--- a/crates/crab-s3-gateway/src/repository.rs
+++ b/crates/crab-s3-gateway/src/repository.rs
@@ -136,6 +136,7 @@ pub(crate) struct ReadViewCache {
 pub(crate) struct WriteMaintenance {
     epoch: AtomicU64,
     active: AtomicUsize,
+    next_catalog_maintenance_epoch: AtomicU64,
     catalog_maintenance_running: std::sync::atomic::AtomicBool,
     state: StdMutex<MaintenanceState>,
 }
@@ -150,6 +151,7 @@ impl WriteMaintenance {
         Self {
             epoch: AtomicU64::new(0),
             active: AtomicUsize::new(0),
+            next_catalog_maintenance_epoch: AtomicU64::new(CATALOG_MAINTENANCE_EPOCHS),
             catalog_maintenance_running: std::sync::atomic::AtomicBool::new(false),
             state: StdMutex::new(MaintenanceState {
                 scheduled: CancellationToken::new(),
@@ -204,16 +206,28 @@ impl WriteMaintenance {
     }
 
     fn claim_catalog_maintenance(&self, epoch: u64) -> bool {
-        epoch.is_multiple_of(CATALOG_MAINTENANCE_EPOCHS)
-            && self
+        if epoch < self.next_catalog_maintenance_epoch.load(Ordering::Acquire)
+            || self
                 .catalog_maintenance_running
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
+                .is_err()
+        {
+            return false;
+        }
+        self.next_catalog_maintenance_epoch.store(
+            epoch.saturating_add(CATALOG_MAINTENANCE_EPOCHS),
+            Ordering::Release,
+        );
+        true
     }
 
     fn finish_catalog_maintenance(&self) {
         self.catalog_maintenance_running
             .store(false, Ordering::Release);
+    }
+
+    pub(crate) fn current_epoch(&self) -> u64 {
+        self.epoch.load(Ordering::Acquire)
     }
 
     #[cfg(test)]
@@ -246,18 +260,23 @@ pub(crate) fn schedule_catalog_maintenance(
     let maintenance = Arc::clone(&repository.maintenance);
     let cancel = cancel.child_token();
     tokio::spawn(async move {
-        let result = crab_write::generation::ensure_catalog_readable(
-            &store,
-            &layout,
-            MAINTENANCE_TTL,
-            &cancel,
-        )
-        .await;
-        maintenance.finish_catalog_maintenance();
-        match result {
-            Ok(_) => {}
-            Err(crab_write::WriteError::Cancelled) if cancel.is_cancelled() => {}
-            Err(error) => tracing::warn!(%error, "S3 bounded catalog maintenance failed"),
+        loop {
+            let result = crab_write::generation::ensure_catalog_readable(
+                &store,
+                &layout,
+                MAINTENANCE_TTL,
+                &cancel,
+            )
+            .await;
+            maintenance.finish_catalog_maintenance();
+            match result {
+                Ok(_) => {}
+                Err(crab_write::WriteError::Cancelled) if cancel.is_cancelled() => return,
+                Err(error) => tracing::warn!(%error, "S3 bounded catalog maintenance failed"),
+            }
+            if !maintenance.claim_catalog_maintenance(maintenance.current_epoch()) {
+                return;
+            }
         }
     });
 }
@@ -485,10 +504,11 @@ mod tests {
         let maintenance = WriteMaintenance::new();
 
         assert!(!maintenance.claim_catalog_maintenance(63));
-        assert!(maintenance.claim_catalog_maintenance(64));
+        assert!(maintenance.claim_catalog_maintenance(65));
         assert!(!maintenance.claim_catalog_maintenance(128));
         maintenance.finish_catalog_maintenance();
-        assert!(maintenance.claim_catalog_maintenance(128));
+        assert!(!maintenance.claim_catalog_maintenance(128));
+        assert!(maintenance.claim_catalog_maintenance(129));
     }
 
     #[test]

--- a/crates/crab-s3-gateway/src/repository.rs
+++ b/crates/crab-s3-gateway/src/repository.rs
@@ -282,13 +282,13 @@ impl ReadViewCache {
         if let Some(view) = self.observed_since(requested_at).await {
             return Ok(view);
         }
-        let snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+        let mut snapshot = crab_metadata::manifest_store::read_repository_snapshot(
             &repository.store,
             &repository.layout,
         )
         .await?;
         let observed_at = tokio::time::Instant::now();
-        let key = ReadViewKey {
+        let mut key = ReadViewKey {
             generation: snapshot.manifest.generation,
             snapshot_digest: snapshot.digest()?,
         };
@@ -315,7 +315,16 @@ impl ReadViewCache {
                     {
                         Ok(remote) => remote,
                         Err(crab_remote_git::Error::RepositoryIndexing { .. }) => {
-                            RemoteGitRepository::from_snapshot(
+                            snapshot = crab_metadata::manifest_store::read_repository_snapshot(
+                                &repository.store,
+                                &repository.layout,
+                            )
+                            .await?;
+                            key = ReadViewKey {
+                                generation: snapshot.manifest.generation,
+                                snapshot_digest: snapshot.digest()?,
+                            };
+                            RemoteGitRepository::from_snapshot_with_catalog_tail(
                                 repository.layout.clone(),
                                 &snapshot,
                                 repository.identity.clone(),
@@ -328,7 +337,7 @@ impl ReadViewCache {
                         Err(error) => return Err(error.into()),
                     }
                 } else {
-                    RemoteGitRepository::from_snapshot(
+                    RemoteGitRepository::from_snapshot_with_catalog_tail(
                         repository.layout.clone(),
                         &snapshot,
                         repository.identity.clone(),

--- a/crates/crab-write/README.md
+++ b/crates/crab-write/README.md
@@ -64,6 +64,12 @@ the last verified maintenance snapshot until the periodic revalidation. The shar
 anchor parser also serves native push, repack and history recovery; malformed index
 hashes retain their source errors.
 
+`generation::ensure_catalog_readable` owns generation election and both GC-writer
+fences while compacting committed ref-journal entries and advancing exact-object
+catalog coverage. It is the bounded-cadence path for continuously active services;
+it deliberately omits commit-graph traversal. `generation::ensure_readable` uses
+the same lifecycle and additionally builds the commit graph for a quiet generation.
+
 `generation::maintain_commit_graph` derives a missing generation-bound split
 commit graph through bounded `crab-remote-git` batches after catalog readiness.
 It reuses the preceding generation's validated graph when available, uploads
@@ -106,6 +112,14 @@ and renewed through completion; passing an earlier snapshot is not a concurrency
 check. Existing committed journal edits count toward the old-value comparison,
 even before generation compaction. The function preserves exact new OIDs, tag
 peeling, HEAD changes, uploaded pack/shard references and visibility evidence.
+
+`journal::commit_existing_ref_edit` is the bounded fast path for a caller that
+retains one existing ref's exact visible transaction together with its old OID.
+While holding that ref's lease, it verifies the small mutable head and immutable
+parent transaction before publishing the update, so its work is independent of
+repository pack count. A mismatch returns `RefChanged`. Ref creation, deletion,
+multi-ref publication and namespace changes must use `commit_edits` with a full
+coherent snapshot.
 
 Creations and deletions additionally hold the renewable `git-ref-namespace`
 internal lease, reread the coherent repository snapshot, and validate the final

--- a/crates/crab-write/src/generation.rs
+++ b/crates/crab-write/src/generation.rs
@@ -71,6 +71,47 @@ pub async fn ensure_readable(
     ttl: Duration,
     cancel: &CancellationToken,
 ) -> Result<()> {
+    ensure_readable_state(
+        store,
+        layout,
+        ttl,
+        cancel,
+        Some(CommitGraphMaintenance {
+            identity,
+            runtime,
+            options,
+        }),
+    )
+    .await
+}
+
+/// Elect one owner and publish committed repository state needed for object lookup.
+///
+/// This bounded maintenance path compacts the ref journal and advances exact-object
+/// catalog coverage, but deliberately leaves commit-graph construction to
+/// [`ensure_readable`]. Every acquired lease and GC fence is released before return.
+pub async fn ensure_catalog_readable(
+    store: &Store,
+    layout: &StoreLayout<Store>,
+    ttl: Duration,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    ensure_readable_state(store, layout, ttl, cancel, None).await
+}
+
+struct CommitGraphMaintenance<'a> {
+    identity: &'a RepositoryIdentity,
+    runtime: Arc<RemoteGitRuntime>,
+    options: RepositoryOptions,
+}
+
+async fn ensure_readable_state(
+    store: &Store,
+    layout: &StoreLayout<Store>,
+    ttl: Duration,
+    cancel: &CancellationToken,
+    commit_graph: Option<CommitGraphMaintenance<'_>>,
+) -> Result<()> {
     let mut context = PushLockAcquireContext::new(Arc::clone(store.inner()));
     let mut owner = match context
         .try_acquire_internal(layout.repo_prefix(), GIT_GENERATION_OWNER_RESOURCE, ttl)
@@ -97,9 +138,20 @@ pub async fn ensure_readable(
             else {
                 return Ok(());
             };
-            maintain_commit_graph(store, layout, &manifest, identity, runtime, options, cancel)
-                .await
-                .map(drop)
+            let Some(commit_graph) = commit_graph else {
+                return Ok(());
+            };
+            maintain_commit_graph(
+                store,
+                layout,
+                &manifest,
+                commit_graph.identity,
+                commit_graph.runtime,
+                commit_graph.options,
+                cancel,
+            )
+            .await
+            .map(drop)
         }
         .await;
         for fence in [repo, global] {

--- a/crates/crab-write/src/journal.rs
+++ b/crates/crab-write/src/journal.rs
@@ -106,6 +106,68 @@ pub async fn commit_edits(
     .await
 }
 
+/// Commit one existing ref update against its captured visible journal position.
+///
+/// The caller must hold that ref's lease and must have obtained
+/// `expected_transaction` together with the prepared old object ID. Ref creation,
+/// deletion, and namespace changes require [`commit_edits`] and a full repository
+/// snapshot.
+pub async fn commit_existing_ref_edit(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    expected_transaction: &str,
+    edit: RefJournalEdit,
+    packs: Vec<PackManifestEntry>,
+    options: CommitOptions<'_>,
+) -> Result<RefJournalCommitResult> {
+    let CommitOptions {
+        plan_id,
+        lock_ttl: _,
+        cancel,
+    } = options;
+    check_cancelled(cancel)?;
+    if edit.old_oid.is_none() || edit.new_oid.is_none() {
+        return Err(WriteError::RefChanged {
+            ref_name: edit.ref_name.clone(),
+            path: router.repo_prefix().to_owned(),
+        });
+    }
+    let observed = ref_journal::read_ref_head(store, router, &edit.ref_name).await?;
+    if observed.visible_transaction.as_deref() != Some(expected_transaction) {
+        return Err(WriteError::RefChanged {
+            ref_name: edit.ref_name.clone(),
+            path: router
+                .ref_journal_head_path(&ref_journal::ref_name_hash(&edit.ref_name))
+                .to_string(),
+        });
+    }
+    let parent = ref_journal::read_transaction(store, router, expected_transaction).await?;
+    let current_oid = parent
+        .edits
+        .iter()
+        .find(|parent_edit| parent_edit.ref_name == edit.ref_name)
+        .and_then(|parent_edit| parent_edit.new_oid.as_ref());
+    if current_oid != edit.old_oid.as_ref() {
+        return Err(WriteError::RefChanged {
+            ref_name: edit.ref_name,
+            path: router
+                .ref_journal_transaction_path(expected_transaction)
+                .to_string(),
+        });
+    }
+    let transaction = RefJournalTransaction::new(
+        std::collections::BTreeMap::from([(
+            edit.ref_name.clone(),
+            Some(expected_transaction.to_owned()),
+        )]),
+        vec![edit],
+        None,
+        packs,
+        vec![],
+    )?;
+    commit_transaction_with_heads(store, router, transaction, vec![observed], plan_id, cancel).await
+}
+
 fn check_old_values(
     router: &StoreLayout<Store>,
     snapshot: &RepositorySnapshot,
@@ -165,6 +227,17 @@ async fn commit_transaction(
             .insert(edit.ref_name.clone(), observed.visible_transaction.clone());
         expected_heads.push(observed);
     }
+    commit_transaction_with_heads(store, router, transaction, expected_heads, plan_id, cancel).await
+}
+
+async fn commit_transaction_with_heads(
+    store: &Store,
+    router: &StoreLayout<Store>,
+    transaction: RefJournalTransaction,
+    expected_heads: Vec<ref_journal::RefJournalHeadSnapshot>,
+    plan_id: Option<&str>,
+    cancel: &CancellationToken,
+) -> Result<RefJournalCommitResult> {
     Ok(match plan_id {
         Some(plan_id) => {
             ref_journal::commit_ref_transaction_for_plan(

--- a/crates/crab-write/tests/journal.rs
+++ b/crates/crab-write/tests/journal.rs
@@ -6,7 +6,10 @@ use crab_metadata::{manifest_store, manifests::Manifest, ref_journal};
 use crab_storage::{Store, StoreLayout};
 use crab_write::{
     WriteError,
-    journal::{CommitOptions, commit_edits, compact_for_owner, compact_for_reader},
+    journal::{
+        CommitOptions, commit_edits, commit_existing_ref_edit, compact_for_owner,
+        compact_for_reader,
+    },
 };
 use futures_util::TryStreamExt;
 use object_store::ObjectStoreExt;
@@ -65,6 +68,59 @@ fn edit(name: &str, old: Option<char>, new: Option<char>) -> ref_journal::RefJou
         lock_holder: None,
         visibility_evidence_hash: None,
     }
+}
+
+#[tokio::test]
+async fn existing_ref_commit_uses_the_captured_journal_position() {
+    let (store, layout) = storage("existing-ref-position").await;
+    let lease = pending(&store, &layout).await;
+    let initial = ref_journal::read_ref_head(&store, &layout, REF)
+        .await
+        .unwrap()
+        .visible_transaction
+        .unwrap();
+    let cancel = CancellationToken::new();
+
+    commit_existing_ref_edit(
+        &store,
+        &layout,
+        &initial,
+        edit(REF, Some('a'), Some('b')),
+        vec![],
+        CommitOptions::new(TTL, &cancel),
+    )
+    .await
+    .unwrap();
+    let wrong_old = commit_existing_ref_edit(
+        &store,
+        &layout,
+        &ref_journal::read_ref_head(&store, &layout, REF)
+            .await
+            .unwrap()
+            .visible_transaction
+            .unwrap(),
+        edit(REF, Some('z'), Some('c')),
+        vec![],
+        CommitOptions::new(TTL, &cancel),
+    )
+    .await;
+    let stale = commit_existing_ref_edit(
+        &store,
+        &layout,
+        &initial,
+        edit(REF, Some('b'), Some('c')),
+        vec![],
+        CommitOptions::new(TTL, &cancel),
+    )
+    .await;
+
+    assert!(matches!(wrong_old, Err(WriteError::RefChanged { .. })));
+    assert!(matches!(stale, Err(WriteError::RefChanged { .. })));
+    let state = manifest_store::read_repository_snapshot(&store, &layout)
+        .await
+        .unwrap();
+    assert_eq!(state.journal.refs.get(REF), Some(&"b".repeat(40)));
+    lease.release().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- serialize same-branch S3 mutations through a bounded FIFO actor and amortize preparation, generated-pack upload, proof publication, and journal work across each batch while retaining one Git commit and one S3 result per request
- keep exact-tip tree and attribute state under one bounded process budget, checkpoint the durable gateway-authored namespace, and serve proven-complete `ListObjectsV2` pages without reopening SlateDB or walking Git trees
- bind snapshot reads to a proven base object catalog plus the complete immutable journal pack tail, making combined lookup misses definitive without rescanning historical pack indexes
- spool generated Git objects once, maintain the ref journal/catalog during sustained traffic, and preserve canonical object-store reconstruction for restarts, mixed Git/S3 branches, incomplete checkpoints, and catalog publication races

Object storage remains the authority. SlateDB and all process caches remain bounded, derived accelerators; no external database, queue, lock service, or coordinator is introduced.

## Correctness boundaries

- each accepted mutation retains FIFO condition evaluation, a distinct commit, durable pack/proof/attribute delta, and a journal-linearized acknowledgement
- a cached parent is revalidated under the object-store ref lease before publishing a commit or returning a prepared no-op or precondition outcome; conflicts rebuild from the winning snapshot
- only a complete delta ancestry rooted at an empty gateway-created branch may replace canonical Git-tree listing, including generated `.gitattributes` objects
- catalog acceleration is used only when its immutable pack inventory is an exact subset of the pinned snapshot; missing, oversized, invalid, or unavailable derived catalog state falls back to the canonical complete pack-index path
- multipart completion remains isolated from ordinary batches for retry identity and durability
- the catalog-maintenance cadence uses monotonic 64-publication thresholds, coalesces concurrent attempts, and catches up when another threshold is crossed while maintenance runs

## Post-implementation audit

The complete PR was audited across entry points, owners, callers, callees, sibling paths, current `main` behavior, tests, and object-store/SlateDB contracts. The audit found and fixed:

- proven empty catalog tails being collapsed into an unproven state, causing historical pack rescans
- optional catalog inventories being read without the pinned snapshot cardinality bound and derived-catalog open failures becoming hard read failures
- stale warm all-no-op/precondition batches returning without ref revalidation
- generated LFS `.gitattributes` blobs being omitted from the proven-complete S3 namespace manifest
- sustained catalog maintenance firing only on exact epoch multiples, which overlapping branches could skip

After these corrections, no unresolved correctness, durability, security, or bounded-resource findings remain in the reviewed scope. This is the best fix for the stated object-store-only architecture: authoritative ordering and durability stay in immutable objects, ref heads, leases, and journal markers; SlateDB and process memory remain optional accelerators.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked -p crab-git -p crab-metadata -p crab-remote-git -p crab-write -p crab-s3-gateway` (1,015 passed; 2 existing ignored stress/microbench tests)
- `cargo clippy --locked --all-targets -p crab-git -p crab-metadata -p crab-remote-git -p crab-write -p crab-s3-gateway -- -D warnings`
- `cargo build --release --locked -p crab-s3-gateway`

All Cargo output used `/Volumes/Workspace/crabbuild-target/crab-5623-s3-gateway-batching`.

A 15-minute live RustFS/SigV4 run completed 70,715/70,715 acknowledged 4 KiB PUTs with 16 writers and no write failures: 78.554 PUT/s overall, 176.314 ms p50, 388.222 ms p95, terminal throughput ratio 0.832, and terminal p95 ratio 0.965. That qualification exposed an end-of-run paging cache gap in the first binary. After the fix, a fresh gateway process listed all 70,715 keys across 71 signed pages in 7.295 s, with zero duplicates, malformed keys, or sequence gaps; a second full scan took 6.144 s. A post-restart signed range GET returned byte-exact bytes 0-31 with `Content-Range: bytes 0-31/4096`.
