### PR TITLE
deploy(http-server): add one-command Compose stack

### DIFF
--- a/.github/workflows/http-server-container.yml
+++ b/.github/workflows/http-server-container.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Validate deployment profiles
         run: |
           jq empty crates/crab-http-server/deploy/ecs/task-definition.example.json
+          docker compose --file crates/crab-http-server/deploy/compose.yaml config --quiet
+          docker run --rm \
+            --volume "$PWD/crates/crab-http-server/deploy/compose.Caddyfile:/etc/caddy/Caddyfile:ro" \
+            caddy:2.10.2-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d \
+            caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
           for values in eks-values.example.yaml gke-values.example.yaml aks-values.example.yaml; do
             docker run --rm \
               --volume "$PWD/crates/crab-http-server/deploy/helm/crab-http-server:/chart:ro" \
@@ -47,5 +52,35 @@ jobs:
           test "$(docker image inspect crab-http-server:test --format '{{.Config.StopSignal}}')" = "SIGTERM"
           docker image inspect crab-http-server:test --format '{{json .Config.Healthcheck.Test}}' | grep -F -- '"healthcheck"'
           test "$(docker run --rm --entrypoint /usr/bin/id crab-http-server:test -u)" = "10001"
+          docker run --rm --entrypoint /usr/bin/test crab-http-server:test \
+            -s /etc/ssl/certs/ca-certificates.crt
           docker run --rm crab-http-server:test --help | grep -F -- "--config"
           docker run --rm crab-http-server:test --config /dev/null repository --help | grep -F -- "create"
+      - name: Exercise the Compose quick start and restart
+        env:
+          CRAB_HTTP_SERVER_IMAGE: crab-http-server:test
+        run: |
+          cleanup() {
+            result=$?
+            if [ "$result" -ne 0 ]; then
+              docker compose --file crates/crab-http-server/deploy/compose.yaml ps --all || true
+              docker compose --file crates/crab-http-server/deploy/compose.yaml logs --no-color || true
+            fi
+            docker compose --file crates/crab-http-server/deploy/compose.yaml \
+              down --volumes --remove-orphans || true
+            exit "$result"
+          }
+          trap cleanup EXIT
+
+          docker compose --file crates/crab-http-server/deploy/compose.yaml \
+            up --detach --no-build --wait --wait-timeout 120
+          curl --fail --silent --show-error http://127.0.0.1:8788/api/repos |
+            jq --exit-status \
+              '.repositories | map(select(.owner == "demo" and .name == "hello")) | length == 1'
+
+          docker compose --file crates/crab-http-server/deploy/compose.yaml down
+          docker compose --file crates/crab-http-server/deploy/compose.yaml \
+            up --detach --no-build --wait --wait-timeout 120
+          curl --fail --silent --show-error http://127.0.0.1:8788/api/repos |
+            jq --exit-status \
+              '.repositories | map(select(.owner == "demo" and .name == "hello")) | length == 1'

--- a/crates/crab-http-server/DESIGN.md
+++ b/crates/crab-http-server/DESIGN.md
@@ -7,10 +7,10 @@ storage, deployment, ownership, cancellation, and recovery boundaries.
 
 > **Current status:** The runtime has a provider-neutral storage root, durable
 > CAS repository catalog, shared identity state, dynamic replica refresh,
