### PR TITLE
feat(repository): add format-aware file previews

### DIFF
--- a/crates/crab-http-server/REFERENCE.md
+++ b/crates/crab-http-server/REFERENCE.md
@@ -360,7 +360,7 @@ The blame view links commit OIDs and subjects to immutable commit details. Its a
 | Repository root | Selected commit, file table, repository details, rendered README, request timing, and Code menu |
 | Branch and tag picker | Search, keyboard navigation, default-branch state, and writer-only creation from the viewed commit |
 | Branches and tags | Natural sorting, protected/default labels, copied names, immutable tips, default comparison, and guarded deletion |
-| Tree and file workspace | Resizable lazy folder-first tree, preserved expansion, breadcrumbs, source, preview, blame, raw bytes, copy, download, edit, and delete |
+| Tree and file workspace | Resizable lazy folder-first tree, preserved expansion, breadcrumbs, source, format-aware preview, blame, raw bytes, copy, download, edit, and delete |
 | History and comparison | Signed pagination, first-parent path history, a persistent change tree with independently scrolling jump-linked diffs, split/unified layouts, and exact revision links |
 | Go to file | Bounded full-tree fuzzy search without blob reads; `T` opens and focuses search |
 | Releases | Releases/Tags navigation, search, drafts, publication, edits, deletion, source ZIPs, and binary assets |
@@ -405,7 +405,11 @@ Root commits compare against an empty tree. Path history follows the exact first
 
 ### Render repository content safely
 
-Markdown README files render beneath directory listings. Markdown file views switch between source, preview, and blame.
+Markdown README files render beneath directory listings. Recognized file views switch between source and a format-aware preview; ordinary UTF-8 Git blobs also offer blame.
+
+Preview-capable formats include raster and SVG images, PDF, common audio and video containers, CSV/TSV, JSON/JSON Lines, Jupyter notebooks, Office Open XML and OpenDocument packages, SQLite, Parquet, Arrow/Feather, NumPy/NPZ, Safetensors, GGUF, ZIP-derived packages, and TAR archives. Data formats share searchable, paginated tables. Crab runs only read queries against an in-browser SQLite copy, notebooks never execute cells or HTML outputs, and model previews inspect metadata without loading or running weights. Office previews preserve document text, worksheets, and slide structure rather than promising pixel-identical desktop rendering.
+
+Preview parsers are loaded only for the selected format and run in the signed-in browser. Crab does not send repository contents to a third-party conversion service. Source text is embedded in JSON only through 1 MiB; recognized larger text formats fetch their exact bytes for preview. Unrecognized binary formats use a bounded universal inspector with extension hints, magic-signature detection, a safe text sample when applicable, and a 512-byte hex/ASCII view. Interactive previews are capped at 50 MiB; oversized files retain exact raw and download actions with an explicit fallback instead of attempting unbounded parsing.
 
 Relative links stay inside the selected repository revision. Relative raster images load through the signature-checked `asset` endpoint. SVG, other local formats, and external images remain links. This prevents repository content from becoming same-origin active content or forcing signed-in browsers to contact third-party hosts.
 

--- a/crates/crab-http-server/deploy/Dockerfile
+++ b/crates/crab-http-server/deploy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:22.12.0-bookworm-slim@sha256:35531c52ce27b6575d69755c73e65d4468dba93a25644eed56dc12879cae9213 AS frontend
+FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS frontend
 
 WORKDIR /build
 COPY packages/repository/package.json packages/repository/package-lock.json packages/repository/

--- a/crates/crab-http-server/src/api.rs
+++ b/crates/crab-http-server/src/api.rs
@@ -17,6 +17,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{auth::Principal, server::Server};
 
+const MAX_INLINE_TEXT_BYTES: usize = 1024 * 1024;
+
 #[derive(Clone, Copy, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Action {
@@ -486,12 +488,13 @@ async fn optional_blob(
 }
 
 fn content_json(blob: &Blob) -> Value {
-    let text = if blob.bytes.contains(&0) {
+    let decoded = if blob.bytes.contains(&0) {
         None
     } else {
         std::str::from_utf8(&blob.bytes).ok()
     };
-    json!({"oid":blob.metadata.oid.to_string(),"size":blob.bytes.len(),"mode":format!("{:06o}",blob.metadata.mode.raw()),"classification":format!("{:?}",blob.metadata.classification),"text":text})
+    let text = decoded.filter(|_| blob.bytes.len() <= MAX_INLINE_TEXT_BYTES);
+    json!({"oid":blob.metadata.oid.to_string(),"size":blob.bytes.len(),"mode":format!("{:06o}",blob.metadata.mode.raw()),"classification":format!("{:?}",blob.metadata.classification),"text":text,"text_truncated":decoded.is_some() && text.is_none()})
 }
 
 fn image_content_type(bytes: &[u8]) -> Option<&'static str> {
@@ -683,6 +686,17 @@ mod tests {
                 < search_score("src/engine/chunk_file.rs", "cfr").unwrap()
         );
         assert!(search_score("src/engine/chunk_file.rs", "not-here").is_none());
+    }
+
+    #[test]
+    fn file_metadata_keeps_large_utf8_available_without_embedding_it_in_json() {
+        let value = content_json(&blob(&vec![b'x'; MAX_INLINE_TEXT_BYTES + 1]));
+        assert_eq!(value["text"], Value::Null);
+        assert_eq!(value["text_truncated"], true);
+
+        let value = content_json(&blob(b"small text"));
+        assert_eq!(value["text"], "small text");
+        assert_eq!(value["text_truncated"], false);
     }
 
     #[test]

--- a/crates/crab-http-server/src/assets.rs
+++ b/crates/crab-http-server/src/assets.rs
@@ -34,7 +34,7 @@ pub(crate) async fn serve(request: Request) -> Response {
     };
     let content_type = match name.rsplit('.').next() {
         Some("html") => "text/html; charset=utf-8",
-        Some("js") => "text/javascript; charset=utf-8",
+        Some("js" | "mjs") => "text/javascript; charset=utf-8",
         Some("css") => "text/css; charset=utf-8",
         Some("svg") => "image/svg+xml",
         Some("json") => "application/json",
@@ -108,6 +108,26 @@ mod tests {
                 .unwrap()
                 .to_bytes()
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn javascript_modules_receive_an_executable_media_type() {
+        let path = ASSETS
+            .iter()
+            .map(|(name, _)| *name)
+            .find(|name| name.ends_with(".mjs"))
+            .expect("the repository bundle includes an ES module asset");
+        let response = serve(
+            Request::builder()
+                .uri(format!("/{path}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            response.headers()["content-type"],
+            "text/javascript; charset=utf-8"
         );
     }
 }

--- a/crates/crab-http-server/src/server.rs
+++ b/crates/crab-http-server/src/server.rs
@@ -664,7 +664,7 @@ async fn boundary(State(server): State<Arc<Server>>, mut request: Request, next:
         [
             ("x-content-type-options", "nosniff"),
             ("referrer-policy", "same-origin"),
-            ("content-security-policy", "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; img-src 'self' data: blob:; base-uri 'none'; frame-ancestors 'none'"),
+            ("content-security-policy", "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"),
         ], response,
     ).into_response()
 }

--- a/packages/repository/package-lock.json
+++ b/packages/repository/package-lock.json
@@ -652,9 +652,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -674,9 +671,6 @@
       "integrity": "sha512-Ls5UWYFFn63casTZEczbeyEg3vRDRkv9lscuGwfchtY5yLLQhgOB8SN4YGxmfJ5vTaBwZ2YUxBS3NtmjJmFXdA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -698,9 +692,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -721,9 +712,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,9 +731,6 @@
       "integrity": "sha512-xrGvmS3v55hmZ86ls/kBLVNMUTYio3f6Ik0DireemG994VfPAwiA3ZXA0Uf1bByctkB3NQ1Sfb+H5bkdUnnzfQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -808,9 +793,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -905,6 +887,17 @@
       "peerDependencies": {
         "react": "^18.3.1 || ^19.0.0",
         "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/trees/node_modules/@pierre/theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "vscode": "^1.0.0"
       }
     },
     "node_modules/@pierre/trees/node_modules/@pierre/theming": {
@@ -1144,9 +1137,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1161,9 +1151,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1178,9 +1165,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,9 +1179,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,9 +1193,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1229,9 +1207,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,9 +1221,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1263,9 +1235,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,9 +1249,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1297,9 +1263,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1314,9 +1277,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1331,9 +1291,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1348,9 +1305,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/repository/package-lock.json
+++ b/packages/repository/package-lock.json
@@ -13,11 +13,18 @@
         "@primer/octicons-react": "19.22.0",
         "@primer/primitives": "11.10.0",
         "@primer/react": "38.38.0",
+        "apache-arrow": "21.2.0",
+        "fflate": "0.8.3",
+        "hyllama": "0.2.2",
+        "hyparquet": "1.30.1",
+        "hyparquet-compressors": "1.1.1",
+        "pdfjs-dist": "6.3.289",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-is": "19.2.4",
         "react-markdown": "10.1.0",
-        "remark-gfm": "4.0.1"
+        "remark-gfm": "4.0.1",
+        "sql.js": "1.14.2"
       },
       "devDependencies": {
         "@axe-core/playwright": "4.13.0",
@@ -25,6 +32,8 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@types/react-is": "19.2.0",
+        "@types/sql.js": "1.4.11",
+        "hyparquet-writer": "0.16.9",
         "prettier": "3.8.3",
         "typescript": "5.9.3",
         "vite": "7.3.6",
@@ -526,6 +535,271 @@
       "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.9.tgz",
+      "integrity": "sha512-QviPdJImDi/jMAvBfqaw+19BndMd/sizXVW3NnpMd3VJGz++QXkOHcP9kWR/smHG0hNjHeyuHFyrx/5lD0oNcQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.9",
+        "@napi-rs/canvas-darwin-arm64": "1.0.9",
+        "@napi-rs/canvas-darwin-x64": "1.0.9",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.9",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.9",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.9",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.9",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.9",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.9",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.9",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.9"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.9.tgz",
+      "integrity": "sha512-4LGXk2/0HVzE29K8SzML5WubgCp++B1FH3qgl35XmSZE+lLdr6P9VRQEnZ0MCLZMTSuJP41yyhtoiVNEuvrTIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.9.tgz",
+      "integrity": "sha512-YNdfLBzY0W/Pep9fo2L6RmoNlNksnn05LRnX66W63R3ij58S25QOTcjdtEt2v8+PnCESzqZsYzUo+QPeIR44NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.9.tgz",
+      "integrity": "sha512-ceZQSknTEcy3dOXoekv59LTCkXjvnLsq+VW5PeNNDHEPQbRS5Ervkm1EaDa7WLAjiYWMLuSQTRTHao1dEX4prg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.9.tgz",
+      "integrity": "sha512-XhfI0Wwv4llhd6nnWDtY3kQKjq0r+y1i91PlJlJI24ag2U9WrnwbG1qS3+fDLEyouwEVFchiKkTEHozK+5iUNA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.9.tgz",
+      "integrity": "sha512-012oiYtKaE7i9oxc8q7nraT7kDOpLcaCmFLzVe9Ty34RHDdoDzbWLrVh827CNxYh/EADX1eSikA3ymLjo/nNuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.9.tgz",
+      "integrity": "sha512-Ls5UWYFFn63casTZEczbeyEg3vRDRkv9lscuGwfchtY5yLLQhgOB8SN4YGxmfJ5vTaBwZ2YUxBS3NtmjJmFXdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.9.tgz",
+      "integrity": "sha512-hLKEGxV7ZiRHqndePTokgDMdBlo/rDfzg7P4p4QIv9pUhuYobnu3R2NIFLCRghG0nwfo+s2sw+c1xZFeCmEAsw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.9.tgz",
+      "integrity": "sha512-6kaz3w0QMy77PDWk6rJ1ksIihdad3qzEyX2o2oGT8GwCaypfT5mhjr8buOO5hstyLxcWXDScuz56RsINLtBPIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.9.tgz",
+      "integrity": "sha512-xrGvmS3v55hmZ86ls/kBLVNMUTYio3f6Ik0DireemG994VfPAwiA3ZXA0Uf1bByctkB3NQ1Sfb+H5bkdUnnzfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.9.tgz",
+      "integrity": "sha512-yjmVS3ArZeRVCP7jqbPq4rpZa/BhTeI7ELE2XqJg3snICQBDevLZyArxswHkiTnT34KRic33/4fLirrHI+SY8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.9.tgz",
+      "integrity": "sha512-QlSYQdMQslB81nlABo9wNfQ6npFhE7/O+saCZdqVGueGanyRk4jCogD5EwQenfP3kIq9e+mm6GreQBjX5MrA8g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
@@ -631,17 +905,6 @@
       "peerDependencies": {
         "react": "^18.3.1 || ^19.0.0",
         "react-dom": "^18.3.1 || ^19.0.0"
-      }
-    },
-    "node_modules/@pierre/trees/node_modules/@pierre/theme": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.1.0.tgz",
-      "integrity": "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "vscode": "^1.0.0"
       }
     },
     "node_modules/@pierre/trees/node_modules/@pierre/theming": {
@@ -1352,6 +1615,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.6",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.6.tgz",
+      "integrity": "sha512-uN+9i8bFT5CUcZfyIEYDrSueACEyKGbUs5kC/72DGlZZoinh84sJfVV0i8UOJD1asdzkvLPBRrKs41kZ8MdEXg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1391,6 +1661,15 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.6.tgz",
+      "integrity": "sha512-JR6Q/PV5DKFvjrGFVqQJdeG0qvsqQQLDa3TzFrqVwhqRXqwNaxPo2KYCtCQXpOdIulCouKwT7a6in9nFthBAzw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1418,6 +1697,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -1543,6 +1833,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/apache-arrow": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.2.0.tgz",
+      "integrity": "sha512-Hxe6Agq26gQOM954qpzYSllJBPJl+e16U5CkfuMUhLrNba+5nKkttIVlflaovN6oaTratqMGAO8H5u/aNhmHWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^25.2.0",
+        "flatbuffers": "^25.1.24",
+        "json-with-bigint": "^3.5.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
       }
     },
     "node_modules/assertion-error": {
@@ -1858,6 +2163,18 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/focus-visible": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.1.tgz",
@@ -1878,6 +2195,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
@@ -1977,6 +2300,51 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/hyllama": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/hyllama/-/hyllama-0.2.2.tgz",
+      "integrity": "sha512-3mwjn9Z+8YPprLGtDZFEWAHKRO2Mv+QFCfEWmZswjQksVrBr+fvE/6t8c1Zm1Pfu92y98Nc930N7ZKIFaprMlQ==",
+      "license": "MIT"
+    },
+    "node_modules/hyparquet": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.30.1.tgz",
+      "integrity": "sha512-307mnGbxzx0nXPGTV6Mhp10gKIu6t+NhvBQJF+PVQsHA295sqznlVOqEAH+fohH2Rqx7NV0Myh9rmuM9E9Ch+w==",
+      "license": "MIT"
+    },
+    "node_modules/hyparquet-compressors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
+      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
+      "license": "MIT",
+      "dependencies": {
+        "fzstd": "0.1.1",
+        "hysnappy": "1.0.0"
+      }
+    },
+    "node_modules/hyparquet-writer": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/hyparquet-writer/-/hyparquet-writer-0.16.9.tgz",
+      "integrity": "sha512-VZvH4Vq9lQwZa/+1y4YrEwF9+FAe5pED+mVN4AHflCoFk5LG2RemMHW9iwVlVqug7fO3ATwEMSG68cr3uZAkjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hyparquet": "1.29.2"
+      }
+    },
+    "node_modules/hyparquet-writer/node_modules/hyparquet": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.29.2.tgz",
+      "integrity": "sha512-2LxinZ8X0JqToST+9OXcy9t3t5Q7ZneMTkSqUx/36Hv18pCTk/N71IWZc7APTSNG1Me39l/jjEvzZSZ0R+Knbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hysnappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
+      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
+      "license": "MIT"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -2038,6 +2406,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.12.tgz",
+      "integrity": "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==",
+      "license": "MIT"
     },
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
@@ -3008,6 +3382,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdfjs-dist": {
+      "version": "6.3.289",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.3.289.tgz",
+      "integrity": "sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3415,6 +3801,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sql.js": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.2.tgz",
+      "integrity": "sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw==",
+      "license": "MIT"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3525,6 +3917,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3538,6 +3936,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -18,11 +18,18 @@
     "@primer/octicons-react": "19.22.0",
     "@primer/primitives": "11.10.0",
     "@primer/react": "38.38.0",
