### PR TITLE
feat(http): improve repository browsing and editing

### DIFF
--- a/crates/crab-http-server/REFERENCE.md
+++ b/crates/crab-http-server/REFERENCE.md
@@ -322,12 +322,12 @@ The blame view links commit OIDs and subjects to immutable commit details. Its a
 | Repository root | Selected commit, file table, repository details, rendered README, request timing, and Code menu |
 | Branch and tag picker | Search, keyboard navigation, default-branch state, and writer-only creation from the viewed commit |
 | Branches and tags | Natural sorting, protected/default labels, copied names, immutable tips, default comparison, and guarded deletion |
-| Tree and file workspace | Lazy folder-first tree, preserved expansion, breadcrumbs, source, preview, blame, raw bytes, copy, download, edit, and delete |
-| History and comparison | Signed pagination, first-parent path history, commit changes, split/unified diffs, and exact revision links |
+| Tree and file workspace | Resizable lazy folder-first tree, preserved expansion, breadcrumbs, source, preview, blame, raw bytes, copy, download, edit, and delete |
+| History and comparison | Signed pagination, first-parent path history, commit changes in a status-aware file tree, split/unified diffs, and exact revision links |
 | Go to file | Bounded full-tree fuzzy search without blob reads; `T` opens and focuses search |
 | Releases | Releases/Tags navigation, search, drafts, publication, edits, deletion, source ZIPs, and binary assets |
-| Pull requests | Conversation, Commits, Checks, Files changed, reviews, approval state, and merge controls |
-| Issues and metadata | Searchable issues, comments, labels, assignees, Markdown preview, and conflict recovery |
+| Pull requests | Conversation, Commits, Checks, Files changed, reviews, shared Markdown formatting, approval state, and merge controls |
+| Issues and metadata | Searchable issues, comments, labels, assignees, Markdown formatting and preview, and conflict recovery |
 | Settings | Default branch, exact protection rules, and archive state with stale-version checks |
 | Appearance | System, light, and dark themes persisted across desktop and narrow layouts |
 

--- a/crates/crab-http-server/REFERENCE.md
+++ b/crates/crab-http-server/REFERENCE.md
@@ -323,7 +323,7 @@ The blame view links commit OIDs and subjects to immutable commit details. Its a
 | Branch and tag picker | Search, keyboard navigation, default-branch state, and writer-only creation from the viewed commit |
 | Branches and tags | Natural sorting, protected/default labels, copied names, immutable tips, default comparison, and guarded deletion |
 | Tree and file workspace | Resizable lazy folder-first tree, preserved expansion, breadcrumbs, source, preview, blame, raw bytes, copy, download, edit, and delete |
-| History and comparison | Signed pagination, first-parent path history, commit changes in a status-aware file tree, split/unified diffs, and exact revision links |
+| History and comparison | Signed pagination, first-parent path history, a persistent change tree with independently scrolling jump-linked diffs, split/unified layouts, and exact revision links |
 | Go to file | Bounded full-tree fuzzy search without blob reads; `T` opens and focuses search |
 | Releases | Releases/Tags navigation, search, drafts, publication, edits, deletion, source ZIPs, and binary assets |
 | Pull requests | Conversation, Commits, Checks, Files changed, reviews, shared Markdown formatting, approval state, and merge controls |