-> private management listener, Helm profiles for EKS/GKE/AKS, and an ECS
-> Fargate task profile. Static artifacts do not constitute live cloud
-> qualification. Abrupt write-process crash recovery and index-receipt
-> reconstruction remain incomplete.
+> private management listener, a local Compose profile, Helm profiles for
+> EKS/GKE/AKS, and an ECS Fargate task profile. Static artifacts do not
+> constitute live cloud qualification. Abrupt write-process crash recovery and
+> index-receipt reconstruction remain incomplete.
 
 Use [the HTTP server reference](REFERENCE.md#native-git-push) for operator commands and route limits. Use this document when changing receive, publication, coordination, or recovery code.
 
@@ -72,6 +72,10 @@ The following are deliberate non-goals:
 - No durable state on pod or Fargate scratch disks
 - No Lambda deployment pretending to support the streaming data plane
 - No automatic creation or deletion of the operator's bucket/container
+
+The last rule applies to production roots. The local Compose profile owns a
+dedicated RustFS volume and can safely bootstrap its bucket and demo repository
+inside that explicit development boundary.
 
 ## Use one durable repository catalog
 
@@ -192,6 +196,7 @@ cache and coordination identities from colliding across clouds.
 
 | Runtime | Provider-native identity | URL |
 | --- | --- | --- |
+| Local Compose | Synthetic stack-local credentials | `s3://crab-http-server/repositories` |
 | EKS | EKS Pod Identity | `s3://bucket/root` |
 | GKE | Workload Identity Federation for GKE | `gs://bucket/root` |
 | AKS | Microsoft Entra Workload ID | `az://account/container/root` |
@@ -207,6 +212,31 @@ ECS cannot mount Secrets Manager values as files, so its task entrypoint writes
 three protected files to disposable scratch, unsets the injected environment
 variables, and execs the same binary. Repository, catalog, and session state
 never depend on that scratch volume.
+
+### Preserve local trust through a container proxy
+
+Unauthenticated operation accepts loopback listeners only. Publishing Crab's
+listener directly from an ordinary bridge-network container would require it
+to bind to an unspecified address and would erase that invariant. The Compose
+profile instead shares one network namespace between Crab and a small Caddy
+proxy:
+
+```mermaid
+flowchart LR
+    Host[Host 127.0.0.1] -->|published 8788 → 8080| Proxy[Caddy]
+    subgraph Namespace[shared network namespace]
+      Proxy -->|127.0.0.1:8788| Crab[Crab public listener]
+      Crab -.->|127.0.0.1:8789| Health[private management listener]
+    end
+    Crab -->|Compose-private DNS| Store[(RustFS)]
+```
+
+Caddy disables automatic HTTPS, preserves streaming by flushing upstream
+responses immediately, and normalizes the upstream `Host` to Crab's loopback
+origin. Docker publishes only Caddy's port and restricts it to host loopback.
+No server flag, trusted-proxy escape hatch, or alternate authentication path is
+needed. Production profiles terminate HTTPS at their provider load balancer
+and require OIDC instead.
 
 ### Exclude Lambda from the data plane
 

--- a/crates/crab-http-server/README.md
+++ b/crates/crab-http-server/README.md
@@ -28,8 +28,21 @@ or local Git object database.
 
 ## Build and run
 
-Run from the repository root. You need Node 22.12+, Rust, an existing bucket,
-and storage credentials. Build the frontend first: `build.rs` embeds its output.
+For the fastest local start, use Docker Engine with Compose v2:
+
+```sh
+docker compose --file crates/crab-http-server/deploy/compose.yaml \
+  up --detach --build --wait
+```
+
+Then open <http://127.0.0.1:8788/demo/hello>. The stack creates a persistent
+local object store and demo repository automatically. See the
+[Compose operations guide](deploy/README.md#start-locally-with-docker-compose)
+for repository commands, configuration overrides, and safe teardown.
+
+To build outside Docker, run from the repository root. You need Node 22.12+,
+Rust, an existing bucket, and storage credentials. Build the frontend first:
+`build.rs` embeds its output.
 
 Choose a unique Cargo target directory for this checkout on the mounted workspace
 volume, following root `AGENTS.md`. This example uses `/Volumes/Workspace`:
@@ -67,6 +80,7 @@ and a canonical HTTPS origin. For container deployment, use the
 | Task | Read |
 | --- | --- |
 | Configure catalog, storage root, temporary space, and credentials | [Development setup](REFERENCE.md#run-the-current-development-build) |
+| Start locally with Docker Compose | [Local Compose stack](deploy/README.md#start-locally-with-docker-compose) |
 | Deploy on EKS, GKE, AKS, or ECS | [Deployment profiles](deploy/README.md) |
 | Probe readiness and drain the service | [Container operation](REFERENCE.md#run-the-container) |
 | Understand browser APIs and publication ownership | [Application behavior](REFERENCE.md#repository-browser-and-application-apis) |

--- a/crates/crab-http-server/REFERENCE.md
+++ b/crates/crab-http-server/REFERENCE.md
@@ -222,6 +222,44 @@ the configured management address.
 
 The checked-in image builds the locked React application and Rust server from digest-pinned bases. The runtime installs no packages, runs as UID/GID 10001, embeds the frontend, and uses a dedicated temporary directory.
 
+### Start the complete local stack
+
+Docker Compose provides the shortest path from checkout to a usable server:
+
+```sh
+docker compose --file crates/crab-http-server/deploy/compose.yaml \
+  up --detach --build --wait
+```
+
+The stack provisions its own private RustFS bucket and durable catalog, then
+idempotently creates `demo/hello`. Open
+<http://127.0.0.1:8788/demo/hello> or inspect discovery directly:
+
+```sh
+curl --fail http://127.0.0.1:8788/api/repos
+```
+
+Only Caddy's public port is published, and only on host loopback. Caddy shares
+the server container's network namespace and forwards streaming bodies to
+Crab's `127.0.0.1:8788` listener. Crab therefore retains the same local-trust
+security rule as a direct development process; its `127.0.0.1:8789`
+management listener and RustFS remain unreachable from the host network.
+
+```text
+host loopback                  shared container namespace       private network
+127.0.0.1:8788 ──> Caddy :8080 ──> Crab 127.0.0.1:8788 ──> RustFS :9000
+                                      │
+                                      └──> management 127.0.0.1:8789
+```
+
+The named `repository-data` volume survives `docker compose down` and server
+recreation. Use `down --volumes` only when intentionally deleting the local
+catalog and repositories. This profile has synthetic credentials and no OIDC;
+never expose it remotely. Use the orchestrator profiles below for team service.
+
+The complete command set, image overrides, port and scratch sizing, repository
+administration, and teardown behavior live in `deploy/README.md`.
+
 ### Build the image
 
 Build from the repository root so Docker can access the workspace and frontend inputs:

--- a/crates/crab-http-server/deploy/Dockerfile
+++ b/crates/crab-http-server/deploy/Dockerfile
@@ -26,8 +26,10 @@ RUN printf 'crab:x:10001:\n' >> /etc/group \
     && install -d -o 10001 -g 10001 /etc/crab /var/lib/crab/tmp
 
 COPY --from=builder /build/target/release/crab-http-server /usr/local/bin/crab-http-server
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-ENV TMPDIR=/var/lib/crab/tmp
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    TMPDIR=/var/lib/crab/tmp
 USER crab:crab
 EXPOSE 8788 8789
 STOPSIGNAL SIGTERM

--- a/crates/crab-http-server/deploy/README.md
+++ b/crates/crab-http-server/deploy/README.md
@@ -1,7 +1,7 @@
 # Deployment profiles
 
-`crab-http-server` has one provider-neutral runtime contract and two checked-in
-deployment profiles:
+`crab-http-server` has one provider-neutral runtime contract, a one-command
+local stack, and checked-in production deployment profiles:
 
 ```mermaid
 flowchart LR
@@ -15,6 +15,7 @@ flowchart LR
 
 | Target | Deployment asset | Workload identity | Storage URLs |
 |---|---|---|---|
+| Local Docker | `compose.yaml` | Synthetic local credentials | Private RustFS volume |
 | EKS | `helm/crab-http-server` | EKS Pod Identity association | `s3://bucket/root` |
 | GKE | `helm/crab-http-server` | GKE Workload Identity Federation | `gs://bucket/root` |
 | AKS | `helm/crab-http-server` | AKS Workload ID | `az://account/container/root` |
@@ -23,6 +24,70 @@ flowchart LR
 These assets are portable implementation evidence. A provider is only
 release-qualified after its live test matrix passes; the chart or task
 definition alone is not that claim.
+
+## Start locally with Docker Compose
+
+Docker Engine with Compose v2 is the only prerequisite. From the repository
+root, run:
+
+```sh
+docker compose --file crates/crab-http-server/deploy/compose.yaml \
+  up --detach --build --wait
+```
+
+Open <http://127.0.0.1:8788/demo/hello>. The first start builds the locked
+server image, starts a private RustFS object store, creates its bucket, creates
+the `demo/hello` Crab repository, and waits until the complete stack is ready.
+Later starts are idempotent.
+
+```mermaid
+flowchart LR
+    Browser[Browser / Git] -->|127.0.0.1:8788| Proxy[Caddy stream proxy]
+    Proxy -->|shared loopback| Server[crab-http-server]
+    Server -->|private Compose network| RustFS[(persistent RustFS volume)]
+    Server -. readiness .-> Management[127.0.0.1:8789]
+```
+
+The proxy shares the server's network namespace. It is the only process bound
+to Docker's published port; Crab still binds to loopback and keeps its
+unauthenticated local-trust invariant. The management listener and RustFS are
+not published to the host. This profile is for local development and
+evaluation, not remote or multi-user service.
+
+### Operate the local stack
+
+Use the one-shot repository service to manage the durable catalog:
+
+```sh
+docker compose --file crates/crab-http-server/deploy/compose.yaml run --rm \
+  repository-init --config /etc/crab/server.toml repository create \
+  --owner my-team --name my-project --prefix my-team/my-project
+
+docker compose --file crates/crab-http-server/deploy/compose.yaml run --rm \
+  repository-init --config /etc/crab/server.toml repository list
+```
+
+Inspect or stop the stack without deleting repositories:
+
+```sh
+docker compose --file crates/crab-http-server/deploy/compose.yaml logs --follow server proxy
+docker compose --file crates/crab-http-server/deploy/compose.yaml down
+```
+
+`docker compose ... down --volumes` permanently removes the local RustFS
+volume, including the catalog and every repository. The defaults need no
+`.env` file. These optional environment variables customize local operation:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CRAB_HTTP_SERVER_PORT` | `8788` | Localhost port published by Docker |
+| `CRAB_TMP_SIZE` | `2g` | Bounded receive-pack and index scratch space |
+| `CRAB_HTTP_SERVER_IMAGE` | `crab-http-server:local` | Server image name or prebuilt image reference |
+
+The dependency images are version- and digest-pinned. `RUSTFS_IMAGE`,
+`AWS_CLI_IMAGE`, and `CADDY_IMAGE` exist for controlled mirrors; keep them
+pinned when overriding. To use a prebuilt server image, set
+`CRAB_HTTP_SERVER_IMAGE` and add `--no-build` to `up`.
 
 ## Repository lifecycle
 

--- a/crates/crab-http-server/deploy/compose.Caddyfile
+++ b/crates/crab-http-server/deploy/compose.Caddyfile
@@ -1,0 +1,11 @@
+{
+	admin off
+	auto_https off
+}
+
+:8080 {
+	reverse_proxy 127.0.0.1:8788 {
+		flush_interval -1
+		header_up Host 127.0.0.1:8788
+	}
+}

--- a/crates/crab-http-server/deploy/compose.server.toml
+++ b/crates/crab-http-server/deploy/compose.server.toml
@@ -1,0 +1,5 @@
+listen = "127.0.0.1:8788"
+management_listen = "127.0.0.1:8789"
+
+[storage]
+url = "s3://crab-http-server/repositories"

--- a/crates/crab-http-server/deploy/compose.yaml
+++ b/crates/crab-http-server/deploy/compose.yaml
@@ -1,0 +1,135 @@
+name: crab-http-server
+
+x-server-build: &server-build
+  context: ../../..
+  dockerfile: crates/crab-http-server/deploy/Dockerfile
+
+x-storage-environment: &storage-environment
+  AWS_ACCESS_KEY_ID: crab-local-access
+  AWS_SECRET_ACCESS_KEY: crab-local-secret-key
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_ENDPOINT_URL_S3: http://rustfs:9000
+  AWS_ALLOW_HTTP: "true"
+  AWS_VIRTUAL_HOSTED_STYLE_REQUEST: "false"
+  AWS_EC2_METADATA_DISABLED: "true"
+  AWS_CLI_AUTO_PROMPT: "off"
+  AWS_PAGER: ""
+
+x-server-service: &server-service
+  image: ${CRAB_HTTP_SERVER_IMAGE:-crab-http-server:local}
+  build: *server-build
+  environment: *storage-environment
+  volumes:
+    - ./compose.server.toml:/etc/crab/server.toml:ro
+  read_only: true
+  cap_drop:
+    - ALL
+  security_opt:
+    - no-new-privileges:true
+  tmpfs:
+    - /var/lib/crab/tmp:rw,noexec,nosuid,nodev,size=${CRAB_TMP_SIZE:-2g},uid=10001,gid=10001,mode=0700
+
+services:
+  rustfs:
+    image: ${RUSTFS_IMAGE:-rustfs/rustfs:1.0.0-beta.8-glibc@sha256:040304b66e029a5cde4bed140b41513e925909839a9b912a40a98340610d1f66}
+    environment:
+      RUSTFS_ACCESS_KEY: crab-local-access
+      RUSTFS_SECRET_KEY: crab-local-secret-key
+      RUSTFS_CONSOLE_ENABLE: "false"
+      RUSTFS_OBS_LOG_DIRECTORY: /data/logs
+    volumes:
+      - repository-data:/data
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "http://127.0.0.1:9000/health/ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 5s
+    restart: unless-stopped
+
+  bucket-init:
+    image: ${AWS_CLI_IMAGE:-public.ecr.aws/aws-cli/aws-cli:2.27.41@sha256:1c2d7a51b1ff4f460bc3f1e1ee46a6cef47c7429ad9089ef99012a95e472a1a5}
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        if aws --endpoint-url http://rustfs:9000 s3api head-bucket --bucket crab-http-server 2>/dev/null; then
+          exit 0
+        fi
+        aws --endpoint-url http://rustfs:9000 s3api create-bucket --bucket crab-http-server
+    environment: *storage-environment
+    user: "65534:65534"
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=16m,uid=65534,gid=65534,mode=0700
+    restart: "no"
+
+  repository-init:
+    <<: *server-service
+    command:
+      - --config
+      - /etc/crab/server.toml
+      - repository
+      - create
+      - --owner
+      - demo
+      - --name
+      - hello
+      - --prefix
+      - demo/hello
+      - --description
+      - A repository created by Docker Compose
+    depends_on:
+      bucket-init:
+        condition: service_completed_successfully
+    restart: "no"
+
+  server:
+    <<: *server-service
+    ports:
+      - 127.0.0.1:${CRAB_HTTP_SERVER_PORT:-8788}:8080
+    depends_on:
+      repository-init:
+        condition: service_completed_successfully
+    stop_grace_period: 10m
+    restart: unless-stopped
+
+  proxy:
+    image: ${CADDY_IMAGE:-caddy:2.10.2-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d}
+    network_mode: service:server
+    user: "65534:65534"
+    volumes:
+      - ./compose.Caddyfile:/etc/caddy/Caddyfile:ro
+    read_only: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /config:rw,noexec,nosuid,nodev,size=8m,uid=65534,gid=65534,mode=0700
+      - /data:rw,noexec,nosuid,nodev,size=8m,uid=65534,gid=65534,mode=0700
+    depends_on:
+      server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "http://127.0.0.1:8080/api/repos"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 2s
+    restart: unless-stopped
+
+volumes:
+  repository-data:


### PR DESCRIPTION
## Summary

- add a one-command Docker Compose stack with persistent RustFS storage and idempotent bucket/repository bootstrap
- preserve unauthenticated loopback trust through a Caddy sidecar sharing the server network namespace
- add the CA trust bundle required by HTTPS storage and OIDC to the minimal runtime image
- document local operation, customization, persistence, and safe teardown in the server reference and design
- qualify startup and durable restart through the container CI workflow

## Proof

- `docker compose --file crates/crab-http-server/deploy/compose.yaml config --quiet`
- Caddy configuration and least-capability execution under its final non-root, read-only runtime constraints
- RustFS readiness plus two consecutive successful bucket bootstrap runs
- HTTP server container CI: production image build, runtime/CA contract, repository bootstrap, public proxy request, teardown, and persisted restart
- workflow YAML parse and `git diff --check`

The full Compose qualification is green in the HTTP server container workflow.