+    "apache-arrow": "21.2.0",
+    "fflate": "0.8.3",
+    "hyllama": "0.2.2",
+    "hyparquet": "1.30.1",
+    "hyparquet-compressors": "1.1.1",
+    "pdfjs-dist": "6.3.289",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-is": "19.2.4",
     "react-markdown": "10.1.0",
-    "remark-gfm": "4.0.1"
+    "remark-gfm": "4.0.1",
+    "sql.js": "1.14.2"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.13.0",
@@ -30,6 +37,8 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/react-is": "19.2.0",
+    "@types/sql.js": "1.4.11",
+    "hyparquet-writer": "0.16.9",
     "prettier": "3.8.3",
     "typescript": "5.9.3",
     "vite": "7.3.6",

--- a/packages/repository/src/api.ts
+++ b/packages/repository/src/api.ts
@@ -78,6 +78,7 @@ export interface Content {
   mode: string;
   classification: string;
   text: string | null;
+  text_truncated: boolean;
 }
 export interface Change {
   path: string;

--- a/packages/repository/src/content.tsx
+++ b/packages/repository/src/content.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useEffect,
   useMemo,
   useRef,
@@ -31,8 +33,15 @@ import {
 } from "./api";
 import { Link, Result, date, short } from "./ui";
 import { compareFileItems } from "./entry-sort";
-import { RepositoryMarkdown } from "./repository-markdown";
 import { PaneResizer } from "./pane-resizer";
+import {
+  previewDescriptor,
+  type PreviewDescriptor,
+} from "./file-preview-model";
+
+const FilePreview = lazy(() =>
+  import("./file-preview").then((module) => ({ default: module.FilePreview })),
+);
 
 type Props = {
   repo: Repository;
@@ -74,14 +83,26 @@ function changePanelId(pathHex: string) {
 }
 
 export function FileView({ repo, rev, path, name, theme, write }: Props) {
+  const preview = previewDescriptor(name);
+  const previewFirst =
+    preview !== null &&
+    !["markdown", "delimited", "json"].includes(preview.kind);
   const state = useRequest<Content>(
     endpoint(repo, "file", { rev, path_hex: path }),
   );
-  const [view, setView] = useState<"code" | "preview" | "blame">("code");
+  const [view, setView] = useState<"code" | "preview" | "blame">(
+    previewFirst ? "preview" : "code",
+  );
   const [blamePaneWidth, setBlamePaneWidth] = useState(
     DEFAULT_BLAME_PANE_WIDTH,
   );
   const [copied, setCopied] = useState(false);
+  useEffect(() => {
+    setView(previewFirst ? "preview" : "code");
+  }, [path, previewFirst]);
+  useEffect(() => {
+    if (preview === null && state.data?.text === null) setView("preview");
+  }, [preview, state.data?.oid, state.data?.text]);
   const blame = useRequest<Blame>(
     view === "blame" ? endpoint(repo, "blame", { rev, path_hex: path }) : null,
   );
@@ -97,6 +118,11 @@ export function FileView({ repo, rev, path, name, theme, write }: Props) {
     () => ({ theme: themes, themeType: theme, disableFileHeader: true }),
     [theme],
   );
+  const activePreview: PreviewDescriptor | null =
+    preview ??
+    (state.data?.text === null
+      ? { kind: "generic", label: "File inspector" }
+      : null);
   return (
     <Result state={state}>
       {(content) => (
@@ -106,28 +132,37 @@ export function FileView({ repo, rev, path, name, theme, write }: Props) {
               <SegmentedControl
                 aria-label="File view"
                 onChange={(index) => {
-                  const views =
-                    /\.(?:md|markdown)$/i.test(name) && content.text !== null
-                      ? (["code", "preview", "blame"] as const)
-                      : (["code", "blame"] as const);
+                  const views = [
+                    "code",
+                    ...(activePreview ? (["preview"] as const) : []),
+                    ...(content.text !== null &&
+                    content.classification === "OrdinaryGit"
+                      ? (["blame"] as const)
+                      : []),
+                  ] as const;
                   setView(views[index] ?? "code");
                 }}
               >
                 <SegmentedControl.Button selected={view === "code"}>
-                  Code
+                  {content.text === null ? "Info" : "Code"}
                 </SegmentedControl.Button>
-                {/\.(?:md|markdown)$/i.test(name) && content.text !== null && (
+                {activePreview && (
                   <SegmentedControl.Button selected={view === "preview"}>
                     Preview
                   </SegmentedControl.Button>
                 )}
-                <SegmentedControl.Button selected={view === "blame"}>
-                  Blame
-                </SegmentedControl.Button>
+                {content.text !== null &&
+                  content.classification === "OrdinaryGit" && (
+                    <SegmentedControl.Button selected={view === "blame"}>
+                      Blame
+                    </SegmentedControl.Button>
+                  )}
               </SegmentedControl>
               <span className="file-metadata muted">
                 {content.text === null
-                  ? "Binary"
+                  ? content.text_truncated
+                    ? (activePreview?.label ?? "Large text file")
+                    : (activePreview?.label ?? "Binary file")
                   : `${content.text === "" ? 0 : content.text.split("\n").length - Number(content.text.endsWith("\n"))} lines`}{" "}
                 <span aria-hidden="true">·</span> {formatSize(content.size)}
               </span>
@@ -208,20 +243,36 @@ export function FileView({ repo, rev, path, name, theme, write }: Props) {
           {view === "blame" && (blame.loading || blame.error) && (
             <Result state={blame}>{() => null}</Result>
           )}
-          {content.text === null ? (
-            <div className="notice">
-              <strong>Binary file</strong>
-              <p>Download this file to view its contents.</p>
-            </div>
-          ) : view === "preview" ? (
-            <RepositoryMarkdown
-              repo={repo}
-              rev={rev}
-              directory={parentHex(path)}
-              className="file-markdown-preview"
+          {view === "preview" && activePreview ? (
+            <Suspense
+              fallback={
+                <div className="file-preview-notice" role="status">
+                  Loading preview tools…
+                </div>
+              }
             >
-              {content.text}
-            </RepositoryMarkdown>
+              <FilePreview
+                descriptor={activePreview}
+                repo={repo}
+                rev={rev}
+                directory={parentHex(path)}
+                name={name}
+                text={content.text}
+                size={content.size}
+                blobUrl={endpoint(repo, "blob", { rev, path_hex: path })}
+              />
+            </Suspense>
+          ) : content.text === null ? (
+            <div className="notice">
+              <strong>
+                {content.text_truncated ? "Large text file" : "Binary file"}
+              </strong>
+              <p>
+                {content.text_truncated
+                  ? "Inline source is limited to 1 MB. Download the exact stored bytes to inspect the complete file."
+                  : "Crab does not recognize a safe interactive preview for this format. Download the exact stored bytes to inspect it locally."}
+              </p>
+            </div>
           ) : view === "blame" ? (
             blame.data ? (
               <div className="blame-view" aria-label="Blame view">

--- a/packages/repository/src/data-explorer.tsx
+++ b/packages/repository/src/data-explorer.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import { SearchIcon } from "@primer/octicons-react";
+import { Button } from "@primer/react";
+import { displayCell, type TableData } from "./file-preview-model";
+
+const PAGE_SIZE = 100;
+
+export function DataTable({ data, name }: { data: TableData; name: string }) {
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(0);
+  const filtered = useMemo(() => {
+    const term = query.trim().toLocaleLowerCase();
+    if (!term) return data.rows;
+    return data.rows.filter((row) =>
+      row.some((value) =>
+        displayCell(value).toLocaleLowerCase().includes(term),
+      ),
+    );
+  }, [data.rows, query]);
+  const pages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const current = Math.min(page, pages - 1);
+  const rows = filtered.slice(current * PAGE_SIZE, (current + 1) * PAGE_SIZE);
+  if (!data.columns.length)
+    return (
+      <div className="file-preview-notice" role="status">
+        No tabular records were found in this file.
+      </div>
+    );
+  return (
+    <section className="data-explorer" aria-label={`${name} data explorer`}>
+      <header className="data-explorer-toolbar">
+        <label className="data-search">
+          <SearchIcon aria-hidden="true" />
+          <span className="sr-only">Search rows</span>
+          <input
+            type="search"
+            value={query}
+            placeholder="Search loaded rows"
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setPage(0);
+            }}
+          />
+        </label>
+        <span className="muted">
+          {filtered.length.toLocaleString()} loaded
+          {data.totalRows !== data.rows.length
+            ? ` · ${data.totalRows.toLocaleString()} total`
+            : ""}
+          {" · "}
+          {data.columns.length.toLocaleString()} columns
+        </span>
+      </header>
+      <div className="data-grid-scroll" tabIndex={0}>
+        <table className="data-grid">
+          <caption className="sr-only">{name}</caption>
+          <thead>
+            <tr>
+              <th className="data-row-number" scope="col">
+                #
+              </th>
+              {data.columns.map((column, columnIndex) => (
+                <th key={`${column}:${columnIndex}`} scope="col">
+                  {column}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={current * PAGE_SIZE + rowIndex}>
+                <th className="data-row-number" scope="row">
+                  {current * PAGE_SIZE + rowIndex + 1}
+                </th>
+                {data.columns.map((column, columnIndex) => (
+                  <td
+                    key={`${column}:${columnIndex}`}
+                    title={displayCell(row[columnIndex])}
+                  >
+                    {displayCell(row[columnIndex])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <footer className="data-explorer-footer">
+        <span className="muted">
+          {data.note ?? "All loaded rows are shown."}
+        </span>
+        {pages > 1 && (
+          <div className="data-pagination">
+            <Button
+              disabled={current === 0}
+              onClick={() => setPage(current - 1)}
+            >
+              Previous
+            </Button>
+            <span>
+              Page {current + 1} of {pages}
+            </span>
+            <Button
+              disabled={current + 1 === pages}
+              onClick={() => setPage(current + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        )}
+      </footer>
+    </section>
+  );
+}

--- a/packages/repository/src/file-preview-loaders.ts
+++ b/packages/repository/src/file-preview-loaders.ts
@@ -1,0 +1,169 @@
+import {
+  extension,
+  parseNumpyHeader,
+  tableFromValues,
+  type TableData,
+} from "./file-preview-model";
+import { unzipSelected } from "./file-preview-office";
+
+export type DatabasePreview = {
+  tables: Array<{
+    name: string;
+    type: string;
+    definition: string;
+    data: TableData;
+  }>;
+};
+
+export async function loadSqlite(bytes: Uint8Array): Promise<DatabasePreview> {
+  const [{ default: initSqlJs }, { default: wasmUrl }] = await Promise.all([
+    import("sql.js"),
+    import("sql.js/dist/sql-wasm.wasm?url"),
+  ]);
+  const SQL = await initSqlJs({ locateFile: () => wasmUrl });
+  const database = new SQL.Database(bytes);
+  try {
+    const catalog = database.exec(
+      "SELECT name, type, COALESCE(sql, '') FROM sqlite_master " +
+        "WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' ORDER BY name LIMIT 50",
+    )[0];
+    const tables = (catalog?.values ?? []).map(
+      ([nameValue, typeValue, definitionValue]) => {
+        const name = String(nameValue);
+        const escaped = name.replaceAll('"', '""');
+        const sample = database.exec(`SELECT * FROM "${escaped}" LIMIT 100`)[0];
+        return {
+          name,
+          type: String(typeValue),
+          definition: String(definitionValue),
+          data: {
+            columns: sample?.columns ?? [],
+            rows: sample?.values ?? [],
+            totalRows: sample?.values.length ?? 0,
+            note: "Showing at most 100 rows. Crab runs only read queries against an in-browser copy.",
+          },
+        };
+      },
+    );
+    return { tables };
+  } finally {
+    database.close();
+  }
+}
+
+export async function loadParquet(bytes: Uint8Array): Promise<TableData> {
+  const [{ parquetMetadataAsync, parquetReadObjects }, { compressors }] =
+    await Promise.all([import("hyparquet"), import("hyparquet-compressors")]);
+  const file = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+  const metadata = await parquetMetadataAsync(file);
+  const totalRows = Number(metadata.num_rows);
+  const rows = await parquetReadObjects({
+    file,
+    compressors,
+    rowStart: 0,
+    rowEnd: Math.min(totalRows, 500),
+  });
+  return {
+    ...tableFromValues(rows),
+    totalRows,
+    note:
+      totalRows > rows.length
+        ? `Showing ${rows.length.toLocaleString()} of ${totalRows.toLocaleString()} rows.`
+        : undefined,
+  };
+}
+
+export async function loadArrow(bytes: Uint8Array): Promise<TableData> {
+  const { tableFromIPC } = await import("apache-arrow");
+  const table = tableFromIPC(bytes);
+  const columns = table.schema.fields.map((field) => field.name);
+  const count = Math.min(table.numRows, 500);
+  const vectors = columns.map((_, index) => table.getChildAt(index));
+  const rows = Array.from({ length: count }, (_, row) =>
+    vectors.map((vector) => vector?.get(row)),
+  );
+  return {
+    columns,
+    rows,
+    totalRows: table.numRows,
+    note:
+      table.numRows > count
+        ? `Showing ${count.toLocaleString()} of ${table.numRows.toLocaleString()} rows.`
+        : undefined,
+  };
+}
+
+export async function loadNumpy(
+  bytes: Uint8Array,
+  name: string,
+): Promise<TableData> {
+  if (extension(name) === "npy") {
+    const array = parseNumpyHeader(bytes);
+    return {
+      columns: ["Array", "Data type", "Shape", "Memory order", "Data bytes"],
+      rows: [
+        [
+          name.split("/").pop() ?? name,
+          array.dtype,
+          array.shape.join(" × ") || "scalar",
+          array.order,
+          bytes.byteLength - array.dataOffset,
+        ],
+      ],
+      totalRows: 1,
+    };
+  }
+  const files = await unzipSelected(bytes, (path) =>
+    path.toLowerCase().endsWith(".npy"),
+  );
+  const rows = Object.entries(files).map(([path, value]) => {
+    const array = parseNumpyHeader(value);
+    return [
+      path,
+      array.dtype,
+      array.shape.join(" × ") || "scalar",
+      array.order,
+      value.byteLength - array.dataOffset,
+    ];
+  });
+  return {
+    columns: ["Array", "Data type", "Shape", "Memory order", "Data bytes"],
+    rows,
+    totalRows: rows.length,
+  };
+}
+
+export async function loadGguf(bytes: Uint8Array): Promise<{
+  metadata: TableData;
+  tensors: TableData;
+}> {
+  const { ggufMetadata } = await import("hyllama");
+  const value = ggufMetadata(
+    bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer,
+  );
+  const metadataRows = Object.entries(value.metadata);
+  return {
+    metadata: {
+      columns: ["Property", "Value"],
+      rows: metadataRows,
+      totalRows: metadataRows.length,
+    },
+    tensors: {
+      columns: ["Tensor", "Dimensions", "Shape", "Type", "Offset"],
+      rows: value.tensorInfos.map((tensor) => [
+        tensor.name,
+        tensor.nDims,
+        tensor.shape.join(" × "),
+        tensor.type,
+        tensor.offset,
+      ]),
+      totalRows: value.tensorInfos.length,
+    },
+  };
+}

--- a/packages/repository/src/file-preview-model.test.ts
+++ b/packages/repository/src/file-preview-model.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseDelimited,
+  parseJsonTable,
+  parseNumpyHeader,
+  parseSafetensors,
+  previewDescriptor,
+} from "./file-preview-model";
+
+describe("file preview classification", () => {
+  it.each([
+    ["diagram.svg", "image"],
+    ["paper.PDF", "pdf"],
+    ["metrics.csv", "delimited"],
+    ["analysis.ipynb", "notebook"],
+    ["report.xlsx", "office"],
+    ["events.sqlite3", "sqlite"],
+    ["features.parquet", "parquet"],
+    ["batch.arrow", "arrow"],
+    ["weights.safetensors", "safetensors"],
+    ["model.gguf", "gguf"],
+    ["package.whl", "archive"],
+  ])("routes %s to the %s preview", (name, kind) => {
+    expect(previewDescriptor(name)?.kind).toBe(kind);
+  });
+
+  it("leaves unknown executable formats on the exact-byte fallback", () => {
+    expect(previewDescriptor("release.exe")).toBeNull();
+  });
+});
+
+describe("tabular previews", () => {
+  it("parses quoted delimiters, escaped quotes, and line breaks", () => {
+    expect(
+      parseDelimited(
+        'name,notes\nAlice,"one,two"\nBob,"said ""ship""\nnow"\n',
+        ",",
+      ),
+    ).toMatchObject({
+      columns: ["name", "notes"],
+      rows: [
+        ["Alice", "one,two"],
+        ["Bob", 'said "ship"\nnow'],
+      ],
+      totalRows: 2,
+    });
+  });
+
+  it("normalizes JSON objects into a union-column table", () => {
+    expect(
+      parseJsonTable('[{"name":"Alice"},{"name":"Bob","score":9}]', false),
+    ).toEqual({
+      columns: ["name", "score"],
+      rows: [
+        ["Alice", undefined],
+        ["Bob", 9],
+      ],
+      totalRows: 2,
+      note: undefined,
+    });
+  });
+});
+
+describe("machine-learning metadata previews", () => {
+  it("reads Safetensors tensor names, shapes, and byte spans", () => {
+    const header = new TextEncoder().encode(
+      JSON.stringify({
+        encoder: { dtype: "F32", shape: [2, 3], data_offsets: [0, 24] },
+      }),
+    );
+    const bytes = new Uint8Array(8 + header.length + 24);
+    new DataView(bytes.buffer).setBigUint64(0, BigInt(header.length), true);
+    bytes.set(header, 8);
+    expect(parseSafetensors(bytes).rows).toEqual([
+      ["encoder", "F32", "2 × 3", 24],
+    ]);
+  });
+
+  it("reads NumPy dtype, shape, order, and payload offset", () => {
+    const rawHeader =
+      "{'descr': '<f4', 'fortran_order': False, 'shape': (2, 3), }";
+    const padding = " ".repeat((16 - ((10 + rawHeader.length + 1) % 16)) % 16);
+    const header = new TextEncoder().encode(`${rawHeader}${padding}\n`);
+    const bytes = new Uint8Array(10 + header.length + 24);
+    bytes.set([0x93, 0x4e, 0x55, 0x4d, 0x50, 0x59, 1, 0], 0);
+    new DataView(bytes.buffer).setUint16(8, header.length, true);
+    bytes.set(header, 10);
+    expect(parseNumpyHeader(bytes)).toEqual({
+      dtype: "<f4",
+      shape: [2, 3],
+      order: "C",
+      dataOffset: 10 + header.length,
+    });
+  });
+});

--- a/packages/repository/src/file-preview-model.ts
+++ b/packages/repository/src/file-preview-model.ts
@@ -1,0 +1,300 @@
+export type PreviewKind =
+  | "markdown"
+  | "image"
+  | "pdf"
+  | "audio"
+  | "video"
+  | "delimited"
+  | "json"
+  | "notebook"
+  | "office"
+  | "sqlite"
+  | "parquet"
+  | "arrow"
+  | "numpy"
+  | "safetensors"
+  | "gguf"
+  | "archive"
+  | "generic";
+
+export type PreviewDescriptor = {
+  kind: PreviewKind;
+  label: string;
+  mime?: string;
+};
+
+export type TableData = {
+  columns: string[];
+  rows: unknown[][];
+  totalRows: number;
+  note?: string;
+};
+
+const types: Record<string, PreviewDescriptor> = {
+  md: { kind: "markdown", label: "Markdown" },
+  markdown: { kind: "markdown", label: "Markdown" },
+  png: { kind: "image", label: "PNG image", mime: "image/png" },
+  jpg: { kind: "image", label: "JPEG image", mime: "image/jpeg" },
+  jpeg: { kind: "image", label: "JPEG image", mime: "image/jpeg" },
+  gif: { kind: "image", label: "GIF image", mime: "image/gif" },
+  webp: { kind: "image", label: "WebP image", mime: "image/webp" },
+  avif: { kind: "image", label: "AVIF image", mime: "image/avif" },
+  bmp: { kind: "image", label: "Bitmap image", mime: "image/bmp" },
+  ico: { kind: "image", label: "Icon", mime: "image/x-icon" },
+  svg: { kind: "image", label: "SVG image", mime: "image/svg+xml" },
+  pdf: { kind: "pdf", label: "PDF document", mime: "application/pdf" },
+  mp3: { kind: "audio", label: "MP3 audio", mime: "audio/mpeg" },
+  wav: { kind: "audio", label: "Wave audio", mime: "audio/wav" },
+  flac: { kind: "audio", label: "FLAC audio", mime: "audio/flac" },
+  ogg: { kind: "audio", label: "Ogg media", mime: "audio/ogg" },
+  m4a: { kind: "audio", label: "MPEG-4 audio", mime: "audio/mp4" },
+  aac: { kind: "audio", label: "AAC audio", mime: "audio/aac" },
+  mp4: { kind: "video", label: "MPEG-4 video", mime: "video/mp4" },
+  m4v: { kind: "video", label: "MPEG-4 video", mime: "video/mp4" },
+  webm: { kind: "video", label: "WebM video", mime: "video/webm" },
+  mov: { kind: "video", label: "QuickTime video", mime: "video/quicktime" },
+  csv: { kind: "delimited", label: "CSV dataset" },
+  tsv: { kind: "delimited", label: "TSV dataset" },
+  json: { kind: "json", label: "JSON data" },
+  jsonl: { kind: "json", label: "JSON Lines data" },
+  ndjson: { kind: "json", label: "JSON Lines data" },
+  ipynb: { kind: "notebook", label: "Jupyter notebook" },
+  docx: { kind: "office", label: "Word document" },
+  xlsx: { kind: "office", label: "Excel workbook" },
+  pptx: { kind: "office", label: "PowerPoint presentation" },
+  odt: { kind: "office", label: "OpenDocument text" },
+  ods: { kind: "office", label: "OpenDocument spreadsheet" },
+  odp: { kind: "office", label: "OpenDocument presentation" },
+  sqlite: { kind: "sqlite", label: "SQLite database" },
+  sqlite3: { kind: "sqlite", label: "SQLite database" },
+  db: { kind: "sqlite", label: "SQLite database" },
+  parquet: { kind: "parquet", label: "Parquet dataset" },
+  arrow: { kind: "arrow", label: "Arrow dataset" },
+  feather: { kind: "arrow", label: "Feather dataset" },
+  ipc: { kind: "arrow", label: "Arrow IPC dataset" },
+  npy: { kind: "numpy", label: "NumPy array" },
+  npz: { kind: "numpy", label: "NumPy archive" },
+  safetensors: { kind: "safetensors", label: "Safetensors model" },
+  gguf: { kind: "gguf", label: "GGUF model" },
+  zip: { kind: "archive", label: "ZIP archive" },
+  jar: { kind: "archive", label: "Java archive" },
+  war: { kind: "archive", label: "Web archive" },
+  apk: { kind: "archive", label: "Android package" },
+  ipa: { kind: "archive", label: "iOS package" },
+  whl: { kind: "archive", label: "Python wheel" },
+  pt: { kind: "archive", label: "PyTorch archive" },
+  pth: { kind: "archive", label: "PyTorch artifact" },
+  tar: { kind: "archive", label: "TAR archive" },
+};
+
+export function extension(name: string) {
+  return name.split(/[?#]/, 1)[0].split(".").pop()?.toLowerCase() ?? "";
+}
+
+export function previewDescriptor(name: string) {
+  return types[extension(name)] ?? null;
+}
+
+const MAX_TABLE_ROWS = 5_000;
+
+export function parseDelimited(text: string, delimiter: string): TableData {
+  const records: string[][] = [];
+  let record: string[] = [];
+  let field = "";
+  let quoted = false;
+  for (let index = 0; index <= text.length; index += 1) {
+    const character = text[index];
+    if (quoted) {
+      if (character === '"' && text[index + 1] === '"') {
+        field += '"';
+        index += 1;
+      } else if (character === '"') {
+        quoted = false;
+      } else if (character !== undefined) {
+        field += character;
+      }
+      continue;
+    }
+    if (character === '"' && field === "") {
+      quoted = true;
+    } else if (character === delimiter) {
+      record.push(field);
+      field = "";
+    } else if (character === "\n" || character === undefined) {
+      if (field.endsWith("\r")) field = field.slice(0, -1);
+      record.push(field);
+      if (record.some((value) => value !== "")) records.push(record);
+      record = [];
+      field = "";
+      if (records.length > MAX_TABLE_ROWS) break;
+    } else {
+      field += character;
+    }
+  }
+  if (!records.length) return { columns: [], rows: [], totalRows: 0 };
+  const width = Math.max(...records.map((row) => row.length));
+  const seen = new Map<string, number>();
+  const columns = Array.from({ length: width }, (_, index) => {
+    const base = records[0]?.[index]?.trim() || `Column ${index + 1}`;
+    const occurrence = (seen.get(base) ?? 0) + 1;
+    seen.set(base, occurrence);
+    return occurrence === 1 ? base : `${base} (${occurrence})`;
+  });
+  const rows = records
+    .slice(1, MAX_TABLE_ROWS + 1)
+    .map((row) =>
+      Array.from({ length: width }, (_, index) => row[index] ?? ""),
+    );
+  return {
+    columns,
+    rows,
+    totalRows: Math.max(0, records.length - 1),
+    note:
+      records.length > MAX_TABLE_ROWS
+        ? `Showing the first ${MAX_TABLE_ROWS.toLocaleString()} rows.`
+        : undefined,
+  };
+}
+
+export function tableFromValues(values: unknown[]): TableData {
+  if (!values.length) return { columns: [], rows: [], totalRows: 0 };
+  const objects = values.every(
+    (value) =>
+      value !== null && typeof value === "object" && !Array.isArray(value),
+  );
+  if (!objects)
+    return {
+      columns: ["Value"],
+      rows: values.slice(0, MAX_TABLE_ROWS).map((value) => [value]),
+      totalRows: values.length,
+    };
+  const columns = Array.from(
+    new Set(
+      values
+        .slice(0, MAX_TABLE_ROWS)
+        .flatMap((value) => Object.keys(value as Record<string, unknown>)),
+    ),
+  );
+  return {
+    columns,
+    rows: values
+      .slice(0, MAX_TABLE_ROWS)
+      .map((value) =>
+        columns.map((column) => (value as Record<string, unknown>)[column]),
+      ),
+    totalRows: values.length,
+    note:
+      values.length > MAX_TABLE_ROWS
+        ? `Showing the first ${MAX_TABLE_ROWS.toLocaleString()} rows.`
+        : undefined,
+  };
+}
+
+export function parseJsonTable(text: string, lines: boolean): TableData {
+  if (lines) {
+    const values = text
+      .split(/\r?\n/)
+      .filter((line) => line.trim())
+      .slice(0, MAX_TABLE_ROWS + 1)
+      .map((line) => JSON.parse(line) as unknown);
+    return tableFromValues(values);
+  }
+  const value: unknown = JSON.parse(text);
+  if (Array.isArray(value)) return tableFromValues(value);
+  if (value !== null && typeof value === "object")
+    return {
+      columns: ["Key", "Value"],
+      rows: Object.entries(value),
+      totalRows: Object.keys(value).length,
+    };
+  return { columns: ["Value"], rows: [[value]], totalRows: 1 };
+}
+
+export function parseSafetensors(bytes: Uint8Array): TableData {
+  if (bytes.byteLength < 8) throw new Error("Safetensors header is incomplete");
+  const headerLength = Number(
+    new DataView(bytes.buffer, bytes.byteOffset, 8).getBigUint64(0, true),
+  );
+  if (
+    !Number.isSafeInteger(headerLength) ||
+    headerLength > bytes.byteLength - 8
+  )
+    throw new Error("Safetensors header length is invalid");
+  const header = JSON.parse(
+    new TextDecoder().decode(bytes.subarray(8, 8 + headerLength)),
+  ) as Record<
+    string,
+    { dtype?: string; shape?: number[]; data_offsets?: [number, number] }
+  >;
+  const tensors = Object.entries(header).filter(
+    ([name]) => name !== "__metadata__",
+  );
+  return {
+    columns: ["Tensor", "Data type", "Shape", "Bytes"],
+    rows: tensors.map(([name, tensor]) => [
+      name,
+      tensor.dtype ?? "—",
+      tensor.shape?.join(" × ") ?? "—",
+      tensor.data_offsets
+        ? tensor.data_offsets[1] - tensor.data_offsets[0]
+        : "—",
+    ]),
+    totalRows: tensors.length,
+  };
+}
+
+export type NumpyArray = {
+  dtype: string;
+  shape: number[];
+  order: "C" | "Fortran";
+  dataOffset: number;
+};
+
+export function parseNumpyHeader(bytes: Uint8Array): NumpyArray {
+  if (
+    bytes.byteLength < 10 ||
+    bytes[0] !== 0x93 ||
+    new TextDecoder().decode(bytes.subarray(1, 6)) !== "NUMPY"
+  )
+    throw new Error("NumPy file signature is invalid");
+  const major = bytes[6];
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const headerSize =
+    major === 1 ? view.getUint16(8, true) : view.getUint32(8, true);
+  const dataOffset = major === 1 ? 10 + headerSize : 12 + headerSize;
+  if (dataOffset > bytes.byteLength)
+    throw new Error("NumPy header is incomplete");
+  const header = new TextDecoder("latin1").decode(
+    bytes.subarray(major === 1 ? 10 : 12, dataOffset),
+  );
+  const dtype = /['"]descr['"]\s*:\s*['"]([^'"]+)['"]/.exec(header)?.[1];
+  const shapeText = /['"]shape['"]\s*:\s*\(([^)]*)\)/.exec(header)?.[1];
+  if (!dtype || shapeText === undefined)
+    throw new Error("NumPy header is unsupported");
+  return {
+    dtype,
+    shape: shapeText
+      .split(",")
+      .map((value) => Number(value.trim()))
+      .filter(Number.isFinite),
+    order: /['"]fortran_order['"]\s*:\s*True/.test(header) ? "Fortran" : "C",
+    dataOffset,
+  };
+}
+
+export function displayCell(value: unknown) {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Uint8Array) return `<${value.byteLength} bytes>`;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, (_, nested) =>
+        typeof nested === "bigint" ? nested.toString() : nested,
+      );
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}

--- a/packages/repository/src/file-preview-office.ts
+++ b/packages/repository/src/file-preview-office.ts
@@ -1,0 +1,318 @@
+import { unzip } from "fflate";
+import type { TableData } from "./file-preview-model";
+
+const MAX_EXPANDED_BYTES = 30 * 1024 * 1024;
+const decoder = new TextDecoder();
+
+export type OfficePreview =
+  | {
+      kind: "document";
+      sections: Array<{
+        title?: string;
+        paragraphs: string[];
+        table?: TableData;
+      }>;
+    }
+  | { kind: "workbook"; sheets: Array<{ name: string; table: TableData }> }
+  | { kind: "presentation"; slides: Array<{ title: string; lines: string[] }> };
+
+export function unzipSelected(
+  bytes: Uint8Array,
+  include: (name: string) => boolean,
+) {
+  return new Promise<Record<string, Uint8Array>>((resolve, reject) => {
+    let expanded = 0;
+    unzip(
+      bytes,
+      {
+        filter(file) {
+          if (!include(file.name)) return false;
+          expanded += file.originalSize;
+          return expanded <= MAX_EXPANDED_BYTES;
+        },
+      },
+      (error, files) => {
+        if (error) reject(error);
+        else if (expanded > MAX_EXPANDED_BYTES)
+          reject(new Error("Expanded preview data exceeds 30 MB"));
+        else resolve(files);
+      },
+    );
+  });
+}
+
+function document(bytes?: Uint8Array) {
+  if (!bytes)
+    throw new Error("The document package is missing required content");
+  const value = new DOMParser().parseFromString(
+    decoder.decode(bytes),
+    "application/xml",
+  );
+  if (value.querySelector("parsererror"))
+    throw new Error("Document XML is invalid");
+  return value;
+}
+
+function descendants(node: ParentNode, localName: string) {
+  return Array.from(node.querySelectorAll("*")).filter(
+    (element) => element.localName === localName,
+  );
+}
+
+function textRuns(node: ParentNode) {
+  return descendants(node, "t")
+    .map((element) => element.textContent ?? "")
+    .join("")
+    .trim();
+}
+
+function tableFromRows(rows: Element[]): TableData {
+  const values = rows.map((row) =>
+    descendants(row, "tc").map((cell) => textRuns(cell)),
+  );
+  const width = Math.max(0, ...values.map((row) => row.length));
+  return {
+    columns: Array.from({ length: width }, (_, index) => `Column ${index + 1}`),
+    rows: values,
+    totalRows: values.length,
+  };
+}
+
+function spreadsheetColumnName(index: number) {
+  let name = "";
+  for (let value = index + 1; value > 0; value = Math.floor((value - 1) / 26))
+    name = String.fromCharCode(65 + ((value - 1) % 26)) + name;
+  return name;
+}
+
+async function wordPreview(bytes: Uint8Array): Promise<OfficePreview> {
+  const files = await unzipSelected(
+    bytes,
+    (name) => name === "word/document.xml",
+  );
+  const body = descendants(document(files["word/document.xml"]), "body")[0];
+  if (!body) throw new Error("Word document body is missing");
+  const sections: Extract<OfficePreview, { kind: "document" }>["sections"] = [];
+  for (const child of Array.from(body.children)) {
+    if (child.localName === "p") {
+      const text = textRuns(child);
+      if (text) sections.push({ paragraphs: [text] });
+    } else if (child.localName === "tbl") {
+      sections.push({
+        paragraphs: [],
+        table: tableFromRows(descendants(child, "tr")),
+      });
+    }
+  }
+  return { kind: "document", sections };
+}
+
+function sharedStrings(files: Record<string, Uint8Array>) {
+  const shared = files["xl/sharedStrings.xml"];
+  if (!shared) return [];
+  return descendants(document(shared), "si").map(textRuns);
+}
+
+function spreadsheetCell(cell: Element, shared: string[]) {
+  const type = cell.getAttribute("t");
+  const value =
+    descendants(cell, type === "inlineStr" ? "t" : "v")[0]?.textContent ?? "";
+  if (type === "s") return shared[Number(value)] ?? value;
+  if (type === "b") return value === "1";
+  if (type === "str" || type === "inlineStr") return value;
+  const numeric = Number(value);
+  return value !== "" && Number.isFinite(numeric) ? numeric : value;
+}
+
+function columnIndex(reference: string) {
+  let value = 0;
+  for (const character of reference.match(/^[A-Z]+/)?.[0] ?? "")
+    value = value * 26 + character.charCodeAt(0) - 64;
+  return Math.max(0, value - 1);
+}
+
+async function workbookPreview(bytes: Uint8Array): Promise<OfficePreview> {
+  const files = await unzipSelected(
+    bytes,
+    (name) =>
+      name === "xl/workbook.xml" ||
+      name === "xl/sharedStrings.xml" ||
+      /^xl\/worksheets\/sheet\d+\.xml$/.test(name),
+  );
+  const names = files["xl/workbook.xml"]
+    ? descendants(document(files["xl/workbook.xml"]), "sheet").map(
+        (sheet) => sheet.getAttribute("name") ?? "Sheet",
+      )
+    : [];
+  const shared = sharedStrings(files);
+  const paths = Object.keys(files)
+    .filter((name) => /^xl\/worksheets\/sheet\d+\.xml$/.test(name))
+    .sort((left, right) =>
+      left.localeCompare(right, undefined, { numeric: true }),
+    );
+  const sheets = paths.map((path, sheetIndex) => {
+    const rows = descendants(document(files[path]), "row").slice(0, 5_001);
+    const values = rows.map((row) => {
+      const cells = descendants(row, "c");
+      const width = Math.max(
+        0,
+        ...cells.map((cell) => columnIndex(cell.getAttribute("r") ?? "A") + 1),
+      );
+      const result: unknown[] = Array.from({ length: width }, () => "");
+      for (const cell of cells)
+        result[columnIndex(cell.getAttribute("r") ?? "A")] = spreadsheetCell(
+          cell,
+          shared,
+        );
+      return result;
+    });
+    const width = Math.max(0, ...values.map((row) => row.length));
+    return {
+      name: names[sheetIndex] ?? `Sheet ${sheetIndex + 1}`,
+      table: {
+        columns: Array.from({ length: width }, (_, index) =>
+          spreadsheetColumnName(index),
+        ),
+        rows: values,
+        totalRows: values.length,
+        note: rows.length > 5_000 ? "Showing the first 5,000 rows." : undefined,
+      },
+    };
+  });
+  return { kind: "workbook", sheets };
+}
+
+async function presentationPreview(bytes: Uint8Array): Promise<OfficePreview> {
+  const files = await unzipSelected(bytes, (name) =>
+    /^ppt\/slides\/slide\d+\.xml$/.test(name),
+  );
+  const paths = Object.keys(files).sort((left, right) =>
+    left.localeCompare(right, undefined, { numeric: true }),
+  );
+  return {
+    kind: "presentation",
+    slides: paths.map((path, index) => {
+      const lines = descendants(document(files[path]), "p")
+        .map(textRuns)
+        .filter(Boolean);
+      return { title: lines[0] || `Slide ${index + 1}`, lines: lines.slice(1) };
+    }),
+  };
+}
+
+async function openDocumentPreview(
+  bytes: Uint8Array,
+  extension: string,
+): Promise<OfficePreview> {
+  const files = await unzipSelected(bytes, (name) => name === "content.xml");
+  const content = document(files["content.xml"]);
+  if (extension === "ods") {
+    const sheets = descendants(content, "table").map((sheet, index) => {
+      const rows = descendants(sheet, "table-row").slice(0, 5_000);
+      return {
+        name: sheet.getAttribute("table:name") ?? `Sheet ${index + 1}`,
+        table: {
+          columns: Array.from(
+            {
+              length: Math.max(
+                0,
+                ...rows.map((row) => descendants(row, "table-cell").length),
+              ),
+            },
+            (_, column) => spreadsheetColumnName(column),
+          ),
+          rows: rows.map((row) =>
+            descendants(row, "table-cell").map((cell) => textRuns(cell)),
+          ),
+          totalRows: rows.length,
+        },
+      };
+    });
+    return { kind: "workbook", sheets };
+  }
+  if (extension === "odp") {
+    return {
+      kind: "presentation",
+      slides: descendants(content, "page").map((page, index) => {
+        const lines = descendants(page, "p").map(textRuns).filter(Boolean);
+        return {
+          title: lines[0] || `Slide ${index + 1}`,
+          lines: lines.slice(1),
+        };
+      }),
+    };
+  }
+  return {
+    kind: "document",
+    sections: descendants(content, "p")
+      .map(textRuns)
+      .filter(Boolean)
+      .map((text) => ({ paragraphs: [text] })),
+  };
+}
+
+export async function parseOffice(
+  bytes: Uint8Array,
+  extension: string,
+): Promise<OfficePreview> {
+  if (extension === "docx") return wordPreview(bytes);
+  if (extension === "xlsx") return workbookPreview(bytes);
+  if (extension === "pptx") return presentationPreview(bytes);
+  return openDocumentPreview(bytes, extension);
+}
+
+export async function archiveInventory(
+  bytes: Uint8Array,
+  extension: string,
+): Promise<TableData> {
+  if (extension === "tar") return tarInventory(bytes);
+  const entries: Array<[string, number, number, string]> = [];
+  await new Promise<void>((resolve, reject) => {
+    unzip(
+      bytes,
+      {
+        filter(file) {
+          entries.push([
+            file.name,
+            file.originalSize,
+            file.size,
+            file.name.endsWith("/") ? "Directory" : "File",
+          ]);
+          return false;
+        },
+      },
+      (error) => (error ? reject(error) : resolve()),
+    );
+  });
+  return {
+    columns: ["Path", "Bytes", "Compressed bytes", "Type"],
+    rows: entries.slice(0, 5_000),
+    totalRows: entries.length,
+    note:
+      entries.length > 5_000 ? "Showing the first 5,000 entries." : undefined,
+  };
+}
+
+function tarInventory(bytes: Uint8Array): TableData {
+  const rows: unknown[][] = [];
+  for (let offset = 0; offset + 512 <= bytes.length && rows.length < 5_000; ) {
+    const header = bytes.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+    const name = decoder.decode(header.subarray(0, 100)).replace(/\0.*$/, "");
+    const size = Number.parseInt(
+      decoder.decode(header.subarray(124, 136)).replace(/\0.*$/, "").trim() ||
+        "0",
+      8,
+    );
+    const type = header[156] === 53 ? "Directory" : "File";
+    rows.push([name, size, type]);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+  return {
+    columns: ["Path", "Bytes", "Type"],
+    rows,
+    totalRows: rows.length,
+    note:
+      rows.length === 5_000 ? "Showing the first 5,000 entries." : undefined,
+  };
+}

--- a/packages/repository/src/file-preview.tsx
+++ b/packages/repository/src/file-preview.tsx
@@ -1,0 +1,602 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Spinner } from "@primer/react";
+import type { Repository } from "./api";
+import { DataTable } from "./data-explorer";
+import { RepositoryMarkdown } from "./repository-markdown";
+import {
+  extension,
+  parseDelimited,
+  parseJsonTable,
+  parseSafetensors,
+  type PreviewDescriptor,
+} from "./file-preview-model";
+import {
+  archiveInventory,
+  parseOffice,
+  type OfficePreview,
+} from "./file-preview-office";
+import {
+  loadArrow,
+  loadGguf,
+  loadNumpy,
+  loadParquet,
+  loadSqlite,
+  type DatabasePreview,
+} from "./file-preview-loaders";
+import { PdfPreview } from "./pdf-preview";
+import { GenericFilePreview } from "./generic-file-preview";
+
+const MAX_PREVIEW_BYTES = 50 * 1024 * 1024;
+
+type Props = {
+  descriptor: PreviewDescriptor;
+  repo: Repository;
+  rev: string;
+  directory: string;
+  name: string;
+  text: string | null;
+  size: number;
+  blobUrl: string;
+};
+
+type BinaryState = {
+  bytes?: Uint8Array;
+  error?: string;
+  loading: boolean;
+};
+
+function useBinary(url: string, size: number): BinaryState {
+  const [state, setState] = useState<BinaryState>({ loading: true });
+  useEffect(() => {
+    const controller = new AbortController();
+    if (size > MAX_PREVIEW_BYTES) {
+      setState({
+        loading: false,
+        error: `Interactive previews are limited to ${formatBytes(MAX_PREVIEW_BYTES)}. Download this ${formatBytes(size)} file to inspect it locally.`,
+      });
+      return () => controller.abort();
+    }
+    setState({ loading: true });
+    fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/octet-stream" },
+    })
+      .then(async (response) => {
+        if (!response.ok)
+          throw new Error(
+            `File bytes could not be loaded (${response.status})`,
+          );
+        const buffer = await response.arrayBuffer();
+        if (!controller.signal.aborted)
+          setState({ loading: false, bytes: new Uint8Array(buffer) });
+      })
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted)
+          setState({
+            loading: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "File bytes could not be loaded",
+          });
+      });
+    return () => controller.abort();
+  }, [size, url]);
+  return state;
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes.toLocaleString()} bytes`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function PreviewNotice({
+  children,
+  error = false,
+}: {
+  children: ReactNode;
+  error?: boolean;
+}) {
+  return (
+    <div
+      className={`file-preview-notice${error ? " error" : ""}`}
+      role={error ? "alert" : "status"}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TextDataPreview({
+  descriptor,
+  name,
+  text,
+}: Pick<Props, "descriptor" | "name" | "text">) {
+  try {
+    const data =
+      descriptor.kind === "delimited"
+        ? parseDelimited(text ?? "", extension(name) === "tsv" ? "\t" : ",")
+        : parseJsonTable(
+            text ?? "",
+            ["jsonl", "ndjson"].includes(extension(name)),
+          );
+    return <DataTable data={data} name={descriptor.label} />;
+  } catch (error) {
+    return (
+      <PreviewNotice error>
+        <strong>This file could not be parsed as {descriptor.label}.</strong>
+        <p>{error instanceof Error ? error.message : "The data is invalid."}</p>
+      </PreviewNotice>
+    );
+  }
+}
+
+type Notebook = {
+  cells?: Array<{
+    cell_type?: string;
+    execution_count?: number | null;
+    source?: string | string[];
+    outputs?: Array<{
+      output_type?: string;
+      text?: string | string[];
+      data?: Record<string, string | string[]>;
+    }>;
+  }>;
+};
+
+function sourceText(value?: string | string[]) {
+  return Array.isArray(value) ? value.join("") : (value ?? "");
+}
+
+function NotebookPreview({
+  repo,
+  rev,
+  directory,
+  text,
+}: Pick<Props, "repo" | "rev" | "directory" | "text">) {
+  let notebook: Notebook;
+  try {
+    notebook = JSON.parse(text ?? "") as Notebook;
+  } catch (error) {
+    return (
+      <PreviewNotice error>
+        {error instanceof Error ? error.message : "Notebook JSON is invalid"}
+      </PreviewNotice>
+    );
+  }
+  return (
+    <div className="notebook-preview">
+      {(notebook.cells ?? []).slice(0, 200).map((cell, index) => (
+        <section
+          className={`notebook-cell ${cell.cell_type ?? "raw"}`}
+          key={index}
+        >
+          <div className="notebook-gutter">
+            {cell.cell_type === "code"
+              ? `In [${cell.execution_count ?? " "}]`
+              : "Text"}
+          </div>
+          <div className="notebook-content">
+            {cell.cell_type === "markdown" ? (
+              <RepositoryMarkdown repo={repo} rev={rev} directory={directory}>
+                {sourceText(cell.source)}
+              </RepositoryMarkdown>
+            ) : (
+              <pre>{sourceText(cell.source)}</pre>
+            )}
+            {cell.outputs?.map((output, outputIndex) => {
+              const plain = sourceText(
+                output.data?.["text/plain"] ?? output.text,
+              );
+              const image = sourceText(output.data?.["image/png"]);
+              return (
+                <div className="notebook-output" key={outputIndex}>
+                  {image ? (
+                    <img
+                      src={`data:image/png;base64,${image.replaceAll(/\s/g, "")}`}
+                      alt="Notebook output"
+                    />
+                  ) : (
+                    <pre>{plain || `[${output.output_type ?? "output"}]`}</pre>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+      {(notebook.cells?.length ?? 0) > 200 && (
+        <PreviewNotice>Showing the first 200 notebook cells.</PreviewNotice>
+      )}
+    </div>
+  );
+}
+
+function useObjectUrl(bytes: Uint8Array, mime: string) {
+  const url = useMemo(
+    () =>
+      URL.createObjectURL(
+        new Blob(
+          [
+            bytes.buffer.slice(
+              bytes.byteOffset,
+              bytes.byteOffset + bytes.byteLength,
+            ) as ArrayBuffer,
+          ],
+          { type: mime },
+        ),
+      ),
+    [bytes, mime],
+  );
+  useEffect(() => () => URL.revokeObjectURL(url), [url]);
+  return url;
+}
+
+function MediaPreview({
+  descriptor,
+  bytes,
+  name,
+}: {
+  descriptor: PreviewDescriptor;
+  bytes: Uint8Array;
+  name: string;
+}) {
+  const url = useObjectUrl(
+    bytes,
+    descriptor.mime ?? "application/octet-stream",
+  );
+  const [zoom, setZoom] = useState(100);
+  if (descriptor.kind === "image")
+    return (
+      <div className="media-preview">
+        <div className="media-preview-toolbar">
+          <label>
+            Zoom
+            <input
+              aria-label="Image zoom"
+              type="range"
+              min="25"
+              max="300"
+              step="25"
+              value={zoom}
+              onChange={(event) => setZoom(Number(event.target.value))}
+            />
+            <output>{zoom}%</output>
+          </label>
+        </div>
+        <div className="image-stage" tabIndex={0}>
+          <img
+            src={url}
+            alt={`Preview of ${name}`}
+            style={{ width: `${zoom}%` }}
+          />
+        </div>
+      </div>
+    );
+  if (descriptor.kind === "pdf")
+    return <PdfPreview bytes={bytes} name={name} />;
+  if (descriptor.kind === "audio")
+    return (
+      <div className="media-player">
+        <audio src={url} controls aria-label={`Audio preview of ${name}`} />
+      </div>
+    );
+  return (
+    <div className="media-player video-player">
+      <video src={url} controls aria-label={`Video preview of ${name}`} />
+    </div>
+  );
+}
+
+function AsyncValue<T>({
+  cacheKey,
+  load,
+  children,
+}: {
+  cacheKey: string;
+  load: () => Promise<T>;
+  children: (value: T) => ReactNode;
+}) {
+  const loader = useRef(load);
+  loader.current = load;
+  const [state, setState] = useState<{ value?: T; error?: string }>({});
+  useEffect(() => {
+    let active = true;
+    setState({});
+    loader
+      .current()
+      .then((value) => active && setState({ value }))
+      .catch(
+        (error: unknown) =>
+          active &&
+          setState({
+            error:
+              error instanceof Error ? error.message : "Preview parsing failed",
+          }),
+      );
+    return () => {
+      active = false;
+    };
+  }, [cacheKey]);
+  if (state.error)
+    return (
+      <PreviewNotice error>
+        <strong>This preview could not be rendered.</strong>
+        <p>{state.error}</p>
+      </PreviewNotice>
+    );
+  if (state.value === undefined)
+    return (
+      <PreviewNotice>
+        <Spinner size="small" /> Parsing this file in your browser…
+      </PreviewNotice>
+    );
+  return children(state.value);
+}
+
+function OfficeFilePreview({
+  bytes,
+  name,
+}: {
+  bytes: Uint8Array;
+  name: string;
+}) {
+  const [section, setSection] = useState(0);
+  return (
+    <AsyncValue
+      cacheKey={name}
+      load={() => parseOffice(bytes, extension(name))}
+    >
+      {(value: OfficePreview) => {
+        if (value.kind === "workbook") {
+          const selected =
+            value.sheets[Math.min(section, value.sheets.length - 1)];
+          return (
+            <div className="office-preview">
+              <nav className="preview-tabs" aria-label="Workbook sheets">
+                {value.sheets.map((sheet, index) => (
+                  <button
+                    key={sheet.name}
+                    className={index === section ? "active" : ""}
+                    aria-current={index === section ? "page" : undefined}
+                    onClick={() => setSection(index)}
+                  >
+                    {sheet.name}
+                  </button>
+                ))}
+              </nav>
+              {selected ? (
+                <DataTable data={selected.table} name={selected.name} />
+              ) : (
+                <PreviewNotice>No worksheets were found.</PreviewNotice>
+              )}
+            </div>
+          );
+        }
+        if (value.kind === "presentation")
+          return (
+            <div className="slide-deck-preview">
+              {value.slides.map((slide, index) => (
+                <section
+                  className="slide-preview"
+                  key={index}
+                  aria-label={`Slide ${index + 1}`}
+                >
+                  <span>{index + 1}</span>
+                  <h2>{slide.title}</h2>
+                  {slide.lines.map((line, lineIndex) => (
+                    <p key={lineIndex}>{line}</p>
+                  ))}
+                </section>
+              ))}
+            </div>
+          );
+        return (
+          <article className="document-preview">
+            {value.sections.map((item, index) =>
+              item.table ? (
+                <DataTable
+                  key={index}
+                  data={item.table}
+                  name={`Table ${index + 1}`}
+                />
+              ) : (
+                item.paragraphs.map((paragraph, paragraphIndex) => (
+                  <p key={`${index}:${paragraphIndex}`}>{paragraph}</p>
+                ))
+              ),
+            )}
+          </article>
+        );
+      }}
+    </AsyncValue>
+  );
+}
+
+function DatabaseFilePreview({
+  bytes,
+  name,
+}: {
+  bytes: Uint8Array;
+  name: string;
+}) {
+  const [selected, setSelected] = useState(0);
+  return (
+    <AsyncValue cacheKey={name} load={() => loadSqlite(bytes)}>
+      {(value: DatabasePreview) => {
+        const table = value.tables[Math.min(selected, value.tables.length - 1)];
+        if (!table)
+          return (
+            <PreviewNotice>
+              This database has no user tables or views.
+            </PreviewNotice>
+          );
+        return (
+          <div className="database-preview">
+            <aside aria-label="Database objects">
+              <strong>Database objects</strong>
+              {value.tables.map((item, index) => (
+                <button
+                  key={item.name}
+                  className={index === selected ? "active" : ""}
+                  aria-current={index === selected ? "page" : undefined}
+                  onClick={() => setSelected(index)}
+                >
+                  <span>{item.name}</span>
+                  <small>{item.type}</small>
+                </button>
+              ))}
+            </aside>
+            <div className="database-table">
+              <details>
+                <summary>Schema for {table.name}</summary>
+                <pre>{table.definition || "No stored schema statement"}</pre>
+              </details>
+              <DataTable data={table.data} name={table.name} />
+            </div>
+          </div>
+        );
+      }}
+    </AsyncValue>
+  );
+}
+
+function StructuredBinaryPreview({
+  descriptor,
+  bytes,
+  name,
+}: {
+  descriptor: PreviewDescriptor;
+  bytes: Uint8Array;
+  name: string;
+}) {
+  if (descriptor.kind === "generic")
+    return <GenericFilePreview bytes={bytes} name={name} />;
+  if (descriptor.kind === "office")
+    return <OfficeFilePreview bytes={bytes} name={name} />;
+  if (descriptor.kind === "sqlite")
+    return <DatabaseFilePreview bytes={bytes} name={name} />;
+  if (descriptor.kind === "safetensors")
+    try {
+      return <DataTable data={parseSafetensors(bytes)} name="Model tensors" />;
+    } catch (error) {
+      return (
+        <PreviewNotice error>
+          {error instanceof Error ? error.message : "Invalid Safetensors file"}
+        </PreviewNotice>
+      );
+    }
+  if (descriptor.kind === "gguf")
+    return (
+      <AsyncValue cacheKey={name} load={() => loadGguf(bytes)}>
+        {(value) => (
+          <div className="stacked-data-preview">
+            <DataTable data={value.metadata} name="Model metadata" />
+            <DataTable data={value.tensors} name="Model tensors" />
+          </div>
+        )}
+      </AsyncValue>
+    );
+  const loader =
+    descriptor.kind === "parquet"
+      ? () => loadParquet(bytes)
+      : descriptor.kind === "arrow"
+        ? () => loadArrow(bytes)
+        : descriptor.kind === "numpy"
+          ? () => loadNumpy(bytes, name)
+          : () => archiveInventory(bytes, extension(name));
+  return (
+    <AsyncValue cacheKey={`${descriptor.kind}:${name}`} load={loader}>
+      {(value) => <DataTable data={value} name={descriptor.label} />}
+    </AsyncValue>
+  );
+}
+
+function BinaryPreview({ descriptor, blobUrl, name, size, ...props }: Props) {
+  const state = useBinary(blobUrl, size);
+  if (state.error)
+    return (
+      <PreviewNotice error>
+        <strong>Interactive preview unavailable.</strong>
+        <p>{state.error}</p>
+      </PreviewNotice>
+    );
+  if (state.loading || !state.bytes)
+    return (
+      <PreviewNotice>
+        <Spinner size="small" /> Loading {formatBytes(size)} for a private
+        in-browser preview…
+      </PreviewNotice>
+    );
+  if (["markdown", "delimited", "json", "notebook"].includes(descriptor.kind)) {
+    try {
+      const text = new TextDecoder("utf-8", { fatal: true }).decode(
+        state.bytes,
+      );
+      return (
+        <FilePreview
+          {...props}
+          descriptor={descriptor}
+          blobUrl={blobUrl}
+          name={name}
+          size={size}
+          text={text}
+        />
+      );
+    } catch {
+      return (
+        <PreviewNotice error>
+          This file is not valid UTF-8 and cannot use the {descriptor.label}{" "}
+          preview.
+        </PreviewNotice>
+      );
+    }
+  }
+  if (["image", "pdf", "audio", "video"].includes(descriptor.kind))
+    return (
+      <MediaPreview descriptor={descriptor} bytes={state.bytes} name={name} />
+    );
+  return (
+    <StructuredBinaryPreview
+      descriptor={descriptor}
+      bytes={state.bytes}
+      name={name}
+    />
+  );
+}
+
+export function FilePreview(props: Props) {
+  if (props.descriptor.kind === "markdown")
+    return (
+      <RepositoryMarkdown
+        repo={props.repo}
+        rev={props.rev}
+        directory={props.directory}
+        className="file-markdown-preview"
+      >
+        {props.text ?? ""}
+      </RepositoryMarkdown>
+    );
+  if (props.descriptor.kind === "notebook")
+    return (
+      <NotebookPreview
+        repo={props.repo}
+        rev={props.rev}
+        directory={props.directory}
+        text={props.text}
+      />
+    );
+  if (
+    ["delimited", "json"].includes(props.descriptor.kind) &&
+    props.text !== null
+  )
+    return (
+      <TextDataPreview
+        descriptor={props.descriptor}
+        name={props.name}
+        text={props.text}
+      />
+    );
+  return <BinaryPreview {...props} />;
+}

--- a/packages/repository/src/generic-file-preview.tsx
+++ b/packages/repository/src/generic-file-preview.tsx
@@ -1,0 +1,135 @@
+import { extension } from "./file-preview-model";
+
+const SAMPLE_BYTES = 64 * 1024;
+const HEX_BYTES = 512;
+
+const formatLabels: Record<string, string> = {
+  avro: "Apache Avro container",
+  bin: "Binary data",
+  dicom: "DICOM medical image",
+  dcm: "DICOM medical image",
+  dll: "Windows library",
+  dylib: "macOS library",
+  exe: "Windows executable",
+  h5: "HDF5 dataset",
+  hdf5: "HDF5 dataset",
+  joblib: "Joblib artifact",
+  onnx: "ONNX model",
+  orc: "Apache ORC dataset",
+  pickle: "Python pickle",
+  pkl: "Python pickle",
+  protobuf: "Protocol Buffers data",
+  proto3: "Protocol Buffers data",
+  so: "Shared library",
+};
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes.toLocaleString()} bytes`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function startsWith(bytes: Uint8Array, signature: number[]) {
+  return signature.every((byte, index) => bytes[index] === byte);
+}
+
+function signature(bytes: Uint8Array) {
+  if (startsWith(bytes, [0x7f, 0x45, 0x4c, 0x46])) return "ELF executable";
+  if (startsWith(bytes, [0x4d, 0x5a])) return "Portable Executable";
+  if (startsWith(bytes, [0x1f, 0x8b])) return "Gzip stream";
+  if (startsWith(bytes, [0x42, 0x5a, 0x68])) return "Bzip2 stream";
+  if (startsWith(bytes, [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]))
+    return "7-Zip archive";
+  if (startsWith(bytes, [0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a]))
+    return "HDF5 container";
+  if (startsWith(bytes, [0x4f, 0x62, 0x6a, 0x01]))
+    return "Apache Avro container";
+  if (startsWith(bytes, [0x4f, 0x52, 0x43])) return "Apache ORC dataset";
+  if (
+    bytes.length >= 132 &&
+    String.fromCharCode(...bytes.subarray(128, 132)) === "DICM"
+  )
+    return "DICOM file";
+  return "No known magic signature";
+}
+
+function textSample(bytes: Uint8Array) {
+  const sample = bytes.subarray(0, Math.min(bytes.length, SAMPLE_BYTES));
+  if (sample.includes(0)) return null;
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(sample);
+    const controls = Array.from(text).filter(
+      (character) => character < " " && !"\n\r\t".includes(character),
+    ).length;
+    return controls / Math.max(text.length, 1) < 0.02 ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+function hexDump(bytes: Uint8Array) {
+  const sample = bytes.subarray(0, Math.min(bytes.length, HEX_BYTES));
+  const lines: string[] = [];
+  for (let offset = 0; offset < sample.length; offset += 16) {
+    const row = sample.subarray(offset, offset + 16);
+    const hex = Array.from(row, (byte) => byte.toString(16).padStart(2, "0"))
+      .join(" ")
+      .padEnd(47);
+    const ascii = Array.from(row, (byte) =>
+      byte >= 32 && byte <= 126 ? String.fromCharCode(byte) : ".",
+    ).join("");
+    lines.push(`${offset.toString(16).padStart(8, "0")}  ${hex}  |${ascii}|`);
+  }
+  return lines.join("\n");
+}
+
+export function GenericFilePreview({
+  bytes,
+  name,
+}: {
+  bytes: Uint8Array;
+  name: string;
+}) {
+  const suffix = extension(name);
+  const text = textSample(bytes);
+  return (
+    <div className="generic-file-preview">
+      <dl className="file-facts">
+        <div>
+          <dt>Format</dt>
+          <dd>
+            {formatLabels[suffix] ??
+              (suffix ? `${suffix.toUpperCase()} file` : "Binary file")}
+          </dd>
+        </div>
+        <div>
+          <dt>Size</dt>
+          <dd>{formatBytes(bytes.length)}</dd>
+        </div>
+        <div>
+          <dt>Signature</dt>
+          <dd>{signature(bytes)}</dd>
+        </div>
+        <div>
+          <dt>Inspection</dt>
+          <dd>
+            First {Math.min(bytes.length, SAMPLE_BYTES).toLocaleString()} bytes
+          </dd>
+        </div>
+      </dl>
+      {text !== null && (
+        <section className="generic-preview-section">
+          <h3>Text sample</h3>
+          <pre>{text}</pre>
+        </section>
+      )}
+      <section className="generic-preview-section">
+        <h3>Hex and ASCII</h3>
+        <pre>{hexDump(bytes)}</pre>
+        {bytes.length > HEX_BYTES && (
+          <p>Hex view is limited to the first {HEX_BYTES} bytes.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/repository/src/pdf-preview.tsx
+++ b/packages/repository/src/pdf-preview.tsx
@@ -1,0 +1,160 @@
+import { Spinner } from "@primer/react";
+import { useEffect, useRef, useState } from "react";
+import type {
+  PDFDocumentLoadingTask,
+  PDFDocumentProxy,
+  RenderTask,
+} from "pdfjs-dist";
+import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+
+export function PdfPreview({
+  bytes,
+  name,
+}: {
+  bytes: Uint8Array;
+  name: string;
+}) {
+  const canvas = useRef<HTMLCanvasElement>(null);
+  const [document, setDocument] = useState<PDFDocumentProxy>();
+  const [page, setPage] = useState(1);
+  const [zoom, setZoom] = useState(125);
+  const [pageText, setPageText] = useState("");
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+    let loading: PDFDocumentLoadingTask | undefined;
+    void import("pdfjs-dist")
+      .then(async ({ getDocument, GlobalWorkerOptions }) => {
+        // The query distinguishes the executable worker response from any
+        // previously cached binary-media response for the same content hash.
+        GlobalWorkerOptions.workerSrc = `${pdfWorkerUrl}?module=1`;
+        loading = getDocument({ data: bytes.slice() });
+        const loaded = await loading.promise;
+        if (active) setDocument(loaded);
+        else await loading.destroy();
+      })
+      .catch((reason: unknown) => {
+        if (active)
+          setError(
+            reason instanceof Error ? reason.message : "PDF loading failed",
+          );
+      });
+    return () => {
+      active = false;
+      if (loading) void loading.destroy();
+    };
+  }, [bytes]);
+
+  useEffect(() => {
+    if (!document || !canvas.current) return;
+    let active = true;
+    let rendering: RenderTask | undefined;
+    setPageText("");
+    void document
+      .getPage(page)
+      .then(async (pdfPage) => {
+        if (!active || !canvas.current) return;
+        const viewport = pdfPage.getViewport({ scale: zoom / 100 });
+        const context = canvas.current.getContext("2d");
+        if (!context) throw new Error("Canvas rendering is unavailable");
+        const ratio = Math.min(window.devicePixelRatio || 1, 2);
+        canvas.current.width = Math.floor(viewport.width * ratio);
+        canvas.current.height = Math.floor(viewport.height * ratio);
+        canvas.current.style.width = `${Math.floor(viewport.width)}px`;
+        canvas.current.style.height = `${Math.floor(viewport.height)}px`;
+        rendering = pdfPage.render({
+          canvas: canvas.current,
+          canvasContext: context,
+          transform: ratio === 1 ? undefined : [ratio, 0, 0, ratio, 0, 0],
+          viewport,
+        });
+        const text = await pdfPage.getTextContent();
+        if (active)
+          setPageText(
+            text.items.map((item) => ("str" in item ? item.str : "")).join(" "),
+          );
+        await rendering.promise;
+      })
+      .catch((reason: unknown) => {
+        if (
+          active &&
+          !(
+            reason instanceof Error &&
+            reason.name === "RenderingCancelledException"
+          )
+        )
+          setError(
+            reason instanceof Error ? reason.message : "PDF rendering failed",
+          );
+      });
+    return () => {
+      active = false;
+      rendering?.cancel();
+    };
+  }, [document, page, zoom]);
+
+  if (error)
+    return (
+      <div className="file-preview-notice error" role="alert">
+        <div>
+          <strong>This PDF could not be rendered.</strong>
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  if (!document)
+    return (
+      <div className="file-preview-notice" role="status">
+        <Spinner size="small" /> Preparing this PDF in your browser…
+      </div>
+    );
+  return (
+    <div className="pdf-preview">
+      <div className="pdf-preview-toolbar">
+        <div className="pdf-page-controls">
+          <button
+            className="button-link"
+            disabled={page === 1}
+            onClick={() => setPage((value) => Math.max(1, value - 1))}
+          >
+            Previous
+          </button>
+          <span>
+            Page {page} of {document.numPages}
+          </span>
+          <button
+            className="button-link"
+            disabled={page === document.numPages}
+            onClick={() =>
+              setPage((value) => Math.min(document.numPages, value + 1))
+            }
+          >
+            Next
+          </button>
+        </div>
+        <label>
+          Zoom
+          <input
+            aria-label="PDF zoom"
+            type="range"
+            min="50"
+            max="200"
+            step="25"
+            value={zoom}
+            onChange={(event) => setZoom(Number(event.target.value))}
+          />
+          <output>{zoom}%</output>
+        </label>
+      </div>
+      <div className="pdf-page-stage" tabIndex={0}>
+        <canvas
+          ref={canvas}
+          role="img"
+          aria-label={`Page ${page} of ${name}`}
+        />
+        <span className="sr-only">{pageText}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/repository/src/style.css
+++ b/packages/repository/src/style.css
@@ -4151,6 +4151,466 @@ main {
 .file-panel .button-link {
   padding: 4px 12px;
 }
+.file-preview-notice {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 240px;
+  padding: 32px;
+  text-align: center;
+  color: var(--fgColor-muted);
+  background: var(--bgColor-muted);
+}
+.file-preview-notice.error {
+  display: block;
+  color: var(--fgColor-default);
+  background: var(--bgColor-danger-muted);
+}
+.data-explorer {
+  min-width: 0;
+  background: var(--bgColor-default);
+}
+.data-explorer-toolbar,
+.data-explorer-footer,
+.media-preview-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 48px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--borderColor-muted);
+}
+.data-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: min(360px, 100%);
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  background: var(--bgColor-default);
+  color: var(--fgColor-muted);
+}
+.data-search:focus-within {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -1px;
+}
+.data-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  color: var(--fgColor-default);
+  background: transparent;
+}
+.data-grid-scroll {
+  max-height: min(68vh, 760px);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+.data-grid-scroll:focus-visible,
+.image-stage:focus-visible {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -2px;
+}
+.data-grid {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-family: var(--fontStack-monospace);
+  font-size: 12px;
+  line-height: 20px;
+}
+.data-grid th,
+.data-grid td {
+  max-width: 420px;
+  padding: 5px 10px;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-right: 1px solid var(--borderColor-muted);
+  border-bottom: 1px solid var(--borderColor-muted);
+}
+.data-grid thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  font-family: var(--fontStack-system);
+  font-weight: 600;
+  background: var(--bgColor-muted);
+}
+.data-grid .data-row-number {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  min-width: 48px;
+  color: var(--fgColor-muted);
+  text-align: right;
+  background: var(--bgColor-muted);
+}
+.data-grid thead .data-row-number {
+  z-index: 3;
+}
+.data-grid tbody tr:hover td {
+  background: var(--control-transparent-bgColor-hover);
+}
+.data-explorer-footer {
+  min-height: 52px;
+  border-top: 1px solid var(--borderColor-muted);
+  border-bottom: 0;
+}
+.data-pagination {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+.media-preview {
+  min-width: 0;
+}
+.media-preview-toolbar {
+  justify-content: flex-end;
+}
+.media-preview-toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--fgColor-muted);
+  font-size: 12px;
+}
+.media-preview-toolbar input {
+  accent-color: var(--fgColor-accent);
+}
+.media-preview-toolbar output {
+  width: 42px;
+  color: var(--fgColor-default);
+  font-family: var(--fontStack-monospace);
+}
+.image-stage {
+  min-height: 320px;
+  max-height: 75vh;
+  overflow: auto;
+  padding: 32px;
+  text-align: center;
+  background-color: var(--bgColor-muted);
+  background-image:
+    linear-gradient(45deg, var(--borderColor-muted) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--borderColor-muted) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--borderColor-muted) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--borderColor-muted) 75%);
+  background-position:
+    0 0,
+    0 8px,
+    8px -8px,
+    -8px 0;
+  background-size: 16px 16px;
+}
+.image-stage img {
+  display: block;
+  max-width: none;
+  height: auto;
+  margin: auto;
+  object-fit: contain;
+}
+.pdf-preview {
+  background: var(--bgColor-muted);
+}
+.pdf-preview-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 52px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--borderColor-muted);
+  background: var(--bgColor-default);
+}
+.pdf-preview-toolbar label,
+.pdf-page-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--fgColor-muted);
+  font-size: 12px;
+}
+.pdf-preview-toolbar input {
+  accent-color: var(--fgColor-accent);
+}
+.pdf-preview-toolbar output {
+  width: 42px;
+  color: var(--fgColor-default);
+  font-family: var(--fontStack-monospace);
+}
+.pdf-page-stage {
+  min-height: 620px;
+  max-height: min(78vh, 960px);
+  overflow: auto;
+  padding: 32px;
+  text-align: center;
+}
+.pdf-page-stage:focus-visible {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -2px;
+}
+.pdf-page-stage canvas {
+  display: block;
+  max-width: none;
+  margin: 0 auto;
+  background: #fff;
+  box-shadow: var(--shadow-floating-medium);
+}
+.generic-file-preview {
+  min-width: 0;
+  padding: 20px;
+  background: var(--bgColor-muted);
+}
+.file-facts {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0 0 16px;
+  border: 1px solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  background: var(--borderColor-muted);
+}
+.file-facts div {
+  min-width: 0;
+  padding: 12px;
+  background: var(--bgColor-default);
+}
+.file-facts dt {
+  margin-bottom: 4px;
+  color: var(--fgColor-muted);
+  font-size: 12px;
+}
+.file-facts dd {
+  overflow: hidden;
+  margin: 0;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.generic-preview-section {
+  overflow: hidden;
+  margin-top: 16px;
+  border: 1px solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  background: var(--bgColor-default);
+}
+.generic-preview-section h3,
+.generic-preview-section p {
+  margin: 0;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--borderColor-muted);
+  font-size: 13px;
+}
+.generic-preview-section p {
+  border-top: 1px solid var(--borderColor-muted);
+  border-bottom: 0;
+  color: var(--fgColor-muted);
+  font-weight: 400;
+}
+.generic-preview-section pre {
+  max-height: min(52vh, 640px);
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  font: 12px/1.55 var(--fontStack-monospace);
+  tab-size: 4;
+}
+.media-player {
+  display: grid;
+  min-height: 240px;
+  place-items: center;
+  padding: 32px;
+  background: var(--bgColor-muted);
+}
+.media-player audio {
+  width: min(640px, 100%);
+}
+.media-player video {
+  width: min(1080px, 100%);
+  max-height: 72vh;
+  background: #000;
+}
+.notebook-preview {
+  padding: 24px;
+  background: var(--bgColor-muted);
+}
+.notebook-cell {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  max-width: 1180px;
+  margin: 0 auto 16px;
+}
+.notebook-gutter {
+  padding: 12px 10px;
+  color: var(--fgColor-muted);
+  font-family: var(--fontStack-monospace);
+  font-size: 12px;
+  text-align: right;
+}
+.notebook-content {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  background: var(--bgColor-default);
+}
+.notebook-content > pre,
+.notebook-output pre {
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+.notebook-content .discussion-markdown {
+  padding: 20px 24px;
+}
+.notebook-output {
+  overflow: auto;
+  border-top: 1px solid var(--borderColor-muted);
+}
+.notebook-output img {
+  display: block;
+  max-width: 100%;
+  margin: 16px auto;
+}
+.preview-tabs {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  padding: 8px 10px 0;
+  border-bottom: 1px solid var(--borderColor-default);
+  background: var(--bgColor-muted);
+}
+.preview-tabs button {
+  min-height: 34px;
+  padding: 0 12px;
+  color: var(--fgColor-muted);
+  border: 1px solid transparent;
+  border-bottom: 0;
+  border-radius: var(--borderRadius-medium) var(--borderRadius-medium) 0 0;
+  background: transparent;
+}
+.preview-tabs button.active {
+  color: var(--fgColor-default);
+  border-color: var(--borderColor-default);
+  background: var(--bgColor-default);
+}
+.document-preview {
+  max-width: 880px;
+  min-height: 720px;
+  margin: 32px auto;
+  padding: 64px 72px;
+  border: 1px solid var(--borderColor-muted);
+  box-shadow: var(--shadow-floating-small);
+  background: var(--bgColor-default);
+  font-size: 16px;
+  line-height: 1.7;
+}
+.document-preview p + p {
+  margin-top: 12px;
+}
+.document-preview .data-explorer {
+  margin: 20px 0;
+  border: 1px solid var(--borderColor-default);
+}
+.slide-deck-preview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+  padding: 24px;
+  background: var(--bgColor-muted);
+}
+.slide-preview {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: auto;
+  padding: 40px;
+  border: 1px solid var(--borderColor-default);
+  box-shadow: var(--shadow-floating-small);
+  background: var(--bgColor-default);
+}
+.slide-preview > span {
+  position: absolute;
+  right: 12px;
+  bottom: 8px;
+  color: var(--fgColor-muted);
+  font-family: var(--fontStack-monospace);
+  font-size: 11px;
+}
+.slide-preview h2 {
+  margin-bottom: 20px;
+  font-size: clamp(20px, 2vw, 30px);
+}
+.slide-preview p {
+  font-size: 16px;
+}
+.database-preview {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  min-height: 520px;
+}
+.database-preview > aside {
+  padding: 12px 0;
+  overflow: auto;
+  border-right: 1px solid var(--borderColor-default);
+  background: var(--bgColor-muted);
+}
+.database-preview > aside > strong {
+  display: block;
+  padding: 4px 12px 10px;
+}
+.database-preview > aside button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: 0;
+  color: var(--fgColor-default);
+  background: transparent;
+  text-align: left;
+}
+.database-preview > aside button:hover,
+.database-preview > aside button.active {
+  background: var(--bgColor-accent-muted);
+}
+.database-preview > aside button.active {
+  box-shadow: inset 2px 0 var(--borderColor-accent-emphasis);
+}
+.database-preview > aside small {
+  color: var(--fgColor-muted);
+}
+.database-table {
+  min-width: 0;
+}
+.database-table > details {
+  padding: 12px;
+  border-bottom: 1px solid var(--borderColor-muted);
+}
+.database-table > details pre {
+  overflow: auto;
+  white-space: pre-wrap;
+}
+.stacked-data-preview {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+  background: var(--bgColor-muted);
+}
+.stacked-data-preview > .data-explorer {
+  border: 1px solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  overflow: hidden;
+}
 .session-control + .theme-control {
   margin-left: 0;
 }
@@ -4254,6 +4714,78 @@ main {
   }
   .file-markdown-preview {
     padding: 24px 16px;
+  }
+  .data-explorer-toolbar,
+  .data-explorer-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .data-search {
+    width: 100%;
+  }
+  .data-pagination {
+    justify-content: space-between;
+  }
+  .image-stage,
+  .notebook-preview {
+    padding: 16px;
+  }
+  .notebook-cell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .notebook-gutter {
+    padding: 4px 0;
+    text-align: left;
+  }
+  .pdf-preview {
+    min-height: 70vh;
+  }
+  .pdf-preview-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .pdf-preview-toolbar label,
+  .pdf-page-controls {
+    justify-content: space-between;
+  }
+  .pdf-page-stage {
+    min-height: 60vh;
+    padding: 16px;
+  }
+  .generic-file-preview {
+    padding: 12px;
+  }
+  .file-facts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .document-preview {
+    min-height: 0;
+    margin: 0;
+    padding: 28px 20px;
+    border: 0;
+    box-shadow: none;
+  }
+  .slide-deck-preview {
+    grid-template-columns: minmax(0, 1fr);
+    padding: 12px;
+  }
+  .slide-preview {
+    padding: 24px;
+  }
+  .database-preview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .database-preview > aside {
+    display: flex;
+    border-right: 0;
+    border-bottom: 1px solid var(--borderColor-default);
+  }
+  .database-preview > aside > strong {
+    display: none;
+  }
+  .database-preview > aside button {
+    width: auto;
+    flex: 0 0 auto;
   }
   .refs-page > h2 {
     margin-bottom: 16px;

--- a/packages/repository/src/vite-env.d.ts
+++ b/packages/repository/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/repository/tests/browser/repository.e2e.ts
+++ b/packages/repository/tests/browser/repository.e2e.ts
@@ -1,4 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
+import { tableFromArrays, tableToIPC } from "apache-arrow";
+import { strToU8, zipSync } from "fflate";
+import { parquetWriteBuffer } from "hyparquet-writer";
+import initSqlJs from "sql.js";
 import { expectNoAccessibilityViolations } from "./accessibility";
 
 const oid = "a".repeat(40);
@@ -13,6 +17,68 @@ const pathHex = (path: string) =>
   Array.from(new TextEncoder().encode(path), (byte) =>
     byte.toString(16).padStart(2, "0"),
   ).join("");
+
+function pdfBytes(text: string) {
+  const stream = `BT /F1 20 Tf 72 720 Td (${text}) Tj ET`;
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+    `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+  ];
+  let value = "%PDF-1.4\n";
+  const offsets = [0];
+  for (const [index, object] of objects.entries()) {
+    offsets.push(Buffer.byteLength(value));
+    value += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  }
+  const xref = Buffer.byteLength(value);
+  value += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  value += offsets
+    .slice(1)
+    .map((offset) => `${String(offset).padStart(10, "0")} 00000 n \n`)
+    .join("");
+  value += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  return strToU8(value);
+}
+
+async function routePreviewFiles(
+  page: Page,
+  files: Record<
+    string,
+    { text: string | null; bytes: Uint8Array; textTruncated?: boolean }
+  >,
+) {
+  await page.route("**/api/repos/team/project/file?*", async (route) => {
+    const path = new URL(route.request().url()).searchParams.get("path_hex");
+    const file = Object.entries(files).find(
+      ([name]) => pathHex(name) === path,
+    )?.[1];
+    if (!file) return route.fallback();
+    return route.fulfill({
+      json: {
+        oid,
+        size: file.bytes.byteLength,
+        mode: "100644",
+        classification: "OrdinaryGit",
+        text: file.text,
+        text_truncated: file.textTruncated ?? false,
+      },
+    });
+  });
+  await page.route("**/api/repos/team/project/blob?*", async (route) => {
+    const path = new URL(route.request().url()).searchParams.get("path_hex");
+    const file = Object.entries(files).find(
+      ([name]) => pathHex(name) === path,
+    )?.[1];
+    if (!file) return route.fallback();
+    return route.fulfill({
+      body: Buffer.from(file.bytes),
+      contentType: "application/octet-stream",
+    });
+  });
+}
 
 async function selectTheme(page: Page, theme: "light" | "dark") {
   await page
@@ -381,6 +447,7 @@ test.beforeEach(async ({ page }) => {
           mode: "100644",
           classification: "OrdinaryGit",
           text,
+          text_truncated: false,
         },
       });
     }
@@ -929,6 +996,133 @@ test("Markdown files switch between source and a repository-aware preview", asyn
   );
   await page.getByRole("button", { name: "Code", exact: true }).click();
   await expect(preview).toHaveCount(0);
+});
+
+test("format-aware previews explore data, office files, media, and databases locally", async ({
+  page,
+}) => {
+  const csv = "run,model,score\n1,small,0.91\n2,large,0.98\n";
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40"><rect width="80" height="40" fill="#0969da"/></svg>';
+  const workbook = zipSync({
+    "xl/workbook.xml": strToU8(
+      '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheets><sheet name="Experiments"/></sheets></workbook>',
+    ),
+    "xl/worksheets/sheet1.xml": strToU8(
+      '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row><c r="A1" t="inlineStr"><is><t>epoch</t></is></c><c r="B1" t="inlineStr"><is><t>loss</t></is></c></row><row><c r="A2"><v>1</v></c><c r="B2"><v>0.42</v></c></row></sheetData></worksheet>',
+    ),
+  });
+  const SQL = await initSqlJs();
+  const database = new SQL.Database();
+  database.run(
+    "CREATE TABLE runs (id INTEGER, model TEXT, score REAL); INSERT INTO runs VALUES (1, 'large', 0.98);",
+  );
+  const sqlite = database.export();
+  database.close();
+  const parquet = new Uint8Array(
+    parquetWriteBuffer({
+      columnData: [
+        { name: "run", data: [1, 2], type: "INT32" },
+        { name: "score", data: [0.91, 0.98], type: "DOUBLE" },
+      ],
+    }),
+  );
+  const arrow = tableToIPC(
+    tableFromArrays({ run: [1, 2], model: ["small", "large"] }),
+    "file",
+  );
+  await routePreviewFiles(page, {
+    "metrics.csv": {
+      text: null,
+      bytes: strToU8(csv),
+      textTruncated: true,
+    },
+    "diagram.svg": { text: svg, bytes: strToU8(svg) },
+    "report.xlsx": { text: null, bytes: workbook },
+    "runs.sqlite": { text: null, bytes: sqlite },
+    "features.parquet": { text: null, bytes: parquet },
+    "batch.arrow": { text: null, bytes: arrow },
+    "handbook.pdf": {
+      text: null,
+      bytes: pdfBytes("Private in-browser PDF preview"),
+    },
+    "model.onnx": {
+      text: null,
+      bytes: new Uint8Array([0x08, 0x03, 0x12, 0x00, 0xff, 0x00]),
+    },
+  });
+
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("metrics.csv")}&kind=Blob`,
+  );
+  await page.getByRole("button", { name: "Preview", exact: true }).click();
+  const csvExplorer = page.getByRole("region", {
+    name: "CSV dataset data explorer",
+  });
+  await expect(csvExplorer).toContainText("large");
+  await csvExplorer.getByPlaceholder("Search loaded rows").fill("small");
+  await expect(csvExplorer.getByRole("row")).toHaveCount(2);
+  await expectNoAccessibilityViolations(page);
+
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("diagram.svg")}&kind=Blob`,
+  );
+  const image = page.getByRole("img", { name: "Preview of diagram.svg" });
+  await expect(image).toBeVisible();
+  await expect
+    .poll(() =>
+      image.evaluate((node) => (node as HTMLImageElement).naturalWidth),
+    )
+    .toBe(80);
+
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("report.xlsx")}&kind=Blob`,
+  );
+  await expect(
+    page.getByRole("navigation", { name: "Workbook sheets" }),
+  ).toContainText("Experiments");
+  await expect(page.getByRole("cell", { name: "0.42" })).toBeVisible();
+
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("runs.sqlite")}&kind=Blob`,
+  );
+  await expect(
+    page.getByRole("complementary", { name: "Database objects" }),
+  ).toContainText("runs");
+  await expect(page.getByRole("cell", { name: "large" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "0.98" })).toBeVisible();
+
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("features.parquet")}&kind=Blob`,
+  );
+  await expect(
+    page.getByRole("region", { name: "Parquet dataset data explorer" }),
+  ).toContainText("0.91");
+
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("batch.arrow")}&kind=Blob`,
+  );
+  await expect(
+    page.getByRole("region", { name: "Arrow dataset data explorer" }),
+  ).toContainText("large");
+
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("handbook.pdf")}&kind=Blob`,
+  );
+  await expect(
+    page.getByRole("img", { name: "Page 1 of handbook.pdf" }),
+  ).toBeVisible();
+  await expect(page.getByText("Page 1 of 1")).toBeVisible();
+  await expect(page.getByText("Private in-browser PDF preview")).toBeAttached();
+
+  await page.goto(
+    `/team/project?rev=refs%2Fheads%2Fmain&path=${pathHex("model.onnx")}&kind=Blob`,
+  );
+  await expect(page.getByText("ONNX model")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Hex and ASCII" }),
+  ).toBeVisible();
+  await expect(page.getByText(/00000000\s+08 03 12 00 ff 00/)).toBeVisible();
 });
 
 test("blame and source panes resize with pointer and keyboard controls", async ({


### PR DESCRIPTION
## Summary

- add an extensible file-preview registry for images, PDF, audio/video, notebooks, Office/OpenDocument files, archives, tabular data, SQLite, Parquet, Arrow/Feather, NumPy, Safetensors, and GGUF
- add searchable, paginated data exploration plus safe metadata/text/hex inspection for unknown binary formats
- lazy-load heavy parsers, cap browser previews at 50 MiB, avoid notebook code execution, and keep large source files out of the initial page payload
- serve JavaScript workers with executable media types and extend the content-security policy for safe media and blob-backed previews

## UX

- make Preview the default tab for recognized formats while retaining Code/Raw access
- render PDF pages with zoom and selectable accessibility text
- provide semantic Office and notebook previews and independently scrollable data tables
- show actionable unsupported/oversized/error states instead of blank panes

## Verification

- npm run typecheck
- npm run test -- --run: 25 passed
- npm run build
- Playwright repository suite: 38 passed
- cargo fmt --check -p crab-http-server
- cargo test -p crab-http-server --locked --lib: 73 passed, 3 environment-only tests ignored
- cargo clippy -p crab-http-server --locked --all-targets -- -D warnings
- release build for crab-http-server
- real RustFS/browser E2E with an 18-format preview gallery pushed through native Git; 8 repositories loaded and Parquet bytes checksum-verified end to end
- production npm audit: 0 vulnerabilities