--- a/packages/repository/src/App.tsx
+++ b/packages/repository/src/App.tsx
@@ -1,4 +1,12 @@
-import { Suspense, lazy, useEffect, useLayoutEffect, useState } from "react";
+import {
+  Suspense,
+  lazy,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import {
   BaseStyles,
   Button,
@@ -41,6 +49,7 @@ import {
 import { Link, Result, date, short } from "./ui";
 import { GitAccess } from "./git-access";
 import { FileBreadcrumb, FileNavigation } from "./file-navigation";
+import { PaneResizer } from "./pane-resizer";
 import {
   CreateFile,
   DeleteFile,
@@ -89,6 +98,14 @@ const Settings = lazy(() =>
   import("./settings").then((module) => ({ default: module.Settings })),
 );
 type Theme = "light" | "dark" | "auto";
+const DEFAULT_TREE_PANE_WIDTH = 356;
+const MIN_TREE_PANE_WIDTH = 240;
+const MAX_TREE_PANE_WIDTH = 640;
+const TREE_PANE_KEYBOARD_STEP = 24;
+
+function clampTreePaneWidth(width: number, max = MAX_TREE_PANE_WIDTH) {
+  return Math.min(max, Math.max(MIN_TREE_PANE_WIDTH, Math.round(width)));
+}
 
 export function App() {
   const location = useLocation();
@@ -426,7 +443,27 @@ function RepositoryPage({
   const kind = url.searchParams.get("kind") ?? "Tree";
   const [showTree, setShowTree] = useState(Boolean(path));
   const [searchFocusRequest, setSearchFocusRequest] = useState(0);
+  const [treePaneWidth, setTreePaneWidth] = useState(DEFAULT_TREE_PANE_WIDTH);
+  const [treePaneMax, setTreePaneMax] = useState(MAX_TREE_PANE_WIDTH);
+  const fileLayout = useRef<HTMLDivElement>(null);
   useEffect(() => setShowTree(Boolean(path)), [path]);
+  useLayoutEffect(() => {
+    const layout = fileLayout.current;
+    if (!layout || !showTree) return;
+    const updateLimit = () => {
+      if (matchMedia("(max-width: 640px)").matches) return;
+      const max = Math.max(
+        MIN_TREE_PANE_WIDTH,
+        Math.min(MAX_TREE_PANE_WIDTH, Math.floor(layout.clientWidth / 2)),
+      );
+      setTreePaneMax(max);
+      setTreePaneWidth((width) => clampTreePaneWidth(width, max));
+    };
+    updateLimit();
+    const observer = new ResizeObserver(updateLimit);
+    observer.observe(layout);
+    return () => observer.disconnect();
+  }, [showTree]);
   const overview = view === "code" && !path && !showTree;
   const fileWorkspace = view === "code" && !overview;
   const issuesView = view === "issues" || view === "labels";
@@ -854,6 +891,7 @@ function RepositoryPage({
                           />
                         )}
                         <div
+                          ref={fileLayout}
                           className={
                             overview
                               ? "code-layout overview-layout"
@@ -861,9 +899,17 @@ function RepositoryPage({
                                 ? "code-layout"
                                 : "code-layout no-sidebar"
                           }
+                          style={
+                            {
+                              "--tree-pane-width": `${treePaneWidth}px`,
+                            } as CSSProperties
+                          }
                         >
                           {showTree && (
-                            <aside className="tree-sidebar">
+                            <aside
+                              id="repository-file-tree"
+                              className="tree-sidebar"
+                            >
                               <div className="tree-sidebar-header">
                                 <Button
                                   size="small"
@@ -939,7 +985,25 @@ function RepositoryPage({
                               />
                             </aside>
                           )}
-                          <div className="code-main">
+                          {showTree && (
+                            <PaneResizer
+                              className="tree-resizer"
+                              label="Resize file tree pane"
+                              controls="repository-file-tree repository-file-content"
+                              value={treePaneWidth}
+                              min={MIN_TREE_PANE_WIDTH}
+                              max={treePaneMax}
+                              defaultValue={DEFAULT_TREE_PANE_WIDTH}
+                              step={TREE_PANE_KEYBOARD_STEP}
+                              unit="pixels"
+                              valueText={`${treePaneWidth} pixels wide`}
+                              onChange={setTreePaneWidth}
+                            />
+                          )}
+                          <div
+                            id="repository-file-content"
+                            className="code-main"
+                          >
                             {!showTree && !overview && (
                               <FileNavigation
                                 repo={repo}

--- a/packages/repository/src/content.tsx
+++ b/packages/repository/src/content.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useRef, useState, type CSSProperties } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import { File, MultiFileDiff } from "@pierre/diffs/react";
 import { FileTree, useFileTree } from "@pierre/trees/react";
 import type { GitStatus } from "@pierre/trees";
@@ -61,6 +67,10 @@ function changeStatus(kind: string): GitStatus {
   if (kind === "Added") return "added";
   if (kind === "Deleted") return "deleted";
   return "modified";
+}
+
+function changePanelId(pathHex: string) {
+  return `changed-file-${pathHex}`;
 }
 
 export function FileView({ repo, rev, path, name, theme, write }: Props) {
@@ -365,7 +375,13 @@ export function CommitView({
           </section>
         )}
       </Result>
-      <ChangeComparison state={changes} repo={repo} rev={rev} theme={theme} />
+      <ChangeComparison
+        state={changes}
+        repo={repo}
+        rev={rev}
+        theme={theme}
+        sticky
+      />
     </>
   );
 }
@@ -402,12 +418,14 @@ function ChangeComparison({
   rev,
   base,
   theme,
+  sticky = false,
 }: {
   state: ReturnType<typeof useRequest<Changes>>;
   repo: Repository;
   rev: string;
   base?: string;
   theme: "light" | "dark";
+  sticky?: boolean;
 }) {
   return (
     <Result state={state}>
@@ -419,6 +437,7 @@ function ChangeComparison({
           rev={rev}
           base={base}
           theme={theme}
+          sticky={sticky}
         />
       )}
     </Result>
@@ -431,15 +450,28 @@ function ChangeWorkspace({
   rev,
   base,
   theme,
+  sticky,
 }: {
   changes: Change[];
   repo: Repository;
   rev: string;
   base?: string;
   theme: "light" | "dark";
+  sticky: boolean;
 }) {
-  const [selected, setSelected] = useState(changes[0]?.path_hex ?? null);
-  const selectedChange = changes.find((change) => change.path_hex === selected);
+  const diffPane = useRef<HTMLDivElement>(null);
+
+  function scrollToChange(change: Change) {
+    const pane = diffPane.current;
+    const panel = document.getElementById(changePanelId(change.path_hex));
+    if (!pane || !panel) return;
+    const top =
+      pane.scrollTop +
+      panel.getBoundingClientRect().top -
+      pane.getBoundingClientRect().top;
+    pane.scrollTo({ top });
+  }
+
   return (
     <>
       <h3 id="changed-files-heading">
@@ -447,27 +479,34 @@ function ChangeWorkspace({
       </h3>
       {changes.length ? (
         <section
-          className="change-workspace"
+          className={`change-workspace${sticky ? " change-workspace-sticky" : ""}`}
           aria-labelledby="changed-files-heading"
         >
           <div className="change-tree-pane">
             <ChangeTree
               changes={changes}
-              selected={selectedChange?.path}
-              onSelect={setSelected}
+              selected={changes[0]?.path}
+              onSelect={scrollToChange}
             />
           </div>
-          <div className="change-diff-pane">
-            {selectedChange && (
-              <DiffView
-                key={selectedChange.path_hex}
-                repo={repo}
-                rev={rev}
-                base={base}
-                change={selectedChange}
-                theme={theme}
-              />
-            )}
+          <div
+            ref={diffPane}
+            className="change-diff-pane"
+            aria-label="Changed file diffs"
+          >
+            <div className="change-diff-list">
+              {changes.map((change, index) => (
+                <DiffView
+                  key={change.path_hex}
+                  repo={repo}
+                  rev={rev}
+                  base={base}
+                  change={change}
+                  theme={theme}
+                  eager={index === 0}
+                />
+              ))}
+            </div>
           </div>
         </section>
       ) : (
@@ -484,7 +523,7 @@ function ChangeTree({
 }: {
   changes: Change[];
   selected?: string;
-  onSelect: (path: string) => void;
+  onSelect: (change: Change) => void;
 }) {
   const paths = useMemo(
     () => new Map(changes.map((change) => [change.path, change])),
@@ -515,7 +554,7 @@ function ChangeTree({
       ),
     onSelectionChange(selectedPaths) {
       const change = paths.get(selectedPaths[0] ?? "");
-      if (change) select.current(change.path_hex);
+      if (change) select.current(change);
     },
   });
   return (
@@ -533,9 +572,37 @@ function DiffView({
   base,
   change,
   theme,
-}: Omit<Props, "name" | "path"> & { base?: string; change: Change }) {
+  eager,
+}: Omit<Props, "name" | "path"> & {
+  base?: string;
+  change: Change;
+  eager: boolean;
+}) {
+  const panel = useRef<HTMLElement>(null);
+  const [load, setLoad] = useState(eager);
+  useEffect(() => {
+    const node = panel.current;
+    if (load || !node) return;
+    if (!("IntersectionObserver" in window)) {
+      setLoad(true);
+      return;
+    }
+    const root = node.closest(".change-diff-pane");
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        setLoad(true);
+        observer.disconnect();
+      },
+      { root, rootMargin: "600px 0px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [load]);
   const state = useRequest<Diff>(
-    endpoint(repo, "diff", { rev, base, path_hex: change.path_hex }),
+    load
+      ? endpoint(repo, "diff", { rev, base, path_hex: change.path_hex })
+      : null,
   );
   const [style, setStyle] = useState<"unified" | "split">("split");
   const options = useMemo(
@@ -570,41 +637,55 @@ function DiffView({
     return null;
   }, [state.data]);
   return (
-    <Result state={state}>
-      {(data) => (
-        <section className="panel diff-panel">
-          <div className="panel-header">
-            <div className="diff-file-heading">
-              <strong>{data.path}</strong>
-              <Label variant={changeVariant(change.kind)}>{change.kind}</Label>
-              {change.old?.mode !== change.new?.mode && (
-                <code>
-                  {change.old?.mode ?? "—"} → {change.new?.mode ?? "—"}
-                </code>
-              )}
-            </div>
-            <SegmentedControl
-              aria-label="Diff layout"
-              onChange={(index) => setStyle(index === 0 ? "split" : "unified")}
-            >
-              <SegmentedControl.Button selected={style === "split"}>
-                Split
-              </SegmentedControl.Button>
-              <SegmentedControl.Button selected={style === "unified"}>
-                Unified
-              </SegmentedControl.Button>
-            </SegmentedControl>
-          </div>
-          {files ? (
-            <MultiFileDiff {...files} options={options} style={diffColors} />
-          ) : (
-            <div className="notice">
-              Binary content changed. Browse the corresponding revision to
-              download it.
-            </div>
+    <section
+      ref={panel}
+      id={changePanelId(change.path_hex)}
+      className="panel diff-panel"
+      data-change-path={change.path}
+      aria-labelledby={`${changePanelId(change.path_hex)}-heading`}
+    >
+      <div className="panel-header">
+        <div className="diff-file-heading">
+          <h4 id={`${changePanelId(change.path_hex)}-heading`}>
+            {change.path}
+          </h4>
+          <Label variant={changeVariant(change.kind)}>{change.kind}</Label>
+          {change.old?.mode !== change.new?.mode && (
+            <code>
+              {change.old?.mode ?? "—"} → {change.new?.mode ?? "—"}
+            </code>
           )}
-        </section>
+        </div>
+        <SegmentedControl
+          aria-label={`Diff layout for ${change.path}`}
+          onChange={(index) => setStyle(index === 0 ? "split" : "unified")}
+        >
+          <SegmentedControl.Button selected={style === "split"}>
+            Split
+          </SegmentedControl.Button>
+          <SegmentedControl.Button selected={style === "unified"}>
+            Unified
+          </SegmentedControl.Button>
+        </SegmentedControl>
+      </div>
+      {load ? (
+        <Result state={state} showTiming={false}>
+          {() =>
+            files ? (
+              <MultiFileDiff {...files} options={options} style={diffColors} />
+            ) : (
+              <div className="notice">
+                Binary content changed. Browse the corresponding revision to
+                download it.
+              </div>
+            )
+          }
+        </Result>
+      ) : (
+        <div className="diff-placeholder muted" aria-hidden="true">
+          Diff loads as it comes into view.
+        </div>
       )}
-    </Result>
+    </section>
   );
 }

--- a/packages/repository/src/content.tsx
+++ b/packages/repository/src/content.tsx
@@ -1,11 +1,7 @@
-import {
-  useMemo,
-  useState,
-  type CSSProperties,
-  type KeyboardEvent,
-  type PointerEvent,
-} from "react";
+import { useMemo, useRef, useState, type CSSProperties } from "react";
 import { File, MultiFileDiff } from "@pierre/diffs/react";
+import { FileTree, useFileTree } from "@pierre/trees/react";
+import type { GitStatus } from "@pierre/trees";
 import { IconButton, Label, SegmentedControl } from "@primer/react";
 import {
   CopyIcon,
@@ -20,6 +16,7 @@ import {
   repoHref,
   useRequest,
   type Blame,
+  type Change,
   type Changes,
   type Commit,
   type Content,
@@ -27,7 +24,9 @@ import {
   type Repository,
 } from "./api";
 import { Link, Result, date, short } from "./ui";
+import { compareFileItems } from "./entry-sort";
 import { RepositoryMarkdown } from "./repository-markdown";
+import { PaneResizer } from "./pane-resizer";
 
 type Props = {
   repo: Repository;
@@ -47,16 +46,21 @@ const DEFAULT_BLAME_PANE_WIDTH = 48;
 const MIN_BLAME_PANE_WIDTH = 25;
 const MAX_BLAME_PANE_WIDTH = 75;
 
-function clampBlamePaneWidth(width: number) {
-  return Math.min(
-    MAX_BLAME_PANE_WIDTH,
-    Math.max(MIN_BLAME_PANE_WIDTH, Math.round(width)),
-  );
-}
-
 function formatSize(bytes: number) {
   if (bytes < 1024) return `${bytes.toLocaleString()} bytes`;
   return `${(bytes / 1024).toFixed(2)} KB`;
+}
+
+function changeVariant(kind: string) {
+  if (kind === "Added") return "success" as const;
+  if (kind === "Deleted") return "danger" as const;
+  return "secondary" as const;
+}
+
+function changeStatus(kind: string): GitStatus {
+  if (kind === "Added") return "added";
+  if (kind === "Deleted") return "deleted";
+  return "modified";
 }
 
 export function FileView({ repo, rev, path, name, theme, write }: Props) {
@@ -276,56 +280,18 @@ export function FileView({ repo, rev, path, name, theme, write }: Props) {
                       </div>
                     ))}
                   </div>
-                  <button
-                    type="button"
+                  <PaneResizer
                     className="blame-resizer"
-                    role="separator"
-                    aria-label="Resize blame pane"
-                    aria-controls="blame-commit-pane blame-source-pane"
-                    aria-orientation="vertical"
-                    aria-valuemin={MIN_BLAME_PANE_WIDTH}
-                    aria-valuemax={MAX_BLAME_PANE_WIDTH}
-                    aria-valuenow={blamePaneWidth}
-                    aria-valuetext={`${blamePaneWidth}% blame, ${100 - blamePaneWidth}% source`}
-                    title="Drag or use arrow keys to resize"
-                    onDoubleClick={() =>
-                      setBlamePaneWidth(DEFAULT_BLAME_PANE_WIDTH)
-                    }
-                    onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
-                      let width: number | undefined;
-                      if (event.key === "ArrowLeft") width = blamePaneWidth - 5;
-                      if (event.key === "ArrowRight")
-                        width = blamePaneWidth + 5;
-                      if (event.key === "Home") width = MIN_BLAME_PANE_WIDTH;
-                      if (event.key === "End") width = MAX_BLAME_PANE_WIDTH;
-                      if (width === undefined) return;
-                      event.preventDefault();
-                      setBlamePaneWidth(clampBlamePaneWidth(width));
-                    }}
-                    onPointerDown={(event: PointerEvent<HTMLButtonElement>) => {
-                      event.preventDefault();
-                      event.currentTarget.setPointerCapture(event.pointerId);
-                    }}
-                    onPointerMove={(event: PointerEvent<HTMLButtonElement>) => {
-                      if (
-                        !event.currentTarget.hasPointerCapture(event.pointerId)
-                      )
-                        return;
-                      const grid = event.currentTarget.parentElement;
-                      if (!grid) return;
-                      event.preventDefault();
-                      const bounds = grid.getBoundingClientRect();
-                      setBlamePaneWidth(
-                        clampBlamePaneWidth(
-                          ((event.clientX - bounds.left) / bounds.width) * 100,
-                        ),
-                      );
-                    }}
-                    onPointerUp={(event: PointerEvent<HTMLButtonElement>) => {
-                      event.currentTarget.releasePointerCapture(
-                        event.pointerId,
-                      );
-                    }}
+                    label="Resize blame pane"
+                    controls="blame-commit-pane blame-source-pane"
+                    value={blamePaneWidth}
+                    min={MIN_BLAME_PANE_WIDTH}
+                    max={MAX_BLAME_PANE_WIDTH}
+                    defaultValue={DEFAULT_BLAME_PANE_WIDTH}
+                    step={5}
+                    unit="percent"
+                    valueText={`${blamePaneWidth}% blame, ${100 - blamePaneWidth}% source`}
+                    onChange={setBlamePaneWidth}
                   />
                   <div
                     id="blame-source-pane"
@@ -443,59 +409,121 @@ function ChangeComparison({
   base?: string;
   theme: "light" | "dark";
 }) {
-  const [selected, setSelected] = useState<string | null>(null);
   return (
     <Result state={state}>
       {(value) => (
-        <>
-          <h3>
-            {value.changes.length} changed{" "}
-            {value.changes.length === 1 ? "file" : "files"}
-          </h3>
-          <section className="panel change-list">
-            {value.changes.map((change) => (
-              <button
-                key={change.path_hex}
-                className={selected === change.path_hex ? "selected" : ""}
-                onClick={() => setSelected(change.path_hex)}
-              >
-                <Label
-                  variant={
-                    change.kind === "Added"
-                      ? "success"
-                      : change.kind === "Deleted"
-                        ? "danger"
-                        : "secondary"
-                  }
-                >
-                  {change.kind}
-                </Label>
-                <span>{change.path}</span>
-                {change.old?.mode !== change.new?.mode && (
-                  <code>
-                    {change.old?.mode ?? "—"} → {change.new?.mode ?? "—"}
-                  </code>
-                )}
-              </button>
-            ))}
-          </section>
-          {selected ? (
-            <DiffView
-              key={selected}
-              repo={repo}
-              rev={rev}
-              base={base}
-              path={selected}
-              theme={theme}
-            />
-          ) : (
-            value.changes.length > 0 && (
-              <p className="muted">Select a changed file to view its diff.</p>
-            )
-          )}
-        </>
+        <ChangeWorkspace
+          key={`${value.base ?? "root"}:${value.commit}`}
+          changes={value.changes}
+          repo={repo}
+          rev={rev}
+          base={base}
+          theme={theme}
+        />
       )}
     </Result>
+  );
+}
+
+function ChangeWorkspace({
+  changes,
+  repo,
+  rev,
+  base,
+  theme,
+}: {
+  changes: Change[];
+  repo: Repository;
+  rev: string;
+  base?: string;
+  theme: "light" | "dark";
+}) {
+  const [selected, setSelected] = useState(changes[0]?.path_hex ?? null);
+  const selectedChange = changes.find((change) => change.path_hex === selected);
+  return (
+    <>
+      <h3 id="changed-files-heading">
+        {changes.length} changed {changes.length === 1 ? "file" : "files"}
+      </h3>
+      {changes.length ? (
+        <section
+          className="change-workspace"
+          aria-labelledby="changed-files-heading"
+        >
+          <div className="change-tree-pane">
+            <ChangeTree
+              changes={changes}
+              selected={selectedChange?.path}
+              onSelect={setSelected}
+            />
+          </div>
+          <div className="change-diff-pane">
+            {selectedChange && (
+              <DiffView
+                key={selectedChange.path_hex}
+                repo={repo}
+                rev={rev}
+                base={base}
+                change={selectedChange}
+                theme={theme}
+              />
+            )}
+          </div>
+        </section>
+      ) : (
+        <p className="muted">This comparison has no changed files.</p>
+      )}
+    </>
+  );
+}
+
+function ChangeTree({
+  changes,
+  selected,
+  onSelect,
+}: {
+  changes: Change[];
+  selected?: string;
+  onSelect: (path: string) => void;
+}) {
+  const paths = useMemo(
+    () => new Map(changes.map((change) => [change.path, change])),
+    [changes],
+  );
+  const select = useRef(onSelect);
+  select.current = onSelect;
+  const { model } = useFileTree({
+    paths: changes.map((change) => change.path),
+    gitStatus: changes.map((change) => ({
+      path: change.path,
+      status: changeStatus(change.kind),
+    })),
+    initialExpansion: "open",
+    initialSelectedPaths: selected ? [selected] : [],
+    flattenEmptyDirectories: false,
+    density: "default",
+    itemHeight: 32,
+    icons: { set: "minimal", colored: false },
+    renaming: false,
+    dragAndDrop: false,
+    sort: (left, right) =>
+      compareFileItems(
+        left.basename,
+        left.isDirectory,
+        right.basename,
+        right.isDirectory,
+      ),
+    onSelectionChange(selectedPaths) {
+      const change = paths.get(selectedPaths[0] ?? "");
+      if (change) select.current(change.path_hex);
+    },
+  });
+  return (
+    <FileTree
+      model={model}
+      className="change-file-tree"
+      aria-label="Changed files"
+    />
   );
 }
 
@@ -503,11 +531,11 @@ function DiffView({
   repo,
   rev,
   base,
-  path,
+  change,
   theme,
-}: Omit<Props, "name"> & { base?: string }) {
+}: Omit<Props, "name" | "path"> & { base?: string; change: Change }) {
   const state = useRequest<Diff>(
-    endpoint(repo, "diff", { rev, base, path_hex: path }),
+    endpoint(repo, "diff", { rev, base, path_hex: change.path_hex }),
   );
   const [style, setStyle] = useState<"unified" | "split">("split");
   const options = useMemo(
@@ -546,7 +574,15 @@ function DiffView({
       {(data) => (
         <section className="panel diff-panel">
           <div className="panel-header">
-            <strong>{data.path}</strong>
+            <div className="diff-file-heading">
+              <strong>{data.path}</strong>
+              <Label variant={changeVariant(change.kind)}>{change.kind}</Label>
+              {change.old?.mode !== change.new?.mode && (
+                <code>
+                  {change.old?.mode ?? "—"} → {change.new?.mode ?? "—"}
+                </code>
+              )}
+            </div>
             <SegmentedControl
               aria-label="Diff layout"
               onChange={(index) => setStyle(index === 0 ? "split" : "unified")}

--- a/packages/repository/src/discussion.tsx
+++ b/packages/repository/src/discussion.tsx
@@ -1,6 +1,141 @@
-import { useEffect, useRef, useState, type Ref } from "react";
+import {
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type Ref,
+} from "react";
+import {
+  BoldIcon,
+  CodeIcon,
+  HeadingIcon,
+  ItalicIcon,
+  LinkIcon,
+  ListOrderedIcon,
+  ListUnorderedIcon,
+  MentionIcon,
+  QuoteIcon,
+  TasklistIcon,
+} from "@primer/octicons-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+
+type MarkdownFormat =
+  | "heading"
+  | "bold"
+  | "italic"
+  | "quote"
+  | "code"
+  | "link"
+  | "unordered-list"
+  | "ordered-list"
+  | "task-list"
+  | "mention";
+
+type MarkdownEdit = {
+  value: string;
+  start: number;
+  end: number;
+};
+
+const MARKDOWN_TOOLS = [
+  [
+    { format: "heading", label: "Add heading", icon: HeadingIcon },
+    { format: "bold", label: "Add bold text", icon: BoldIcon },
+    { format: "italic", label: "Add italic text", icon: ItalicIcon },
+  ],
+  [
+    { format: "quote", label: "Insert a quote", icon: QuoteIcon },
+    { format: "code", label: "Insert code", icon: CodeIcon },
+    { format: "link", label: "Add a link", icon: LinkIcon },
+  ],
+  [
+    {
+      format: "unordered-list",
+      label: "Add a bulleted list",
+      icon: ListUnorderedIcon,
+    },
+    {
+      format: "ordered-list",
+      label: "Add a numbered list",
+      icon: ListOrderedIcon,
+    },
+    { format: "task-list", label: "Add a task list", icon: TasklistIcon },
+  ],
+  [{ format: "mention", label: "Mention a user", icon: MentionIcon }],
+] as const;
+
+function wrapSelection(
+  value: string,
+  start: number,
+  end: number,
+  before: string,
+  after: string,
+  placeholder = "",
+): MarkdownEdit {
+  const selected = value.slice(start, end) || placeholder;
+  const next = `${value.slice(0, start)}${before}${selected}${after}${value.slice(end)}`;
+  const selectionStart = start + before.length;
+  return {
+    value: next,
+    start: selectionStart,
+    end: selectionStart + selected.length,
+  };
+}
+
+function prefixLines(
+  value: string,
+  start: number,
+  end: number,
+  prefix: (index: number) => string,
+): MarkdownEdit {
+  const blockStart = value.lastIndexOf("\n", Math.max(0, start - 1)) + 1;
+  const newline = value.indexOf("\n", end);
+  const blockEnd = newline === -1 ? value.length : newline;
+  const lines = value.slice(blockStart, blockEnd).split("\n");
+  const formatted = lines
+    .map((line, index) => `${prefix(index)}${line}`)
+    .join("\n");
+  const next = `${value.slice(0, blockStart)}${formatted}${value.slice(blockEnd)}`;
+  if (start === end) {
+    const offset = prefix(0).length;
+    return { value: next, start: start + offset, end: end + offset };
+  }
+  return { value: next, start: blockStart, end: blockStart + formatted.length };
+}
+
+function formatMarkdown(
+  value: string,
+  start: number,
+  end: number,
+  format: MarkdownFormat,
+): MarkdownEdit {
+  if (format === "heading") return prefixLines(value, start, end, () => "### ");
+  if (format === "bold")
+    return wrapSelection(value, start, end, "**", "**", "bold text");
+  if (format === "italic")
+    return wrapSelection(value, start, end, "_", "_", "italic text");
+  if (format === "quote") return prefixLines(value, start, end, () => "> ");
+  if (format === "code") {
+    const selected = value.slice(start, end);
+    return selected.includes("\n")
+      ? wrapSelection(value, start, end, "```\n", "\n```", "code")
+      : wrapSelection(value, start, end, "`", "`", "code");
+  }
+  if (format === "link")
+    return value.slice(start, end)
+      ? wrapSelection(value, start, end, "[", "](url)")
+      : wrapSelection(value, start, end, "[", "](url)", "link text");
+  if (format === "unordered-list")
+    return prefixLines(value, start, end, () => "- ");
+  if (format === "ordered-list")
+    return prefixLines(value, start, end, (index) => `${index + 1}. `);
+  if (format === "task-list")
+    return prefixLines(value, start, end, () => "- [ ] ");
+  const next = `${value.slice(0, start)}@${value.slice(end)}`;
+  return { value: next, start: start + 1, end: start + 1 };
+}
 
 export function useReturnFocus<T extends HTMLElement>(active: boolean) {
   const target = useRef<T>(null);
@@ -74,50 +209,125 @@ export function Editor({
   ref?: Ref<HTMLTextAreaElement>;
 }) {
   const [preview, setPreview] = useState(false);
+  const textarea = useRef<HTMLTextAreaElement>(null);
+  useImperativeHandle(ref, () => textarea.current as HTMLTextAreaElement);
+
+  function applyFormat(format: MarkdownFormat) {
+    const input = textarea.current;
+    if (!input || disabled) return;
+    const edit = formatMarkdown(
+      value,
+      input.selectionStart,
+      input.selectionEnd,
+      format,
+    );
+    onChange(edit.value);
+    requestAnimationFrame(() => {
+      input.focus();
+      input.setSelectionRange(edit.start, edit.end);
+    });
+  }
+
+  function formatShortcut(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (!(event.ctrlKey || event.metaKey) || event.altKey) return;
+    const format =
+      event.key.toLowerCase() === "b"
+        ? "bold"
+        : event.key.toLowerCase() === "i"
+          ? "italic"
+          : event.key.toLowerCase() === "k"
+            ? "link"
+            : null;
+    if (!format) return;
+    event.preventDefault();
+    applyFormat(format);
+  }
+
   return (
     <div className="discussion-editor">
-      <div
-        className="editor-tabs"
-        role="tablist"
-        aria-label={`${label} mode`}
-        onKeyDown={(event) => {
-          if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key))
-            return;
-          event.preventDefault();
-          const next =
-            event.key === "Home"
-              ? false
-              : event.key === "End"
-                ? true
-                : !preview;
-          setPreview(next);
-          document
-            .getElementById(`${id}-${next ? "preview" : "write"}-tab`)
-            ?.focus();
-        }}
-      >
-        <button
-          type="button"
-          role="tab"
-          id={`${id}-write-tab`}
-          aria-controls={`${id}-write`}
-          aria-selected={!preview}
-          tabIndex={preview ? -1 : 0}
-          onClick={() => setPreview(false)}
+      <div className="editor-header">
+        <div
+          className="editor-tabs"
+          role="tablist"
+          aria-label={`${label} mode`}
+          onKeyDown={(event) => {
+            if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key))
+              return;
+            event.preventDefault();
+            const next =
+              event.key === "Home"
+                ? false
+                : event.key === "End"
+                  ? true
+                  : !preview;
+            setPreview(next);
+            document
+              .getElementById(`${id}-${next ? "preview" : "write"}-tab`)
+              ?.focus();
+          }}
         >
-          Write
-        </button>
-        <button
-          type="button"
-          role="tab"
-          id={`${id}-preview-tab`}
-          aria-controls={`${id}-preview`}
-          aria-selected={preview}
-          tabIndex={preview ? 0 : -1}
-          onClick={() => setPreview(true)}
+          <button
+            type="button"
+            role="tab"
+            id={`${id}-write-tab`}
+            aria-controls={`${id}-write`}
+            aria-selected={!preview}
+            tabIndex={preview ? -1 : 0}
+            onClick={() => setPreview(false)}
+          >
+            Write
+          </button>
+          <button
+            type="button"
+            role="tab"
+            id={`${id}-preview-tab`}
+            aria-controls={`${id}-preview`}
+            aria-selected={preview}
+            tabIndex={preview ? 0 : -1}
+            onClick={() => setPreview(true)}
+          >
+            Preview
+          </button>
+        </div>
+        <div
+          className="editor-toolbar"
+          role="toolbar"
+          aria-label={`${label} formatting`}
+          hidden={preview}
         >
-          Preview
-        </button>
+          {MARKDOWN_TOOLS.map((group, groupIndex) => (
+            <span className="editor-tool-group" key={group[0].format}>
+              {groupIndex > 0 && (
+                <span className="editor-tool-divider" aria-hidden="true" />
+              )}
+              {group.map((tool) => {
+                const Icon = tool.icon;
+                const shortcut =
+                  tool.format === "bold"
+                    ? "Control+B Meta+B"
+                    : tool.format === "italic"
+                      ? "Control+I Meta+I"
+                      : tool.format === "link"
+                        ? "Control+K Meta+K"
+                        : undefined;
+                return (
+                  <button
+                    key={tool.format}
+                    type="button"
+                    className="editor-tool"
+                    aria-label={tool.label}
+                    aria-keyshortcuts={shortcut}
+                    title={tool.label}
+                    disabled={disabled}
+                    onClick={() => applyFormat(tool.format)}
+                  >
+                    <Icon size={16} />
+                  </button>
+                );
+              })}
+            </span>
+          ))}
+        </div>
       </div>
       <div
         id={`${id}-preview`}
@@ -139,7 +349,7 @@ export function Editor({
           {label}
         </label>
         <textarea
-          ref={ref}
+          ref={textarea}
           autoFocus={autoFocus}
           id={id}
           value={value}
@@ -149,6 +359,7 @@ export function Editor({
           maxLength={65_536}
           rows={8}
           placeholder="Add context, ask a question, or share an update…"
+          onKeyDown={formatShortcut}
         />
       </div>
       <p className="editor-help muted">

--- a/packages/repository/src/pane-resizer.tsx
+++ b/packages/repository/src/pane-resizer.tsx
@@ -1,0 +1,77 @@
+import type { KeyboardEvent, PointerEvent } from "react";
+
+type Props = {
+  className: string;
+  label: string;
+  controls: string;
+  value: number;
+  min: number;
+  max: number;
+  defaultValue: number;
+  step: number;
+  unit: "percent" | "pixels";
+  valueText: string;
+  onChange: (value: number) => void;
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export function PaneResizer({
+  className,
+  label,
+  controls,
+  value,
+  min,
+  max,
+  defaultValue,
+  step,
+  unit,
+  valueText,
+  onChange,
+}: Props) {
+  const update = (next: number) => onChange(clamp(next, min, max));
+  return (
+    <button
+      type="button"
+      className={`pane-resizer ${className}`}
+      role="separator"
+      aria-label={label}
+      aria-controls={controls}
+      aria-orientation="vertical"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={value}
+      aria-valuetext={valueText}
+      title="Drag or use arrow keys to resize"
+      onDoubleClick={() => update(defaultValue)}
+      onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
+        let next: number | undefined;
+        if (event.key === "ArrowLeft") next = value - step;
+        if (event.key === "ArrowRight") next = value + step;
+        if (event.key === "Home") next = min;
+        if (event.key === "End") next = max;
+        if (next === undefined) return;
+        event.preventDefault();
+        update(next);
+      }}
+      onPointerDown={(event: PointerEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }}
+      onPointerMove={(event: PointerEvent<HTMLButtonElement>) => {
+        if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+        const container = event.currentTarget.parentElement;
+        if (!container) return;
+        event.preventDefault();
+        const bounds = container.getBoundingClientRect();
+        const offset = event.clientX - bounds.left;
+        update(unit === "percent" ? (offset / bounds.width) * 100 : offset);
+      }}
+      onPointerUp={(event: PointerEvent<HTMLButtonElement>) => {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }}
+    />
+  );
+}

--- a/packages/repository/src/style.css
+++ b/packages/repository/src/style.css
@@ -502,21 +502,28 @@ main {
   display: grid;
   grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
   align-items: stretch;
+  height: calc(100vh - 32px);
+  min-height: 520px;
+  max-height: 960px;
   overflow: hidden;
   border: 1px solid var(--borderColor-default);
   border-radius: var(--borderRadius-medium);
 }
+.change-workspace-sticky {
+  position: sticky;
+  top: 16px;
+}
 .change-tree-pane {
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
   background: var(--bgColor-muted);
   border-right: 1px solid var(--borderColor-default);
 }
 .change-file-tree {
-  position: sticky;
-  top: 16px;
   display: block;
-  height: min(68vh, 720px);
-  min-height: 360px;
+  height: 100%;
+  min-height: 0;
   color: var(--fgColor-default);
   --trees-accent-override: var(--fgColor-accent);
   --trees-bg-override: var(--bgColor-muted);
@@ -535,12 +542,26 @@ main {
 }
 .change-diff-pane {
   min-width: 0;
-  background: var(--bgColor-default);
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scroll-padding-top: 16px;
+  background: var(--bgColor-muted);
 }
 .change-diff-pane .diff-panel {
   margin: 0;
-  border: 0;
-  border-radius: 0;
+}
+.change-diff-list {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+}
+.diff-placeholder {
+  display: grid;
+  min-height: 140px;
+  place-items: center;
+  border-top: 1px solid var(--borderColor-muted);
 }
 .diff-file-heading {
   display: flex;
@@ -548,8 +569,10 @@ main {
   align-items: center;
   gap: 8px;
 }
-.diff-file-heading strong {
+.diff-file-heading h4 {
+  margin: 0;
   overflow: hidden;
+  font-size: 14px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -830,7 +853,11 @@ main {
     flex-direction: column;
   }
   .change-workspace {
+    position: static;
     grid-template-columns: minmax(0, 1fr);
+    height: auto;
+    min-height: 0;
+    max-height: none;
   }
   .change-tree-pane {
     border-right: 0;
@@ -840,6 +867,12 @@ main {
     position: static;
     height: 240px;
     min-height: 0;
+  }
+  .change-diff-pane {
+    overflow: visible;
+  }
+  .change-diff-list {
+    padding: 12px;
   }
   .tree-sidebar {
     position: static;

--- a/packages/repository/src/style.css
+++ b/packages/repository/src/style.css
@@ -498,31 +498,60 @@ main {
   overflow-wrap: anywhere;
   margin: 16px 0;
 }
-.change-list button {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  text-align: left;
-  width: 100%;
-  border: 0;
-  border-bottom: 1px solid var(--borderColor-muted);
-  padding: 12px 16px;
-  background: transparent;
+.change-workspace {
+  display: grid;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  align-items: stretch;
+  overflow: hidden;
+  border: 1px solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+}
+.change-tree-pane {
+  min-width: 0;
+  background: var(--bgColor-muted);
+  border-right: 1px solid var(--borderColor-default);
+}
+.change-file-tree {
+  position: sticky;
+  top: 16px;
+  display: block;
+  height: min(68vh, 720px);
+  min-height: 360px;
   color: var(--fgColor-default);
-  font-size: 14px;
+  --trees-accent-override: var(--fgColor-accent);
+  --trees-bg-override: var(--bgColor-muted);
+  --trees-bg-muted-override: var(--control-transparent-bgColor-hover);
+  --trees-border-color-override: var(--borderColor-default);
+  --trees-fg-override: var(--fgColor-default);
+  --trees-fg-muted-override: var(--fgColor-muted);
+  --trees-font-family-override: var(--fontStack-system);
+  --trees-font-size-override: 14px;
+  --trees-focus-ring-color-override: var(--focus-outlineColor);
+  --trees-git-added-color-override: var(--fgColor-default);
+  --trees-git-deleted-color-override: var(--fgColor-default);
+  --trees-git-modified-color-override: var(--fgColor-default);
+  --trees-item-margin-x-override: 0px;
+  --trees-item-padding-x-override: 6px;
 }
-.change-list button:last-child {
-  border-bottom: 0;
+.change-diff-pane {
+  min-width: 0;
+  background: var(--bgColor-default);
 }
-.change-list button:hover,
-.change-list button.selected {
-  background: var(--bgColor-accent-muted);
+.change-diff-pane .diff-panel {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
 }
-.change-list button span {
-  overflow-wrap: anywhere;
+.diff-file-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
 }
-.change-list code {
-  margin-left: auto;
+.diff-file-heading strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .diff-panel {
   margin-top: 24px;
@@ -554,7 +583,7 @@ main {
   overflow: hidden;
   background: var(--bgColor-muted);
 }
-.blame-resizer {
+.pane-resizer {
   position: relative;
   width: 9px;
   min-width: 9px;
@@ -566,7 +595,7 @@ main {
   border: 0;
   border-inline: 1px solid var(--borderColor-muted);
 }
-.blame-resizer::before {
+.pane-resizer::before {
   position: absolute;
   inset: 0 2px;
   content: "";
@@ -574,7 +603,7 @@ main {
   opacity: 0;
   transition: opacity 120ms ease;
 }
-.blame-resizer::after {
+.pane-resizer::after {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -589,20 +618,20 @@ main {
     height 120ms ease,
     opacity 120ms ease;
 }
-.blame-resizer:hover::before,
-.blame-resizer:focus-visible::before,
-.blame-resizer:active::before {
+.pane-resizer:hover::before,
+.pane-resizer:focus-visible::before,
+.pane-resizer:active::before {
   opacity: 1;
   background: var(--bgColor-accent-muted);
 }
-.blame-resizer:hover::after,
-.blame-resizer:focus-visible::after,
-.blame-resizer:active::after {
+.pane-resizer:hover::after,
+.pane-resizer:focus-visible::after,
+.pane-resizer:active::after {
   height: 44px;
   opacity: 1;
   background: var(--fgColor-accent);
 }
-.blame-resizer:focus-visible {
+.pane-resizer:focus-visible {
   z-index: 1;
   outline: 2px solid var(--focus-outlineColor);
   outline-offset: -2px;
@@ -747,8 +776,8 @@ main {
   letter-spacing: 0.01em;
 }
 @media (prefers-reduced-motion: reduce) {
-  .blame-resizer::before,
-  .blame-resizer::after {
+  .pane-resizer::before,
+  .pane-resizer::after {
     transition: none;
   }
 }
@@ -799,6 +828,18 @@ main {
   .code-layout {
     display: flex;
     flex-direction: column;
+  }
+  .change-workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .change-tree-pane {
+    border-right: 0;
+    border-bottom: 1px solid var(--borderColor-default);
+  }
+  .change-file-tree {
+    position: static;
+    height: 240px;
+    min-height: 0;
   }
   .tree-sidebar {
     position: static;
@@ -2114,15 +2155,26 @@ main {
   padding: 20px;
 }
 .discussion-editor {
+  contain: inline-size;
+  width: 100%;
+  min-width: 0;
   border: 1px solid var(--borderColor-default);
   border-radius: 6px;
   background: var(--bgColor-default);
   overflow: hidden;
 }
-.editor-tabs {
+.editor-header {
   display: flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: stretch;
+  overflow: hidden;
   background: var(--bgColor-muted);
   border-bottom: 1px solid var(--borderColor-default);
+}
+.editor-tabs {
+  display: flex;
+  flex: 0 0 auto;
   gap: 8px;
   padding: 8px 8px 0;
 }
@@ -2141,6 +2193,57 @@ main {
   background: var(--bgColor-default);
   border-color: var(--borderColor-default);
   font-weight: 600;
+}
+.editor-toolbar {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  padding: 6px 8px;
+  margin-left: auto;
+  overflow-x: auto;
+}
+.editor-toolbar[hidden] {
+  display: none;
+}
+.editor-tool-group {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 2px;
+}
+.editor-tool-divider {
+  width: 1px;
+  height: 20px;
+  margin: 0 5px;
+  background: var(--borderColor-muted);
+}
+.editor-tool {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  place-items: center;
+  color: var(--fgColor-muted);
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: var(--borderRadius-medium);
+}
+.editor-tool:hover {
+  color: var(--fgColor-default);
+  background: var(--control-transparent-bgColor-hover);
+}
+.editor-tool:focus-visible {
+  color: var(--fgColor-default);
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -2px;
+}
+.editor-tool:disabled {
+  color: var(--fgColor-disabled);
+  cursor: default;
+  background: transparent;
 }
 .discussion-editor textarea {
   border: 0;
@@ -2315,6 +2418,14 @@ main {
   padding-top: 16px;
 }
 @media (max-width: 640px) {
+  .editor-header {
+    flex-wrap: wrap;
+  }
+  .editor-toolbar {
+    flex: 1 0 100%;
+    justify-content: flex-start;
+    border-top: 1px solid var(--borderColor-muted);
+  }
   .issues-workspace {
     display: block;
   }
@@ -3452,6 +3563,8 @@ main {
 .timing summary {
   cursor: pointer;
   display: inline-block;
+  color: var(--fgColor-default);
+  background: var(--bgColor-default);
 }
 .timing summary:hover {
   color: var(--fgColor-accent);
@@ -3666,7 +3779,9 @@ main {
   padding: 0;
 }
 .repo-file-workspace .code-layout {
-  grid-template-columns: 356px minmax(0, 1fr);
+  grid-template-columns:
+    minmax(240px, var(--tree-pane-width, 356px)) 9px
+    minmax(0, 1fr);
   gap: 0;
 }
 .repo-file-workspace .code-layout.no-sidebar {
@@ -3676,7 +3791,7 @@ main {
   position: sticky;
   top: 0;
   min-height: calc(100vh - 113px);
-  border-width: 0 1px 0 0;
+  border-width: 0;
   border-radius: 0;
 }
 .repo-file-workspace .repository-tree {
@@ -4048,6 +4163,9 @@ main {
   .repo-file-workspace .code-layout {
     display: flex;
     gap: 16px;
+  }
+  .repo-file-workspace .tree-resizer {
+    display: none;
   }
   .repo-file-workspace .tree-sidebar {
     position: static;

--- a/packages/repository/tests/browser/pulls.e2e.ts
+++ b/packages/repository/tests/browser/pulls.e2e.ts
@@ -401,9 +401,23 @@ test("pull request creation, discussion, and files follow the GitHub review flow
     "refs/heads/feature/docs",
   );
   await page.getByLabel("Title", { exact: true }).fill("Document the feature");
-  await page
-    .getByRole("textbox", { name: "Description", exact: true })
-    .fill("This explains the **new behavior**.");
+  const pullForm = page.locator(".pull-form");
+  const description = pullForm.getByRole("textbox", {
+    name: "Description",
+    exact: true,
+  });
+  await description.fill("This explains the new behavior.");
+  await description.evaluate((input: HTMLTextAreaElement) =>
+    input.setSelectionRange(18, 30),
+  );
+  await pullForm
+    .getByRole("button", { name: "Add bold text", exact: true })
+    .click();
+  await expect(description).toHaveValue("This explains the **new behavior**.");
+  await pullForm.getByRole("tab", { name: "Preview", exact: true }).click();
+  await expect(
+    pullForm.getByRole("tabpanel", { name: "Preview", exact: true }),
+  ).toContainText("This explains the new behavior.");
   await page
     .getByRole("button", { name: "Create pull request", exact: true })
     .click();
@@ -463,7 +477,12 @@ test("pull request creation, discussion, and files follow the GitHub review flow
 
   await page.getByRole("link", { name: "Files changed", exact: true }).click();
   await expect(page.getByText("1 changed file", { exact: true })).toBeVisible();
-  await page.getByRole("button", { name: /Modified README.md/ }).click();
+  const changedFiles = page.locator(
+    'file-tree-container[aria-label="Changed files"]',
+  );
+  await expect(
+    changedFiles.getByRole("treeitem", { name: "README.md", exact: true }),
+  ).toHaveAttribute("aria-selected", "true");
   await expect(page.locator(".diff-panel")).toContainText("New content");
   await expectNoAccessibilityViolations(page);
 

--- a/packages/repository/tests/browser/repository.e2e.ts
+++ b/packages/repository/tests/browser/repository.e2e.ts
@@ -543,27 +543,57 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test("repository views pass automated WCAG A and AA checks", async ({
-  page,
-}) => {
-  for (const theme of ["light", "dark"] as const) {
+for (const theme of ["light", "dark"] as const) {
+  test(`repository views pass automated WCAG A and AA checks in ${theme} theme`, async ({
+    page,
+  }) => {
     await page.goto("/team/project");
     await selectTheme(page, theme);
-    for (const location of [
-      "/team/project",
-      `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("README.md")}&kind=Blob`,
-      `/team/project?view=commit&rev=${oid}`,
-      "/team/project?view=issues",
-      "/team/project?view=issues&issue=new",
-      "/team/project?view=branches",
-      "/team/project?view=settings",
+    for (const view of [
+      {
+        location: "/team/project",
+        ready: page.getByRole("region", { name: "Folders and files" }),
+      },
+      {
+        location: `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("README.md")}&kind=Blob`,
+        ready: page.locator(".file-panel"),
+      },
+      {
+        location: `/team/project?view=commit&rev=${oid}`,
+        ready: page.getByRole("heading", {
+          name: "3 changed files",
+          exact: true,
+        }),
+      },
+      {
+        location: "/team/project?view=issues",
+        ready: page.getByRole("heading", { name: "All issues" }),
+      },
+      {
+        location: "/team/project?view=issues&issue=new",
+        ready: page.getByRole("heading", { name: "New issue", exact: true }),
+      },
+      {
+        location: "/team/project?view=branches",
+        ready: page.getByRole("heading", {
+          name: "Branches",
+          exact: true,
+          level: 2,
+        }),
+      },
+      {
+        location: "/team/project?view=settings",
+        ready: page.getByRole("heading", { name: "General", exact: true }),
+      },
     ]) {
-      await page.goto(location);
-      await page.waitForLoadState("networkidle");
-      await expectNoAccessibilityViolations(page);
+      await test.step(view.location, async () => {
+        await page.goto(view.location);
+        await expect(view.ready).toBeVisible();
+        await expectNoAccessibilityViolations(page);
+      });
     }
-  }
-});
+  });
+}
 
 test("new issue Markdown toolbar formats selections and remains usable on mobile", async ({
   page,

--- a/packages/repository/tests/browser/repository.e2e.ts
+++ b/packages/repository/tests/browser/repository.e2e.ts
@@ -415,6 +415,93 @@ test.beforeEach(async ({ page }) => {
           ],
         },
       });
+    if (url.pathname.endsWith("/changes"))
+      return route.fulfill({
+        json: {
+          base: null,
+          commit: oid,
+          changes: [
+            {
+              path: "src/index.ts",
+              path_hex: pathHex("src/index.ts"),
+              kind: "Modified",
+              old: {
+                path: "src/index.ts",
+                path_hex: pathHex("src/index.ts"),
+                kind: "Blob",
+                oid: "1".repeat(40),
+                mode: "100644",
+              },
+              new: {
+                path: "src/index.ts",
+                path_hex: pathHex("src/index.ts"),
+                kind: "Blob",
+                oid: "2".repeat(40),
+                mode: "100644",
+              },
+            },
+            {
+              path: "src/lib/new.ts",
+              path_hex: pathHex("src/lib/new.ts"),
+              kind: "Added",
+              old: null,
+              new: {
+                path: "src/lib/new.ts",
+                path_hex: pathHex("src/lib/new.ts"),
+                kind: "Blob",
+                oid: "3".repeat(40),
+                mode: "100644",
+              },
+            },
+            {
+              path: "docs/old.md",
+              path_hex: pathHex("docs/old.md"),
+              kind: "Deleted",
+              old: {
+                path: "docs/old.md",
+                path_hex: pathHex("docs/old.md"),
+                kind: "Blob",
+                oid: "4".repeat(40),
+                mode: "100644",
+              },
+              new: null,
+            },
+          ],
+        },
+      });
+    if (url.pathname.endsWith("/diff")) {
+      const path = ["src/index.ts", "src/lib/new.ts", "docs/old.md"].find(
+        (candidate) => pathHex(candidate) === url.searchParams.get("path_hex"),
+      );
+      if (!path) throw new Error("Unexpected changed-file fixture path");
+      const added = path === "src/lib/new.ts";
+      const deleted = path === "docs/old.md";
+      return route.fulfill({
+        json: {
+          base: null,
+          commit: oid,
+          path,
+          old: added
+            ? null
+            : {
+                oid: "5".repeat(40),
+                size: 12,
+                mode: "100644",
+                classification: "OrdinaryGit",
+                text: "Old content\n",
+              },
+          new: deleted
+            ? null
+            : {
+                oid: "6".repeat(40),
+                size: 12,
+                mode: "100644",
+                classification: "OrdinaryGit",
+                text: "New content\n",
+              },
+        },
+      });
+    }
     if (url.pathname.endsWith("/issues"))
       return route.fulfill({
         json: {
@@ -465,7 +552,9 @@ test("repository views pass automated WCAG A and AA checks", async ({
     for (const location of [
       "/team/project",
       `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("README.md")}&kind=Blob`,
+      `/team/project?view=commit&rev=${oid}`,
       "/team/project?view=issues",
+      "/team/project?view=issues&issue=new",
       "/team/project?view=branches",
       "/team/project?view=settings",
     ]) {
@@ -474,6 +563,129 @@ test("repository views pass automated WCAG A and AA checks", async ({
       await expectNoAccessibilityViolations(page);
     }
   }
+});
+
+test("new issue Markdown toolbar formats selections and remains usable on mobile", async ({
+  page,
+}) => {
+  await page.goto("/team/project?view=issues&issue=new");
+  const editor = page.locator(".discussion-editor");
+  const toolbar = editor.getByRole("toolbar", {
+    name: "Description formatting",
+  });
+  await expect(
+    toolbar.getByRole("button", { name: "Add heading", exact: true }),
+  ).toBeVisible();
+  await expect(
+    toolbar.getByRole("button", { name: "Add a task list", exact: true }),
+  ).toBeVisible();
+  await expect(
+    toolbar.getByRole("button", { name: "Mention a user", exact: true }),
+  ).toBeVisible();
+
+  const description = editor.getByRole("textbox", {
+    name: "Description",
+    exact: true,
+  });
+  await description.fill("Ship safely");
+  await description.evaluate((input: HTMLTextAreaElement) =>
+    input.setSelectionRange(5, 11),
+  );
+  await toolbar
+    .getByRole("button", { name: "Add bold text", exact: true })
+    .click();
+  await expect(description).toHaveValue("Ship **safely**");
+  await expect(description).toBeFocused();
+  await page.keyboard.press("ControlOrMeta+i");
+  await expect(description).toHaveValue("Ship **_safely_**");
+
+  await editor.getByRole("tab", { name: "Preview", exact: true }).click();
+  await expect(toolbar).toBeHidden();
+  await expect(
+    editor
+      .getByRole("tabpanel", { name: "Preview", exact: true })
+      .locator("strong em"),
+  ).toHaveText("safely");
+
+  await editor.getByRole("tab", { name: "Write", exact: true }).click();
+  await description.fill("test\nship");
+  await description.selectText();
+  await toolbar
+    .getByRole("button", { name: "Add a task list", exact: true })
+    .click();
+  await expect(description).toHaveValue("- [ ] test\n- [ ] ship");
+
+  await page.setViewportSize({ width: 320, height: 900 });
+  await toolbar
+    .getByRole("button", { name: "Mention a user", exact: true })
+    .focus();
+  const bounds = await toolbar.boundingBox();
+  expect(bounds).not.toBeNull();
+  expect(bounds!.x).toBeGreaterThanOrEqual(0);
+  expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(320);
+  await expectNoAccessibilityViolations(page);
+});
+
+test("commit page presents changed files as a responsive status tree", async ({
+  page,
+}) => {
+  await page.goto(`/team/project?view=commit&rev=${oid}`);
+
+  await expect(
+    page.getByRole("heading", { name: "3 changed files", exact: true }),
+  ).toBeVisible();
+  const tree = page.locator('file-tree-container[aria-label="Changed files"]');
+  await expect(
+    tree.getByRole("treeitem", { name: "docs", exact: true }),
+  ).toHaveAttribute("aria-expanded", "true");
+  await expect(
+    tree.getByRole("treeitem", { name: "src", exact: true }),
+  ).toHaveAttribute("aria-expanded", "true");
+  await expect(
+    tree.getByRole("treeitem", { name: "lib", exact: true }),
+  ).toHaveAttribute("aria-expanded", "true");
+
+  const modified = tree.getByRole("treeitem", {
+    name: "index.ts",
+    exact: true,
+  });
+  await expect(modified).toHaveAttribute("aria-selected", "true");
+  const diff = page.locator(".change-diff-pane");
+  await expect(diff).toContainText("src/index.ts");
+  await expect(diff).toContainText("Modified");
+  await expect(diff).toContainText("New content");
+
+  const added = tree.getByRole("treeitem", { name: "new.ts", exact: true });
+  await added.click();
+  await expect(added).toHaveAttribute("aria-selected", "true");
+  await expect(diff).toContainText("src/lib/new.ts");
+  await expect(diff).toContainText("Added");
+
+  await expect
+    .poll(async () => {
+      const treeRight = await tree.evaluate(
+        (node) => node.getBoundingClientRect().right,
+      );
+      const diffLeft = await diff.evaluate(
+        (node) => node.getBoundingClientRect().left,
+      );
+      return diffLeft - treeRight;
+    })
+    .toBeGreaterThanOrEqual(0);
+
+  await page.setViewportSize({ width: 600, height: 900 });
+  await expect
+    .poll(async () => {
+      const treeBottom = await tree.evaluate(
+        (node) => node.getBoundingClientRect().bottom,
+      );
+      const diffTop = await diff.evaluate(
+        (node) => node.getBoundingClientRect().top,
+      );
+      return diffTop - treeBottom;
+    })
+    .toBeGreaterThanOrEqual(0);
+  await expectNoAccessibilityViolations(page);
 });
 
 test("overview groups files with their commit and opens the tree when navigating", async ({
@@ -674,6 +886,48 @@ test("blame and source panes resize with pointer and keyboard controls", async (
   await expect(separator).toHaveAttribute("aria-valuenow", "30");
   await separator.dblclick();
   await expect(separator).toHaveAttribute("aria-valuenow", "48");
+});
+
+test("file tree and content panes resize with pointer and keyboard controls", async ({
+  page,
+}) => {
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("README.md")}&kind=Blob`,
+  );
+
+  const separator = page.getByRole("separator", {
+    name: "Resize file tree pane",
+  });
+  const treePane = page.locator(".tree-sidebar");
+  const contentPane = page.locator(".code-main");
+  await expect(separator).toHaveAttribute("aria-valuenow", "356");
+  await expect(treePane).toBeVisible();
+  await expect(contentPane).toBeVisible();
+  await expectNoAccessibilityViolations(page);
+
+  const initialWidth = (await treePane.boundingBox())?.width ?? 0;
+  const handle = await separator.boundingBox();
+  if (!handle) throw new Error("File tree resize handle is not visible");
+  await page.mouse.move(handle.x + handle.width / 2, handle.y + 20);
+  await page.mouse.down();
+  await page.mouse.move(handle.x + handle.width / 2 + 120, handle.y + 20);
+  await page.mouse.up();
+  await expect
+    .poll(async () => (await treePane.boundingBox())?.width ?? 0)
+    .toBeGreaterThan(initialWidth + 80);
+
+  await separator.press("Home");
+  await expect(separator).toHaveAttribute("aria-valuenow", "240");
+  await separator.press("ArrowRight");
+  await expect(separator).toHaveAttribute("aria-valuenow", "264");
+  await separator.dblclick();
+  await expect(separator).toHaveAttribute("aria-valuenow", "356");
+
+  await page.setViewportSize({ width: 600, height: 900 });
+  await expect(separator).toBeHidden();
+  await expect(treePane).toBeVisible();
+  await expect(contentPane).toBeVisible();
+  await expectNoAccessibilityViolations(page);
 });
 
 test("blame commit messages open their commit details", async ({ page }) => {

--- a/packages/repository/tests/browser/repository.e2e.ts
+++ b/packages/repository/tests/browser/repository.e2e.ts
@@ -626,7 +626,7 @@ test("new issue Markdown toolbar formats selections and remains usable on mobile
   await expectNoAccessibilityViolations(page);
 });
 
-test("commit page presents changed files as a responsive status tree", async ({
+test("commit page keeps a sticky file tree beside independently scrolling diffs", async ({
   page,
 }) => {
   await page.goto(`/team/project?view=commit&rev=${oid}`);
@@ -650,16 +650,60 @@ test("commit page presents changed files as a responsive status tree", async ({
     exact: true,
   });
   await expect(modified).toHaveAttribute("aria-selected", "true");
+  const workspace = page.locator(".change-workspace");
   const diff = page.locator(".change-diff-pane");
-  await expect(diff).toContainText("src/index.ts");
-  await expect(diff).toContainText("Modified");
-  await expect(diff).toContainText("New content");
+  const panels = diff.locator(".diff-panel");
+  await expect(panels).toHaveCount(3);
+  await expect(
+    diff.getByRole("heading", { name: "src/index.ts", exact: true }),
+  ).toBeVisible();
+  await expect(
+    diff.getByRole("heading", { name: "src/lib/new.ts", exact: true }),
+  ).toBeVisible();
+  await expect(
+    diff.getByRole("heading", { name: "docs/old.md", exact: true }),
+  ).toBeVisible();
+  await expect(panels.first()).toContainText("Modified");
+  await expect(panels.first()).toContainText("New content");
 
-  const added = tree.getByRole("treeitem", { name: "new.ts", exact: true });
-  await added.click();
-  await expect(added).toHaveAttribute("aria-selected", "true");
-  await expect(diff).toContainText("src/lib/new.ts");
-  await expect(diff).toContainText("Added");
+  await expect(workspace).toHaveCSS("position", "sticky");
+  await expect(diff).toHaveCSS("overflow-y", "auto");
+  const treeScroll = tree.locator('[data-file-tree-virtualized-scroll="true"]');
+  await expect(treeScroll).toHaveCSS("overflow-y", "auto");
+
+  await workspace.evaluate((node) => {
+    node.style.height = "300px";
+    node.style.minHeight = "0";
+  });
+  await expect
+    .poll(() => diff.evaluate((node) => node.scrollHeight > node.clientHeight))
+    .toBe(true);
+
+  const deleted = tree.getByRole("treeitem", { name: "old.md", exact: true });
+  const deletedPanel = diff.locator(`#changed-file-${pathHex("docs/old.md")}`);
+  await deleted.click();
+  await expect(deleted).toHaveAttribute("aria-selected", "true");
+  await expect
+    .poll(() => diff.evaluate((node) => node.scrollTop))
+    .toBeGreaterThan(0);
+  await expect
+    .poll(async () => {
+      const paneTop = await diff.evaluate(
+        (node) => node.getBoundingClientRect().top,
+      );
+      const paneBottom = await diff.evaluate(
+        (node) => node.getBoundingClientRect().bottom,
+      );
+      const panelTop = await deletedPanel.evaluate(
+        (node) => node.getBoundingClientRect().top,
+      );
+      const panelBottom = await deletedPanel.evaluate(
+        (node) => node.getBoundingClientRect().bottom,
+      );
+      return panelTop >= paneTop && panelBottom <= paneBottom;
+    })
+    .toBe(true);
+  await expect(panels.first()).toBeAttached();
 
   await expect
     .poll(async () => {
@@ -673,7 +717,13 @@ test("commit page presents changed files as a responsive status tree", async ({
     })
     .toBeGreaterThanOrEqual(0);
 
+  await workspace.evaluate((node) => {
+    node.style.removeProperty("height");
+    node.style.removeProperty("min-height");
+  });
   await page.setViewportSize({ width: 600, height: 900 });
+  await expect(workspace).toHaveCSS("position", "static");
+  await expect(diff).toHaveCSS("overflow-y", "visible");
   await expect
     .poll(async () => {
       const treeBottom = await tree.evaluate(


### PR DESCRIPTION
## Summary

- present commit changes in a status-aware file tree and link blame subjects to immutable commit details
- add one accessible pane-resizer contract for the file tree and blame views, with pointer, keyboard, reset, and mobile behavior
- add GitHub-style Markdown formatting controls to issue, pull request, review, comment, and release editors
- refine active editor borders and the compact Crab footer signature

## Verification

- npm run format:check
- npm run typecheck
- npm test — 9 passed
- npm run test:browser — 36 passed
- npm run build
- cargo build -p crab-http-server --release --locked
- live RustFS-backed server with seven real repositories; verified file-tree resize from 356px to 380px and reset to 356px in the browser

## Implementation notes

The file tree and blame panes share packages/repository/src/pane-resizer.tsx so pointer and keyboard behavior cannot drift. At narrow widths, the repository workspace stacks vertically and removes the horizontal resize handle.